### PR TITLE
CASH-1243 Update Braintree checkout mutation definition to include deviceData for Kount

### DIFF
--- a/src/graphql/mutation/braintreeDepositAndCheckout.graphql
+++ b/src/graphql/mutation/braintreeDepositAndCheckout.graphql
@@ -1,5 +1,5 @@
-mutation doNoncePaymentDepositAndCheckout($basketId: String, $amount: Money!, $nonce: String!, $savePaymentMethod: Boolean) {
+mutation doNoncePaymentDepositAndCheckout($basketId: String, $amount: Money!, $nonce: String!, $savePaymentMethod: Boolean, $deviceData: String) {
 	shop (basketId: $basketId) {
-		doNoncePaymentDepositAndCheckout (amount: $amount, nonce: $nonce, savePaymentMethod: $savePaymentMethod)
+		doNoncePaymentDepositAndCheckout (amount: $amount, nonce: $nonce, savePaymentMethod: $savePaymentMethod, deviceData: $deviceData)
 	}
 }


### PR DESCRIPTION
I don't really know if this breaks anything else! I didn't see any other references to this mutation or to `braintreeDepositAndCheckout.graphql` outside the Braintree checkout component.