### PR TITLE
CASH-550: Fix styling

### DIFF
--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<www-page class="lend-by-category-page" :gray-background="true">
+	<www-page class="lend-by-category-page">
 		<lend-header />
 
 		<FeaturedLoans


### PR DESCRIPTION
* SASS was `scoped` previously, so background never was gray