### PR TITLE
Update loan channel queries to not specify false filters.

### DIFF
--- a/src/graphql/query/categoryAdminControl.graphql
+++ b/src/graphql/query/categoryAdminControl.graphql
@@ -1,6 +1,6 @@
 query categoryAdminControl {
 	lend {
-		loanChannels(offset:0, limit:1000, popular: false, applyMinLoanCount: false) {
+		loanChannels(offset:0, limit:1000) {
 			totalCount
 			values {
 				id

--- a/src/graphql/query/loanChannelPage.graphql
+++ b/src/graphql/query/loanChannelPage.graphql
@@ -5,7 +5,7 @@ query loanChannelPage {
 		}
 	}
 	lend {
-		loanChannels(offset:0, limit:1000, popular: false, applyMinLoanCount: false) {
+		loanChannels(offset:0, limit:1000) {
 			totalCount
 			values {
 				id


### PR DESCRIPTION
@foochris The updates made to loan channel queries changed the way the popular: false mechanism works in an unexpected way. It seems that specifying 'false' now excludes the loan channels that are marked as popular. Removing the filter altogether got this working again.

Current state is popular categories are broken on dev, see -> /lend-by-category/education