### PR TITLE
CASH-1142, CASH-1087: Sync margins when expanding DetailedLoanCard and add scroll when expanding

### DIFF
--- a/src/components/LoansByCategory/CategoryRowHover.vue
+++ b/src/components/LoansByCategory/CategoryRowHover.vue
@@ -308,7 +308,7 @@ export default {
 			deep: true,
 		},
 		detailedLoanIndex(newValue, oldValue) {
-			if (this.runningOnServer()) {
+			if (this.$isServer) {
 				return;
 			}
 
@@ -431,11 +431,8 @@ export default {
 		handleSetPreventUpdatingDetailedCard(newState) {
 			this.setPreventUpdatingDetailedCard(newState);
 		},
-		runningOnServer() {
-			return typeof window === 'undefined' || typeof document === 'undefined';
-		},
 		smoothScrollToLoanRow() {
-			if (!this.runningOnServer() && this.$refs.innerWrapper) {
+			if (!this.$isServer && this.$refs.innerWrapper) {
 				const bodyRect = document.body.getBoundingClientRect();
 				const detailedLoanCardRect = this.$refs.innerWrapper.getBoundingClientRect();
 
@@ -444,7 +441,7 @@ export default {
 			}
 		},
 		smoothScrollToDetailedPanel() {
-			if (!this.runningOnServer() && this.$refs.detailedLoanCardContainer) {
+			if (!this.$isServer && this.$refs.detailedLoanCardContainer) {
 				const bodyRect = document.body.getBoundingClientRect();
 				const detailedLoanCardRect = this.$refs.detailedLoanCardContainer.getBoundingClientRect();
 


### PR DESCRIPTION
* Sync margin animation of DetailedLoanCard to be same as HoverLoanCard expansion
* On mobile: scroll to DetailedLoanCard when switching loans or initially expanding DetailedLoanCard
* On desktop: scroll to CategoryLoanRowHover only when initially expanding DetailedLoanCard