### PR TITLE
CASH-960: Add row animations for cards to move out of the way

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -2,11 +2,15 @@
 	<div
 		class="hover-loan-card"
 		:class="{
-			'row-has-detailed-loan-cache-id': rowHasDetailedLoanCacheId,
+			expanded,
+			'row-has-detailed-loan': rowHasDetailedLoan,
 			'is-detailed': isDetailed,
+			'shift-left': shiftLeft,
+			'shift-left-double': shiftLeftDouble,
+			'shift-right': shiftRight,
+			'shift-right-double': shiftRightDouble,
 		}"
 		@mouseenter="handleMouseEnter"
-		@mouseleave="handleMouseLeave"
 	>
 		<div
 			class="hover-loan-card-wrapper"
@@ -32,7 +36,7 @@
 			<div
 				class="more-details-wrapper"
 				:class="{expanded}"
-				@click="updateDetailedLoanCacheId"
+				@click="updateDetailedLoanIndex"
 			>
 				<kv-icon class="more-details-arrow" name="medium-chevron" />
 			</div>
@@ -53,6 +57,10 @@ export default {
 		KvIcon,
 	},
 	props: {
+		cardNumber: {
+			type: Number,
+			default: null,
+		},
 		expiringSoonMessage: {
 			type: String,
 			default: ''
@@ -69,31 +77,46 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-		detailedLoanCacheId: {
-			type: String,
+		detailedLoanIndex: {
+			type: Number,
 			default: null,
 		},
-		hoverLoanCacheId: {
-			type: String,
+		hoverLoanIndex: {
+			type: Number,
 			default: null,
+		},
+		shiftIncrement: {
+			type: Number,
+			default: 0,
 		},
 	},
 	computed: {
 		expanded() {
-			return !this.rowHasDetailedLoanCacheId && this.hover;
+			return !this.rowHasDetailedLoan && this.hover;
 		},
 		hover() {
-			return this.loanCacheId === this.hoverLoanCacheId;
+			return this.loanIndex === this.hoverLoanIndex;
 		},
 		isDetailed() {
-			return this.loanCacheId === this.detailedLoanCacheId;
+			return this.loanIndex === this.detailedLoanIndex;
 		},
-		loanCacheId() {
-			// eslint-disable-next-line no-underscore-dangle
-			return `${this.loan.__typename}:${this.loan.id}`;
+		loanIndex() {
+			return this.cardNumber - 1;
 		},
-		rowHasDetailedLoanCacheId() {
-			return this.detailedLoanCacheId !== null;
+		rowHasDetailedLoan() {
+			return this.detailedLoanIndex !== null;
+		},
+		shiftLeft() {
+			return this.shiftIncrement === -1;
+		},
+		shiftLeftDouble() {
+			return this.shiftIncrement === -2;
+		},
+		shiftRight() {
+			return this.shiftIncrement === 1;
+		},
+		shiftRightDouble() {
+			return this.shiftIncrement === 2;
 		},
 	},
 	mixins: [
@@ -101,19 +124,16 @@ export default {
 	],
 	methods: {
 		handleMouseEnter() {
-			if (this.rowHasDetailedLoanCacheId && !this.isDetailed) {
-				this.updateDetailedLoanCacheId();
+			if (this.rowHasDetailedLoan && !this.isDetailed) {
+				this.updateDetailedLoanIndex();
 			}
-			this.updateHoverLoanCacheId(true);
+			this.updateHoverLoanIndex();
 		},
-		handleMouseLeave() {
-			this.updateHoverLoanCacheId(false);
+		updateHoverLoanIndex() {
+			this.$emit('update-hover-loan-index', this.loanIndex);
 		},
-		updateHoverLoanCacheId(hover) {
-			this.$emit('update-hover-loan-cache-id', hover ? this.loanCacheId : null);
-		},
-		updateDetailedLoanCacheId() {
-			this.$emit('update-detailed-loan-cache-id', this.loanCacheId);
+		updateDetailedLoanIndex() {
+			this.$emit('update-detailed-loan-index', this.loanIndex);
 		},
 	},
 };
@@ -124,19 +144,28 @@ export default {
 
 .hover-loan-card {
 	$chevron-animation-duration: 0.2s;
-	$card-expansion-duration: 0.2s;
+	$card-expansion-duration: 0.15s;
+	$card-expansion-curve: linear;
+	$chevron-animation-out: $chevron-animation-duration linear;
+	$chevron-animation-in: $chevron-animation-out $card-expansion-duration;
 
 	padding: rem-calc(25) rem-calc(10) rem-calc(41) rem-calc(10);
-	transition: padding-bottom $card-expansion-duration linear;
+
+	/*
+		Using variables due to:
+		1) Limitations disabling max-len in eslint in SASS
+		2) Incorrect SASS transpilation when using multi-line
+	*/
+	$transition1: padding-bottom $card-expansion-duration $card-expansion-curve;
+	$transition2: transform $card-expansion-duration $card-expansion-curve;
+
+	transition: $transition1, $transition2;
 
 	.hover-loan-card-wrapper {
 		position: relative;
 		transition: opacity $card-expansion-duration ease-out;
 
 		.more-details-wrapper {
-			$chevron-animation-out: $chevron-animation-duration linear;
-			$chevron-animation-in: $chevron-animation-out $card-expansion-duration;
-
 			position: absolute;
 			bottom: rem-calc(-50);
 			left: 50%;
@@ -151,20 +180,49 @@ export default {
 				width: rem-calc(30);
 				height: rem-calc(12);
 			}
+		}
+	}
 
-			&.expanded {
+	&.shift-left {
+		transform: translateX(-200px);
+	}
+
+	&.shift-left-double {
+		transform: translateX(-400px);
+	}
+
+	&.shift-right {
+		transform: translateX(200px);
+	}
+
+	&.shift-right-double {
+		transform: translateX(400px);
+	}
+
+	&.expanded {
+		z-index: 1;
+
+		.hover-loan-card-wrapper {
+			.more-details-wrapper {
 				opacity: 1;
 				transform: translate(-50%, 0);
 				pointer-events: initial;
-				transition:
-					opacity $chevron-animation-in,
-					transform $chevron-animation-in,
-					pointer-events 0 linear $card-expansion-duration;
+
+				/*
+					Using variables due to:
+					1) Limitations disabling max-len in eslint in SASS
+					2) Incorrect SASS transpilation when using multi-line
+				*/
+				$transition1: opacity $chevron-animation-in;
+				$transition2: transform $chevron-animation-in;
+				$transition3: pointer-events 0s linear $card-expansion-duration;
+
+				transition: $transition1, $transition2, $transition3;
 			}
 		}
 	}
 
-	&.row-has-detailed-loan-cache-id {
+	&.row-has-detailed-loan {
 		padding-bottom: rem-calc(9);
 
 		.hover-loan-card-wrapper {

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -107,16 +107,16 @@ export default {
 			return this.detailedLoanIndex !== null;
 		},
 		shiftLeft() {
-			return this.shiftIncrement === -1;
+			return !this.rowHasDetailedLoan && this.shiftIncrement === -1;
 		},
 		shiftLeftDouble() {
-			return this.shiftIncrement === -2;
+			return !this.rowHasDetailedLoan && this.shiftIncrement === -2;
 		},
 		shiftRight() {
-			return this.shiftIncrement === 1;
+			return !this.rowHasDetailedLoan && this.shiftIncrement === 1;
 		},
 		shiftRightDouble() {
-			return this.shiftIncrement === 2;
+			return !this.rowHasDetailedLoan && this.shiftIncrement === 2;
 		},
 	},
 	mixins: [

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -135,11 +135,11 @@ export default {
 @import "settings";
 
 .hover-loan-card-large {
-	$card-expansion-duration: 0.2s;
+	$card-expansion-duration: 0.15s;
+	$card-expansion-curve: linear;
 
 	background: $white;
 	flex-shrink: 0;
-	transition: transform $card-expansion-duration ease-in, opacity $card-expansion-duration ease-out;
 	width: rem-calc(580);
 	height: rem-calc(250);
 	display: flex;
@@ -151,6 +151,18 @@ export default {
 	transform: scale(1, 1);
 	opacity: 1;
 	z-index: 1;
+	pointer-events: initial;
+
+	/*
+		Using variables due to:
+		1) Limitations disabling max-len in eslint in SASS
+		2) Incorrect SASS transpilation when using multi-line
+	*/
+	$transition1: transform $card-expansion-duration $card-expansion-curve;
+	$transition2: opacity $card-expansion-duration ease-out;
+	$transition3: pointer-events 0s linear $card-expansion-duration;
+
+	transition: $transition1, $transition2, $transition3;
 
 	.hover-loan-card-image {
 		/* Design width: 332px */
@@ -183,6 +195,9 @@ export default {
 				overflow: hidden;
 				text-overflow: ellipsis;
 				font-weight: 500;
+
+				/* Next line prevents a weird visual bug on chrome */
+				margin-top: rem-calc(1);
 			}
 		}
 
@@ -204,8 +219,7 @@ export default {
 		transform: scale(calc(9 / 29), 0.9);
 		opacity: 0;
 		pointer-events: none;
-		// Comment line below for original transition
-		transition: transform $card-expansion-duration ease-out, opacity $card-expansion-duration ease-in;
+		transition: transform $card-expansion-duration $card-expansion-curve, opacity $card-expansion-duration ease-in;
 	}
 }
 </style>

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
@@ -55,7 +55,8 @@ export default {
 @import "settings";
 
 .hover-loan-card-small {
-	$card-expansion-duration: 0.2s;
+	$card-expansion-duration: 0.15s;
+	$card-expansion-curve: linear;
 
 	width: rem-calc(180);
 	background: $white;
@@ -66,9 +67,18 @@ export default {
 	border-radius: rem-calc(3);
 	transform: scale(1, 1);
 	opacity: 1;
-	// Swap comments on lines below for original transition
-	transition: transform $card-expansion-duration ease-out, opacity $card-expansion-duration ease-in;
-	// transition: transform $card-expansion-duration ease-in, opacity $card-expansion-duration ease-out;
+	pointer-events: initial;
+
+	/*
+		Using variables due to:
+		1) Limitations disabling max-len in eslint in SASS
+		2) Incorrect SASS transpilation when using multi-line
+	*/
+	$transition1: transform $card-expansion-duration $card-expansion-curve;
+	$transition2: opacity $card-expansion-duration ease-in;
+	$transition3: pointer-events 0s linear $card-expansion-duration;
+
+	transition: $transition1, $transition2, $transition3;
 
 	.hover-loan-card-image {
 		border-radius: rem-calc(3) rem-calc(3) 0 0;
@@ -108,10 +118,11 @@ export default {
 	}
 
 	&.expanded {
-		transform: scale(calc(29 / 9), calc(10 / 9));
+		// Re-enable next line to add card expansion animation
+		// transform: scale(calc(29 / 9), calc(10 / 9));
 		opacity: 0;
-		// Comment line below for original transition
-		transition: transform $card-expansion-duration ease-in, opacity $card-expansion-duration ease-out;
+		pointer-events: none;
+		transition: transform $card-expansion-duration $card-expansion-curve, opacity $card-expansion-duration ease-out;
 	}
 }
 </style>

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -29,11 +29,12 @@
 		:right-arrow-position="rightArrowPosition"
 		:left-arrow-position="leftArrowPosition"
 
-		:detailed-loan-cache-id="detailedLoanCacheId"
-		:hover-loan-cache-id="hoverLoanCacheId"
+		:detailed-loan-index="detailedLoanIndex"
+		:hover-loan-index="hoverLoanIndex"
+		:shift-increment="shiftIncrement"
 
-		@update-detailed-loan-cache-id="updateDetailedLoanCacheId"
-		@update-hover-loan-cache-id="updateHoverLoanCacheId"
+		@update-detailed-loan-index="updateDetailedLoanIndex"
+		@update-hover-loan-index="updateHoverLoanIndex"
 	/>
 	<!--
 		Blocks of attributes above:
@@ -143,13 +144,17 @@ export default {
 			type: Number,
 			default: undefined,
 		},
-		detailedLoanCacheId: {
-			type: String,
+		detailedLoanIndex: {
+			type: Number,
 			default: null,
 		},
-		hoverLoanCacheId: {
-			type: String,
+		hoverLoanIndex: {
+			type: Number,
 			default: null,
+		},
+		shiftIncrement: {
+			type: Number,
+			default: 0,
 		},
 	},
 	inject: ['apollo'],
@@ -276,11 +281,11 @@ export default {
 		handleAddToBasket(payload) {
 			this.$emit('add-to-basket', payload);
 		},
-		updateDetailedLoanCacheId(loanCacheId) {
-			this.$emit('update-detailed-loan-cache-id', loanCacheId);
+		updateDetailedLoanIndex(detailedLoanIndex) {
+			this.$emit('update-detailed-loan-index', detailedLoanIndex);
 		},
-		updateHoverLoanCacheId(loanCacheId) {
-			this.$emit('update-hover-loan-cache-id', loanCacheId);
+		updateHoverLoanIndex(hoverLoanIndex) {
+			this.$emit('update-hover-loan-index', hoverLoanIndex);
 		},
 	},
 };

--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -36,6 +36,7 @@
 			<component
 				:is="categoryRowType"
 				class="loan-category-row"
+				:class="{'hover-row': showHoverLoanCards}"
 				v-for="(category, index) in categories"
 				:key="category.id"
 				:loan-channel="category"
@@ -618,6 +619,10 @@ export default {
 
 		@include breakpoint(medium) {
 			margin: 0 0 rem-calc(40);
+		}
+
+		&.hover-row {
+			margin: 0 0 1rem;
 		}
 
 		&:last-of-type {


### PR DESCRIPTION
Additions:
* Add (and do tons of tweaks to) animations for cards to move out of the way
* Only pass loan card index to CategoryRowHover to ease math of card movement
* Simplify transitions to use more variables to allow further fine tweaking

Fixes:
* Disable pointer events during transition from small to large card
* Move mouseleave events to row level to make all animations much more smooth
* Fix visual bug causing a jumping flag on Chrome

Expandable loan panel support:
* Adjust bottom of CategoryRowHover for better loan panel placement
* Add computed detailedLoanCacheId to CategoryRowHover for loan panel use

Note: Another PR is required to handle loans at ends of the row