### PR TITLE
Hide basket bar for autolending settings page

### DIFF
--- a/src/pages/Autolending/AutolendingPage.vue
+++ b/src/pages/Autolending/AutolendingPage.vue
@@ -230,5 +230,9 @@ $autolending-font-size: rem-calc(18.8);
 			}
 		}
 	}
+
+	.basket-bar {
+		display: none;
+	}
 }
 </style>


### PR DESCRIPTION
* Basket bar overlaps save settings button for mobile. Hid basket bar so that save settings button can be clicked.
* CASH-1502