### PR TITLE
Only load dart-sass if running in node

### DIFF
--- a/build/style-loaders.js
+++ b/build/style-loaders.js
@@ -1,3 +1,10 @@
+// If document is defined, dart-sass will attempt to run as if it were in the browser. However, some
+// code editors expose document, so dart-sass will sometimes throw errors when this config is loaded
+// by editor plugins. We won't use webpack in a browser, so to resolve the issue we can just check
+// for document before attempting to load dart-sass.
+var isNode = typeof document === 'undefined';
+var sass = isNode ? require('dart-sass') : function() {};
+
 module.exports = [
 	'css-loader',
 	{
@@ -13,7 +20,7 @@ module.exports = [
 	{
 		loader: 'sass-loader',
 		options: {
-			implementation: require('dart-sass'),
+			implementation: sass,
 			includePaths: [
 				'src/assets/fonts',
 				'src/assets/scss',


### PR DESCRIPTION
I had been running into this error for a while that was preventing the linter-eslint in Atom from actually linting anything, but I could never figure out what was causing it because linting would always work from the command line. Finally happened to narrow it down to dart-sass trying to access document.scripts if document is defined (something that dart2js inserts automatically apparently). Atom is based on chromium, so it happens to have a document defined, but it does not define document.scripts. Dart tries to iterate that as an array, and so tries to access document.scripts.length, which end up throwing a 'Cannot read length of undefined' error.