### PR TITLE
CASH-676: Expandable Loan Card

### DIFF
--- a/src/api/StateLink.js
+++ b/src/api/StateLink.js
@@ -4,6 +4,7 @@ import experiment from './localResolvers/experiment';
 import tipMessage from './localResolvers/tipMessage';
 import usingTouch from './localResolvers/usingTouch';
 import basketAddInterstitial from './localResolvers/addToBasketInterstitial';
+import activeLoan from './localResolvers/activeLoan';
 
 export default ({ cache, ...options }) => {
 	return withClientState({
@@ -13,6 +14,7 @@ export default ({ cache, ...options }) => {
 			tipMessage(options),
 			usingTouch(options),
 			basketAddInterstitial(options),
+			activeLoan(options),
 		),
 	});
 };

--- a/src/api/localResolvers/activeLoan.js
+++ b/src/api/localResolvers/activeLoan.js
@@ -1,0 +1,65 @@
+/*
+ * Active loan resolvers
+ */
+export default () => {
+	return {
+		defaults: {
+			activeLoan: {
+				hoverLoanId: 0,
+				xCoordinate: 0,
+				yCoordinate: 0,
+				loan: JSON.stringify({
+					activity: {},
+					userProperties: {},
+					loanFundraisingInfo: {},
+					geocode: {
+						country: {},
+					},
+					image: {},
+				}),
+				tracking: JSON.stringify({}),
+				__typename: 'ActiveLoan',
+			}
+		},
+		resolvers: {
+			Mutation: {
+				updateActiveLoan(
+					_,
+					{
+						hoverLoanId = 0,
+						xCoordinate = 0,
+						yCoordinate = 0,
+						loan = JSON.stringify({
+							activity: {},
+							userProperties: {},
+							loanFundraisingInfo: {},
+							geocode: {
+								country: {},
+							},
+							image: {},
+						}),
+						tracking = JSON.stringify({}),
+					},
+					context,
+				) {
+					const data = {
+						activeLoan: {
+							hoverLoanId,
+							xCoordinate,
+							yCoordinate,
+							loan,
+							tracking,
+							__typename: 'ActiveLoan',
+						}
+					};
+
+					context.cache.writeData({
+						data,
+					});
+
+					return data;
+				},
+			},
+		},
+	};
+};

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -12,6 +12,7 @@ type Mutation {
 	updateUsingTouch(usingTouch: Boolean): Boolean
 	updateAddToBasketInterstitial(active: Boolean, visible: Boolean, loanId: Int): Boolean
 	updateExperimentVersion(id: String, version: String): Experiment
+	activeLoan(hoverLoanId: Int): Boolean
 }
 
 type Query {
@@ -19,6 +20,7 @@ type Query {
 	tip: TipMessage
 	usingTouch: Boolean
 	basketAddInterstitial: BasketAddInterstitial
+	activeLoan: ActiveLoan
 }
 
 type TipMessage {
@@ -33,3 +35,11 @@ type BasketAddInterstitial {
 	visible: Boolean
 	loanId: Int
 }
+
+type ActiveLoan {
+	hoverLoanId: Int
+	xCoordinate: Number
+	yCoordinate: Number
+	loan: String
+	tracking: String
+ }

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -39,8 +39,8 @@ type BasketAddInterstitial {
 
 type ActiveLoan {
 	hoverLoanId: Int
-	xCoordinate: Number
-	yCoordinate: Number
+	xCoordinate: Int
+	yCoordinate: Int
 	loan: String
 	tracking: String
  }

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -41,12 +41,16 @@
 <script>
 import KvIcon from '@/components/Kv/KvIcon';
 import KvButton from '@/components/Kv/KvButton';
+import lockScrollUtils from '@/plugins/lock-scroll';
 
 export default {
 	components: {
 		KvIcon,
 		KvButton
 	},
+	mixins: [
+		lockScrollUtils,
+	],
 	data() {
 		return {
 			isShown: false
@@ -108,16 +112,6 @@ export default {
 			// remove scroll lock class from body
 			this.unlockScroll();
 		},
-		lockScroll() {
-			if (typeof window !== 'undefined') {
-				document.body.classList.add('scroll-locked');
-			}
-		},
-		unlockScroll() {
-			if (typeof window !== 'undefined') {
-				document.body.classList.remove('scroll-locked');
-			}
-		}
 	}
 };
 </script>

--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfoHeaderExpandable.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfoHeaderExpandable.vue
@@ -1,0 +1,71 @@
+<template>
+	<div class="borrower-info-header-expandable" :class="{expanded}">
+		<div class="name" v-if="name">{{ name }}</div>
+		<div class="details" v-if="country || activity">
+			{{ country ? `${country}` : '' }}
+			{{ country && activity ? '|' : '' }}
+			{{ activity ? `${activity}` : '' }}
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	props: {
+		country: {
+			type: String,
+			default: '',
+		},
+		activity: {
+			type: String,
+			default: '',
+		},
+		loanId: {
+			type: Number,
+			default: null,
+		},
+		name: {
+			type: String,
+			default: '',
+		},
+		expanded: {
+			type: Boolean,
+			default: false,
+		},
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+@import 'settings';
+
+.borrower-info-header-expandable {
+	white-space: nowrap;
+	margin-bottom: rem-calc(10);
+
+	.expandable {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.name {
+		@extend .expandable;
+
+		font-size: rem-calc(20);
+		line-height: rem-calc(28);
+		font-weight: $global-weight-highlight;
+		margin-bottom: rem-calc(5);
+	}
+
+	.details {
+		@extend .expandable;
+
+		color: $kiva-text-light;
+		line-height: rem-calc(20);
+	}
+
+	&.expanded {
+		white-space: initial;
+	}
+}
+</style>

--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfoHeaderExpandable.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfoHeaderExpandable.vue
@@ -1,40 +1,13 @@
-<template>
-	<div class="borrower-info-header-expandable" :class="{expanded}">
-		<div class="name" v-if="name">{{ name }}</div>
-		<div class="details" v-if="country || activity">
-			{{ country ? `${country}` : '' }}
-			{{ country && activity ? '|' : '' }}
-			{{ activity ? `${activity}` : '' }}
+<template functional>
+	<div class="borrower-info-header-expandable" :class="{'expanded': props.expanded}">
+		<div class="name" v-if="props.name">{{ props.name }}</div>
+		<div class="details" v-if="props.country || props.activity">
+			{{ props.country ? `${props.country}` : '' }}
+			{{ props.country && props.activity ? '|' : '' }}
+			{{ props.activity ? `${props.activity}` : '' }}
 		</div>
 	</div>
 </template>
-
-<script>
-export default {
-	props: {
-		country: {
-			type: String,
-			default: '',
-		},
-		activity: {
-			type: String,
-			default: '',
-		},
-		loanId: {
-			type: Number,
-			default: null,
-		},
-		name: {
-			type: String,
-			default: '',
-		},
-		expanded: {
-			type: Boolean,
-			default: false,
-		},
-	},
-};
-</script>
 
 <style lang="scss" scoped>
 @import 'settings';

--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -53,7 +53,7 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		isLend25Button: {
+		isSimpleLendButton: {
 			type: Boolean,
 			default: false
 		},
@@ -76,7 +76,7 @@ export default {
 				return LoanExpiredText;
 			}
 
-			return this.isLend25Button ? Lend25Button : LendIncrementButton;
+			return this.isSimpleLendButton ? Lend25Button : LendIncrementButton;
 		},
 	},
 	methods: {

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
@@ -1,0 +1,127 @@
+<template>
+	<div class="expandable-loan-card" :class="{ expanded }">
+		<loan-card-image
+			:loan-id="loan.id"
+			:name="loan.name"
+			:retina-image-url="loan.image.retina"
+			:standard-image-url="loan.image.default"
+			:is-visitor="isVisitor"
+			:is-favorite="isFavorite"
+			:loan-image-hash="loan.image.hash"
+
+			@track-loan-card-interaction="trackInteraction"
+			@favorite-toggled="toggleFavorite"
+		/>
+		<div>
+			<div class="expandable-loan-card-bottom">
+				<borrower-info-header-expandable
+					:country="loan.geocode.country.name"
+					:activity="loan.activity.name"
+					:name="loan.name"
+					:loan-id="loan.id"
+					:single-line="true"
+					class="list-loan-card-borrower-info-header"
+				/>
+				<fundraising-status
+					:amount-left="amountLeft"
+					:percent-raised="percentRaised"
+					:expiring-soon-message="expiringSoonMessage"
+					:is-funded="loan.status==='funded'"
+					:single-line="true"
+				/>
+				<borrower-info-body
+					:amount="loan.loanAmount"
+					:borrower-count="loan.borrowerCount"
+					:name="loan.name"
+					:status="loan.status"
+					:use="loan.use"
+					:loan-id="loan.id"
+				/>
+				<action-button
+					class="expandable-loan-card-action-button"
+					:loan-id="loan.id"
+					:loan="loan"
+					:items-in-basket="itemsInBasket"
+					:is-lent-to="loan.userProperties.lentTo"
+					:is-funded="isFunded"
+					:is-selected-by-another="isSelectedByAnother"
+					:is-simple-lend-button="true"
+
+					@click.native="trackInteraction({
+						interactionType: 'addToBasket',
+						interactionElement: 'Lend25'
+					})"
+
+					@add-to-basket="$emit('add-to-basket', $event)"
+				/>
+				<matching-text
+					:matching-text="loan.matchingText"
+					:is-funded="isFunded"
+					:is-selected-by-another="isSelectedByAnother"
+				/>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import activeLoanMixin from '@/plugins/active-loan-mixin';
+import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
+import BorrowerInfoHeaderExpandable from '@/components/LoanCards/BorrowerInfo/BorrowerInfoHeaderExpandable';
+import BorrowerInfoBody from '@/components/LoanCards/BorrowerInfo/BorrowerInfoBody';
+import FundraisingStatus from '@/components/LoanCards/FundraisingStatus';
+import LoanCardImage from '@/components/LoanCards/LoanCardImage';
+import MatchingText from '@/components/LoanCards/MatchingText';
+import expandableLoanCardMixin from '@/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin';
+
+export default {
+	components: {
+		ActionButton,
+		BorrowerInfoHeaderExpandable,
+		BorrowerInfoBody,
+		FundraisingStatus,
+		LoanCardImage,
+		MatchingText,
+	},
+	mixins: [
+		expandableLoanCardMixin,
+		activeLoanMixin,
+	],
+};
+</script>
+
+<style lang="scss" scoped>
+@import 'settings';
+
+.expandable-loan-card {
+	background-color: $white;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: rem-calc(254);
+	margin: auto;
+	transition: box-shadow linear 0.15s;
+
+	.expandable-loan-card-bottom {
+		border: 1px solid $kiva-stroke-gray;
+		padding: 0.5rem 0.75rem 0.75rem 0.75rem;
+		max-height: rem-calc(100);
+		transition: max-height ease-out 0.2s;
+		overflow-y: hidden;
+
+		.expandable-loan-card-action-button {
+			margin-top: rem-calc(20);
+		}
+	}
+
+	&:hover {
+		box-shadow: rem-calc(2) rem-calc(2) rem-calc(4) rgba(0, 0, 0, 0.1);
+	}
+
+	&.expanded {
+		.expandable-loan-card-bottom {
+			max-height: rem-calc(350);
+		}
+	}
+}
+</style>

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
@@ -1,6 +1,12 @@
 <template>
 	<div class="expandable-loan-card" :class="{ expanded }">
+		<div class="expandable-loan-card-close show-for-small-only">
+			<button @click.prevent="clearHoverLoan" class="close-button" aria-label="Close">
+				<kv-icon name="small-x" />
+			</button>
+		</div>
 		<loan-card-image
+			class="loan-card-image-component"
 			:loan-id="loan.id"
 			:name="loan.name"
 			:retina-image-url="loan.image.retina"
@@ -8,6 +14,7 @@
 			:is-visitor="isVisitor"
 			:is-favorite="isFavorite"
 			:loan-image-hash="loan.image.hash"
+			:disable-link="disableImageLink"
 
 			@track-loan-card-interaction="trackInteraction"
 			@favorite-toggled="toggleFavorite"
@@ -73,6 +80,7 @@ import FundraisingStatus from '@/components/LoanCards/FundraisingStatus';
 import LoanCardImage from '@/components/LoanCards/LoanCardImage';
 import MatchingText from '@/components/LoanCards/MatchingText';
 import expandableLoanCardMixin from '@/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin';
+import KvIcon from '@/components/Kv/KvIcon';
 
 export default {
 	components: {
@@ -82,11 +90,17 @@ export default {
 		FundraisingStatus,
 		LoanCardImage,
 		MatchingText,
+		KvIcon,
 	},
 	mixins: [
 		expandableLoanCardMixin,
 		activeLoanMixin,
 	],
+	computed: {
+		disableImageLink() {
+			return this.usingTouch && !this.expanded;
+		},
+	},
 };
 </script>
 
@@ -100,10 +114,39 @@ export default {
 	height: 100%;
 	width: rem-calc(254);
 	margin: auto;
-	transition: box-shadow linear 0.15s;
+	transition: box-shadow linear 0.1s;
+
+	.expandable-loan-card-close {
+		display: none;
+		position: relative;
+		height: 46px;
+		width: 100%;
+
+		.close-button {
+			width: 3rem;
+			position: absolute;
+			right: rem-calc(12);
+			top: 1rem;
+			text-align: right;
+
+			.icon.icon-small-x {
+				height: 1rem;
+				width: 1rem;
+				fill: $subtle-gray;
+				transition: fill 0.16s linear;
+			}
+
+			&:hover {
+				.icon.icon-small-x {
+					fill: $charcoal;
+				}
+			}
+		}
+	}
 
 	.expandable-loan-card-bottom {
 		border: 1px solid $kiva-stroke-gray;
+		border-top: none;
 		padding: 0.5rem 0.75rem 0.75rem 0.75rem;
 		max-height: rem-calc(100);
 		transition: max-height ease-out 0.2s;
@@ -114,13 +157,24 @@ export default {
 		}
 	}
 
-	&:hover {
-		box-shadow: rem-calc(2) rem-calc(2) rem-calc(4) rgba(0, 0, 0, 0.1);
-	}
-
 	&.expanded {
+		box-shadow: rem-calc(2) rem-calc(2) rem-calc(4) rgba(0, 0, 0, 0.1);
+
 		.expandable-loan-card-bottom {
 			max-height: rem-calc(350);
+		}
+
+		@include breakpoint(small only) {
+			width: 100%;
+			height: initial;
+
+			.expandable-loan-card-close {
+				display: block;
+			}
+
+			.loan-card-image-component {
+				margin: 0 0.5rem;
+			}
 		}
 	}
 }

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed.vue
@@ -1,0 +1,67 @@
+<template>
+	<div
+		class="expandable-loan-card-collapsed column column-block"
+		@mouseenter="handleMouseEnter"
+		ref="expandableLoanCard"
+	>
+		<expandable-loan-card
+			:amount-left="amountLeft"
+			:expiring-soon-message="expiringSoonMessage"
+			:is-favorite="isFavorite"
+			:is-funded="isFunded"
+			:is-selected-by-another="isSelectedByAnother"
+			:is-visitor="isVisitor"
+			:items-in-basket="itemsInBasket"
+			:loan="loan"
+			:percent-raised="percentRaised"
+
+			:expanded="false"
+			:category-id="categoryId"
+			:category-set-id="categorySetId"
+			:row-number="rowNumber"
+			:card-number="cardNumber"
+
+			@track-loan-card-interaction="trackInteraction"
+			@favorite-toggled="toggleFavorite"
+		/>
+	</div>
+</template>
+
+<script>
+import activeLoanMixin from '@/plugins/active-loan-mixin';
+import ExpandableLoanCard from '@/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard';
+import expandableLoanCardMixin from '@/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin';
+
+export default {
+	components: {
+		ExpandableLoanCard,
+	},
+	mixins: [
+		expandableLoanCardMixin,
+		activeLoanMixin,
+	],
+	methods: {
+		handleMouseEnter() {
+			const bodyRect = document.body.getBoundingClientRect();
+			const expandableLoanCardRect = this.$refs.expandableLoanCard.getBoundingClientRect();
+
+			this.setHoverLoan({
+				xCoordinate: expandableLoanCardRect.left - bodyRect.left,
+				yCoordinate: expandableLoanCardRect.top - bodyRect.top,
+				loan: JSON.stringify(this.loan),
+				hoverLoanId: this.loan.id,
+				tracking: JSON.stringify({
+					categoryId: this.categoryId,
+					categorySetId: this.categorySetId,
+					rowNumber: this.rowNumber,
+					cardNumber: this.cardNumber,
+				}),
+			});
+		},
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+.expandable-loan-card-collapsed {}
+</style>

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed.vue
@@ -61,7 +61,3 @@ export default {
 	},
 };
 </script>
-
-<style lang="scss" scoped>
-.expandable-loan-card-collapsed {}
-</style>

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed.vue
@@ -20,6 +20,7 @@
 			:category-set-id="categorySetId"
 			:row-number="rowNumber"
 			:card-number="cardNumber"
+			:using-touch="usingTouch"
 
 			@track-loan-card-interaction="trackInteraction"
 			@favorite-toggled="toggleFavorite"

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
@@ -1,0 +1,72 @@
+<template>
+	<div
+		class="expandable-loan-card-expanded column column-block"
+		v-show="show"
+		@mouseleave="clearHoverLoan"
+		ref="expandedContainer"
+	>
+		<loan-card-controller
+			loan-card-type="ExpandableLoanCard"
+			:loan="hoverLoan"
+			:items-in-basket="itemsInBasket"
+			:category-id="tracking.categoryId"
+			:category-set-id="tracking.categorySetId"
+			:row-number="tracking.rowNumber"
+			:card-number="tracking.cardNumber"
+			:enable-tracking="true"
+			:is-visitor="isVisitor"
+			:expanded="expanded"
+		/>
+	</div>
+</template>
+
+<script>
+import activeLoanMixin from '@/plugins/active-loan-mixin';
+import LoanCardController from '@/components/LoanCards/LoanCardController';
+
+export default {
+	components: {
+		LoanCardController,
+	},
+	mixins: [
+		activeLoanMixin,
+	],
+	props: {
+		isVisitor: {
+			type: Boolean,
+			required: true,
+		},
+		itemsInBasket: {
+			type: Array,
+			default: () => [],
+		},
+	},
+	data() {
+		return {
+			expanded: false,
+			show: false,
+		};
+	},
+	methods: {
+		onActiveLoanChange() {
+			const xOffset = this.tracking.cardNumber === 1 ? -15 : -5;
+			this.$refs.expandedContainer.style.top = `${this.hoverLoanYCoordinate}px`;
+			this.$refs.expandedContainer.style.left = `${this.hoverLoanXCoordinate + xOffset}px`;
+			this.expanded = false;
+			this.show = true;
+			setTimeout(() => { this.expanded = true; }, 0);
+		},
+		onActiveLoanClear() {
+			this.expanded = false;
+			this.show = false;
+		},
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+.expandable-loan-card-expanded {
+	position: absolute;
+	z-index: 1001;
+}
+</style>

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
@@ -6,6 +6,7 @@
 		ref="expandedContainer"
 	>
 		<loan-card-controller
+			class="loan-card-controller-component"
 			loan-card-type="ExpandableLoanCard"
 			:loan="hoverLoan"
 			:items-in-basket="itemsInBasket"
@@ -22,6 +23,7 @@
 
 <script>
 import activeLoanMixin from '@/plugins/active-loan-mixin';
+import lockScrollUtils from '@/plugins/lock-scroll';
 import LoanCardController from '@/components/LoanCards/LoanCardController';
 
 export default {
@@ -30,6 +32,7 @@ export default {
 	},
 	mixins: [
 		activeLoanMixin,
+		lockScrollUtils,
 	],
 	props: {
 		isVisitor: {
@@ -40,33 +43,82 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+		usingTouch: {
+			type: Boolean,
+			required: true,
+		},
 	},
 	data() {
 		return {
 			expanded: false,
 			show: false,
+			hoverIsActive: true,
 		};
 	},
 	methods: {
+		collapseCard() {
+			this.clearHoverLoan();
+			this.pauseHover(500);
+		},
 		onActiveLoanChange() {
-			const xOffset = this.tracking.cardNumber === 1 ? -15 : -5;
+			if (!this.hoverIsActive) {
+				this.clearHoverLoan();
+				return;
+			}
+			const xOffset = (this.tracking.cardNumber === 1 && !this.usingTouch) ? -15 : -5;
 			this.$refs.expandedContainer.style.top = `${this.hoverLoanYCoordinate}px`;
 			this.$refs.expandedContainer.style.left = `${this.hoverLoanXCoordinate + xOffset}px`;
 			this.expanded = false;
 			this.show = true;
-			setTimeout(() => { this.expanded = true; }, 0);
+			this.lockScrollSmallOnly();
+			this.$nextTick(() => { this.expanded = true; });
 		},
 		onActiveLoanClear() {
 			this.expanded = false;
 			this.show = false;
+			this.unlockScrollSmallOnly();
+		},
+		pauseHover(timeUntilResume) {
+			this.hoverIsActive = false;
+			if (timeUntilResume) {
+				setTimeout(this.resumeHover, timeUntilResume);
+			}
+		},
+		resumeHover() {
+			this.hoverIsActive = true;
 		},
 	},
 };
 </script>
 
 <style lang="scss" scoped>
+@import 'settings';
+
 .expandable-loan-card-expanded {
-	position: absolute;
 	z-index: 1001;
+
+	@include breakpoint(small only) {
+		position: fixed;
+		background: $ghost;
+
+		/* !important is required since positioning for desktop is set in JS */
+		top: 0 !important;
+		left: 0 !important;
+		bottom: 0;
+		right: 0;
+		margin: 0;
+		padding: 0;
+
+		.loan-card-controller-component {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+		}
+	}
+
+	@include breakpoint(medium) {
+		position: absolute;
+	}
 }
 </style>

--- a/src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
+++ b/src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
@@ -1,0 +1,77 @@
+export default {
+	props: {
+		amountLeft: {
+			type: Number,
+			default: 0,
+		},
+		expiringSoonMessage: {
+			type: String,
+			default: '',
+		},
+		isFavorite: {
+			type: Boolean,
+			default: false,
+		},
+		isFunded: {
+			type: Boolean,
+			default: false,
+		},
+		isSelectedByAnother: {
+			type: Boolean,
+			default: false,
+		},
+		isVisitor: {
+			type: Boolean,
+			required: true,
+		},
+		itemsInBasket: {
+			type: Array,
+			default: () => [],
+		},
+		loan: {
+			type: Object,
+			default: () => {
+				return {
+					userProperties: {},
+					loanFundraisingInfo: {},
+					geocode: {
+						country: {},
+					},
+					image: {},
+				};
+			},
+		},
+		percentRaised: {
+			type: Number,
+			default: 0,
+		},
+		expanded: {
+			type: Boolean,
+			default: false,
+		},
+		categoryId: {
+			type: Number,
+			default: null,
+		},
+		categorySetId: {
+			type: String,
+			default: '',
+		},
+		rowNumber: {
+			type: Number,
+			default: null,
+		},
+		cardNumber: {
+			type: Number,
+			default: null,
+		},
+	},
+	methods: {
+		toggleFavorite() {
+			this.$emit('toggle-favorite');
+		},
+		trackInteraction(args) {
+			this.$emit('track-interaction', args);
+		},
+	},
+};

--- a/src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
+++ b/src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
@@ -65,6 +65,10 @@ export default {
 			type: Number,
 			default: null,
 		},
+		usingTouch: {
+			type: Boolean,
+			required: true,
+		},
 	},
 	methods: {
 		toggleFavorite() {

--- a/src/components/LoanCards/FundraisingStatus.vue
+++ b/src/components/LoanCards/FundraisingStatus.vue
@@ -56,16 +56,22 @@
 	}
 
 	.single-line {
-		align-items: baseline;
 		display: flex;
-		flex-direction: row;
+		flex-direction: row-reverse;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.625rem;
 
 		.fundraising-meter {
 			width: 60%;
+			margin: 0;
 		}
 
 		.left-and-to-go-line {
-			margin-left: rem-calc(8);
+			flex-shrink: 0;
+			color: $subtle-gray;
+			font-style: italic;
+			font-weight: $global-weight-normal;
 		}
 	}
 </style>

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -15,6 +15,12 @@
 		:percent-raised="percentRaised"
 		:title="title"
 		:is="loanCardType"
+
+		:expanded="expanded"
+		:category-id="categoryId"
+		:category-set-id="categorySetId"
+		:row-number="rowNumber"
+
 		@track-interaction="trackInteraction"
 		@toggle-favorite="toggleFavorite"
 		@add-to-basket="handleAddToBasket"
@@ -26,6 +32,8 @@
 import AdaptiveMicroLoanCard from '@/components/LoanCards/AdaptiveMicroLoanCard';
 import FeaturedHeroLoan from '@/components/LoansByCategory/FeaturedHeroLoan';
 import GridLoanCard from '@/components/LoanCards/GridLoanCard';
+import ExpandableLoanCardCollapsed from '@/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardCollapsed';
+import ExpandableLoanCard from '@/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard';
 import GridMicroLoanCard from '@/components/LoanCards/GridMicroLoanCard';
 import ListLoanCard from '@/components/LoanCards/ListLoanCard';
 import {
@@ -41,6 +49,8 @@ export default {
 		AdaptiveMicroLoanCard,
 		FeaturedHeroLoan,
 		GridLoanCard,
+		ExpandableLoanCard,
+		ExpandableLoanCardCollapsed,
 		GridMicroLoanCard,
 		ListLoanCard,
 	},
@@ -55,15 +65,15 @@ export default {
 		},
 		categoryId: {
 			type: Number,
-			default: null
+			default: null,
 		},
 		categorySetId: {
 			type: String,
-			default: ''
+			default: '',
 		},
 		rowNumber: {
 			type: Number,
-			default: null
+			default: null,
 		},
 		cardNumber: {
 			type: Number,
@@ -80,7 +90,7 @@ export default {
 					},
 					image: {},
 				};
-			}
+			},
 		},
 		isVisitor: {
 			type: Boolean,
@@ -92,7 +102,7 @@ export default {
 		},
 		imageEnhancementExperimentVersion: {
 			type: String,
-			default: ''
+			default: '',
 		},
 		experimentData: {
 			type: Object,
@@ -100,7 +110,11 @@ export default {
 		},
 		title: {
 			type: String,
-			default: ''
+			default: '',
+		},
+		expanded: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	inject: ['apollo'],
@@ -179,7 +193,7 @@ export default {
 					categoryId: this.categoryId,
 					row: this.rowNumber,
 					position: this.cardNumber,
-				}
+				},
 			};
 
 			this.$kvTrackSelfDescribingEvent(loanInteractionTrackData);
@@ -193,7 +207,7 @@ export default {
 				variables: {
 					loan_id: this.loan.id,
 					is_favorite: this.isFavorite
-				}
+				},
 			}).then(data => {
 				if (data.errors) {
 					this.isFavorite = !this.isFavorite;

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -20,6 +20,7 @@
 		:category-id="categoryId"
 		:category-set-id="categorySetId"
 		:row-number="rowNumber"
+		:using-touch="usingTouch"
 
 		@track-interaction="trackInteraction"
 		@toggle-favorite="toggleFavorite"
@@ -113,6 +114,10 @@ export default {
 			default: '',
 		},
 		expanded: {
+			type: Boolean,
+			default: false,
+		},
+		usingTouch: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/components/LoanCards/LoanCardImage.vue
+++ b/src/components/LoanCards/LoanCardImage.vue
@@ -12,10 +12,7 @@
 				:src = "formattedImageStandardUrl"
 				:alt = "'photo of ' + name"
 
-				@click="$emit('track-loan-card-interaction', {
-					interactionType: 'viewBorrowerPage',
-					interactionElement: 'photo'
-				})"
+				@click="handleImageClick"
 			>
 
 			<favorite-star class="favorite-star"
@@ -75,7 +72,11 @@ export default {
 		useDefaultStyles: {
 			type: Boolean,
 			default: true
-		}
+		},
+		disableLink: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	computed: {
@@ -89,16 +90,26 @@ export default {
 
 		linkTarget() {
 			return this.openInNewTab ? '_blank' : '_self';
-		}
+		},
 	},
 
 	methods: {
 		formatImageUrl(imageUrl, transformations) {
 			return (this.imageEnhancementExperimentVersion === 'variant-b' ? this.formatCloudinaryUrl(transformations) : imageUrl);  // eslint-disable-line
 		},
-
 		formatCloudinaryUrl(transformations) {
 			return `https://res.cloudinary.com/kiva/${transformations}/e_viesus_correct/e_sharpen:150/a_ignore,fl_progressive,q_auto:best/remote/${this.loanImageHash}.jpg`; // eslint-disable-line
+		},
+		handleImageClick(event) {
+			if (this.disableLink) {
+				event.preventDefault();
+				event.stopPropagation();
+				return;
+			}
+			this.$emit('track-loan-card-interaction', {
+				interactionType: 'viewBorrowerPage',
+				interactionElement: 'photo'
+			});
 		},
 	},
 };

--- a/src/components/LoansByCategory/CategoryRow.vue
+++ b/src/components/LoansByCategory/CategoryRow.vue
@@ -51,6 +51,7 @@
 						:enable-tracking="true"
 						:is-visitor="!isLoggedIn"
 						:image-enhancement-experiment-version="imageEnhancementExperimentVersion"
+						:using-touch="usingTouch"
 					/>
 
 					<div v-if="showViewAllLink" class="column column-block is-in-category-row view-all-loans-category">
@@ -130,6 +131,10 @@ export default {
 		showCategoryDescription: {
 			type: Boolean,
 			default: false
+		},
+		usingTouch: {
+			type: Boolean,
+			required: true,
 		},
 	},
 	data() {
@@ -248,12 +253,14 @@ export default {
 			if (this.scrollPos < 0) {
 				const newLeftMargin = Math.min(0, this.scrollPos + this.shiftIncrement);
 				this.scrollPos = newLeftMargin;
+				this.$emit('scrolling-row');
 			}
 		},
 		scrollRowRight() {
 			if (this.scrollPos > this.minLeftMargin) {
 				const newLeftMargin = this.scrollPos - this.shiftIncrement;
 				this.scrollPos = newLeftMargin;
+				this.$emit('scrolling-row');
 			}
 		},
 	},

--- a/src/components/LoansByCategory/CategoryRow.vue
+++ b/src/components/LoansByCategory/CategoryRow.vue
@@ -37,9 +37,8 @@
 					v-touch:swipe.left="scrollRowRight"
 					v-touch:swipe.right="scrollRowLeft"
 				>
-					<component
-						:is="loanCardType"
-						loan-card-type="GridLoanCard"
+					<loan-card-controller
+						:loan-card-type="loanCardType"
 						class="is-in-category-row"
 						v-for="(loan, index) in loans"
 						:key="loan.id"
@@ -120,9 +119,9 @@ export default {
 			type: String,
 			default: 'Control'
 		},
-		isMicro: {
+		showExpandableLoanCards: {
 			type: Boolean,
-			default: false
+			default: false,
 		},
 		imageEnhancementExperimentVersion: {
 			type: String,
@@ -146,7 +145,7 @@ export default {
 	},
 	computed: {
 		loanCardType() {
-			return this.isMicro ? 'GridMicroLoanCard' : 'LoanCardController';
+			return this.showExpandableLoanCards ? 'ExpandableLoanCardCollapsed' : 'GridLoanCard';
 		},
 		loanCardTypeKebabCase() {
 			return _kebabCase(this.loanCardType);

--- a/src/graphql/mutation/updateActiveLoan.graphql
+++ b/src/graphql/mutation/updateActiveLoan.graphql
@@ -1,0 +1,3 @@
+mutation updateActiveLoan($xCoordinate: Int, $yCoordinate: Int, $hoverLoanId: Int, $loan: String, $tracking: String) {
+	updateActiveLoan(xCoordinate: $xCoordinate, yCoordinate: $yCoordinate, hoverLoanId: $hoverLoanId, loan: $loan, tracking: $tracking ) @client
+}

--- a/src/graphql/query/activeLoanClient.graphql
+++ b/src/graphql/query/activeLoanClient.graphql
@@ -1,0 +1,9 @@
+query {
+	activeLoan @client {
+		xCoordinate
+		yCoordinate
+		loan
+		hoverLoanId
+		tracking
+	}
+}

--- a/src/graphql/query/lendByCategory/lendByCategory.graphql
+++ b/src/graphql/query/lendByCategory/lendByCategory.graphql
@@ -45,4 +45,5 @@ query($basketId: String) {
 			}
 		}
 	}
+	usingTouch @client
 }

--- a/src/pages/Lend/Filter/FilterComponents/LendFilterMenu.vue
+++ b/src/pages/Lend/Filter/FilterComponents/LendFilterMenu.vue
@@ -74,6 +74,7 @@ import FilterSectionLoanDetails from '@/pages/Lend/Filter/FilterSections/LoanDet
 import FilterSectionSort from '@/pages/Lend/Filter/FilterSections/FilterSectionSort';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvButton from '@/components/Kv/KvButton';
+import lockScrollUtils from '@/plugins/lock-scroll';
 
 export default {
 	components: {
@@ -92,6 +93,9 @@ export default {
 		KvIcon,
 		KvButton,
 	},
+	mixins: [
+		lockScrollUtils,
+	],
 	data() {
 		return {
 			filterMenuOpen: false,
@@ -117,12 +121,12 @@ export default {
 	},
 	methods: {
 		hideFilterMenu() {
-			this.unlockScroll();
+			this.unlockScrollSmallOnly();
 			this.filterMenuOpen = false;
 			this.$emit('hide-filter-menu');
 		},
 		toggleFilterMenu() {
-			this.lockScroll();
+			this.lockScrollSmallOnly();
 			this.filterMenuOpen = !this.filterMenuOpen;
 			this.$emit(this.filterMenuOpen ? 'show-filter-menu' : 'hide-filter-menu');
 		},
@@ -139,16 +143,6 @@ export default {
 		clearAllRefinements(refine) {
 			refine();
 			this.$emit('clear-custom-categories');
-		},
-		lockScroll() {
-			if (typeof window !== 'undefined') {
-				document.body.classList.add('scroll-locked-small-only');
-			}
-		},
-		unlockScroll() {
-			if (typeof window !== 'undefined') {
-				document.body.classList.remove('scroll-locked-small-only');
-			}
 		},
 	},
 };

--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -41,6 +41,8 @@
 				:image-enhancement-experiment-version="imageEnhancementExperimentVersion"
 				:show-category-description="showCategoryDescription"
 				:show-expandable-loan-cards="showExpandableLoanCards"
+				:using-touch="usingTouch"
+				@scrolling-row="handleScrollingRow"
 			/>
 		</div>
 
@@ -71,8 +73,10 @@
 
 		<expandable-loan-card-expanded
 			v-if="showExpandableLoanCards"
+			ref="expandableLoanCardComponent"
 			:is-visitor="!isLoggedIn"
 			:items-in-basket="itemsInBasket"
+			:using-touch="usingTouch"
 		/>
 	</www-page>
 </template>
@@ -309,6 +313,11 @@ export default {
 					this.itemsInBasket = _map(_get(data, 'shop.basket.items.values'), 'id');
 				},
 			});
+		},
+		handleScrollingRow() {
+			if (this.$refs.expandableLoanCardComponent) {
+				this.$refs.expandableLoanCardComponent.collapseCard();
+			}
 		},
 	},
 	apollo: {

--- a/src/plugins/active-loan-mixin.js
+++ b/src/plugins/active-loan-mixin.js
@@ -1,0 +1,89 @@
+import _get from 'lodash/get';
+import activeLoanClient from '@/graphql/query/activeLoanClient.graphql';
+import updateActiveLoan from '@/graphql/mutation/updateActiveLoan.graphql';
+
+const emptyActiveLoan = {
+	xCoordinate: 0,
+	yCoordinate: 0,
+	loan: JSON.stringify({
+		activity: {},
+		userProperties: {},
+		loanFundraisingInfo: {},
+		geocode: {
+			country: {},
+		},
+		image: {},
+	}),
+	hoverLoanId: 0,
+	tracking: JSON.stringify({}),
+};
+
+export default {
+	inject: ['apollo'],
+	data() {
+		return {
+			activeLoan: emptyActiveLoan,
+		};
+	},
+	computed: {
+		hoverLoan() {
+			return JSON.parse(this.activeLoan.loan);
+		},
+		hoverLoanXCoordinate() {
+			return this.activeLoan.xCoordinate;
+		},
+		hoverLoanYCoordinate() {
+			return this.activeLoan.yCoordinate;
+		},
+		tracking() {
+			return JSON.parse(this.activeLoan.tracking);
+		},
+	},
+	methods: {
+		setHoverLoan({
+			xCoordinate,
+			yCoordinate,
+			hoverLoanId,
+			loan,
+			tracking,
+		}) {
+			this.apollo.mutate({
+				mutation: updateActiveLoan,
+				variables: Object.assign({}, this.activeLoan, {
+					xCoordinate,
+					yCoordinate,
+					hoverLoanId,
+					loan,
+					tracking,
+				}),
+			});
+		},
+		clearHoverLoan() {
+			this.apollo.mutate({
+				mutation: updateActiveLoan,
+				variables: emptyActiveLoan,
+			});
+		},
+		onActiveLoanChange() {},
+		onActiveLoanClear() {},
+	},
+	mounted() {
+		this.apollo.watchQuery({ query: activeLoanClient }).subscribe({
+			next: ({ data }) => {
+				const activeLoanState = _get(data, 'activeLoan');
+				this.activeLoan = Object.assign({}, this.activeLoan, {
+					xCoordinate: activeLoanState.xCoordinate,
+					yCoordinate: activeLoanState.yCoordinate,
+					loan: activeLoanState.loan,
+					hoverLoanId: activeLoanState.hoverLoanId,
+					tracking: activeLoanState.tracking,
+				});
+				if (activeLoanState.hoverLoanId) {
+					this.onActiveLoanChange();
+				} else {
+					this.onActiveLoanClear();
+				}
+			},
+		});
+	},
+};

--- a/src/plugins/lock-scroll.js
+++ b/src/plugins/lock-scroll.js
@@ -1,0 +1,24 @@
+export default {
+	methods: {
+		lockScroll() {
+			if (typeof window !== 'undefined') {
+				document.body.classList.add('scroll-locked');
+			}
+		},
+		unlockScroll() {
+			if (typeof window !== 'undefined') {
+				document.body.classList.remove('scroll-locked');
+			}
+		},
+		lockScrollSmallOnly() {
+			if (typeof window !== 'undefined') {
+				document.body.classList.add('scroll-locked-small-only');
+			}
+		},
+		unlockScrollSmallOnly() {
+			if (typeof window !== 'undefined') {
+				document.body.classList.remove('scroll-locked-small-only');
+			}
+		},
+	},
+};

--- a/src/util/experimentPreFetch.js
+++ b/src/util/experimentPreFetch.js
@@ -9,6 +9,7 @@ const activeExperiments = [
 	'lend_filter',
 	'pinned_filter',
 	'algolia_search',
+	'expandable_loan_cards',
 ];
 
 // TODO: Enhance Error handling


### PR DESCRIPTION
This PR contains code for the basic desktop and mobile functionality of CASH-676. There are design/UX tweaks that will be incoming.
```
uiexp.expandable_loan_cards
string
{"name": "ExpandableLoanCards","enabled": true,"startTime": "2018-08-29T00:00","endTime": "2020-02-16T15:00","control": {"key": "variant-a","name": "Control (variant-a)"},"variants": {"variant-b": {"name": "Expandable Loan Cards"}},"distribution": {"variant-a": 0.5,"variant-b": 0.5}}
CASH-676: Expandable Loan Cards
```