### PR TITLE
CASH-1074: Allow custom click behavior for loan card image and read more link

### DIFF
--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfoBody.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfoBody.vue
@@ -9,10 +9,7 @@
 			v-kv-track-event="['Lending', 'click-Read more', 'Read more', loanId, 'true']"
 		>
 			<span
-				@click="$emit('track-loan-card-interaction', {
-					interactionType: 'viewBorrowerPage',
-					interactionElement: 'readMore'
-				})"
+				@click="handleReadMoreLink"
 			>
 				{{ readMoreLinkText }}
 			</span>
@@ -60,6 +57,10 @@ export default {
 			type: String,
 			default: 'Read more',
 		},
+		disableLink: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		helpedLanguage() {
@@ -88,7 +89,20 @@ export default {
 			}
 			return convertedUse;
 		},
-	}
+	},
+	methods: {
+		handleReadMoreLink(event) {
+			this.$emit('read-more-link', event);
+			if (this.disableLink) {
+				event.preventDefault();
+				return;
+			}
+			this.$emit('track-loan-card-interaction', {
+				interactionType: 'viewBorrowerPage',
+				interactionElement: 'readMore'
+			});
+		},
+	},
 };
 </script>
 

--- a/src/components/LoanCards/LoanCardImage.vue
+++ b/src/components/LoanCards/LoanCardImage.vue
@@ -100,9 +100,9 @@ export default {
 			return `https://res.cloudinary.com/kiva/${transformations}/e_viesus_correct/e_sharpen:150/a_ignore,fl_progressive,q_auto:best/remote/${this.loanImageHash}.jpg`; // eslint-disable-line
 		},
 		handleImageClick(event) {
+			this.$emit('image-click');
 			if (this.disableLink) {
 				event.preventDefault();
-				event.stopPropagation();
 				return;
 			}
 			this.$emit('track-loan-card-interaction', {


### PR DESCRIPTION
* For the HoverLoanCards, clicking the image as well as the read more links expand the details panel.
* We need to ensure the link as well as the tracking is disabled in a way that maintains correct behavior for the rest of the loan cards.