### PR TITLE
Ensure paypal credit payments are not allowed. This prevents paypal f…

### DIFF
--- a/src/components/Checkout/PayPalExpress.vue
+++ b/src/components/Checkout/PayPalExpress.vue
@@ -251,6 +251,9 @@ export default {
 						shape: 'rect',
 						size: (typeof window === 'object' && window.innerWidth > 480) ? 'medium' : 'responsive',
 						fundingicons: !this.showBraintree
+					},
+					funding: {
+						disallowed: [paypal.FUNDING.CREDIT]
 					}
 				},
 				'#paypal-button'


### PR DESCRIPTION
…rom injecting a second 'Credit' button beside the paypal button. Guest checkout is still active with this setting in place.