### PR TITLE
Remove isExpiringSoon as condition for loan card display of Expiring …

### DIFF
--- a/src/components/LoanCards/FundraisingStatus.vue
+++ b/src/components/LoanCards/FundraisingStatus.vue
@@ -10,7 +10,7 @@
 		</div>
 
 		<div class="left-and-to-go-line">
-			<span v-if="props.isExpiringSoon"
+			<span v-if="props.expiringSoonMessage !== ''"
 				class="loan-message">{{ props.expiringSoonMessage }}</span>
 			<span v-if="props.isFunded" class="funded">Funded</span>
 			<span v-else>${{ props.amountLeft | numeral('0,0') }} to go</span>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -34,7 +34,6 @@
 				<fundraising-status
 					:amount-left="amountLeft"
 					:percent-raised="percentRaised"
-					:is-expiring-soon="loan.loanFundraisingInfo.isExpiringSoon"
 					:expiring-soon-message="expiringSoonMessage"
 					:is-funded="loan.status==='funded'"
 				/>

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -106,7 +106,6 @@
 					<fundraising-status
 						:amount-left="amountLeft"
 						:percent-raised="percentRaised"
-						:is-expiring-soon="loan.loanFundraisingInfo.isExpiringSoon"
 						:expiring-soon-message="expiringSoonMessage"
 						:is-funded="isFunded"
 					/>

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -125,10 +125,12 @@ export default {
 			return (this.loan.loanAmount - this.amountLeft) / this.loan.loanAmount;
 		},
 		expiringSoonMessage() {
-			if (!this.loan.loanFundraisingInfo.isExpiringSoon) {
+			const days = differenceInDays(this.loan.plannedExpirationDate, Date.now());
+			// Send empty message if expiration is greater than 6 days
+			// > This matches the wwwApp implmentation
+			if (days >= 6) {
 				return '';
 			}
-			const days = differenceInDays(this.loan.plannedExpirationDate, Date.now());
 			if (days >= 2) {
 				return `Only ${days} days left! `;
 			}


### PR DESCRIPTION
…Soon message. We now just use calculations against plannedExpirationDate to show a message from 5 days to go or less. The isExpiringSoon field is still valid in the context of loans in the basket.