### PR TITLE
Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: node_js
-node_js:
-  - "6"
+matrix:
+  fast_finish: true
+  include:
+    - node_js: '8'
+    - node_js: 'node'
+      if: branch = master
 before_install:
-  - npm install -g npm@5.6
+  - npm install -g npm@5.7
   - npm install -g greenkeeper-lockfile@1
 before_script:
   - greenkeeper-lockfile-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: node_js
 matrix:
   fast_finish: true
   include:
-    - node_js: '8'
+    - node_js: '8.11'
     - node_js: 'node'
-      if: branch = master
+      if: head_branch = master
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ matrix:
     - node_js: '8'
     - node_js: 'node'
       if: branch = master
+branches:
+  only:
+    - master
+    - /^release-.*$/
 before_install:
   - npm install -g npm@5.7
   - npm install -g greenkeeper-lockfile@1


### PR DESCRIPTION
This will make it so that pull requests are only built in node 8 (once). This also makes it so that only the master branch is built in both node 8 and the latest node version. It does this using the [Travis Build Matrix](https://docs.travis-ci.com/user/build-matrix/) to limit the branches that are built when pushed to to only master and any release branches, and only building in the latest node version when the branch is master.