### PR TITLE
CASH-960: Add support for end cards

### DIFF
--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
@@ -83,6 +83,7 @@ import FundraisingStatus from '@/components/LoanCards/FundraisingStatus';
 import LoanCardImage from '@/components/LoanCards/LoanCardImage';
 import MatchingText from '@/components/LoanCards/MatchingText';
 import expandableLoanCardMixin from '@/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin';
+import categoryRowArrowsVisibleMixin from '@/plugins/category-row-arrows-visible-mixin';
 import KvIcon from '@/components/Kv/KvIcon';
 
 export default {
@@ -98,6 +99,7 @@ export default {
 	mixins: [
 		expandableLoanCardMixin,
 		activeLoanMixin,
+		categoryRowArrowsVisibleMixin,
 	],
 	computed: {
 		disableImageLink() {
@@ -105,23 +107,7 @@ export default {
 			We are using the lack of CSS hover support to gate the visibility of the arrows. That doesn't sync with
 			usingTouch unfortunately.
 			*/
-			return !this.arrowsVisible() && !this.expanded;
-		},
-	},
-	methods: {
-		arrowsVisible() {
-			/*
-			We are using the lack of CSS hover support to gate the visibility of the arrows. That doesn't sync with
-			usingTouch unfortunately.
-			*/
-			if (typeof window === 'undefined' || typeof document === 'undefined') {
-				return true;
-			}
-			const rightArrow = document.querySelector('.arrow.right-arrow');
-			if (!rightArrow) {
-				return true;
-			}
-			return window.getComputedStyle(rightArrow).display !== 'none';
+			return !this.categoryRowArrowsVisible() && !this.expanded;
 		},
 	},
 };

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCardExpanded.vue
@@ -34,6 +34,7 @@ import _get from 'lodash/get';
 import activeLoanClient from '@/graphql/query/activeLoanClient.graphql';
 import activeLoanMixin from '@/plugins/active-loan-mixin';
 import lockScrollUtils from '@/plugins/lock-scroll';
+import categoryRowArrowsVisibleMixin from '@/plugins/category-row-arrows-visible-mixin';
 import LoanCardController from '@/components/LoanCards/LoanCardController';
 
 export default {
@@ -43,6 +44,7 @@ export default {
 	mixins: [
 		activeLoanMixin,
 		lockScrollUtils,
+		categoryRowArrowsVisibleMixin,
 	],
 	props: {
 		isVisitor: {
@@ -73,7 +75,7 @@ export default {
 			return this.leftArrowPosition !== undefined && this.hoverLoanXCoordinate < this.leftArrowPosition;
 		},
 		shouldNotExpandCard() {
-			const isUnderArrowOnDesktop = this.arrowsVisible() && this.isUnderArrow;
+			const isUnderArrowOnDesktop = this.categoryRowArrowsVisible() && this.isUnderArrow;
 			const isOffScreenOnTablet = document.documentElement.clientWidth > 480
 				&& (this.hoverLoanXCoordinate + 254) > document.documentElement.clientWidth;
 			return !this.hoverIsActive || isUnderArrowOnDesktop || isOffScreenOnTablet;
@@ -125,20 +127,6 @@ export default {
 		},
 		resumeHover() {
 			this.hoverIsActive = true;
-		},
-		arrowsVisible() {
-			/*
-			We are using the lack of CSS hover support to gate the visibility of the arrows. That doesn't sync with
-			usingTouch unfortunately.
-			*/
-			if (typeof window === 'undefined' || typeof document === 'undefined') {
-				return true;
-			}
-			const rightArrow = document.querySelector('.arrow.right-arrow');
-			if (!rightArrow) {
-				return true;
-			}
-			return window.getComputedStyle(rightArrow).display !== 'none';
 		},
 	},
 	mounted() {

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -151,11 +151,6 @@ export default {
 
 	padding: rem-calc(25) rem-calc(10) rem-calc(41) rem-calc(10);
 
-	/*
-		Using variables due to:
-		1) Limitations disabling max-len in eslint in SASS
-		2) Incorrect SASS transpilation when using multi-line
-	*/
 	$transition1: padding-bottom $card-expansion-duration $card-expansion-curve;
 	$transition2: transform $card-expansion-duration $card-expansion-curve;
 
@@ -208,16 +203,10 @@ export default {
 				transform: translate(-50%, 0);
 				pointer-events: initial;
 
-				/*
-					Using variables due to:
-					1) Limitations disabling max-len in eslint in SASS
-					2) Incorrect SASS transpilation when using multi-line
-				*/
 				$transition1: opacity $chevron-animation-in;
 				$transition2: transform $chevron-animation-in;
-				$transition3: pointer-events 0s linear $card-expansion-duration;
 
-				transition: $transition1, $transition2, $transition3;
+				transition: $transition1, $transition2;
 			}
 		}
 	}

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -153,16 +153,10 @@ export default {
 	z-index: 1;
 	pointer-events: initial;
 
-	/*
-		Using variables due to:
-		1) Limitations disabling max-len in eslint in SASS
-		2) Incorrect SASS transpilation when using multi-line
-	*/
 	$transition1: transform $card-expansion-duration $card-expansion-curve;
 	$transition2: opacity $card-expansion-duration ease-out;
-	$transition3: pointer-events 0s linear $card-expansion-duration;
 
-	transition: $transition1, $transition2, $transition3;
+	transition: $transition1, $transition2;
 
 	.hover-loan-card-image {
 		/* Design width: 332px */

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
@@ -69,16 +69,10 @@ export default {
 	opacity: 1;
 	pointer-events: initial;
 
-	/*
-		Using variables due to:
-		1) Limitations disabling max-len in eslint in SASS
-		2) Incorrect SASS transpilation when using multi-line
-	*/
 	$transition1: transform $card-expansion-duration $card-expansion-curve;
 	$transition2: opacity $card-expansion-duration ease-in;
-	$transition3: pointer-events 0s linear $card-expansion-duration;
 
-	transition: $transition1, $transition2, $transition3;
+	transition: $transition1, $transition2;
 
 	.hover-loan-card-image {
 		border-radius: rem-calc(3) rem-calc(3) 0 0;

--- a/src/plugins/category-row-arrows-visible-mixin.js
+++ b/src/plugins/category-row-arrows-visible-mixin.js
@@ -1,0 +1,17 @@
+export default {
+	methods: {
+		categoryRowArrowsVisible() {
+			/*
+			We are using the lack of CSS hover support to gate the visibility of the arrows
+			*/
+			if (typeof window === 'undefined' || typeof document === 'undefined') {
+				return true;
+			}
+			const rightArrow = document.querySelector('.arrow.right-arrow');
+			if (!rightArrow) {
+				return true;
+			}
+			return window.getComputedStyle(rightArrow).display !== 'none';
+		},
+	},
+};


### PR DESCRIPTION
Additions:
* Add code for rearranging cards when expanding first card in row and template for rearranging when expanding last card in a row

Fixes:
* Increases code reuse
* Cleanup comments and transitions
* Fixes horizontal scrollbar appearing intermittently in row

Known Issues/Limitations:
* Currently moving from the first card in the row to the second card causes one card to be skipped, this will be fixed in the subsequent PR