### PR TITLE
Add clientside check for bonus credit after login

### DIFF
--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -80,6 +80,8 @@ query {
 				kivaCreditRemaining
 				kivaCreditToReapply
 				loanReservationTotal
+				bonusAvailableTotal
+				bonusAppliedTotal
 			}
 		}
 	}

--- a/src/graphql/query/checkout/shopBasketUpdate.graphql
+++ b/src/graphql/query/checkout/shopBasketUpdate.graphql
@@ -40,6 +40,8 @@ query {
 				kivaCreditRemaining
 				kivaCreditToReapply
 				loanReservationTotal
+				bonusAvailableTotal
+				bonusAppliedTotal
 			}
 		}
 	}

--- a/src/graphql/query/checkout/shopTotals.graphql
+++ b/src/graphql/query/checkout/shopTotals.graphql
@@ -12,6 +12,8 @@ query {
 				kivaCreditRemaining
 				kivaCreditToReapply
 				loanReservationTotal
+				bonusAvailableTotal
+				bonusAppliedTotal
 			}
 		}
 	}

--- a/src/pages/Checkout/CheckoutBetaPage.vue
+++ b/src/pages/Checkout/CheckoutBetaPage.vue
@@ -228,6 +228,13 @@ export default {
 		if (this.myId !== null && this.myId !== undefined && !this.isActivelyLoggedIn) {
 			this.switchToLogin();
 		}
+		// redirect to standard basket if bonus credit is available
+
+		if (typeof window !== 'undefined') {
+			if (parseFloat(this.totals.bonusAvailableTotal) > 0 && parseFloat(this.totals.bonusAppliedTotal) > 0) {
+				window.location = '/basket?kexpn=checkout_beta.minimal_checkout&kexpv=a';
+			}
+		}
 	},
 	methods: {
 		validateCreditBasket() {


### PR DESCRIPTION
We can only do a redirect from the client at this point so this check will typically fire after the page refreshes due to a login event.