### PR TITLE
Small fix for small screens

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -140,7 +140,7 @@ export default {
 	methods: {
 		handleMouseEnter() {
 			if (this.rowHasDetailedLoan && !this.isDetailed) {
-				if (!this.preventUpdatingDetailedCard) {
+				if (!this.preventUpdatingDetailedCard && this.hoverEffectActive()) {
 					this.updateDetailedLoanIndex();
 				}
 			} else if (this.hoverEffectActive()) {


### PR DESCRIPTION
* Hovering over a loan card when the detailed panel was open would trigger a card switch on small screens, this fix ensures hover behavior for expanding HoverCards and expanding DetailedLoanCard is consistent