### PR TITLE
vue-75 don't underline select a borrower to text on hover

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/BonusBanner.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/BonusBanner.vue
@@ -21,6 +21,10 @@ a.bonus-banner .content {
 		color: $kiva-darkgreen;
 	}
 
+	.leading-text &:hover {
+		text-decoration: none;
+	}
+
 	@include breakpoint(medium) {
 		line-height: 2.5rem;
 	}


### PR DESCRIPTION
We're leaving the whole banner clickable, but I need a  new line of css to prevent the text from getting a blue underline on mouseover or touch. 