### PR TITLE
Graphql loan search status defaults to fund if none is supplied. This…

### DIFF
--- a/src/graphql/query/algoliaLoanStatus.graphql
+++ b/src/graphql/query/algoliaLoanStatus.graphql
@@ -3,7 +3,7 @@ query (
 	$numberOfLoans: Int = 1,
 ) {
 	lend {
-		loans(limit: $numberOfLoans, filters: {loanIds: $ids}) {
+		loans(limit: $numberOfLoans, filters: {loanIds: $ids, status: all}) {
 			totalCount
 			values {
 				id


### PR DESCRIPTION
… ensures we get updated data for the funded loans too so we can reflect that in the page.