### PR TITLE
Fix post-auth team redirect

### DIFF
--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -85,12 +85,13 @@ module.exports = function authRouter(config = {}) {
 
 	// For all other routes, check the login sync cookie to see if login or logout is needed
 	router.use((req, res, next) => {
-		if (req.path === '/process-browser-auth') {
+		// don't try to perform login sync for the following paths
+		const bypassPaths = ['/error', '/join-team', '/process-browser-auth', '/register/social'];
+		if (bypassPaths.includes(req.path)) {
 			next();
 		} else if (isNotedLoggedIn(req) && !req.user) {
 			// Store current url to redirect to after auth
 			req.session.doneUrl = req.originalUrl;
-
 			// Attempt silent authentication (prompt=none)
 			passport.authenticate('auth0', {
 				audience: config.auth0.apiAudience,

--- a/server/util/getSessionCookies.js
+++ b/server/util/getSessionCookies.js
@@ -1,10 +1,20 @@
 const fetch = require('./fetch');
 const setCookieParser = require('set-cookie-parser');
 
+const getCookieString = cookies => {
+	return Object.keys(cookies)
+		.map(key => `${key}=${cookies[key]}`)
+		.join(';');
+};
+
 module.exports = function getSessionCookies(url = '', requestCookies = {}) {
 	return new Promise((resolve, reject) => {
 		if (url.length && (!requestCookies.kv || !requestCookies.kvis || !requestCookies.kvbskt)) {
-			fetch(url).then(res => {
+			fetch(url, {
+				headers: {
+					Cookie: getCookieString(requestCookies),
+				},
+			}).then(res => {
 				const setCookies = res.headers.getAll('set-cookie');
 				const parsed = setCookieParser(setCookies);
 				const cookies = parsed.reduce((cookieObject, cookie) => {

--- a/src/components/WwwFrame/EndOfYearAppealBanner/AppealBanner.vue
+++ b/src/components/WwwFrame/EndOfYearAppealBanner/AppealBanner.vue
@@ -127,7 +127,7 @@ export default {
 	computed: {
 		showAppeal() {
 			// make sure the appeal is enable + we're not on certain blacklisted pages
-			const blacklist = ['/checkout', '/error', '/register/social'];
+			const blacklist = ['/checkout', '/error', '/join-team', '/register/social'];
 			return (this.appealEnabled || this.appealMatchEnabled) && !blacklist.includes(this.$route.path);
 		},
 	},


### PR DESCRIPTION
Login sync was forcing users to go through the post-auth flow twice, causing the double team invite. Also, certain cookies being missing caused a new session to be generated, which would cause the invite handling to be skipped.