### PR TITLE
Gather any availabled loan ids from local storage for reporting

### DIFF
--- a/src/components/LoansByCategory/RecentlyViewedLoans.vue
+++ b/src/components/LoansByCategory/RecentlyViewedLoans.vue
@@ -71,17 +71,16 @@ export default {
 		this.showRecentlyViewed = _get(recentlyViewedEXP, 'experiment.version') === 'variant-a';
 
 		let recentLoanIds = [];
+		// fetch recently viewed from localStorage (currently set in wwwApp on Borrower Profile)
+		const recentlyViewed = WebStorage('recentlyViewedLoans');
+		// decode, parse then set recently viewed loan data
+		try {
+			recentLoanIds = JSON.parse(atob(recentlyViewed));
+		} catch (e) {
+			// no-op
+		}
 
 		if (this.showRecentlyViewed) {
-			// fetch recently viewed from localStorage (currently set in wwwApp on Borrower Profile)
-			const recentlyViewed = WebStorage('recentlyViewedLoans');
-			// decode, parse then set recently viewed loan data
-			try {
-				recentLoanIds = JSON.parse(atob(recentlyViewed));
-			} catch (e) {
-				// no-op
-			}
-
 			if (recentLoanIds.length) {
 				// query our custom loan set
 				this.apollo.query({

--- a/src/components/LoansByCategory/RecentlyViewedLoans.vue
+++ b/src/components/LoansByCategory/RecentlyViewedLoans.vue
@@ -103,12 +103,15 @@ export default {
 			this.zeroRecentLoans = true;
 		}
 		// Track Assignment + Number of Loans
-		this.$kvTrackEvent(
-			'Lending',
-			'EXP-CASH-348-Recently-Viewed-Loans',
-			this.showRecentlyViewed ? 'b' : 'a',
-			recentLoanIds.length
-		);
+		// > Only fire if there are recent loans available to show.
+		if (recentLoanIds.length) {
+			this.$kvTrackEvent(
+				'Lending',
+				'EXP-CASH-348-Recently-Viewed-Loans',
+				this.showRecentlyViewed ? 'b' : 'a',
+				recentLoanIds.length
+			);
+		}
 	},
 };
 </script>


### PR DESCRIPTION
Moved check for recently loans in local storage up a level so we can report if those in control "could" have been shown their recently viewed loans.