### PR TITLE
CASH-1054: Implement mobile behavior of hover loan cards

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -11,6 +11,7 @@
 			'shift-right-double': shiftRightDouble,
 		}"
 		@mouseenter="handleMouseEnter"
+		@click="handleClick"
 	>
 		<div
 			class="hover-loan-card-wrapper"
@@ -50,6 +51,7 @@ import HoverLoanCardSmall from './HoverLoanCardSmall';
 import HoverLoanCardLarge from './HoverLoanCardLarge';
 import hoverLoanCardMixin from './hoverLoanCardMixin';
 import KvIcon from '@/components/Kv/KvIcon';
+import categoryRowArrowsVisibleMixin from '@/plugins/category-row-arrows-visible-mixin';
 
 export default {
 	components: {
@@ -122,19 +124,32 @@ export default {
 	},
 	mixins: [
 		hoverLoanCardMixin,
+		categoryRowArrowsVisibleMixin,
 	],
 	methods: {
 		handleMouseEnter() {
 			if (this.rowHasDetailedLoan && !this.isDetailed) {
 				this.updateDetailedLoanIndex();
+			} else if (this.hoverEffectActive()) {
+				this.updateHoverLoanIndex();
 			}
-			this.updateHoverLoanIndex();
+		},
+		hoverEffectActive() {
+			const windowWidth = document.documentElement.clientWidth;
+			const arrowsVisible = this.categoryRowArrowsVisible();
+
+			return (arrowsVisible && windowWidth >= 800) || (!arrowsVisible && windowWidth >= 768);
 		},
 		updateHoverLoanIndex() {
 			this.$emit('update-hover-loan-index', this.loanIndex);
 		},
 		updateDetailedLoanIndex() {
 			this.$emit('update-detailed-loan-index', this.loanIndex);
+		},
+		handleClick() {
+			if (!this.hoverEffectActive()) {
+				this.$emit('update-detailed-loan-index', this.loanIndex);
+			}
 		},
 	},
 };


### PR DESCRIPTION
* Loan cards will only expand on screens where 3 or more cards are visible
* Clicking/tapping on loan cards on screens where fewer than 3 cards are visible will now directly expand the details panel