### PR TITLE
Switching pay with card/ pay with paypal order

### DIFF
--- a/src/components/Checkout/PaymentWrapper.vue
+++ b/src/components/Checkout/PaymentWrapper.vue
@@ -53,13 +53,13 @@ export default {
 		return {
 			options: [
 				{
+					title: 'Pay with card',
+					key: 'bt'
+				},
+				{
 					title: 'Pay with PayPal',
 					key: 'pp',
 				},
-				{
-					title: 'Pay with card',
-					key: 'bt'
-				}
 			],
 			selectedOption: 'pp',
 		};


### PR DESCRIPTION
This change swaps the pay with paypal/ pay with card options in the payment toggle component.