### PR TITLE
button spacing

### DIFF
--- a/src/pages/StyleGuide.vue
+++ b/src/pages/StyleGuide.vue
@@ -79,4 +79,9 @@ $header-color: $kiva-green;
 	color: #888;
 	font-size: 80%;
 }
+
+// spacing for button on /styleguide/buttons
+.styleguide-wrap .button {
+	margin-top: rem-calc(5);
+}
 </style>


### PR DESCRIPTION
I noticed the buttons were sitting right on the bottom border of the .elem-desc and that was the only place it was occurring, so I added a little room for them. All the css for styleguide was present within the StyleGuide.vue file instead of the individual buttons, so I put it there, lmk if you want me to move this out and into StyleguideButtons.vue.