### PR TITLE
fix og:image dimensions and turn off footer cache

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -57,8 +57,8 @@ export default {
 				{ property: 'og:description', vmid: 'og:description', content: 'Support women, entrepreneurs, students and refugees around the world with as little as $25 on Kiva. 100% of your loans go to support borrowers.' },
 				{ property: 'theme-color', content: '#4faf4e' },
 				{ property: 'og:image', content: 'https://www-kiva-org.global.ssl.fastly.net/cms/kiva-og-image.jpg' },
-				{ property: 'og:image:width', content: '196' },
-				{ property: 'og:image:height', content: '106' },
+				{ property: 'og:image:width', content: '1200' },
+				{ property: 'og:image:height', content: '630' },
 			]).concat([
 				// Microsoft Tile Tags
 				{

--- a/src/components/WwwFrame/TheFooter.vue
+++ b/src/components/WwwFrame/TheFooter.vue
@@ -108,7 +108,7 @@ export default {
 		},
 	},
 	name: 'TheFooter',
-	serverCacheKey: () => 'footer',
+	// serverCacheKey: () => 'footer',
 	data() {
 		return {
 			isProtocolLive: false,


### PR DESCRIPTION
These 2 items are in the release branch (release-09262018) that will push out /protocol .

1. We forgot to update the dimensions with the new og:image so those are updates.

2. I've unfortunately, discovered a weird issue with our cache wherein the client renders multiple times if there is a mismatch with the html from the footer html that is cached. I've turned it off for now b/c it results in the paypal button being rendered 3 times stacked up. India is doing testing on this and I don't want to freak them out...

One fix is to clear memcached after any changes are made to cached content. Having an easy way to clear specific entried in memcached would be one solution. I'll continue trying to find a solution in our initialization and render of the paypal button too as it likely applies to any other 3rd party stuff (maps) that we may implement later.