### PR TITLE
new script command to start dev in inspect mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"dev": "cross-env NODE_ENV=development node --max-old-space-size=2048 server/dev-server.js",
 		"start": "cross-env NODE_ENV=production node --max-old-space-size=2048 server/index.js",
+		"inspect-dev": "cross-env NODE_ENV=development node --inspect --max-old-space-size=4096 server/dev-server.js",
 		"inspect": "cross-env NODE_ENV=production node --inspect --max-old-space-size=4096 server/index.js",
 		"build": "rimraf dist && node build/build.js",
 		"build:trace": "rimraf dist && node --trace-deprecation build/build.js",


### PR DESCRIPTION
starts "dev mode" using the --inspect flag. has nothing to do with the 'dev' environment.