### PR TITLE
Small fix for the height placement of the Kiva cards remove x

### DIFF
--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -309,5 +309,6 @@ export default {
 	width: 1.1rem;
 	height: 1rem;
 	cursor: pointer;
+	vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
Small css tweek for the kiva card remove x to sit more nicely on the /checkout page.