### PR TITLE
Declare disjunctive facets that our custom categories use. This sets …

### DIFF
--- a/src/pages/AlgoliaPOC.vue
+++ b/src/pages/AlgoliaPOC.vue
@@ -18,6 +18,7 @@
 							:hitsPerPage="12"
 							ref="aisConfigure"
 							:disjunctiveFacetsRefinements="disjunctiveFacets"
+							:disjunctiveFacets="disjunctiveFacetsKeys"
 						>
 							<div slot-scope="{ searchParameters }">
 								Currently applied filters:

--- a/src/plugins/algolia-config-mixin.js
+++ b/src/plugins/algolia-config-mixin.js
@@ -7,6 +7,11 @@ export default {
 			// environment + index config
 			algoliaDefaultIndex: this.algoliaConfig.defaultIndex,
 			algoliaGroup: this.algoliaConfig.group,
+			disjunctiveFacetsKeys: [
+				'sector.name',
+				'themeData.loanThemeTypeName',
+				'tags.name'
+			],
 			/* eslint-disable max-len */
 			// aka. Loan Channel config
 			// INFO: These properties provide an analogue to our loan channels


### PR DESCRIPTION
…the context for the other components and more importantly makes the removal of facets from current refinements possible.