### PR TITLE
Create new process for turning on a specific experiment version using…

### DIFF
--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -1,6 +1,7 @@
 import _isUndefined from 'lodash/isUndefined';
 import _filter from 'lodash/filter';
 import _fromPairs from 'lodash/fromPairs';
+// import _get from 'lodash/get';
 import _toPairs from 'lodash/toPairs';
 import { isWithinRange } from 'date-fns';
 import cookieStore from '@/util/cookieStore';
@@ -196,6 +197,29 @@ export default () => {
 						version: updatedVersion,
 						__typename: 'Experiment',
 					};
+				},
+				// COMING SOON
+				// eslint-disable-next-line
+				cleanExperimentCookie(_, data, context) {
+					// get array of active experiment ids from cache
+					// const activeExperiments = JSON.parse(_get(
+					// 	context,
+					// 	`cache.data.data['Setting:ui.active_experiments'].value` // eslint-disable-line
+					// ));
+					// console.log('------- Active Exps in cookie cleaner -------');
+					// console.log(activeExperiments);
+
+					// if (activeExperiments.length) {
+					// 	const currentAssignments = parseExpCookie(cookieStore.get('uiab'));
+					// 	console.log('current cookie assignments: ', currentAssignments);
+					// 	const remainingAssignments = _filter(currentAssignments, (value, index) => {
+					// 		return activeExperiments.indexOf(index) !== -1;
+					// 	});
+					// 	console.log('new cookie assignments: ', remainingAssignments);
+					// 	// cookieStore.set('uiab', serializeExpCookie(remainingAssignments), { path: '/' });
+					// }
+
+					return true;
 				}
 			}
 		}

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -12,6 +12,7 @@ type Mutation {
 	updateUsingTouch(usingTouch: Boolean): Boolean
 	updateAddToBasketInterstitial(active: Boolean, visible: Boolean, loanId: Int): Boolean
 	updateExperimentVersion(id: String, version: String): Experiment
+	cleanExperimentCookie: Boolean
 }
 
 type Query {

--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -15,6 +15,7 @@
 </template>
 
 <script>
+import _get from 'lodash/get';
 import { fetchAllExpSettings } from '@/util/experimentPreFetch';
 import CookieBanner from '@/components/WwwFrame/CookieBanner';
 import TheHeader from './TheHeader';
@@ -46,8 +47,11 @@ export default {
 		},
 	},
 	apollo: {
-		preFetch(config, client) {
-			return fetchAllExpSettings(client);
+		preFetch(config, client, args) {
+			return fetchAllExpSettings(config, client, {
+				query: _get(args, 'route.query'),
+				path: _get(args, 'route.path')
+			});
 		}
 	}
 };

--- a/src/graphql/mutation/experimentCookieCleaner.graphql
+++ b/src/graphql/mutation/experimentCookieCleaner.graphql
@@ -1,0 +1,3 @@
+mutation cleanExperimentCookie {
+	cleanExperimentCookie @client
+}

--- a/src/graphql/query/experimentIds.graphql
+++ b/src/graphql/query/experimentIds.graphql
@@ -1,0 +1,8 @@
+query {
+	general {
+		activeExperiments: uiConfigSetting(key: "active_experiments") {
+			key
+			value
+		}
+	}
+}


### PR DESCRIPTION
… a url query parameter. Passing the setuiab query param with an 'active' exp id and version will switch to that version. Also setup prelimiary work for global active experiment fetching and cookie clean up.