### PR TITLE
add gaurd for experiment version and assignment

### DIFF
--- a/src/components/Forms/RegisterForm.vue
+++ b/src/components/Forms/RegisterForm.vue
@@ -139,6 +139,7 @@
 </template>
 
 <script>
+import _get from 'lodash/get';
 import formDataEntries from 'form-data-entries';
 import loginRegUtils from '@/plugins/login-reg-mixin';
 import { readJSONSetting } from '@/util/settingsUtils';
@@ -332,14 +333,14 @@ export default {
 		setupExperimentState() {
 			// get assigned exp version from apollo cache
 			const regExpVersion = this.apollo.readQuery({ query: regExpQuery });
-			this.expVersion = regExpVersion.experiment.version;
+			this.expVersion = _get(regExpVersion, 'experiment.version') || null;
 
 			// get experiment data from apollo cache
 			// - only required at this point for the variant name or other associated data
 			const regExpSetting = this.apollo.readQuery({ query: regExpDataQuery });
 			const expData = readJSONSetting(regExpSetting, 'general.experiment.value') || {};
-			if (this.expVersion !== 'control' && expData.variants[this.expVersion]) {
-				this.expName = expData.variants[this.expVersion].name || null;
+			if (this.expVersion && this.expVersion !== 'control') {
+				this.expName = _get(expData, `variants[${this.expVersion}].name`) || null;
 			}
 
 			// Set up + track our First Name Only State

--- a/src/components/Forms/RegisterForm.vue
+++ b/src/components/Forms/RegisterForm.vue
@@ -338,8 +338,8 @@ export default {
 			// - only required at this point for the variant name or other associated data
 			const regExpSetting = this.apollo.readQuery({ query: regExpDataQuery });
 			const expData = readJSONSetting(regExpSetting, 'general.experiment.value') || {};
-			if (this.expVersion !== 'control') {
-				this.expName = expData.variants[this.expVersion].name;
+			if (this.expVersion !== 'control' && expData.variants[this.expVersion]) {
+				this.expName = expData.variants[this.expVersion].name || null;
 			}
 
 			// Set up + track our First Name Only State


### PR DESCRIPTION
@emuvente Your start and end time guards for experiments work well! And serve as great reminders as to what they are set as lol...

Realized today that the endTime for uiexp.register_fields was 2018-10-14 which was causing a page level 500 error due to the expVersion not being assigned.

Added this guard which will ensure I don't use it if it's absent...could have just checked for undefined but wanted to make sure the variant values were covered too.