### PR TITLE
zipcode -> postal code, payment holder same width for pp and bt

### DIFF
--- a/src/components/Checkout/BraintreeCheckout.vue
+++ b/src/components/Checkout/BraintreeCheckout.vue
@@ -20,7 +20,7 @@
 					<div id="kv-cvv" class="kv-braintree-wrapper"></div>
 				</div>
 				<div class="small-4 columns">
-					<label>Zip code</label>
+					<label>Postal code</label>
 					<div id="kv-postal-code" class="kv-braintree-wrapper"></div>
 				</div>
 			</div>

--- a/src/components/Checkout/BraintreeCheckout.vue
+++ b/src/components/Checkout/BraintreeCheckout.vue
@@ -322,6 +322,7 @@ $error-red: #fdeceb;
 		#braintree-submit {
 			width: 100%;
 			margin-top: 0.8rem;
+			font-size: 1.25rem;
 
 			.icon-lock {
 				height: rem-calc(20);

--- a/src/components/Checkout/PaymentWrapper.vue
+++ b/src/components/Checkout/PaymentWrapper.vue
@@ -80,14 +80,24 @@ export default {
 $form-border-radius: rem-calc(3);
 
 .payment-holder {
-	display: block;
+	display: inline-block;
+	white-space: nowrap;
 	text-align: center;
-	float: right;
 	border: 1px solid $subtle-gray; //#c3c3c3
-	padding: 0 2rem 1.5rem;
+	padding: 0 0.6rem 1.5rem;
 	border-radius: $form-border-radius;
-	margin-top: 3rem;
-	width: rem-calc(400);
+	margin: 3rem auto 0 auto;
+	min-width: rem-calc(300);
+	width: 100%;
+
+	@include breakpoint(medium) {
+		float: right;
+		display: block;
+	}
+
+	@include breakpoint(large) {
+		padding: 0 2rem 1.5rem;
+	}
 
 	.card-header {
 		position: relative;

--- a/src/components/Checkout/PaymentWrapper.vue
+++ b/src/components/Checkout/PaymentWrapper.vue
@@ -87,6 +87,7 @@ $form-border-radius: rem-calc(3);
 	padding: 0 2rem 1.5rem;
 	border-radius: $form-border-radius;
 	margin-top: 3rem;
+	width: rem-calc(400);
 
 	.card-header {
 		position: relative;


### PR DESCRIPTION
Adam made the following requests: 
1) "Zip code" is supposed to be "Postal code"
2) Doesn't seem like zip code is verifying - I put in a jumble of 10 numbers and it didn't turn red.
3) Paypal option should be in the same width box as credit card so that the toggles stay in the same place between selections

This fixes #1 & #3 
#2 seems to be an issue with how braintree is doing their validation for the postal code field.
