### PR TITLE
Use simpler graphql cache for server renders

### DIFF
--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -29,6 +29,8 @@ export default function createApolloClient({
 			if (object.__typename === 'Shop') return 'Shop';
 			return defaultDataIdFromObject(object);
 		},
+		// Use a simpler underlying cache for server renders
+		resultCaching: typeof window !== 'undefined',
 	});
 
 	return new ApolloClient({


### PR DESCRIPTION
I think the stale basketId issues we've been seeing might be resolved by using this option to use a simpler cache during the server render, see https://github.com/apollographql/apollo-client/blob/master/packages/apollo-cache-inmemory/src/inMemoryCache.ts#L119