### PR TITLE
Limit apollo-link-http version to ^1.5.0 excluding 1.5.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -411,9 +411,9 @@
 			}
 		},
 		"apollo-link-http": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.3.tgz",
-			"integrity": "sha512-t49wBXzdXpVdiqr82Lj0x6hORVVtIQQ5hLfVKjmQXiA/uv0o0Np8mAcOBZRYJvpVRHkaLvv5w/4MRbc8h5UGuQ==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/apollo-link-http/-/apollo-link-http-1.5.2.tgz",
+			"integrity": "sha512-TVOslggUbEdxuKYScqZ6PcMm85CkO93PDQpcdq1HASnHHEnK6TkR37hfGhZ8tGHMfxsmTYwH/A76a9AVPN3B4w==",
 			"requires": {
 				"apollo-link": "1.2.1",
 				"apollo-link-http-common": "0.2.3"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"apollo-cache-inmemory": "^1.1.1",
 		"apollo-client": "^2.0.3",
-		"apollo-link-http": "^1.5.3",
+		"apollo-link-http": "^1.5 <1.5.3 || ^1.5.4",
 		"cookie": "^0.3.1",
 		"cross-env": "^5.1.1",
 		"date-fns": "^1.29.0",


### PR DESCRIPTION
apollo-link-http v1.5.3 has a bug which is crashing our server: https://github.com/apollographql/apollo-link/issues/542