### PR TITLE
2019-04-14: Workaround Algolia issue

### DIFF
--- a/src/pages/Lend/Filter/LendFilterMenu.vue
+++ b/src/pages/Lend/Filter/LendFilterMenu.vue
@@ -84,11 +84,6 @@ export default {
 		KvIcon,
 		KvButton,
 	},
-	data() {
-		return {
-			filterMenuOpen: false,
-		};
-	},
 	props: {
 		defaultSortIndices: {
 			type: Array,
@@ -96,6 +91,10 @@ export default {
 		},
 		customCategories: {
 			type: Object,
+			required: true,
+		},
+		filterMenuOpen: {
+			type: Boolean,
 			required: true,
 		},
 		selectedCustomCategories: {
@@ -106,11 +105,9 @@ export default {
 	methods: {
 		hideFilterMenu() {
 			this.filterMenuOpen = false;
-			this.$emit('hide-filter-menu');
 		},
 		toggleFilterMenu() {
 			this.filterMenuOpen = !this.filterMenuOpen;
-			this.$emit(this.filterMenuOpen ? 'show-filter-menu' : 'hide-filter-menu');
 		},
 		showAdvancedFilters() {
 			window.location.href = '/lend';

--- a/src/pages/Lend/Filter/LendFilterMenu.vue
+++ b/src/pages/Lend/Filter/LendFilterMenu.vue
@@ -84,11 +84,12 @@ export default {
 		KvIcon,
 		KvButton,
 	},
+	data() {
+		return {
+			filterMenuOpen: false,
+		};
+	},
 	props: {
-		filterMenuOpen: {
-			type: Boolean,
-			required: true,
-		},
 		defaultSortIndices: {
 			type: Array,
 			required: true,
@@ -104,9 +105,11 @@ export default {
 	},
 	methods: {
 		hideFilterMenu() {
+			this.filterMenuOpen = false;
 			this.$emit('hide-filter-menu');
 		},
 		toggleFilterMenu() {
+			this.filterMenuOpen = !this.filterMenuOpen;
 			this.$emit('toggle-filter-menu');
 		},
 		showAdvancedFilters() {

--- a/src/pages/Lend/Filter/LendFilterMenu.vue
+++ b/src/pages/Lend/Filter/LendFilterMenu.vue
@@ -110,7 +110,7 @@ export default {
 		},
 		toggleFilterMenu() {
 			this.filterMenuOpen = !this.filterMenuOpen;
-			this.$emit('toggle-filter-menu');
+			this.$emit(this.filterMenuOpen ? 'show-filter-menu' : 'hide-filter-menu');
 		},
 		showAdvancedFilters() {
 			window.location.href = '/lend';

--- a/src/pages/Lend/Filter/LendFilterPage.vue
+++ b/src/pages/Lend/Filter/LendFilterPage.vue
@@ -4,7 +4,7 @@
 			class="filter-page-lend-header"
 			browse-url="/lend-by-category"
 			filter-url="/lend/filter" />
-		<div class="row page-content" :class="{'filter-menu-open': filterMenuOpen}">
+		<div class="row page-content">
 			<ais-instant-search
 				v-if="searchClient"
 				:search-client="searchClient"
@@ -13,7 +13,6 @@
 					:default-sort-indices="defaultSortIndices"
 					:custom-categories="customCategories"
 					:selected-custom-categories="selectedCustomCategories"
-					:filter-menu-open="filterMenuOpen"
 					@clear-custom-categories="clearCustomCategories"
 					@hide-filter-menu="hideFilterMenu"
 					@toggle-filter-menu="toggleFilterMenu"
@@ -37,7 +36,9 @@
 						<template slot-scope="{ page, hitsPerPage, queryID, index }">
 							<ais-hits
 								class="loan-card-group row"
-								:results-per-page="12">
+								:class="{'filter-menu-open': filterMenuOpen}"
+								:results-per-page="12"
+							>
 								<template slot="default" slot-scope="{ items }">
 									<algolia-adapter
 										v-for="(item, itemIndex) in items" :key="item.id"
@@ -235,11 +236,10 @@ export default {
 		padding: 0 2rem;
 
 		.loan-card-group {
+			opacity: 1;
 			transition: opacity $filter-transition;
-		}
 
-		&.filter-menu-open {
-			.loan-card-group {
+			&.filter-menu-open {
 				opacity: 0.2;
 			}
 		}

--- a/src/pages/Lend/Filter/LendFilterPage.vue
+++ b/src/pages/Lend/Filter/LendFilterPage.vue
@@ -15,7 +15,7 @@
 					:selected-custom-categories="selectedCustomCategories"
 					@clear-custom-categories="clearCustomCategories"
 					@hide-filter-menu="hideFilterMenu"
-					@toggle-filter-menu="toggleFilterMenu"
+					@show-filter-menu="showFilterMenu"
 					@toggle-custom-category="toggleCustomCategory"
 				/>
 				<!-- eslint-disable vue/attribute-hyphenation -->
@@ -195,8 +195,8 @@ export default {
 		hideFilterMenu() {
 			this.filterMenuOpen = false;
 		},
-		toggleFilterMenu() {
-			this.filterMenuOpen = !this.filterMenuOpen;
+		showFilterMenu() {
+			this.filterMenuOpen = true;
 		},
 		toggleCustomCategory(categoryId) {
 			this.$set(

--- a/src/pages/Lend/Filter/LendFilterPage.vue
+++ b/src/pages/Lend/Filter/LendFilterPage.vue
@@ -13,9 +13,8 @@
 					:default-sort-indices="defaultSortIndices"
 					:custom-categories="customCategories"
 					:selected-custom-categories="selectedCustomCategories"
+					:filter-menu-open.sync="filterMenuOpen"
 					@clear-custom-categories="clearCustomCategories"
-					@hide-filter-menu="hideFilterMenu"
-					@show-filter-menu="showFilterMenu"
 					@toggle-custom-category="toggleCustomCategory"
 				/>
 				<!-- eslint-disable vue/attribute-hyphenation -->
@@ -192,12 +191,6 @@ export default {
 		}
 	},
 	methods: {
-		hideFilterMenu() {
-			this.filterMenuOpen = false;
-		},
-		showFilterMenu() {
-			this.filterMenuOpen = true;
-		},
 		toggleCustomCategory(categoryId) {
 			this.$set(
 				this.selectedCustomCategories,


### PR DESCRIPTION
This PR fixes an issue that would cause filters set using `ais-refinement-list` to be lost

The issue seems to occur due to:
1. We cannot derive classes based on props that are updated by parent components (hence `.sync` - using an uglier syncing-to-parent method and deriving class in child using `data` works too)
2. We cannot update classes in parent components of a filter