### PR TITLE
cash-1326 changing btVSpp exp name

### DIFF
--- a/src/components/Checkout/PaymentWrapper.vue
+++ b/src/components/Checkout/PaymentWrapper.vue
@@ -69,6 +69,7 @@ export default {
 		};
 	},
 	created() {
+		console.log('selectedOption', this.selectedOption);
 		if (this.expSelectedOption !== '') {
 			this.selectedOption = this.expSelectedOption;
 		}
@@ -77,8 +78,8 @@ export default {
 		if (this.expSelectedOption !== '') {
 			this.$kvTrackEvent(
 				'basket',
-				'EXP-CASH-1167-Aug2019',
-				this.expSelectedOption === 'bt' ? 'b' : 'a'
+				'EXP-CASH-1167-Sept2019',
+				this.selectedOption === 'bt' ? 'b' : 'a'
 			);
 		}
 	},

--- a/src/components/Checkout/PaymentWrapper.vue
+++ b/src/components/Checkout/PaymentWrapper.vue
@@ -69,7 +69,6 @@ export default {
 		};
 	},
 	created() {
-		console.log('selectedOption', this.selectedOption);
 		if (this.expSelectedOption !== '') {
 			this.selectedOption = this.expSelectedOption;
 		}

--- a/src/graphql/query/checkout/checkoutSettings.graphql
+++ b/src/graphql/query/checkout/checkoutSettings.graphql
@@ -4,7 +4,7 @@ query checkoutSettings($basketId: String) {
 			value
 			key
 		}
-		braintreeVsPaypalExp: uiExperimentSetting(key: "braintree_vs_paypal") {
+		braintreeVsPaypalExp: uiExperimentSetting(key: "bt_vs_paypal") {
 			key
 			value
 		}

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -23,7 +23,7 @@ query initializeCheckout($basketId: String) {
 			value
 			key
 		}
-		braintreeVsPaypalExp: uiExperimentSetting(key: "braintree_vs_paypal") {
+		braintreeVsPaypalExp: uiExperimentSetting(key: "bt_vs_paypal") {
 			key
 			value
 		}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -237,7 +237,7 @@ export default {
 			}).then(() => {
 				return Promise.all([
 					client.query({ query: initializeCheckout, fetchPolicy: 'network-only' }),
-					client.query({ query: experimentQuery, variables: { id: 'braintree_vs_paypal' } }),
+					client.query({ query: experimentQuery, variables: { id: 'bt_vs_paypal' } }),
 				]);
 			});
 		},
@@ -289,7 +289,7 @@ export default {
 
 		// Read assigned version of braintree vs paypal exp
 		const braintreeVsPaypalExpAssignment = this.apollo.readFragment({
-			id: 'Experiment:braintree_vs_paypal',
+			id: 'Experiment:bt_vs_paypal',
 			fragment: experimentVersionFragment,
 		}) || {};
 		this.braintreeVsPaypalVersion = braintreeVsPaypalExpAssignment.version;


### PR DESCRIPTION
Tested this out on my VM and it was still working with the new exp name. I also moved the new exp setting into the settingsManager on dev, qa & production. I'll deleted the old exp setting after verification of this work in dev. 