### PR TITLE
Remove extra click handler for cards without hover state.. Event are …

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -15,7 +15,6 @@
 		<div
 			class="hover-loan-card-wrapper"
 			@mouseenter="handleMouseEnterCardOnly"
-			@click="handleClick"
 		>
 			<hover-loan-card-small
 				:amount-left="amountLeft"
@@ -176,11 +175,6 @@ export default {
 				interactionType: 'hover-details-click',
 				interactionElement: 'hover-card'
 			});
-		},
-		handleClick() {
-			if (!this.hoverEffectActive()) {
-				this.updateDetailedLoanIndex();
-			}
 		},
 		trackInteraction(args) {
 			this.$emit('track-interaction', args);


### PR DESCRIPTION
…already bubbling up from the small and large loan cards.

This clears duplicate setting of selected loan id and tracking events. 