### PR TITLE
CASH-922: Add layer to dismiss expanded card for tablet

### DIFF
--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
@@ -1,23 +1,31 @@
 <template>
-	<div
-		class="expandable-loan-card-expanded column column-block"
-		v-show="show"
-		@mouseleave="clearHoverLoan"
-		ref="expandedContainer"
-	>
-		<loan-card-controller
-			class="loan-card-controller-component"
-			loan-card-type="ExpandableLoanCard"
-			:loan="hoverLoan"
-			:items-in-basket="itemsInBasket"
-			:category-id="tracking.categoryId"
-			:category-set-id="tracking.categorySetId"
-			:row-number="tracking.rowNumber"
-			:card-number="tracking.cardNumber"
-			:enable-tracking="true"
-			:is-visitor="isVisitor"
-			:expanded="expanded"
-		/>
+	<div class="expandable-loan-card-expanded">
+		<div
+			class="expandable-loan-card-expanded-container column column-block"
+			v-show="show"
+			@mouseleave="clearHoverLoan"
+			ref="expandedContainer"
+		>
+			<loan-card-controller
+				class="loan-card-controller-component"
+				loan-card-type="ExpandableLoanCard"
+				:loan="hoverLoan"
+				:items-in-basket="itemsInBasket"
+				:category-id="tracking.categoryId"
+				:category-set-id="tracking.categorySetId"
+				:row-number="tracking.rowNumber"
+				:card-number="tracking.cardNumber"
+				:enable-tracking="true"
+				:is-visitor="isVisitor"
+				:expanded="expanded"
+			/>
+		</div>
+		<div
+			class="expandable-loan-card-expanded-tablet-overlay show-for-medium"
+			v-if="hoverLoanId"
+			@click="clearHoverLoan"
+		>
+		</div>
 	</div>
 </template>
 
@@ -165,30 +173,52 @@ export default {
 @import 'settings';
 
 .expandable-loan-card-expanded {
-	z-index: 1001;
+	.expandable-loan-card-expanded-container {
+		z-index: 1001;
 
-	@include breakpoint(small only) {
-		position: fixed;
-		background: $ghost;
+		@include breakpoint(small only) {
+			position: fixed;
+			background: $ghost;
 
-		/* !important is required since positioning for desktop is set in JS */
-		top: 0 !important;
-		left: 0 !important;
-		bottom: 0;
-		right: 0;
-		margin: 0;
-		padding: 0;
-
-		.loan-card-controller-component {
-			position: absolute;
-			top: 0;
-			left: 0;
+			/* !important is required since positioning for desktop is set in JS */
+			top: 0 !important;
+			left: 0 !important;
+			bottom: 0;
 			right: 0;
+			margin: 0;
+			padding: 0;
+
+			.loan-card-controller-component {
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 0;
+			}
+		}
+
+		@include breakpoint(medium) {
+			position: absolute;
 		}
 	}
 
+	.expandable-loan-card-expanded-tablet-overlay {
+		display: none;
+		pointer-events: none;
+	}
+
 	@include breakpoint(medium) {
-		position: absolute;
+		@media (hover: none) {
+			.expandable-loan-card-expanded-tablet-overlay {
+				display: block;
+				pointer-events: initial;
+				position: fixed;
+				z-index: 1000;
+				top: 0;
+				bottom: 0;
+				left: 0;
+				right: 0;
+			}
+		}
 	}
 }
 </style>

--- a/src/plugins/active-loan-mixin.js
+++ b/src/plugins/active-loan-mixin.js
@@ -27,6 +27,9 @@ export default {
 		hoverLoan() {
 			return JSON.parse(this.activeLoan.loan);
 		},
+		hoverLoanId() {
+			return this.activeLoan.hoverLoanId;
+		},
 		hoverLoanXCoordinate() {
 			return this.activeLoan.xCoordinate;
 		},


### PR DESCRIPTION
* We were initially depending on a user to tap on another loan card to collapse the expanded loan card. This PR adds an invisible layer that's only visible when (1) A loan is expanded (2) Screen size is >480px and (3) CSS hover doesn't exist (tablet)