### PR TITLE
Use Fastly HTTP/2 servers

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -4,7 +4,7 @@ var base = require('./index.js')
 module.exports = merge(base, {
 	app: {
 		host: 'www.dev.kiva.org',
-		publicPath: 'https://www-dev-kiva-org.global.ssl.fastly.net/ui/',
+		publicPath: 'https://www-dev-kiva-org.freetls.fastly.net/ui/',
 		graphqlUri: 'https://api.dev.kivaws.org/graphql',
 		enablePerimeterx: true,
 		perimeterxAppId: 'PX5u4Lz98O',

--- a/config/index.js
+++ b/config/index.js
@@ -3,7 +3,7 @@ var path = require('path')
 module.exports = {
 	app: {
 		host: 'www.kiva.org',
-		publicPath: 'https://www-kiva-org.global.ssl.fastly.net/ui/',
+		publicPath: 'https://www-kiva-org.freetls.fastly.net/ui/',
 		graphqlUri: 'https://api.kivaws.org/graphql',
 		enablePerimeterx: true,
 		perimeterxAppId: 'PXr3pNVz1F',

--- a/config/k8sdev.js
+++ b/config/k8sdev.js
@@ -3,7 +3,7 @@ var dev  = require('./dev.js')
 
 module.exports = merge(dev, {
 	app: {
-		publicPath: 'https://www-dev-kiva-org.global.ssl.fastly.net/',
+		publicPath: 'https://www-dev-kiva-org.freetls.fastly.net/',
 	},
 	server: {
 		memcachedServers: 'k8sdev-elasticache.bu9ifv.0001.usw1.cache.amazonaws.com:11211',

--- a/config/qa.js
+++ b/config/qa.js
@@ -4,7 +4,7 @@ var base = require('./index.js')
 module.exports = merge(base, {
 	app: {
 		host: 'www.qa.kiva.org',
-		publicPath: 'https://www-qa-kiva-org.global.ssl.fastly.net/ui/',
+		publicPath: 'https://www-qa-kiva-org.freetls.fastly.net/ui/',
 		graphqlUri: 'https://api.qa.kivaws.org/graphql',
 		enablePerimeterx: false,
 		perimeterxAppId: '####',

--- a/config/stage.js
+++ b/config/stage.js
@@ -4,7 +4,7 @@ var base = require('./index.js')
 module.exports = merge(base, {
 	app: {
 		host: 'www.stage.kiva.org',
-		publicPath: 'https://www-stage-kiva-org.global.ssl.fastly.net/ui/',
+		publicPath: 'https://www-stage-kiva-org.freetls.fastly.net/ui/',
 		graphqlUri: 'https://api.stage.kivaws.org/graphql',
 		enablePerimeterx: false,
 		perimeterxAppId: '####',

--- a/src/App.vue
+++ b/src/App.vue
@@ -50,7 +50,7 @@ export default {
 				// eslint-disable-next-line max-len
 				{ property: 'og:description', vmid: 'og:description', content: 'Support women, entrepreneurs, students and refugees around the world with as little as $25 on Kiva. 100% of your loans go to support borrowers.' },
 				{ property: 'theme-color', content: '#4faf4e' },
-				{ property: 'og:image', content: 'https://www-kiva-org.global.ssl.fastly.net/cms/kiva-og-image.jpg' },
+				{ property: 'og:image', content: 'https://www-kiva-org.freetls.fastly.net/cms/kiva-og-image.jpg' },
 				{ property: 'og:image:width', content: '1200' },
 				{ property: 'og:image:height', content: '630' },
 			]).concat([
@@ -86,7 +86,7 @@ export default {
 				},
 				{
 					name: 'twitter:image',
-					content: 'https://www-kiva-org.global.ssl.fastly.net/cms/kiva-ogtwitter-image.jpg'
+					content: 'https://www-kiva-org.freetls.fastly.net/cms/kiva-ogtwitter-image.jpg'
 				},
 			]),
 			link: [


### PR DESCRIPTION
We've apparently been able to use HTTP/2 this whole time, we just had to change which url we were using https://docs.fastly.com/en/guides/setting-up-free-tls#support-for-http2-ipv6-and-tls-12