### PR TITLE
Remove unused styles

### DIFF
--- a/src/components/LoanCards/AdaptiveMicroLoanCard.vue
+++ b/src/components/LoanCards/AdaptiveMicroLoanCard.vue
@@ -188,18 +188,6 @@ export default {
 		flex-direction: column;
 		justify-content: space-between;
 	}
-
-	.borrower-image-wrapper {
-		width: 50%;
-		height: auto;
-		margin: 0;
-		padding: 0;
-
-		@include breakpoint(medium) {
-			width: 100%;
-			max-height: rem-calc(132);
-		}
-	}
 }
 
 .minimal-loan-card-data-wrap {


### PR DESCRIPTION
These styles aren't applied since the SASS is `scoped`. I added them manually in prod and none of them made a difference to the styling except for `padding: 0`, which if actually applied broke the image altogether.