### PR TITLE
CASH-1096: Wrap DetailedLoanCard in LoanCardController

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -134,7 +134,7 @@
 						'Lending',
 						'click-Read full borrower details',
 						'Profile Link',
-						loanId
+						loan.id
 					]"
 				>
 					Read full borrower details

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -102,7 +102,7 @@
 			</div>
 		</div>
 		<div class="mobile-sections columns small-12 small-order-3 hide-for-medium">
-			<info-panel :id="`${loanId}-overview-panel`" :expandable="true">
+			<info-panel :id="`${loan.id}-overview-panel`" :expandable="true">
 				<template #title>
 					Overview
 				</template>
@@ -122,9 +122,9 @@
 				:loan-id="loan.id"
 				read-more-link-text=""
 			/>
-			<loan-details-panel :loan-id="loanId" />
-			<partner-info-panel v-if="hasPartner" :loan-id="loanId" />
-			<trustee-info-panel v-if="hasTrustee" :loan-id="loanId" />
+			<loan-details-panel :loan-id="loan.id" />
+			<partner-info-panel v-if="hasPartner" :loan-id="loan.id" />
+			<trustee-info-panel v-if="hasTrustee" :loan-id="loan.id" />
 			<div>
 				<hr>
 				<router-link
@@ -142,7 +142,7 @@
 			</div>
 		</div>
 		<div class="close-button-wrapper">
-			<button @click="$emit('close')" class="close-button">
+			<button @click="$emit('close-detailed-loan-card')" class="close-button">
 				<kv-icon name="x" />
 			</button>
 		</div>
@@ -160,14 +160,36 @@ import BorrowerInfoBody from '@/components/LoanCards/BorrowerInfo/BorrowerInfoBo
 import KvExpandable from '@/components/Kv/KvExpandable';
 import KvIcon from '@/components/Kv/KvIcon';
 import LoanCardImage from '@/components/LoanCards/LoanCardImage';
-import detailedLoanCardFragment from '@/graphql/fragments/detailedLoanCard.graphql';
-import trackInteractionMixin from '@/plugins/track-interaction-mixin';
 import BorrowerInfoName from '@/components/LoanCards/BorrowerInfo/BorrowerInfoName';
 import KvFlag from '@/components/Kv/KvFlag';
 
 export default {
 	props: {
-		loanId: { type: String, default: '' },
+		loan: {
+			type: Object,
+			default: () => {
+				return {
+					userProperties: {},
+					loanFundraisingInfo: {},
+					geocode: {
+						country: {}
+					},
+					image: {}
+				};
+			}
+		},
+		percentRaised: {
+			type: Number,
+			default: 0,
+		},
+		amountLeft: {
+			type: Number,
+			default: 0,
+		},
+		expiringSoonMessage: {
+			type: String,
+			default: '',
+		},
 	},
 	components: {
 		BorrowerInfoBody,
@@ -182,10 +204,6 @@ export default {
 		BorrowerInfoName,
 		KvFlag,
 	},
-	inject: ['apollo'],
-	mixins: [
-		trackInteractionMixin,
-	],
 	data() {
 		return {
 			detailsPanel: LoanDetailsPanel,
@@ -202,12 +220,6 @@ export default {
 		hasTrustee() {
 			return false;
 		},
-		loan() {
-			return this.apollo.readFragment({
-				id: this.loanId,
-				fragment: detailedLoanCardFragment,
-			}) || {};
-		},
 		retinaImageUrl() {
 			// eslint-disable-next-line quotes
 			return _get(this.loan, 'image.retina', '').replace(`/w960h600/`, `/w960h720/`);
@@ -215,6 +227,11 @@ export default {
 		standardImageUrl() {
 			// eslint-disable-next-line quotes
 			return _get(this.loan, 'image.default', '').replace(`/w480h300/`, `/w480h360/`);
+		},
+	},
+	methods: {
+		trackInteraction(args) {
+			this.$emit('track-interaction', args);
 		},
 	},
 };

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
@@ -20,8 +20,8 @@ export default {
 			default: true,
 		},
 		loanId: {
-			type: String,
-			default: '',
+			type: Number,
+			default: 0,
 		},
 	},
 	computed: {

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/PartnerInfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/PartnerInfoPanel.vue
@@ -20,8 +20,8 @@ export default {
 			default: true,
 		},
 		loanId: {
-			type: String,
-			default: '',
+			type: Number,
+			default: 0,
 		},
 	},
 	computed: {

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/TrusteeInfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/TrusteeInfoPanel.vue
@@ -20,8 +20,8 @@ export default {
 			default: true,
 		},
 		loanId: {
-			type: String,
-			default: '',
+			type: Number,
+			default: 0,
 		},
 	},
 	computed: {

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -34,6 +34,7 @@
 
 		@update-detailed-loan-index="updateDetailedLoanIndex"
 		@update-hover-loan-index="updateHoverLoanIndex"
+		@close-detailed-loan-card="handleCloseDetailedLoanCard"
 	/>
 	<!--
 		Blocks of attributes above:
@@ -54,6 +55,7 @@ import ExpandableLoanCard from '@/components/LoanCards/ExpandableLoanCard/Expand
 import GridMicroLoanCard from '@/components/LoanCards/GridMicroLoanCard';
 import ListLoanCard from '@/components/LoanCards/ListLoanCard';
 import HoverLoanCard from '@/components/LoanCards/HoverLoanCard/HoverLoanCard';
+import DetailedLoanCard from '@/components/LoanCards/HoverLoanCard/DetailedLoanCard';
 import {
 	differenceInMinutes,
 	differenceInHours,
@@ -73,6 +75,7 @@ export default {
 		GridMicroLoanCard,
 		ListLoanCard,
 		HoverLoanCard,
+		DetailedLoanCard,
 	},
 	props: {
 		loanCardType: {
@@ -261,6 +264,9 @@ export default {
 		},
 		updateHoverLoanIndex(hoverLoanIndex) {
 			this.$emit('update-hover-loan-index', hoverLoanIndex);
+		},
+		handleCloseDetailedLoanCard() {
+			this.$emit('close-detailed-loan-card');
 		},
 	},
 };

--- a/src/components/LoansByCategory/CategoryRowHover.vue
+++ b/src/components/LoansByCategory/CategoryRowHover.vue
@@ -102,11 +102,19 @@
 		</div>
 
 		<kv-expandable>
-			<detailed-loan-card
+			<loan-card-controller
 				class="expanded-card-row"
 				v-if="detailedLoanCacheId"
-				:loan-id="detailedLoanCacheId"
-				@close="detailedLoanIndex = null"
+				loan-card-type="DetailedLoanCard"
+				:loan="detailedLoan"
+				:items-in-basket="itemsInBasket"
+				:category-id="loanChannel.id"
+				:category-set-id="setId"
+				:row-number="rowNumber"
+				:card-number="detailedLoanIndex + 1"
+				:enable-tracking="true"
+				:is-visitor="!isLoggedIn"
+				@close-detailed-loan-card="detailedLoanIndex = null"
 			/>
 		</kv-expandable>
 	</div>
@@ -117,8 +125,8 @@ import _get from 'lodash/get';
 import _throttle from 'lodash/throttle';
 import LoanCardController from '@/components/LoanCards/LoanCardController';
 import categoryRowArrowsVisibleMixin from '@/plugins/category-row-arrows-visible-mixin';
-import DetailedLoanCard from '@/components/LoanCards/HoverLoanCard/DetailedLoanCard';
 import KvExpandable from '@/components/Kv/KvExpandable';
+import detailedLoanCardFragment from '@/graphql/fragments/detailedLoanCard.graphql';
 
 const hoverCardSmallWidth = 220;
 const hoverCardRightMargin = 10;
@@ -127,7 +135,6 @@ const hoverCardSmallWidthTotal = hoverCardSmallWidth + hoverCardRightMargin * 2;
 export default {
 	components: {
 		LoanCardController,
-		DetailedLoanCard,
 		KvExpandable,
 	},
 	mixins: [
@@ -259,6 +266,12 @@ export default {
 		},
 		noHoverLoan() {
 			return this.hoverLoanIndex === null;
+		},
+		detailedLoan() {
+			return this.apollo.readFragment({
+				id: this.detailedLoanCacheId,
+				fragment: detailedLoanCardFragment,
+			}) || {};
 		},
 	},
 	watch: {

--- a/src/components/LoansByCategory/CategoryRowHover.vue
+++ b/src/components/LoansByCategory/CategoryRowHover.vue
@@ -102,20 +102,21 @@
 		</div>
 
 		<kv-expandable>
-			<loan-card-controller
-				class="expanded-card-row"
-				v-if="detailedLoanCacheId"
-				loan-card-type="DetailedLoanCard"
-				:loan="detailedLoan"
-				:items-in-basket="itemsInBasket"
-				:category-id="loanChannel.id"
-				:category-set-id="setId"
-				:row-number="rowNumber"
-				:card-number="detailedLoanIndex + 1"
-				:enable-tracking="true"
-				:is-visitor="!isLoggedIn"
-				@close-detailed-loan-card="detailedLoanIndex = null"
-			/>
+			<div v-if="detailedLoanCacheId">
+				<loan-card-controller
+					class="expanded-card-row"
+					loan-card-type="DetailedLoanCard"
+					:loan="detailedLoan"
+					:items-in-basket="itemsInBasket"
+					:category-id="loanChannel.id"
+					:category-set-id="setId"
+					:row-number="rowNumber"
+					:card-number="detailedLoanIndex + 1"
+					:enable-tracking="true"
+					:is-visitor="!isLoggedIn"
+					@close-detailed-loan-card="detailedLoanIndex = null"
+				/>
+			</div>
 		</kv-expandable>
 	</div>
 </template>


### PR DESCRIPTION
* We need many of the methods and computed values from LCC to complete the `DetailedLoanCard`

#### Note: 
A known UI bug exists in this change: When the DetailedLoanCard is open and the user hovers over another loan, the card closes and reopens. This is a bug we will have to chase down.