### PR TITLE
CASH-1067: Allow loan card rows to overlap page content

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -10,11 +10,12 @@
 			'shift-right': shiftRight,
 			'shift-right-double': shiftRightDouble,
 		}"
-		@mouseenter="handleMouseEnter"
+		@mouseenter="handleMouseEnterCardMargins"
 		@click="handleClick"
 	>
 		<div
 			class="hover-loan-card-wrapper"
+			@mouseenter="handleMouseEnterCardOnly"
 		>
 			<hover-loan-card-small
 				:amount-left="amountLeft"
@@ -109,6 +110,9 @@ export default {
 		rowHasDetailedLoan() {
 			return this.detailedLoanIndex !== null;
 		},
+		rowHasHoverLoan() {
+			return this.hoverLoanIndex !== null;
+		},
 		shiftLeft() {
 			return !this.rowHasDetailedLoan && this.shiftIncrement === -1;
 		},
@@ -132,6 +136,16 @@ export default {
 				this.updateDetailedLoanIndex();
 			} else if (this.hoverEffectActive()) {
 				this.updateHoverLoanIndex();
+			}
+		},
+		handleMouseEnterCardMargins() {
+			if (this.rowHasHoverLoan) {
+				this.handleMouseEnter();
+			}
+		},
+		handleMouseEnterCardOnly() {
+			if (!this.rowHasHoverLoan) {
+				this.handleMouseEnter();
 			}
 		},
 		hoverEffectActive() {

--- a/src/components/LoansByCategory/CategoryRowHover.vue
+++ b/src/components/LoansByCategory/CategoryRowHover.vue
@@ -19,7 +19,7 @@
 						{{ cleanName }}
 					</template>
 				</h2>
-				<p v-if="showCategoryDescription" class="category-description show-for-large">
+				<p class="category-description show-for-large">
 					{{ loanChannel.description }}
 				</p>
 			</div>
@@ -162,10 +162,6 @@ export default {
 		setId: {
 			type: String,
 			default: 'Control'
-		},
-		showCategoryDescription: {
-			type: Boolean,
-			default: false
 		},
 	},
 	data() {
@@ -488,6 +484,7 @@ $row-max-width: 63.75rem;
 	font-weight: $global-weight-normal;
 	margin-top: rem-calc(12);
 	margin-bottom: 0;
+	min-height: rem-calc(84);
 }
 
 a.view-all-link {

--- a/src/components/LoansByCategory/CategoryRowHover.vue
+++ b/src/components/LoansByCategory/CategoryRowHover.vue
@@ -484,7 +484,7 @@ $row-max-width: 63.75rem;
 	font-weight: $global-weight-normal;
 	margin-top: rem-calc(12);
 	margin-bottom: 0;
-	min-height: rem-calc(84);
+	min-height: rem-calc(56);
 }
 
 a.view-all-link {

--- a/src/components/LoansByCategory/CategoryRowHover.vue
+++ b/src/components/LoansByCategory/CategoryRowHover.vue
@@ -406,7 +406,7 @@ $row-max-width: 63.75rem;
 
 .cards-and-arrows-wrapper {
 	max-width: $row-max-width;
-	margin: 0 auto 1rem;
+	margin: rem-calc(-67) auto 1rem;
 	align-items: center;
 	display: flex;
 	position: relative;


### PR DESCRIPTION
From a user’s standpoint, cards now only expand when you enter the card body, not the card margin. This is implemented as follows:
* Hovering in margins will now only trigger card expansion when another card is already expanded
* To expand a card in a row where no other cards are expanded yet, you must actually enter the card body