### PR TITLE
vue-82 giving more specific css a shot.

### DIFF
--- a/src/components/LoanCards/Buttons/CheckoutNowButton.vue
+++ b/src/components/LoanCards/Buttons/CheckoutNowButton.vue
@@ -43,7 +43,8 @@ a.secondary.button {
 	}
 
 	&:hover,
-	&:active {
+	&:active,
+	&:focus {
 		color: $blue;
 		border: 1px solid $blue;
 		box-shadow: 0 rem-calc(2) $blue;

--- a/src/components/LoanCards/Buttons/CheckoutNowButton.vue
+++ b/src/components/LoanCards/Buttons/CheckoutNowButton.vue
@@ -30,7 +30,7 @@ export default {
 <style lang="scss" scoped>
 @import 'settings';
 
-.secondary.button {
+a.secondary.button {
 	padding: rem-calc(13) 0;
 
 	.icon-check-in-circle {
@@ -48,7 +48,7 @@ export default {
 		border: 1px solid $blue;
 		box-shadow: 0 rem-calc(2) $blue;
 
-		.icon-check-in-circle {
+		svg.icon-check-in-circle {
 			color: $blue;
 		}
 	}


### PR DESCRIPTION
Trying some more specific css here to fix this reported issue: 
"On the mobile devices, the checkout now button is always blue, should be black. Also on ie when the proceed to basket is clicked the checkmark image turns black, all the rest remains blue"

Having issues setting up something to test my vm on mobile so I want to get this into dev and test it out on my phone. 