### PR TITLE
Return null if val and cleanedVal are empty.

### DIFF
--- a/src/util/settingsUtils.js
+++ b/src/util/settingsUtils.js
@@ -27,8 +27,8 @@ export function readBoolSetting(data, key) {
 export function readDateSetting(data, key) {
 	const val = _get(data, key);
 	// extra string cleanup for firefox
-	const cleanedDateVal = val.replace(/[/"]/g, '');
-	return val ? new Date(cleanedDateVal) : null;
+	const cleanedDateVal = val ? val.replace(/[/"]/g, '') : null;
+	return cleanedDateVal ? new Date(cleanedDateVal) : null;
 }
 
 /**


### PR DESCRIPTION
Extra check to try and clear "ApolloMixin promotionalBanner TypeError: Cannot read property 'replace' of undefined" in Example.spec.js