### PR TITLE
fixing Borrower Story overflowing expanded section

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/InfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/InfoPanel.vue
@@ -71,6 +71,7 @@ export default {
 
 .info-panel {
 	background: rgba($white, 0.8);
+	overflow-y: scroll;
 
 	button {
 		text-align: left;


### PR DESCRIPTION
This prevents the borrower story from going outside the expanded card via setting an overflow on the container. 