### PR TITLE
Ensure global Vue instance is clean when imported in the app

### DIFF
--- a/server/util/clearCachedVueModule.js
+++ b/server/util/clearCachedVueModule.js
@@ -1,0 +1,11 @@
+module.exports = () => {
+	const vueModuleId = require.resolve('vue');
+	const vueModule = require.cache[vueModuleId];
+	const vueRuntimeModuleId = vueModule
+		&& vueModule.children
+		&& vueModule.children[0]
+		&& vueModule.children[0].id;
+
+	delete require.cache[vueRuntimeModuleId];
+	delete require.cache[vueModuleId];
+};

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const cookie = require('cookie');
 const { createBundleRenderer } = require('vue-server-renderer');
+const clearCachedVueModule = require('./util/clearCachedVueModule');
 const getGqlFragmentTypes = require('./util/getGqlFragmentTypes');
 const getSessionCookies = require('./util/getSessionCookies');
 const vueSsrCache = require('./util/vueSsrCache');
@@ -85,6 +86,8 @@ module.exports = function createMiddleware({
 				context.cookies = Object.assign(context.cookies, cookieInfo.cookies);
 				// forward any newly fetched 'Set-Cookie' headers
 				cookieInfo.setCookies.forEach(setCookie => res.append('Set-Cookie', setCookie));
+				// Clear module cache of global Vue instance to ensure clean render
+				clearCachedVueModule();
 				// render the app
 				return renderer.renderToString(context);
 			}).then(html => {


### PR DESCRIPTION
This removes the cached Vue module before the server-bundle is processed, ensuring that the next call to import Vue will return a fresh instance with no plugins installed yet (which will resolve the InvariantError caused by the apollo-plugin being installed multiple times)