### PR TITLE
cash-232 loan card text no longer centered

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -704,7 +704,6 @@ export default {
 }
 
 .empty-basket {
-	text-align: center;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
I noticed that the all the loan card elements were centered in this new component, found the line that was the issues, deleted it. 