### PR TITLE
Checkout error reporting

### DIFF
--- a/src/components/Checkout/PayPalExpress.vue
+++ b/src/components/Checkout/PayPalExpress.vue
@@ -103,11 +103,12 @@ export default {
 											.catch(error => {
 												console.error(error);
 												// Fire specific exception to Sentry/Raven
-												Raven.captureException(error.errors ? error.errors : error, {
-													tags: {
-														pp_stage: 'onPaymentGetPaymentTokenCatch'
-													}
-												});
+												Raven.captureException(
+													JSON.stringify(error.errors ? error.errors : error), {
+														tags: {
+															pp_stage: 'onPaymentGetPaymentTokenCatch'
+														}
+													});
 
 												reject(error);
 											});
@@ -124,7 +125,7 @@ export default {
 									console.error(error);
 
 									// Fire specific exception to Sentry/Raven
-									Raven.captureException(error, {
+									Raven.captureException(JSON.stringify(error), {
 										tags: {
 											pp_stage: 'onPaymentValidationCatch'
 										}
@@ -154,7 +155,6 @@ export default {
 													this.setUpdating(false);
 													const errorCode = _get(ppResponse, 'errors[0].code');
 													// -> server supplied language is not geared for lenders
-													// const serverErrorMessage = _get(ppResponse, 'errors[0].message');
 													const standardErrorCode = `(PayPal error: ${errorCode})`;
 													const standardError = `There was an error processing your payment.
 														Please try again. ${standardErrorCode}`;
@@ -162,7 +162,7 @@ export default {
 													this.$showTipMsg(standardError, 'error');
 
 													// Fire specific exception to Sentry/Raven
-													Raven.captureException(ppResponse.errors, {
+													Raven.captureException(JSON.stringify(ppResponse.errors), {
 														tags: {
 															pp_stage: 'onAuthorize',
 															pp_token: data.paymentToken
@@ -202,7 +202,7 @@ export default {
 												this.setUpdating(false);
 
 												// Fire specific exception to Sentry/Raven
-												Raven.captureException(catchError, {
+												Raven.captureException(JSON.stringify(catchError), {
 													tags: {
 														pp_stage: 'onAuthorizeCatch'
 													}
@@ -223,7 +223,7 @@ export default {
 									console.error(error);
 
 									// Fire specific exception to Sentry/Raven
-									Raven.captureException(error, {
+									Raven.captureException(JSON.stringify(error), {
 										tags: {
 											pp_stage: 'onAuthorizeValidationCatch'
 										}

--- a/src/components/Checkout/PayPalExpress.vue
+++ b/src/components/Checkout/PayPalExpress.vue
@@ -103,12 +103,12 @@ export default {
 											.catch(error => {
 												console.error(error);
 												// Fire specific exception to Sentry/Raven
-												Raven.captureException(
-													JSON.stringify(error.errors ? error.errors : error), {
-														tags: {
-															pp_stage: 'onPaymentGetPaymentTokenCatch'
-														}
-													});
+												// eslint-disable-next-line
+												Raven.captureException(JSON.stringify(error.errors ? error.errors : error), {
+													tags: {
+														pp_stage: 'onPaymentGetPaymentTokenCatch'
+													}
+												});
 
 												reject(error);
 											});

--- a/src/plugins/checkout-utils-mixin.js
+++ b/src/plugins/checkout-utils-mixin.js
@@ -1,5 +1,4 @@
 import _get from 'lodash/get';
-import Raven from 'raven-js';
 import shopValidateBasket from '@/graphql/mutation/shopValidatePreCheckout.graphql';
 import shopCheckout from '@/graphql/mutation/shopCheckout.graphql';
 
@@ -96,13 +95,6 @@ export default {
 				}
 			});
 			this.$showTipMsg(errorMessages, 'error');
-
-			// Fire specific exception to Sentry/Raven
-			Raven.captureException(errorMessages, {
-				tags: {
-					checkout: 'showCheckoutError'
-				}
-			});
 		},
 
 		/* Redirect to the thanks

--- a/src/plugins/checkout-utils-mixin.js
+++ b/src/plugins/checkout-utils-mixin.js
@@ -1,4 +1,5 @@
 import _get from 'lodash/get';
+import Raven from 'raven-js';
 import shopValidateBasket from '@/graphql/mutation/shopValidatePreCheckout.graphql';
 import shopCheckout from '@/graphql/mutation/shopCheckout.graphql';
 
@@ -95,6 +96,13 @@ export default {
 				}
 			});
 			this.$showTipMsg(errorMessages, 'error');
+
+			// Fire specific exception to Sentry/Raven
+			Raven.captureException(errorMessages, {
+				tags: {
+					checkout: 'showCheckoutError'
+				}
+			});
 		},
 
 		/* Redirect to the thanks


### PR DESCRIPTION
Turns out Raven/Sentry doesn't parse objects sent to this call. Have to pass them as a string so we don't just get [object: object] :(