### PR TITLE
Need help text wasn't centered correctly.

### DIFF
--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -296,7 +296,7 @@ export default {
 }
 
 .help-lightbox {
-	margin: rem-calc(15) 0;
+	margin: 1.2rem 0;
 
 	@include breakpoint(large) {
 		float: left;


### PR DESCRIPTION
The need help text in the Kiva Card section was not centered vertically correctly. This fixes the text and puts vertically aligns it. 