### PR TITLE
Move promo bottom border location to prevent it from showing when pro…

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/PromoBannerSmall.vue
+++ b/src/components/WwwFrame/PromotionalBanner/PromoBannerSmall.vue
@@ -20,7 +20,6 @@ export default {
 	text-align: center;
 	font-size: $small-text-font-size;
 	border-top: 1px solid $kiva-navdivider-green;
-	border-bottom: 1px solid $divider-green;
 
 	a {
 		text-decoration: none;
@@ -30,6 +29,7 @@ export default {
 		line-height: 1.5;
 		padding: rem-calc(3) 0;
 		background: $kiva-darkgreen;
+		border-bottom: 1px solid $divider-green;
 	}
 
 	.call-to-action-text {


### PR DESCRIPTION
…mo is off. Noticed in my VM that there was an extra border on the bottom of the header due to the promo container still being present when the promo is off. This will fix it for now.

I think we'll have to revisit this at some point depending on the markup/styles of the other banners. One other option would be to set a "promoBarEnabled" flag in global state and pass it to the secondary nav applying the border to the top of that markup ONLY when a promo lives above it.