### PR TITLE
Vue 69

### DIFF
--- a/src/components/LoanCards/ActionButton.vue
+++ b/src/components/LoanCards/ActionButton.vue
@@ -8,8 +8,14 @@
 @import 'settings';
 
 .action-button-wrapper {
-	margin: 0 rem-calc(20);
 	text-align: center;
+	margin-top: rem-calc(30);
 
+	.button {
+		height: 2.9375rem;
+		line-height: 0.9375rem;
+		font-size: 1.125rem;
+		width: 100%;
+	}
 }
 </style>

--- a/src/components/LoanCards/ActionButton.vue
+++ b/src/components/LoanCards/ActionButton.vue
@@ -1,21 +1,15 @@
 <template functional>
-	<div class="action-button-wrapper">
-		<a class="button lend-button">Lend $25</a>
-	</div>
+	<a class="button lend-button">Lend $25</a>
 </template>
 
 <style lang="scss">
 @import 'settings';
 
-.action-button-wrapper {
-	text-align: center;
+.button {
 	margin-top: rem-calc(30);
-
-	.button {
-		height: 2.9375rem;
-		line-height: 0.9375rem;
-		font-size: 1.125rem;
-		width: 100%;
-	}
+	height: 2.9375rem;
+	line-height: 0.9375rem;
+	font-size: 1.125rem;
+	width: 100%;
 }
 </style>

--- a/src/components/LoanCards/ActionButton.vue
+++ b/src/components/LoanCards/ActionButton.vue
@@ -1,0 +1,15 @@
+<template functional>
+	<div class="action-button-wrapper">
+		<a class="button lend-button">Lend $25</a>
+	</div>
+</template>
+
+<style lang="scss">
+@import 'settings';
+
+.action-button-wrapper {
+	margin: 0 rem-calc(20);
+	text-align: center;
+
+}
+</style>

--- a/src/components/LoanCards/BorrowerInfo.vue
+++ b/src/components/LoanCards/BorrowerInfo.vue
@@ -13,6 +13,9 @@
 
 .borrower-info-wrapper {
 	text-align: center;
+	margin-top: rem-calc(20);
+	padding: 0 rem-calc(20);
+	line-height: 1.375rem;
 
 	.name {
 		font-size: 1.375rem;
@@ -22,6 +25,7 @@
 	.country {
 		color: $kiva-text-light;
 		font-weight: 400;
+		margin-bottom: rem-calc(20);
 	}
 }
 </style>

--- a/src/components/LoanCards/BorrowerInfo.vue
+++ b/src/components/LoanCards/BorrowerInfo.vue
@@ -2,7 +2,7 @@
 	<div class="borrower-info-wrapper">
 		<a class="name">{{ props.name }}</a>
 		<div class="country">{{ props.country }}</div>
-		<div class="loan-use">A loan of {{ props.amount }} helps {{ props.name }} {{ props.use }}
+		<div class="loan-use">A loan of {{ props.amount | numeral('$0.00') }} helps {{ props.name }} {{ props.use }}
 			<a class="borrower-page-link" href="">Read more</a>
 		</div>
 	</div>
@@ -13,5 +13,15 @@
 
 .borrower-info-wrapper {
 	text-align: center;
+
+	.name {
+		font-size: 1.375rem;
+		font-weight: 400;
+	}
+
+	.country {
+		color: $kiva-text-light;
+		font-weight: 400;
+	}
 }
 </style>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -16,17 +16,17 @@
 		/>
 
 		<div class="loan-card-footer-wrap">
+			<fundraising-status
+				:amount-left="amountLeft"
+				:percent-raised="percentRaised"
+				:is-expiring-soon="loan.loanFundraisingInfo.isExpiringSoon"
+				:expiring-soon-message="expiringSoonMessage"
+			/>
 
+			<action-button />
+
+			<matching-text :matching-text="loan.matchingText" />
 		</div>
-
-		<fundraising-status
-			:amount-left="amountLeft"
-			:percent-raised="percentRaised"
-			:is-expiring-soon="loan.loanFundraisingInfo.isExpiringSoon"
-			:expiring-soon-message="expiringSoonMessage"
-		/>
-
-		<matching-text :matching-text="loan.matchingText" />
 	</div>
 </template>
 
@@ -81,14 +81,24 @@ export default {
 <style lang="scss" scoped>
 	@import 'settings';
 
+	.column {
+		padding: 0;
+	}
+
 	.grid-loan-card {
 		background-color: $white;
 		border: 1px solid $kiva-stroke-gray;
+		position: relative;
+		//This height will probably have to change
+		height: rem-calc(640);
 	}
 
 	.loan-card-footer-wrap {
-		height: rem-calc(145);
+		width: 100%;
+		height: rem-calc(176);
 		padding: rem-calc(10) rem-calc(20)rem-calc(20);
 		text-align: center;
+		bottom: 0;
+		position: absolute;
 	}
 </style>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -25,7 +25,7 @@
 
 			<action-button />
 
-			<matching-text :matching-text="loan.matchingText" />
+			<matching-text v-if="props.matchingText" :matching-text="loan.matchingText" />
 		</div>
 	</div>
 </template>
@@ -96,7 +96,7 @@ export default {
 	.loan-card-footer-wrap {
 		width: 100%;
 		height: rem-calc(176);
-		padding: rem-calc(10) rem-calc(20)rem-calc(20);
+		padding: rem-calc(10) rem-calc(20) rem-calc(20);
 		text-align: center;
 		bottom: 0;
 		position: absolute;

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -6,7 +6,7 @@
 			:amount="loan.loanAmount"
 			:use="loan.use"
 			:country="loan.geocode.country.name" />
-
+		<action-button />
 		<matching-text :matching-text="loan.matchingText" />
 	</div>
 </template>
@@ -14,11 +14,13 @@
 <script>
 import BorrowerInfo from '@/components/LoanCards/BorrowerInfo';
 import MatchingText from '@/components/LoanCards/MatchingText';
+import ActionButton from '@/components/LoanCards/ActionButton';
 
 export default {
 	components: {
 		BorrowerInfo,
 		MatchingText,
+		ActionButton,
 	},
 	props: {
 		loan: {

--- a/src/components/LoanCards/MatchingText.vue
+++ b/src/components/LoanCards/MatchingText.vue
@@ -1,15 +1,11 @@
 <template functional>
-	<div class="matching-text-wrapper" v-if="props.matchingText">
-		<span class="small-text">2x matching by {{ props.matchingText }}</span>
-	</div>
+	<span class="small-text matching-text">2x matching by {{ props.matchingText }}</span>
 </template>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 
-.matching-text-wrapper {
-	text-align: center;
+.matching-text {
 	color: $kiva-text-light;
-	margin-bottom: rem-calc(20);
 }
 </style>

--- a/src/components/LoanCards/MatchingText.vue
+++ b/src/components/LoanCards/MatchingText.vue
@@ -9,5 +9,7 @@
 
 .matching-text-wrapper {
 	text-align: center;
+	font-size: .875rem;
+	color: $kiva-text-light;
 }
 </style>

--- a/src/components/LoanCards/MatchingText.vue
+++ b/src/components/LoanCards/MatchingText.vue
@@ -1,6 +1,6 @@
 <template functional>
 	<div class="matching-text-wrapper" v-if="props.matchingText">
-		<span>2x matching by {{ props.matchingText }}</span>
+		<span class="small-text">2x matching by {{ props.matchingText }}</span>
 	</div>
 </template>
 
@@ -9,7 +9,7 @@
 
 .matching-text-wrapper {
 	text-align: center;
-	font-size: .875rem;
 	color: $kiva-text-light;
+	margin-bottom: rem-calc(20);
 }
 </style>


### PR DESCRIPTION
Here are changes brought together @jedlin-kiva. 

Upon suggestion from Shua, I've removed the wrapper divs from the MatchingText and ActionButton components. 

Please note: The way that I've anchored the .loan-card-footer-wrap to the bottom of the loan card doesn't work across all screen sizes. Tomorrow my first task is going to be implementing this using flex-box instead of the position: absolute; bottom: 0; method that I've implemented here. I was hoping to get around the the flex-box fix tonight, but I'm running out of steam. I just wanted to make sure these changes were accessible for you in the morning to ensure I wasn't blocking you at all. 