### PR TITLE
Cash 965

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -37,14 +37,14 @@
 				>
 					<span>Story</span>
 				</button>
-				<!-- <button
+				<button
 					class="tab-title"
 					@click="tabComponent = detailsPanel"
 					:class="{ active: tabComponent === detailsPanel }"
 				>
 					<span>Details</span>
 				</button>
-				<button
+				<!-- <button
 					class="tab-title"
 					v-if="hasPartner"
 					@click="tabComponent = partnerPanel"

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
@@ -3,16 +3,67 @@
 		<template #title>
 			Loan Details
 		</template>
-		<p>Details about the loan.</p>
+		<ul>
+			<li>
+				<label>Loan length:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Repayment schedule:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Disbursal date:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Currency exchange loss:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Facilitated by Field Partner:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Is borrower paying interest? </label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Field Partner risk rating:</label>
+				<p class="data">{{  }}</p>
+			</li>
+		</ul>
+		<ul>
+			<!-- The size of the following tag will need to be adjusted -->
+			<h3>{{ COUNTRY }} country facts</h3>
+			<li>
+				<label>Average annual income (USD):</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Funds lent in {{ COUNTRY }}:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Loans currently fundraising:</label>
+				<p class="data">{{  }}</p>
+			</li>
+			<li>
+				<label>Loans transacted in:</label>
+				<p class="data">{{  }}</p>
+			</li>
+		</ul>
 	</info-panel>
 </template>
 
 <script>
 import InfoPanel from './InfoPanel';
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 
 export default {
 	components: {
 		InfoPanel,
+		KvLoadingSpinner,
 	},
 	props: {
 		expandable: {
@@ -31,3 +82,31 @@ export default {
 	},
 };
 </script>
+
+<style lang="scss">
+@import 'settings';
+
+#loading-overlay {
+	position: absolute;
+	width: auto;
+	height: auto;
+	left: 1rem;
+	right: 1rem;
+	bottom: 0;
+	top: 0;
+	background-color: rgba($platinum, 0.7);
+
+	.spinner-wrapper {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		position: relative;
+		height: 100%;
+		top: auto;
+		left: auto;
+		transform: none;
+		transition: top 100ms linear;
+	}
+}
+
+</style>

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
@@ -6,65 +6,97 @@
 		<ul>
 			<li>
 				<label>Loan length:</label>
-				<p class="data">{{  }}</p>
+				<span class="data">
+					{{ }}
+				</span>
 			</li>
 			<li>
 				<label>Repayment schedule:</label>
-				<p class="data">{{  }}</p>
+				<span class="data">
+					{{ repaymentSchedule }} months
+				</span>
 			</li>
 			<li>
 				<label>Disbursal date:</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{ disbursalDate }}
+				</p>
 			</li>
 			<li>
 				<label>Currency exchange loss:</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					<!-- I don't think this is the right piece of data -->
+					{{ currencyExchangeLoss }}
+				</p>
 			</li>
 			<li>
 				<label>Facilitated by Field Partner:</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{}}
+				</p>
 			</li>
 			<li>
 				<label>Is borrower paying interest? </label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{ borrowerPayingInterest }}
+				</p>
 			</li>
 			<li>
 				<label>Field Partner risk rating:</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{ riskRating }}
+				</p>
 			</li>
 		</ul>
 		<ul>
 			<!-- The size of the following tag will need to be adjusted -->
-			<h3>{{ COUNTRY }} country facts</h3>
+			<h3>{{ country }} country facts</h3>
 			<li>
 				<label>Average annual income (USD):</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{ avgAnnualIncome }}
+				</p>
 			</li>
 			<li>
-				<label>Funds lent in {{ COUNTRY }}:</label>
-				<p class="data">{{  }}</p>
+				<label>Funds lent in {{ country }}:</label>
+				<p class="data">
+					{{ fundsLentInCountry }}
+				</p>
 			</li>
 			<li>
 				<label>Loans currently fundraising:</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{ loansCurrentlyFundraising }}
+				</p>
 			</li>
 			<li>
 				<label>Loans transacted in:</label>
-				<p class="data">{{  }}</p>
+				<p class="data">
+					{{ loansTransactedIn }}
+				</p>
 			</li>
 		</ul>
+		<div>
+			<h2>This loan is special because</h2>
+			<p class="data">
+				{{ whySpecial }}
+			</p>
+		</div>
 	</info-panel>
 </template>
 
 <script>
+import _get from 'lodash/get';
 import InfoPanel from './InfoPanel';
-import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+// import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+import loanDetailsQuery from '@/graphql/query/loanDetails.graphql';
 
 export default {
 	components: {
 		InfoPanel,
-		KvLoadingSpinner,
+		// KvLoadingSpinner,
 	},
+	inject: ['apollo'],
 	props: {
 		expandable: {
 			type: Boolean,
@@ -73,6 +105,45 @@ export default {
 		loanId: {
 			type: Number,
 			default: 0,
+		}
+	},
+	data() {
+		return {
+			country: 'test',
+			loanLength: 'test',
+			repaymentSchedule: 'test',
+			disbursalDate: 'test',
+			currencyExchangeLoss: 'test',
+			borrowerPayingInterest: 'test',
+			riskRating: 'test',
+			avgAnnualIncome: 'test',
+			fundsLentInCountry: 'test',
+			loansCurrentlyFundraising: 'test',
+			loansTransactedIn: 'test',
+			whySpecial: 'test',
+		};
+	},
+	apollo: {
+		query: loanDetailsQuery,
+		variables() {
+			return {
+				id: parseInt(this.loanId, 10),
+			};
+		},
+		result({ data }) {
+			this.country = _get(data, 'lend.loan.geocode.country.name');
+			// this.loanLength = _get(data, 'lend.loan.')
+			this.repaymentSchedule = _get(data, 'lend.loan.lenderRepaymentTerm');
+			// This date needs to be formatted
+			this.disbursalDate = _get(data, 'lend.loan.disbursalDate');
+			this.currencyExchangeLoss = _get(data, 'lend.loan.hasCurrencyExchangeLossLenders');
+			this.borrowerPayingInterest = _get(data, 'lend.loan.partner.chargesFeesInterest');
+			this.riskRating = _get(data, 'lend.loan.partner.riskRating');
+			this.avgAnnualIncome = _get(data, 'lend.loan.partner.countries.ppp');
+			this.fundsLentInCountry = _get(data, 'lend.loan.partner.countries.fundsLentInCountry');
+			this.loansCurrentlyFundraising = _get(data, 'lend.loan.partner.countries.numLoansFundraising');
+			// this.loansTransactedIn = _get(data, 'lend.loan.partner.countries.fundsLentInCountry');
+			this.whySpecial = _get(data, 'lend.loan.whySpecial');
 		},
 	},
 	computed: {
@@ -85,6 +156,19 @@ export default {
 
 <style lang="scss">
 @import 'settings';
+
+ul {
+	list-style: none;
+}
+
+label {
+	display: inline-block;
+}
+
+.data {
+	color: $kiva-green;
+	display: inline-block;
+}
 
 #loading-overlay {
 	position: absolute;
@@ -108,5 +192,4 @@ export default {
 		transition: top 100ms linear;
 	}
 }
-
 </style>

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
@@ -3,84 +3,91 @@
 		<template #title>
 			Loan Details
 		</template>
-		<ul>
-			<li>
-				<label>Loan length:</label>
-				<span class="data">
-					{{ loanLength }} months
-				</span>
-			</li>
-			<li>
-				<label>Repayment schedule:</label>
-				<span class="data repayment-schedule-text">
-					{{ repaymentSchedule }}
-				</span>
-			</li>
-			<li>
-				<label>Disbursal date:</label>
+		<div v-if="!loanLength" id="loading-overlay">
+			<div class="spinner-wrapper">
+				<kv-loading-spinner />
+			</div>
+		</div>
+		<div v-else>
+			<ul>
+				<li>
+					<label>Loan length:</label>
+					<span class="data">
+						{{ loanLength }} months
+					</span>
+				</li>
+				<li>
+					<label>Repayment schedule:</label>
+					<span class="data repayment-schedule-text">
+						{{ repaymentSchedule }}
+					</span>
+				</li>
+				<li>
+					<label>Disbursal date:</label>
+					<p class="data">
+						{{ disbursalDateFormatted }}
+					</p>
+				</li>
+				<!-- <li>
+					<label>Currency exchange loss:</label>
+					<p class="data">
+						{{ currencyExchangeLoss }}
+					</p>
+				</li> -->
+				<li>
+					<label>Facilitated by Field Partner:</label>
+					<p class="data">
+						{{ facilitatedByFieldPartnerFormatted }}
+					</p>
+				</li>
+				<li>
+					<label>Is borrower paying interest?</label>
+					<p class="data">
+						{{ borrowerPayingInterestFormatted }}
+					</p>
+				</li>
+				<li>
+					<label>Field Partner risk rating:</label>
+					<p class="data">
+						{{ riskRating }} stars
+					</p>
+				</li>
+			</ul>
+			<ul>
+				<h3 class="country-heading">
+					{{ country }} country facts
+				</h3>
+				<!-- <li>
+					<label>Average annual income (USD):</label>
+					<p class="data">
+						{{ avgAnnualIncome }}
+					</p>
+				</li> -->
+				<li>
+					<label>Funds lent in {{ country }}:</label>
+					<p class="data">
+						{{ fundslentInCountryFormatted }}
+					</p>
+				</li>
+				<li>
+					<label>Loans currently fundraising:</label>
+					<p class="data">
+						{{ loansCurrentlyFundraising }}
+					</p>
+				</li>
+				<!-- <li>
+					<label>Loans transacted in:</label>
+					<p class="data">
+						{{ loansTransactedIn }}
+					</p>
+				</li> -->
+			</ul>
+			<div>
+				<h3>This loan is special because</h3>
 				<p class="data">
-					{{ disbursalDateFormatted }}
+					{{ whySpecial }}
 				</p>
-			</li>
-			<!-- <li>
-				<label>Currency exchange loss:</label>
-				<p class="data">
-					{{ currencyExchangeLoss }}
-				</p>
-			</li> -->
-			<li>
-				<label>Facilitated by Field Partner:</label>
-				<p class="data">
-					{{ facilitatedByFieldPartnerFormatted }}
-				</p>
-			</li>
-			<li>
-				<label>Is borrower paying interest?</label>
-				<p class="data">
-					{{ borrowerPayingInterestFormatted }}
-				</p>
-			</li>
-			<li>
-				<label>Field Partner risk rating:</label>
-				<p class="data">
-					{{ riskRating }} stars
-				</p>
-			</li>
-		</ul>
-		<ul>
-			<h3 class="country-heading">
-				{{ country }} country facts
-			</h3>
-			<!-- <li>
-				<label>Average annual income (USD):</label>
-				<p class="data">
-					{{ avgAnnualIncome }}
-				</p>
-			</li> -->
-			<li>
-				<label>Funds lent in {{ country }}:</label>
-				<p class="data">
-					{{ fundslentInCountryFormatted }}
-				</p>
-			</li>
-			<li>
-				<label>Loans currently fundraising:</label>
-				<p class="data">
-					{{ loansCurrentlyFundraising }}
-				</p>
-			</li>
-			<!-- <li>
-				<label>Loans transacted in:</label>
-				<p class="data">
-					{{ loansTransactedIn }}
-				</p>
-			</li> -->
-		</ul>
-		<div>
-			<h3>This loan is special because</h3>
-			<p class="data">
-				{{ whySpecial }}
-			</p>
+			</div>
 		</div>
 	</info-panel>
 </template>
@@ -91,10 +98,12 @@ import numeral from 'numeral';
 import { format } from 'date-fns';
 import InfoPanel from './InfoPanel';
 import loanDetailsQuery from '@/graphql/query/loanDetails.graphql';
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 
 export default {
 	components: {
 		InfoPanel,
+		KvLoadingSpinner
 	},
 	inject: ['apollo'],
 	props: {
@@ -207,5 +216,4 @@ ul {
 .country-heading {
 	color: $black;
 }
-
 </style>

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
@@ -31,7 +31,7 @@
 			<li>
 				<label>Facilitated by Field Partner:</label>
 				<p class="data">
-					{{}}
+					{{ facilitatedByFieldPartnerFormatted }}
 				</p>
 			</li>
 			<li>
@@ -119,6 +119,7 @@ export default {
 			loanLength: '',
 			repaymentSchedule: '',
 			borrowerPayingInterest: '',
+			facilitatedByFieldPartner: '',
 
 			currencyExchangeLoss: 'test',
 			riskRating: 'test',
@@ -143,6 +144,9 @@ export default {
 			this.loanLength = _get(data, 'lend.loan.lenderRepaymentTerm');
 			this.repaymentSchedule = _get(data, 'lend.loan.repaymentInterval');
 			this.borrowerPayingInterest = _get(data, 'lend.loan.partner.chargesFeesInterest');
+
+			this.facilitatedByFieldPartner = _get(data, 'lend.loan.partnerName');
+			this.trustee = _get(data, 'lend.loan.trusteeName');
 
 			// This data needs to be formatted/calculated/verified
 			this.currencyExchangeLoss = _get(data, 'lend.loan.hasCurrencyExchangeLossLenders');
@@ -171,6 +175,17 @@ export default {
 				formattedReturn = 'Yes';
 			}
 			return formattedReturn;
+		},
+		facilitatedByFieldPartnerFormatted() {
+			let facilitatedByFieldPartnerFormatted = '';
+			if (this.facilitatedByFieldPartner !== '') {
+				facilitatedByFieldPartnerFormatted = this.facilitatedByFieldPartner;
+			} else if (this.trustee !== '') {
+				facilitatedByFieldPartnerFormatted = this.trustee;
+			} else if (this.facilitatedByFieldPartner === '' && this.trustee === '') {
+				facilitatedByFieldPartnerFormatted = 'Not facilitated by a Field Partner or Trustee';
+			}
+			return facilitatedByFieldPartnerFormatted;
 		}
 	},
 };

--- a/src/graphql/query/loanDetails.graphql
+++ b/src/graphql/query/loanDetails.graphql
@@ -6,13 +6,16 @@ query loanDescription(
 			id
 			whySpecial
 			hasCurrencyExchangeLossLenders
+			plannedExpirationDate
+			fundraisingDate
+			lenderRepaymentTerm
+			repaymentInterval
 			geocode {
 				country {
 					name
 				}
 			}
 			... on LoanPartner {
-				lenderRepaymentTerm
 				disbursalDate
 				partnerName
 				partner {
@@ -24,7 +27,7 @@ query loanDescription(
 						numLoansFundraising
 					}
 				}
-			}    
+			}
 		}
 	}
 }

--- a/src/graphql/query/loanDetails.graphql
+++ b/src/graphql/query/loanDetails.graphql
@@ -1,0 +1,24 @@
+query loanDescription(
+	$id: Int!,
+){
+	lend {
+		loan {
+			whySpecial
+			... on LoanPartner {
+				lenderRepaymentTerm
+				disbursalDate
+				hasCurrencyExchangeLossLenders
+				partnerName
+				partner {
+					chargesFeesInterest
+					countries {
+						ppp
+						fundsLentInCountry
+						numLoansFundraising
+						fundsLentInCountry
+					}
+				}
+			}    
+		}
+	}
+}

--- a/src/graphql/query/loanDetails.graphql
+++ b/src/graphql/query/loanDetails.graphql
@@ -28,6 +28,10 @@ query loanDescription(
 					}
 				}
 			}
+			... on LoanDirect {
+				disbursalDate
+				trusteeName
+			}
 		}
 	}
 }

--- a/src/graphql/query/loanDetails.graphql
+++ b/src/graphql/query/loanDetails.graphql
@@ -2,20 +2,26 @@ query loanDescription(
 	$id: Int!,
 ){
 	lend {
-		loan {
+		loan(id: $id) {
+			id
 			whySpecial
+			hasCurrencyExchangeLossLenders
+			geocode {
+				country {
+					name
+				}
+			}
 			... on LoanPartner {
 				lenderRepaymentTerm
 				disbursalDate
-				hasCurrencyExchangeLossLenders
 				partnerName
 				partner {
 					chargesFeesInterest
+					riskRating
 					countries {
 						ppp
 						fundsLentInCountry
 						numLoansFundraising
-						fundsLentInCountry
 					}
 				}
 			}    


### PR DESCRIPTION
This PR get our available graphql data and displays it in the loan details tab of the hover loan card. Other tickets have been created to get the data we need to populate. 
See: 
cash-1148
cash-1149
cash-1150

Figured this was in a fine state for the friday demo though, I didn't want to hold up the work, since we still need to build out the partner tab for the same loan card.

Loading state was added in the most recent commit. 