### PR TITLE
CASH-802: Add JS smooth scrolling

### DIFF
--- a/src/assets/scss/global/page-layout.scss
+++ b/src/assets/scss/global/page-layout.scss
@@ -16,10 +16,6 @@ body.scroll-locked {
 	}
 }
 
-html.smooth-scroll {
-	scroll-behavior: smooth;
-}
-
 code {
 	display: block;
 	overflow: auto;

--- a/src/pages/Lend/AlgoliaPagination.vue
+++ b/src/pages/Lend/AlgoliaPagination.vue
@@ -168,7 +168,7 @@ export default {
 			this.goToPage(this.currentRefinement - 1);
 		},
 		runOnPagination() {
-			this.smoothScrollTo({ yPosition: 0, millisecondsToAnimate: 150 });
+			this.smoothScrollTo({ yPosition: 0, millisecondsToAnimate: 125 });
 		},
 	},
 };

--- a/src/pages/Lend/AlgoliaPagination.vue
+++ b/src/pages/Lend/AlgoliaPagination.vue
@@ -71,12 +71,16 @@
 <script>
 import _range from 'lodash/range';
 import _uniq from 'lodash/uniq';
+import smoothScrollMixin from '@/plugins/smooth-scroll-mixin';
 import KvIcon from '@/components/Kv/KvIcon';
 
 export default {
 	components: {
 		KvIcon,
 	},
+	mixins: [
+		smoothScrollMixin,
+	],
 	props: {
 		currentRefinement: {
 			type: Number,
@@ -164,14 +168,8 @@ export default {
 			this.goToPage(this.currentRefinement - 1);
 		},
 		runOnPagination() {
-			window.scrollTo(0, 0);
+			this.smoothScrollTo({ yPosition: 0, millisecondsToAnimate: 150 });
 		},
-	},
-	mounted() {
-		document.querySelector('html').classList.add('smooth-scroll');
-	},
-	beforeDestroy() {
-		document.querySelector('html').classList.remove('smooth-scroll');
 	},
 };
 </script>

--- a/src/plugins/smooth-scroll-mixin.js
+++ b/src/plugins/smooth-scroll-mixin.js
@@ -1,36 +1,24 @@
 export default {
 	methods: {
-		smoothScrollTo({ yPosition, millisecondsToAnimate = 250, stops }) {
+		smoothScrollTo({ yPosition, millisecondsToAnimate = 200 }) {
 			const startingPosition = window.scrollY;
 			const endTime = (new Date()).getTime() + millisecondsToAnimate;
-			const numberOfStops = stops || Math.ceil(millisecondsToAnimate / 2);
 			const yDifference = startingPosition - yPosition;
 
-			let animationComplete = false;
+			const scroll = () => {
+				const currentTime = (new Date()).getTime();
 
-			for (let i = 0; i < numberOfStops; i += 1) {
-				// eslint-disable-next-line no-loop-func
-				setTimeout(() => {
-					if (animationComplete) {
-						return;
-					}
+				const percentageDone = 1 - ((endTime - currentTime) / millisecondsToAnimate);
+				const percentageToAnimate = Math.min(percentageDone, 1);
+				const newScrollY = startingPosition - (percentageToAnimate * yDifference);
+				window.scrollTo(0, newScrollY);
 
-					const currentTime = (new Date()).getTime();
+				if (currentTime < endTime) {
+					window.requestAnimationFrame(scroll);
+				}
+			};
 
-					const isOverTime = currentTime > endTime;
-					const isLastIteration = i === (numberOfStops - 1);
-					if (isOverTime || isLastIteration) {
-						animationComplete = true;
-						window.scrollTo(0, yPosition);
-						return;
-					}
-
-					const percentageDone = 1 - ((endTime - currentTime) / millisecondsToAnimate);
-					const newScrollY = startingPosition - (percentageDone * yDifference);
-
-					window.scrollTo(0, newScrollY);
-				}, (i / (numberOfStops - 1)) * millisecondsToAnimate);
-			}
+			window.requestAnimationFrame(scroll);
 		},
 	},
 };

--- a/src/plugins/smooth-scroll-mixin.js
+++ b/src/plugins/smooth-scroll-mixin.js
@@ -1,0 +1,36 @@
+export default {
+	methods: {
+		smoothScrollTo({ yPosition, millisecondsToAnimate = 250, stops }) {
+			const startingPosition = window.scrollY;
+			const endTime = (new Date()).getTime() + millisecondsToAnimate;
+			const numberOfStops = stops || Math.ceil(millisecondsToAnimate / 2);
+			const yDifference = startingPosition - yPosition;
+
+			let animationComplete = false;
+
+			for (let i = 0; i < numberOfStops; i += 1) {
+				// eslint-disable-next-line no-loop-func
+				setTimeout(() => {
+					if (animationComplete) {
+						return;
+					}
+
+					const currentTime = (new Date()).getTime();
+
+					const isOverTime = currentTime > endTime;
+					const isLastIteration = i === (numberOfStops - 1);
+					if (isOverTime || isLastIteration) {
+						animationComplete = true;
+						window.scrollTo(0, yPosition);
+						return;
+					}
+
+					const percentageDone = 1 - ((endTime - currentTime) / millisecondsToAnimate);
+					const newScrollY = startingPosition - (percentageDone * yDifference);
+
+					window.scrollTo(0, newScrollY);
+				}, (i / (numberOfStops - 1)) * millisecondsToAnimate);
+			}
+		},
+	},
+};


### PR DESCRIPTION
This approach should work in more browsers than CSS based `smooth-scroll` and it lets us set the animation time (this timing is much more pleasant in my opinion). If we like it we can easily add an `xPosition` scrolling option in the future as well. 