### PR TITLE
CASH-1069: Update hover transitions to accomodate new card dimensions and layout

### DIFF
--- a/src/assets/scss/components/loan-cards/hover-loan-card.scss
+++ b/src/assets/scss/components/loan-cards/hover-loan-card.scss
@@ -1,5 +1,11 @@
 @import 'settings';
 
+// Reference
+$small-default-hover-image-width: rem-calc(480);
+$small-default-hover-image-height: rem-calc(300);
+$large-default-hover-image-width: $small-default-hover-image-width;
+$large-default-hover-image-height: $small-default-hover-image-height;
+
 // Card Styles
 $hover-card-border-radius: rem-calc(3);
 
@@ -9,6 +15,12 @@ $small-hover-card-height: rem-calc(228);
 $large-hover-card-width: rem-calc(440);
 $large-hover-card-height: rem-calc(250);
 $hover-card-right-margin: rem-calc(10);
+
+// Card Section Sizes
+$small-hover-card-image-height: $small-default-hover-image-height / $small-default-hover-image-width * $small-hover-card-width;
+$small-hover-card-data-height: $small-hover-card-height - $small-hover-card-image-height;
+$large-hover-card-image-height: $large-default-hover-image-height / $large-default-hover-image-width * $large-hover-card-width;
+$large-hover-card-data-height: $large-hover-card-height - $large-hover-card-image-height;
 
 // Differences
 $small-hover-card-total-width: $small-hover-card-width + $hover-card-right-margin;
@@ -25,6 +37,12 @@ $height-ratio-small-to-large: $small-hover-card-height / $large-hover-card-heigh
 // Large Card Positioning Shift
 $hover-card-large-left-shift: ($hover-card-width-difference / $small-hover-card-width) * -50%;
 $hover-card-large-top-shift: ($hover-card-height-difference / $small-hover-card-height) * -50%;
+
+// Portrait Card Image Sync Adjustment
+$large-hover-card-image-height-adjusted: $small-hover-card-image-height * $large-hover-card-height / $small-hover-card-height;
+$large-hover-card-image-scale-y: $large-hover-card-image-height-adjusted / $large-hover-card-image-height;
+$small-hover-card-image-height-adjusted: $large-hover-card-image-height * $small-hover-card-height / $large-hover-card-height;
+$small-hover-card-image-scale-y: $small-hover-card-image-height-adjusted / $small-hover-card-image-height;
 
 // Animations
 // Expansion


### PR DESCRIPTION
#### Problem:

The prior animation resulted in a distracting, flashing image

#### Research:

Flashing is due to the change in ratio of image:totalHeight between the 2 card sizes. When the transition starts, the small card starts to disappear and the large card (with a smaller image:totalHeight ratio) appears, resulting in a flash of white where the large card image ends higher than the small card image:
```
Small Card          Large Card
|        |          |        |
|   i1   |          |   i2   |
|        |          |--------| // Flashing Occurs due to
|--------|          |        | // this difference
|        |          |        |
|   c1   |          |   c2   |
|        |t1        |        |t2
```
#### Fix:

We can scale the large image (i2) up when the large card is scaled down to remove the flash. Reversing this scale on expansion will also result in a pleasing “sliding in” of the content (c2).

To calculate how to scale the height of i2 when the large card is scaled down, we can start by solving for the actual height of i2 (to maintain the same ratio of image:totalHeight as the small card) when the large card is at its full size:
```
All variables represent heights, i for image, c for content, t for total.
i2' and c2' represent adjusted heights to match card 1's image:totalHeight ratio

i2'  i1
-- = --
t2'  t1

Thus

i2' = i1 * t2'
      --------
         t1
```
Then we can get the factor to scale the large card image by when the large card is scaled down to the size of the small card by division:
```
scaleYFactor = i2' / i2
```
We then apply this scaleY to the image (i2) when the large card is scaled down and transition back to a scaleY(1) as the large card scales up to remove the flash and make it appear the image is growing naturally in size. We can apply this same logic to the small card image to allow shrinking down of the card to be just as visually pleasing.
