### PR TITLE
CASH-676: Allow tapping partially offscreen loans on phone but not tablet

### DIFF
--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
@@ -64,7 +64,9 @@ export default {
 		},
 		shouldNotExpandCard() {
 			const isUnderArrowOnDesktop = this.arrowsVisible() && this.isUnderArrow;
-			const isOffScreenOnTablet = (this.hoverLoanXCoordinate + 254) > document.documentElement.clientWidth;
+			const isOffScreenOnTablet =
+				document.documentElement.clientWidth > 480
+				&& (this.hoverLoanXCoordinate + 254) > document.documentElement.clientWidth;
 			return !this.hoverIsActive || isUnderArrowOnDesktop || isOffScreenOnTablet;
 		},
 	},


### PR DESCRIPTION
* Since tapping loans on small breakpoint takes over the screen we can allow tapping partially offscreen loans