### PR TITLE
Ensure title remains left aligned after viewing pages with the grid l…

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -99,8 +99,14 @@ export default {
 	margin-bottom: rem-calc(30);
 }
 
-.borrower-info {
-	line-height: 0.8;
-	font-weight: $global-weight-highlight;
+.borrower-info-wrapper {
+	text-align: left;
+	padding: 0;
+
+	.borrower-info {
+		text-align: left;
+		line-height: 0.8;
+		font-weight: $global-weight-highlight;
+	}
 }
 </style>


### PR DESCRIPTION
…oan card. This was discovered when using a router link in the add to basket interstitial to jump directly to /checkout instead of relying on the /basket url redirect which reloads the page and resets all styles.