### PR TITLE
Hide field partner in ListLoanCard for US Direct loans

### DIFF
--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -21,7 +21,7 @@
 				</div>
 				<div class="small-12 columns">
 					<div class="list-loan-card-desktop-column-text-wrapper row">
-						<div class="large-12 xxlarge-7 columns">
+						<div class="large-12 xxlarge-7 columns" v-if="loan.partnerName">
 							<div class="list-loan-card-desktop-column-title">Field Partner</div>
 							<div class="list-loan-card-desktop-column-content">{{ loan.partnerName }}</div>
 						</div>


### PR DESCRIPTION
* Currently US Direct loans have an empty "Field Partner" title under the image. This PR hides the entire Field Partner section if it's empty.