### PR TITLE
Cash 557 lend increment 25

### DIFF
--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -9,8 +9,6 @@
 </template>
 
 <script>
-// import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
-// import _get from 'lodash/get';
 import _includes from 'lodash/includes';
 import Lend25Button from './Lend25Button';
 import LendIncrementButton from './LendIncrementButton';
@@ -48,7 +46,6 @@ export default {
 	},
 	computed: {
 		currentButtonState() {
-			// const experimentLendIncrement = this.lendIncrementExperimentVersion === 'variant-b';
 			const experimentLendIncrement = (
 				this.lendIncrementButtonVersion !== null ||
 				this.lendIncrementButtonVersion !== 'variant-a'
@@ -64,23 +61,6 @@ export default {
 			}
 			return experimentLendIncrement ? LendIncrementButton : Lend25Button;
 		},
-	},
-	data() {
-		return {
-			// lendIncrementExperimentVersion: '',
-		};
-	},
-	methods: {
-		// setupExperimentState() {
-		// 	const lendIncrementExperimentVersion = this.apollo.readQuery({
-		// 		query: experimentAssignmentQuery,
-		// 		variables: { id: 'lend_increment_button' },
-		// 	});
-		// 	this.lendIncrementExperimentVersion = _get(lendIncrementExperimentVersion, 'experiment.version') || null;
-		// },
-	},
-	created() {
-		// this.setupExperimentState();
 	},
 };
 

--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -4,12 +4,13 @@
 		class="action-button smaller"
 		:loan-id="loanId"
 		:loan="loan"
+		:lend-increment-button-version="lendIncrementButtonVersion"
 	/>
 </template>
 
 <script>
-import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
-import _get from 'lodash/get';
+// import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
+// import _get from 'lodash/get';
 import _includes from 'lodash/includes';
 import Lend25Button from './Lend25Button';
 import LendIncrementButton from './LendIncrementButton';
@@ -40,10 +41,18 @@ export default {
 			type: Boolean,
 			default: false
 		},
+		lendIncrementButtonVersion: {
+			type: String,
+			default: ''
+		},
 	},
 	computed: {
 		currentButtonState() {
-			const experimentLendIncrement = this.lendIncrementExperimentVersion === 'variant-b';
+			// const experimentLendIncrement = this.lendIncrementExperimentVersion === 'variant-b';
+			const experimentLendIncrement = (
+				this.lendIncrementButtonVersion !== null ||
+				this.lendIncrementButtonVersion !== 'variant-a'
+			);
 			if (_includes(this.itemsInBasket, this.loanId)) {
 				return CheckoutNowButton;
 			}
@@ -58,20 +67,20 @@ export default {
 	},
 	data() {
 		return {
-			lendIncrementExperimentVersion: '',
+			// lendIncrementExperimentVersion: '',
 		};
 	},
 	methods: {
-		setupExperimentState() {
-			const lendIncrementExperimentVersion = this.apollo.readQuery({
-				query: experimentAssignmentQuery,
-				variables: { id: 'lend_increment_button' },
-			});
-			this.lendIncrementExperimentVersion = _get(lendIncrementExperimentVersion, 'experiment.version') || null;
-		},
+		// setupExperimentState() {
+		// 	const lendIncrementExperimentVersion = this.apollo.readQuery({
+		// 		query: experimentAssignmentQuery,
+		// 		variables: { id: 'lend_increment_button' },
+		// 	});
+		// 	this.lendIncrementExperimentVersion = _get(lendIncrementExperimentVersion, 'experiment.version') || null;
+		// },
 	},
 	created() {
-		this.setupExperimentState();
+		// this.setupExperimentState();
 	},
 };
 

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -32,7 +32,9 @@ export default {
 	},
 	data() {
 		return {
-			selectedOption: this.amountLeft ? Math.min(50, this.amountLeft) : 50,
+			selectedOption: this.amountLeft
+				? Math.min(this.defaultSelectorAmount, this.amountLeft)
+				: this.defaultSelectorAmount,
 			loading: false,
 		};
 	},
@@ -51,6 +53,9 @@ export default {
 		},
 	},
 	computed: {
+		defaultSelectorAmount() {
+			return this.lendIncrementButtonVersion === 'variant-b' ? 50 : 25;
+		},
 		amountLeft() {
 			const { loanAmount, loanFundraisingInfo } = this.loan;
 			const { isExpiringSoon, fundedAmount, reservedAmount } = loanFundraisingInfo;
@@ -89,7 +94,7 @@ export default {
 	watch: {
 		loan: {
 			handler() {
-				this.selectedOption = Math.min(50, this.amountLeft);
+				this.selectedOption = Math.min(this.defaultSelectorAmount, this.amountLeft);
 			},
 			immediate: true,
 		}
@@ -127,6 +132,8 @@ export default {
 
 	.lend-increment-button {
 		margin-bottom: 0;
+		flex-grow: 1;
+		margin-left: 0.8rem;
 
 		&.is-loading {
 			width: 100%;

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -45,6 +45,10 @@ export default {
 			type: Object,
 			default: () => {}
 		},
+		lendIncrementButtonVersion: {
+			type: String,
+			default: ''
+		},
 	},
 	computed: {
 		amountLeft() {

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -45,6 +45,7 @@
 					:items-in-basket="itemsInBasket"
 					:is-lent-to="loan.userProperties.lentTo"
 					:is-funded="isFunded"
+					:lend-increment-button-version="lendIncrementButtonVersion"
 
 					@click.native="trackInteraction({
 						interactionType: 'addToBasket',
@@ -126,6 +127,10 @@ export default {
 			default: null
 		},
 		title: {
+			type: String,
+			default: ''
+		},
+		lendIncrementButtonVersion: {
 			type: String,
 			default: ''
 		},

--- a/src/components/LoanCards/GridMicroLoanCard.vue
+++ b/src/components/LoanCards/GridMicroLoanCard.vue
@@ -50,6 +50,7 @@
 						:is-lent-to="loan.userProperties.lentTo"
 						:is-funded="isFunded"
 						:loan="loan"
+						:lend-increment-button-version="lendIncrementButtonVersion"
 
 						@click.native="trackInteraction({
 							interactionType: 'addToBasket',
@@ -127,6 +128,10 @@ export default {
 			default: null
 		},
 		title: {
+			type: String,
+			default: ''
+		},
+		lendIncrementButtonVersion: {
 			type: String,
 			default: ''
 		},

--- a/src/components/LoansByCategory/CategoryRow.vue
+++ b/src/components/LoansByCategory/CategoryRow.vue
@@ -4,6 +4,7 @@
 			<div class="column small-12">
 				<h2 class="category-name">
 					<router-link
+						v-if="showViewAllLink"
 						class="view-all-link"
 						:to="cleanUrl"
 						:title="`View all ${cleanName} loans`"
@@ -13,6 +14,9 @@
 							`View all ${cleanName} loans`]">
 						{{ cleanName }} <span v-if="showViewAllLink" class="view-all-arrow">&rsaquo;</span>
 					</router-link>
+					<template v-else>
+						{{ cleanName }}
+					</template>
 				</h2>
 			</div>
 		</div>
@@ -43,10 +47,11 @@
 						:card-number="index + 1"
 						:enable-tracking="true"
 						:is-visitor="!isLoggedIn"
+						:lend-increment-button-version="lendIncrementButtonVersion"
 						:image-enhancement-experiment-version="imageEnhancementExperimentVersion"
 					/>
 
-					<div class="column column-block is-in-category-row view-all-loans-category">
+					<div v-if="showViewAllLink" class="column column-block is-in-category-row view-all-loans-category">
 						<router-link
 							:to="cleanUrl"
 							:title="`${viewAllLoansCategoryTitle}`"
@@ -115,6 +120,10 @@ export default {
 		isMicro: {
 			type: Boolean,
 			default: false
+		},
+		lendIncrementButtonVersion: {
+			type: String,
+			default: ''
 		},
 		imageEnhancementExperimentVersion: {
 			type: String,
@@ -333,7 +342,7 @@ a.view-all-link {
 
 	.view-all-arrow {
 		position: absolute;
-		top: -0.85rem;
+		top: -0.95rem;
 		right: -1.4rem;
 		padding: 0 0.3rem;
 		font-weight: $global-weight-normal;

--- a/src/components/LoansByCategory/FeaturedLoans.vue
+++ b/src/components/LoansByCategory/FeaturedLoans.vue
@@ -31,6 +31,7 @@
 						:items-in-basket="itemsInBasket"
 						:enable-tracking="true"
 						:is-visitor="!isLoggedIn"
+						:lend-increment-button-version="lendIncrementButtonVersion"
 						:image-enhancement-experiment-version="imageEnhancementExperimentVersion"
 					/>
 
@@ -45,6 +46,7 @@
 						:items-in-basket="itemsInBasket"
 						:enable-tracking="true"
 						:is-visitor="!isLoggedIn"
+						:lend-increment-button-version="lendIncrementButtonVersion"
 						:image-enhancement-experiment-version="imageEnhancementExperimentVersion"
 					/>
 
@@ -59,6 +61,7 @@
 						:items-in-basket="itemsInBasket"
 						:enable-tracking="true"
 						:is-visitor="!isLoggedIn"
+						:lend-increment-button-version="lendIncrementButtonVersion"
 						:image-enhancement-experiment-version="imageEnhancementExperimentVersion"
 					/>
 				</div>
@@ -103,6 +106,10 @@ export default {
 		isLoggedIn: {
 			type: Boolean,
 			default: false
+		},
+		lendIncrementButtonVersion: {
+			type: String,
+			default: ''
 		},
 		imageEnhancementExperimentVersion: {
 			type: String,

--- a/src/components/LoansByCategory/RecentlyViewedLoans.vue
+++ b/src/components/LoansByCategory/RecentlyViewedLoans.vue
@@ -11,6 +11,7 @@
 					set-id="CASH-363-recently-viewed-update"
 					:is-logged-in="isLoggedIn"
 					:is-micro="isMicro"
+					:lend-increment-button-version="lendIncrementButtonVersion"
 				/>
 			</div>
 		</div>
@@ -44,7 +45,11 @@ export default {
 		isMicro: {
 			type: Boolean,
 			default: false
-		}
+		},
+		lendIncrementButtonVersion: {
+			type: String,
+			default: ''
+		},
 	},
 	data() {
 		return {

--- a/src/graphql/query/lendByCategory/lendByCategory.graphql
+++ b/src/graphql/query/lendByCategory/lendByCategory.graphql
@@ -11,7 +11,7 @@ query {
 			key
 			value
 		}
-		lendIncrementExp: setting(setting: "uiexp.lend_increment_button") {
+		lendIncrementExp: setting(setting: "uiexp.lend_increment_button_v2") {
 			key
 			value
 		}

--- a/src/graphql/query/loanChannelPage.graphql
+++ b/src/graphql/query/loanChannelPage.graphql
@@ -24,7 +24,7 @@ query {
 	}
 	general {
 		# TODO: REMOVE Once Lend Increment Button EXP ENDS
-		lendIncrementExp: setting(setting: "uiexp.lend_increment_button") {
+		lendIncrementExp: setting(setting: "uiexp.lend_increment_button_v2") {
 			key
 			value
 		}

--- a/src/pages/Lend/LoanChannelCategoryPage.vue
+++ b/src/pages/Lend/LoanChannelCategoryPage.vue
@@ -19,6 +19,7 @@
 						:loan="loan"
 						:is-visitor="isVisitor"
 						:items-in-basket="itemsInBasket"
+						:lend-increment-button-version="lendIncrementExpVersion"
 					/>
 					<loading-overlay v-if="loading" />
 				</div>
@@ -113,6 +114,7 @@ export default {
 			itemsInBasket: [],
 			pageQuery: { page: '1' },
 			loading: false,
+			lendIncrementExpVersion: null,
 		};
 	},
 	computed: {
@@ -166,7 +168,7 @@ export default {
 					// setting for lend increment button is prefetched in loanChannelPageQuery
 					// TODO: REMOVE Once Lend Increment Button EXP ENDS
 					// Pre-fetch the assigned version for lend increment button
-					client.query({ query: experimentQuery, variables: { id: 'lend_increment_button' } })
+					client.query({ query: experimentQuery, variables: { id: 'lend_increment_button_v2' } })
 				]);
 			});
 		}
@@ -215,6 +217,16 @@ export default {
 				}
 			}
 		});
+
+		// Read assigned version of lend increment button experiment
+		const lendIncrementExperimentAssignment = this.apollo.readQuery({
+			query: experimentQuery,
+			variables: { id: 'lend_increment_button_v2' },
+		});
+		this.lendIncrementExpVersion = _get(lendIncrementExperimentAssignment, 'experiment.version') || null;
+		if (this.lendIncrementExpVersion !== null) {
+			this.$kvTrackEvent('Lending', 'EXP-CASH-557', this.lendIncrementExpVersion.replace('variant-', ''));
+		}
 	},
 	methods: {
 		pageChange(number) {


### PR DESCRIPTION
Converted the Action + Lend Increment button to rely on a passed in experiment version rather than having to call out to the apollo cache. /lend-vue ssr works again. Added a new variant to the experiment.