### PR TITLE
CASH-682: Add algolia search to lend/filter

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -17,6 +17,7 @@
 				:aria-expanded="searchOpen ? 'true' : 'false'"
 				:aria-pressed="searchOpen ? 'true' : 'false'"
 				aria-controls="top-nav-search-area"
+				v-if="!hideSearchInHeader"
 				@click="toggleSearch"
 				v-kv-track-event="['TopNav','click-search-toggle']"
 			>
@@ -283,6 +284,12 @@ export default {
 			searchOpen: false,
 			legacyExpData: null
 		};
+	},
+	props: {
+		hideSearchInHeader: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		isTrustee() {

--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -2,7 +2,7 @@
 	<div class="www-page">
 		<appeal-banner />
 		<global-promo />
-		<the-header />
+		<the-header :hide-search-in-header="hideSearchInHeader" />
 		<slot name="secondary"></slot>
 		<main :class="{'gray-background': grayBackground}">
 			<slot name="tertiary"></slot>
@@ -37,6 +37,10 @@ export default {
 	},
 	props: {
 		grayBackground: {
+			type: Boolean,
+			default: false,
+		},
+		hideSearchInHeader: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/pages/Lend/AlgoliaSearchBox.vue
+++ b/src/pages/Lend/AlgoliaSearchBox.vue
@@ -1,0 +1,80 @@
+<template>
+	<div class="algolia-search-box">
+		<ais-search-box
+			:placeholder="placeholder"
+		/>
+		<kv-icon class="algolia-magnifying-glass" name="magnify-glass" />
+	</div>
+</template>
+
+<script>
+import KvIcon from '@/components/Kv/KvIcon';
+import { AisSearchBox } from 'vue-instantsearch';
+
+export default {
+	components: {
+		KvIcon,
+		AisSearchBox,
+	},
+	props: {
+		placeholder: {
+			type: String,
+			default: 'Search loans',
+		},
+	},
+};
+</script>
+
+<style lang="scss">
+@import 'settings';
+
+.algolia-search-box {
+	position: relative;
+	max-width: 640px;
+
+	.ais-SearchBox-form {
+		.ais-SearchBox-input {
+			border-radius: rem-calc(2);
+			padding-left: 3rem;
+
+			&::placeholder {
+				font-style: normal;
+			}
+
+			&::-webkit-search-cancel-button {
+				display: none;
+			}
+
+			&::-ms-clear {
+				display: none;
+			}
+		}
+
+		.ais-SearchBox-reset {
+			position: absolute;
+			right: 0;
+			top: 2px;
+			padding: 0.2rem 0.8rem;
+			height: 2.6875rem;
+
+			.ais-SearchBox-resetIcon {
+				fill: #9d9c9e;
+			}
+		}
+
+		.ais-SearchBox-submit {
+			display: none;
+		}
+	}
+
+	.algolia-magnifying-glass {
+		position: absolute;
+		left: 1rem;
+		pointer-events: none;
+		top: 0.75rem;
+		height: rem-calc(18);
+		width: rem-calc(18);
+		fill: $gray;
+	}
+}
+</style>

--- a/src/pages/Lend/Filter/LendFilterPage.vue
+++ b/src/pages/Lend/Filter/LendFilterPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<www-page class="lend-filter-page" :gray-background="true">
+	<www-page class="lend-filter-page" :gray-background="true" :hide-search-in-header="algoliaSearchEnabled">
 		<kv-message>
 			Welcome to Kiva's new filter page! Take it for a spin below, or
 			<a @click="exitLendFilterExp('click-return-classic')">return to the classic view</a> at any time.
@@ -17,7 +17,8 @@
 				class="instant-search-container"
 				:search-client="searchClient"
 				:index-name="algoliaDefaultIndex"
-				:routing="routing">
+				:routing="routing"
+			>
 				<lend-filter-menu
 					:default-sort-indices="defaultSortIndices"
 					:custom-categories="customCategories"
@@ -38,13 +39,15 @@
 						:userToken="userId.toString()"
 						ref="aisConfigure"
 					/>
+					<algolia-search-box class="algolia-search-box-component" v-if="algoliaSearchEnabled" />
 					<selected-refinements
+						class="selected-refinements-component"
 						:custom-categories="customCategories"
 						:selected-custom-categories="selectedCustomCategories"
 						@remove-custom-category="removeCustomCategory"
 						@clear-custom-categories="clearCustomCategories"
 					/>
-					<ais-state-results>
+					<ais-state-results class="ais-state-results-component">
 						<template slot-scope="{ page, hitsPerPage, queryID, index }">
 							<ais-hits
 								class="loan-card-group row"
@@ -66,8 +69,8 @@
 							</ais-hits>
 						</template>
 					</ais-state-results>
-					<algolia-pagination-wrapper :padding="2" />
-					<algolia-pagination-stats :padding="2" />
+					<algolia-pagination-wrapper :padding="2" class="algolia-pagination-component" />
+					<algolia-pagination-stats :padding="2" class="algolia-pagination-stats-component" />
 
 					<ais-state-results>
 						<template slot-scope="stateData">
@@ -110,6 +113,7 @@ import AlgoliaPaginationWrapper from '@/pages/Lend/AlgoliaPaginationWrapper';
 import AlgoliaPaginationStats from '@/pages/Lend/AlgoliaPaginationStats';
 import LendFilterMenu from '@/pages/Lend/Filter/FilterComponents/LendFilterMenu';
 import SelectedRefinements from '@/pages/Lend/Filter/FilterComponents/SelectedRefinements';
+import AlgoliaSearchBox from '@/pages/Lend/AlgoliaSearchBox';
 import AlgoliaTrackState from '@/pages/Lend/Filter/FilterComponents/AlgoliaTrackState';
 
 export default {
@@ -128,6 +132,7 @@ export default {
 		AlgoliaPaginationWrapper,
 		AlgoliaPaginationStats,
 		AlgoliaTrackState,
+		AlgoliaSearchBox,
 	},
 	metaInfo: {
 		title: 'Lend Filter'
@@ -165,6 +170,7 @@ export default {
 			filterMenuOpen: false,
 			selectedCustomCategories: {},
 			filterMenuPinned: false,
+			algoliaSearchEnabled: false,
 		};
 	},
 	computed: {
@@ -225,13 +231,30 @@ export default {
 				variables: { id: 'pinned_filter' },
 			});
 
-			this.pinnedFilterExperimentVersion = _get(pinnedFilterExperimentVersionArray, 'experiment.version') || null;
-			if (this.pinnedFilterExperimentVersion === 'variant-a') {
+			// eslint-disable-next-line max-len
+			const pinnedFilterExperimentVersion = _get(pinnedFilterExperimentVersionArray, 'experiment.version') || null;
+			if (pinnedFilterExperimentVersion === 'variant-a') {
 				this.$kvTrackEvent('Lending', 'EXP-CASH-851-May2019', 'a');
-			} else if (this.pinnedFilterExperimentVersion === 'variant-b') {
+			} else if (pinnedFilterExperimentVersion === 'variant-b') {
 				this.filterMenuPinned = true;
 				this.$kvTrackEvent('Lending', 'EXP-CASH-851-May2019', 'b');
 			}
+		}
+
+		// CASH-682: Experiment - Algolia Search
+		// Only run if filter menu pinned
+		const algoliaSearchExperimentVersionArray = this.apollo.readQuery({
+			query: experimentQuery,
+			variables: { id: 'algolia_search' },
+		});
+
+		// eslint-disable-next-line max-len
+		const algoliaSearchExperimentVersion = _get(algoliaSearchExperimentVersionArray, 'experiment.version') || null;
+		if (algoliaSearchExperimentVersion === 'variant-a') {
+			this.$kvTrackEvent('Lending', 'EXP-CASH-682-Apr2019', 'a');
+		} else if (algoliaSearchExperimentVersion === 'variant-b') {
+			this.algoliaSearchEnabled = true;
+			this.$kvTrackEvent('Lending', 'EXP-CASH-682-Apr2019', 'b');
 		}
 	},
 	methods: {
@@ -282,17 +305,53 @@ export default {
 		.instant-search-container {
 			width: 100%;
 
-			.loan-card-group {
-				opacity: 1;
-				transition: opacity $filter-transition;
+			.lend-filter-results-container {
+				.algolia-search-box-component {
+					margin-top: 1.125rem;
+				}
 
-				&.filter-menu-open {
-					opacity: 0.2;
+				.loan-card-group {
+					opacity: 1;
+					transition: opacity $filter-transition;
+
+					&.filter-menu-open {
+						opacity: 0.2;
+					}
 				}
 			}
 		}
 
 		&.filter-menu-pinned {
+			@include breakpoint(1193px down) {
+				.instant-search-container {
+					.lend-filter-results-container {
+						display: flex;
+						flex-direction: column;
+
+						.algolia-search-box-component {
+							height: 49px;
+							order: 1;
+						}
+
+						.selected-refinements-component {
+							order: 0;
+						}
+
+						.ais-state-results-component {
+							order: 2;
+						}
+
+						.algolia-pagination-component {
+							order: 3;
+						}
+
+						.algolia-pagination-stats-component {
+							order: 4;
+						}
+					}
+				}
+			}
+
 			@include breakpoint(1194px) {
 				max-width: rem-calc(1174);
 
@@ -303,6 +362,11 @@ export default {
 
 					.lend-filter-results-container {
 						max-width: calc(100% - 21rem);
+
+						.algolia-search-box-component {
+							margin-top: 0;
+							max-width: initial;
+						}
 					}
 				}
 			}

--- a/src/pages/Lend/Filter/LendFilterPage.vue
+++ b/src/pages/Lend/Filter/LendFilterPage.vue
@@ -39,7 +39,6 @@
 						:userToken="userId.toString()"
 						ref="aisConfigure"
 					/>
-					<algolia-search-box class="algolia-search-box-component" v-if="algoliaSearchEnabled" />
 					<selected-refinements
 						class="selected-refinements-component"
 						:custom-categories="customCategories"
@@ -47,6 +46,7 @@
 						@remove-custom-category="removeCustomCategory"
 						@clear-custom-categories="clearCustomCategories"
 					/>
+					<algolia-search-box class="algolia-search-box-component" v-if="algoliaSearchEnabled" />
 					<ais-state-results class="ais-state-results-component">
 						<template slot-scope="{ page, hitsPerPage, queryID, index }">
 							<ais-hits
@@ -322,18 +322,27 @@ export default {
 		}
 
 		&.filter-menu-pinned {
-			@include breakpoint(1193px down) {
+			@include breakpoint(1194px) {
+				max-width: rem-calc(1174);
+
 				.instant-search-container {
+					display: flex;
+					flex-direction: row;
+					justify-content: space-between;
+
 					.lend-filter-results-container {
+						max-width: calc(100% - 21rem);
 						display: flex;
 						flex-direction: column;
 
-						.algolia-search-box-component {
-							height: 49px;
+						.selected-refinements-component {
 							order: 1;
 						}
 
-						.selected-refinements-component {
+						.algolia-search-box-component {
+							margin-top: 0;
+							max-width: initial;
+							height: 49px;
 							order: 0;
 						}
 
@@ -347,25 +356,6 @@ export default {
 
 						.algolia-pagination-stats-component {
 							order: 4;
-						}
-					}
-				}
-			}
-
-			@include breakpoint(1194px) {
-				max-width: rem-calc(1174);
-
-				.instant-search-container {
-					display: flex;
-					flex-direction: row;
-					justify-content: space-between;
-
-					.lend-filter-results-container {
-						max-width: calc(100% - 21rem);
-
-						.algolia-search-box-component {
-							margin-top: 0;
-							max-width: initial;
 						}
 					}
 				}

--- a/src/util/experimentPreFetch.js
+++ b/src/util/experimentPreFetch.js
@@ -8,6 +8,7 @@ import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.grap
 const activeExperiments = [
 	'lend_filter',
 	'pinned_filter',
+	'algolia_search',
 ];
 
 // TODO: Enhance Error handling


### PR DESCRIPTION
This looks really good when running concurrently with the pinned filter experiment
```
uiexp.algolia_search
string
{"name": "AlgoliaSearch","enabled": true,"startTime": "2018-08-29T00:00","endTime": "2020-02-16T15:00","control": {"key": "variant-a","name": "Control (variant-a)"},"variants": {"variant-b": {"name": "Algolia Search Enabled"}},"distribution": {"variant-a": 0,"variant-b": 1}}
CASH-682: Algolia Search
```