### PR TITLE
redoing loan cards with flexbox, cleaning up rem->rem-calc

### DIFF
--- a/src/components/LoanCards/ActionButton.vue
+++ b/src/components/LoanCards/ActionButton.vue
@@ -7,9 +7,13 @@
 
 .button {
 	margin-top: rem-calc(30);
-	height: 2.9375rem;
-	line-height: 0.9375rem;
-	font-size: 1.125rem;
+	height: rem-calc(46);
+	line-height: 1;
+	font-size: rem-calc(20);
 	width: 100%;
+
+	@include breakpoint(medium) {
+		line-height: rem-calc(15);
+	}
 }
 </style>

--- a/src/components/LoanCards/BorrowerInfo.vue
+++ b/src/components/LoanCards/BorrowerInfo.vue
@@ -28,9 +28,5 @@
 		font-weight: 400;
 		margin-bottom: rem-calc(20);
 	}
-
-	.loan-use {
-		height: rem-calc(88);
-	}
 }
 </style>

--- a/src/components/LoanCards/BorrowerInfo.vue
+++ b/src/components/LoanCards/BorrowerInfo.vue
@@ -2,7 +2,13 @@
 	<div class="borrower-info-wrapper">
 		<a class="name">{{ props.name }}</a>
 		<div class="country">{{ props.country }}</div>
-		<div class="loan-use">A loan of {{ props.amount | numeral('$0.00') }} helps {{ props.name }} {{ props.use }}
+		<div class="loan-use">
+			<span v-if="props.use.length">
+				A loan of {{ props.amount | numeral('$0.00') }} helps {{ props.name }} {{ props.use }}
+			</span>
+			<span v-else>
+				For the borrower's privacy, this loan has been made anonymous.
+			</span>
 			<a class="borrower-page-link" href="">Read more</a>
 		</div>
 	</div>

--- a/src/components/LoanCards/BorrowerInfo.vue
+++ b/src/components/LoanCards/BorrowerInfo.vue
@@ -15,10 +15,11 @@
 	text-align: center;
 	margin-top: rem-calc(20);
 	padding: 0 rem-calc(20);
-	line-height: 1.375rem;
+	line-height: rem-calc(22);
+	flex-grow: 1;
 
 	.name {
-		font-size: 1.375rem;
+		font-size: rem-calc(22);
 		font-weight: 400;
 	}
 
@@ -26,6 +27,10 @@
 		color: $kiva-text-light;
 		font-weight: 400;
 		margin-bottom: rem-calc(20);
+	}
+
+	.loan-use {
+		height: rem-calc(88);
 	}
 }
 </style>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -25,7 +25,7 @@
 
 			<action-button />
 
-			<matching-text :matching-text="loan.matchingText" v-if="loan.matchingText" />
+			<matching-text :matching-text="loan.matchingText" />
 		</div>
 	</div>
 </template>
@@ -90,14 +90,12 @@ export default {
 		border: 1px solid $kiva-stroke-gray;
 		display: flex;
 		flex-direction: column;
-		flex-grow: 1;
 	}
 
 	.loan-card-footer-wrap {
 		width: 100%;
-		height: rem-calc(176);
 		padding: rem-calc(10) rem-calc(20) rem-calc(20);
 		text-align: center;
-		flex-grow: 1;
+		flex-grow: 0;
 	}
 </style>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -88,9 +88,9 @@ export default {
 	.grid-loan-card {
 		background-color: $white;
 		border: 1px solid $kiva-stroke-gray;
-		position: relative;
-		//This height will probably have to change
-		height: rem-calc(640);
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
 	}
 
 	.loan-card-footer-wrap {
@@ -98,7 +98,6 @@ export default {
 		height: rem-calc(176);
 		padding: rem-calc(10) rem-calc(20) rem-calc(20);
 		text-align: center;
-		bottom: 0;
-		position: absolute;
+		flex-grow: 1;
 	}
 </style>

--- a/src/components/LoanCards/MatchingText.vue
+++ b/src/components/LoanCards/MatchingText.vue
@@ -1,11 +1,25 @@
 <template functional>
-	<span class="small-text matching-text">2x matching by {{ props.matchingText }}</span>
+	<span
+		class="small-text matching-text"
+		:class="{'has-match': props.matchingText }"
+	>
+		2x matching by {{ props.matchingText }}
+	</span>
 </template>
 
 <style lang="scss" scoped>
 @import 'settings';
 
 .matching-text {
+	display: block;
 	color: $kiva-text-light;
+	visibility: hidden;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+
+	&.has-match {
+		visibility: visible;
+	}
 }
 </style>


### PR DESCRIPTION
Here are the loan card pieces cleaned up and implemented with flexbox, loan cards now work across all screen sizes. @jedlin-kiva I also cleaned up the rem vs rem-calc conflict you mentioned in the last code review. 