### PR TITLE
Ensure window.performance is an object and has the timing data before…

### DIFF
--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -37,11 +37,11 @@ export default Vue => {
 					'trackPageView',
 					null,
 					// Include context on pageview for performance
-					[{
+					typeof window.performance === 'object' && window.performance.timing ? [{
 						// eslint-disable-next-line
 						schema: 'https://github.com/snowplow/iglu-central/blob/master/schemas/org.w3/PerformanceTiming/jsonschema/1-0-0',
 						data: window.performance.timing,
-					}],
+					}] : null,
 				);
 			}
 


### PR DESCRIPTION
… using. Should address frequent errors in Opera Mini https://sentry.io/organizations/kiva/issues/1007731541/events/1e64639a1500405d8c2853b9bc3bce38/?project=1201288&query=is%3Aunresolved