### PR TITLE
Add initial delete saved payment method functionality

### DIFF
--- a/src/assets/icons/notice.svg
+++ b/src/assets/icons/notice.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="35px" height="35px" viewBox="0 0 35 35" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 57.1 (83088) - https://sketch.com -->
+    <title>outlined</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Rd6---BT-CCs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="delete-CC2" transform="translate(-230.000000, -124.000000)" fill-rule="nonzero">
+            <g id="outlined" transform="translate(231.000000, 125.000000)">
+                <path d="M16.5,0 C7.387875,0 0,7.387875 0,16.5 C0,25.612125 7.387875,33 16.5,33 C25.612125,33 33,25.612125 33,16.5 C33,7.387875 25.612125,0 16.5,0 Z" id="Shape-2-Copy-Copy-4-path" stroke="#D74937" stroke-width="2"></path>
+                <polygon id="Shape-2-Copy-Copy-4-path" fill="#D74937" points="18.6275 8.25 14.6375 8.25 15.005 18.75 18.26 18.75"></polygon>
+                <path d="M14.375,23.755 C14.375,25.015 15.29375,26.0125 16.6325,26.0125 C17.97125,26.0125 18.89,25.015 18.89,23.755 C18.89,22.41625 17.97125,21.52375 16.6325,21.52375 C15.29375,21.52375 14.375,22.41625 14.375,23.755 L14.375,23.755 Z" id="Shape-2-Copy-Copy-4-path" fill="#D74937"></path>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/components/Checkout/BraintreeCheckout.vue
+++ b/src/components/Checkout/BraintreeCheckout.vue
@@ -30,11 +30,15 @@
 						<!-- Passing in the last 4 digits of the stored card -->
 						<span class="card-last-four-digits">...{{ paymentMethod.details.lastFour }}</span>
 					</label>
-					<label class="delete-card-item" :for="`delete-card-${index}`">
-						<button class="delete-card-button" @click="showDeleteCardPopup(paymentMethod)">
+					<span class="delete-card-item">
+						<button
+							:id="`delete-card-${index}`"
+							class="delete-card-button"
+							@click="showDeleteCardPopup(paymentMethod)"
+						>
 							<kv-icon name="small-x" />
 						</button>
-					</label>
+					</span>
 				</div>
 				<!-- Only show this div if the user has savedPaymentMethods, otherwise it has not context -->
 				<div
@@ -159,8 +163,6 @@
 				<kv-icon name="notice" />
 			</div>
 			<div class="delete-popup-content">
-				<!-- <h2>Are you sure?</h2>
-				<p>You will not be able to undo this action.</p> -->
 				<h3>
 					Are you sure you want to<br>remove this saved card?
 				</h3>
@@ -870,7 +872,7 @@ $error-red: #fdeceb;
 		}
 
 		.delete-card-button {
-			padding-top: 0.5rem;
+			padding-top: 0.7rem;
 
 			.icon {
 				width: 1.25rem;

--- a/src/components/Checkout/PayPalExpress.vue
+++ b/src/components/Checkout/PayPalExpress.vue
@@ -56,6 +56,7 @@ export default {
 	},
 	methods: {
 		initializePaypal() {
+			this.setUpdatingPaymentWrapper(true);
 			// ensure paypal is loaded before calling
 			this.ensurePaypalScript = window.setInterval(() => {
 				if (typeof paypal !== 'undefined' && !this.paypalRendered) {
@@ -248,10 +249,15 @@ export default {
 				},
 				'#paypal-button'
 			);
+			// clear loader
+			this.setUpdatingPaymentWrapper(false);
 		},
 		setUpdating(state) {
 			this.loading = state;
 			this.$emit('updating-totals', state);
+		},
+		setUpdatingPaymentWrapper(state) {
+			this.$emit('updating-payment-wrapper', state);
 		}
 	}
 };
@@ -263,6 +269,7 @@ export default {
 .paypal-holder {
 	display: block;
 	text-align: center;
+	min-height: rem-calc(55);
 
 	@include breakpoint(medium) {
 		text-align: right;

--- a/src/components/Checkout/PaymentWrapper.vue
+++ b/src/components/Checkout/PaymentWrapper.vue
@@ -14,6 +14,7 @@
 					:amount="amount"
 					@refreshtotals="$emit('refreshTotals', $event)"
 					@updating-totals="$emit('updating-totals', $event)"
+					@updating-payment-wrapper="setUpdatingPaymentWrapper"
 				/>
 			</div>
 			<div>
@@ -22,8 +23,14 @@
 					:amount="amount"
 					@refreshtotals="$emit('refreshTotals', $event)"
 					@updating-totals="$emit('updating-totals', $event)"
+					@updating-payment-wrapper="setUpdatingPaymentWrapper"
 				/>
 			</div>
+			<loading-overlay
+				v-show="updatingPaymentWrapper"
+				id="payment-updating-overlay"
+				class="updating-totals-overlay"
+			/>
 		</div>
 		<div class="attribution-text small-12 medium-7 large-6">
 			Thanks to PayPal powered by Braintree,
@@ -36,12 +43,14 @@
 import BraintreeCheckout from '@/components/Checkout/BraintreeCheckout';
 import PayPalExp from '@/components/Checkout/PayPalExpress';
 import KvPillToggle from '@/components/Kv/KvPillToggle';
+import LoadingOverlay from '@/pages/Lend/LoadingOverlay';
 
 export default {
 	components: {
 		BraintreeCheckout,
 		PayPalExp,
-		KvPillToggle
+		KvPillToggle,
+		LoadingOverlay,
 	},
 	props: {
 		amount: {
@@ -65,7 +74,8 @@ export default {
 					key: 'pp',
 				},
 			],
-			selectedOption: 'bt'
+			selectedOption: 'bt',
+			updatingPaymentWrapper: false,
 		};
 	},
 	created() {
@@ -89,6 +99,9 @@ export default {
 			this.selectedOption = key;
 			this.$kvTrackEvent('basket', 'payment type toggled', key);
 		},
+		setUpdatingPaymentWrapper(state) {
+			this.updatingPaymentWrapper = state;
+		}
 	},
 };
 </script>
@@ -99,6 +112,7 @@ export default {
 $form-border-radius: rem-calc(3);
 
 .payment-holder {
+	position: relative;
 	display: inline-block;
 	white-space: nowrap;
 	text-align: center;
@@ -133,6 +147,29 @@ $form-border-radius: rem-calc(3);
 	.paypal-button {
 		text-align: center;
 		margin-top: rem-calc(25);
+	}
+
+	#payment-updating-overlay {
+		margin-top: 1rem;
+		z-index: 1000;
+		width: auto;
+		height: auto;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		top: 0;
+		background-color: rgba($white, 0.7);
+
+		.spinner-wrapper {
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			position: initial;
+			height: 100%;
+			top: auto;
+			left: auto;
+			transform: none;
+		}
 	}
 }
 

--- a/src/components/Kv/KvIcon.vue
+++ b/src/components/Kv/KvIcon.vue
@@ -187,7 +187,8 @@ export default {
 	fill: #C31B00;
 }
 
-.icon-checkbox-bad {
+.icon-checkbox-bad,
+.icon-notice {
 	fill: $kiva-accent-red;
 }
 

--- a/src/graphql/mutation/deleteBraintreeCard.graphql
+++ b/src/graphql/mutation/deleteBraintreeCard.graphql
@@ -1,0 +1,7 @@
+mutation deleteBraintreeCard($token: ID!) {
+  my {
+	  creditCardVault {
+		  deleteCreditCard(token: $token)
+	  }
+  }
+}

--- a/src/graphql/query/myStoredCards.graphql
+++ b/src/graphql/query/myStoredCards.graphql
@@ -1,0 +1,14 @@
+query myStoredCards {
+	my {
+		creditCardVault {
+			creditCards {
+				token
+				last4
+				expirationDate
+				default
+				cardType
+				imageUrl
+			}
+		}
+	}
+}


### PR DESCRIPTION
As the VaultManager delete method is not currently functional, this approach compares payment method information from our backend api with corresponding information from the VaultManager.fetchPaymentMethods function. We can match the card targed for deletion and then use our backend api to delete the card.