### PR TITLE
Another media query targeting the MS Edge browser specifically

### DIFF
--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -191,6 +191,13 @@ export default {
 	}
 }
 
+// Media query targeting IE EDGE
+@supports (-ms-ime-align:auto) {
+	.loan-price {
+		background-position: right -1.2rem center;
+	}
+}
+
 .remove-x {
 	fill: $subtle-gray;
 	display: inline-block;


### PR DESCRIPTION
Looks like the last fix didn't work for MS Edge browser. Here is a new media query with css rule targeted to that browser only.