### PR TITLE
Update usingTouch

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -5,7 +5,6 @@ import _get from 'lodash/get';
 import cookieStore from '@/util/cookieStore';
 import KvAuth0, { MockKvAuth0 } from '@/util/KvAuth0';
 import userIdQuery from '@/graphql/query/userId.graphql';
-import usingTouchMutation from '@/graphql/mutation/updateUsingTouch.graphql';
 import { preFetchAll } from '@/util/apolloPreFetch';
 import createApp from '@/main';
 import '@/assets/iconLoader';
@@ -63,15 +62,6 @@ app.$setKvAnalyticsData(userId);
 
 // fire server rendered pageview
 app.$fireServerPageView();
-
-// Setup adding touch info to the state
-window.addEventListener('touchstart', function onFirstTouch() {
-	apolloClient.mutate({
-		mutation: usingTouchMutation,
-		variables: { usingTouch: true }
-	});
-	window.removeEventListener('touchstart', onFirstTouch);
-});
 
 // Wait until router has resolved all async before hooks and async components
 router.onReady(() => {

--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -16,6 +16,7 @@
 
 <script>
 import _get from 'lodash/get';
+import usingTouchMutation from '@/graphql/mutation/updateUsingTouch.graphql';
 import { fetchAllExpSettings } from '@/util/experimentPreFetch';
 import CookieBanner from '@/components/WwwFrame/CookieBanner';
 import TheHeader from './TheHeader';
@@ -53,7 +54,16 @@ export default {
 				path: _get(args, 'route.path')
 			});
 		}
-	}
+	},
+	mounted() {
+		const usingTouch =
+			('ontouchstart' in window)
+			|| window.TouchEvent;
+		this.apollo.mutate({
+			mutation: usingTouchMutation,
+			variables: { usingTouch }
+		});
+	},
 };
 </script>
 


### PR DESCRIPTION
* Waiting for the first touch event resulted in too long a period where `usingTouch` was incorrectly false. This caused issues in CASH-676 (specifically in tracking which requires knowing if the user is using a touch device).
* This is based on modernizr, removing the deprecated `window.DocumentTouch`: https://github.com/Modernizr/Modernizr/blob/7599d26b7fd49cacad297cd3cf824b9133d76d69/feature-detects/touchevents.js#L39-L40