### PR TITLE
Cleaned up unit tests to remove warnings and errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "The Kiva ui",
 	"author": "braincrave",
 	"private": true,
-	"licencse": "UNLICENCSED",
+	"license": "UNLICENSED",
 	"scripts": {
 		"dev": "cross-env NODE_ENV=development node --max-old-space-size=2048 server/dev-server.js",
 		"start": "cross-env NODE_ENV=production node --max-old-space-size=2048 server/index.js",

--- a/src/graphql/fragments/promoSetting.graphql
+++ b/src/graphql/fragments/promoSetting.graphql
@@ -1,4 +1,0 @@
-fragment promoSetting on Setting {
-	id
-	version
-}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,7 +1,7 @@
 import changeCaseFilter from './change-case-filter';
 import apolloMixin from './apollo-plugin';
 import numeralFilter from './numeral-filter';
-import kvAnayltics from './kv-analytics-plugin';
+import kvAnalytics from './kv-analytics-plugin';
 import tipMessage from './tip-message-plugin';
 
 export default {
@@ -9,7 +9,7 @@ export default {
 		apolloMixin(Vue);
 		Vue.filter('changeCase', changeCaseFilter);
 		Vue.filter('numeral', numeralFilter);
-		kvAnayltics(Vue);
+		kvAnalytics(Vue);
 		tipMessage(Vue);
 	}
 };

--- a/test/unit/specs/components/RouteListing.spec.js
+++ b/test/unit/specs/components/RouteListing.spec.js
@@ -1,14 +1,27 @@
-import Vue from 'vue';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import VueRouter from 'vue-router';
 import RouteListing from '@/pages/UiSiteMap/RouteListing';
 import routes from '@/router/routes';
-import createRouter from '@/router';
 
+const localVue = createLocalVue();
+localVue.use(VueRouter);
+
+// Async components in route causes some issues with components that use
+// require.context. Lets remove the component from the route since we are
+// just testing the number of routes
+const routesWithOutComponents = routes.map(route => ({
+	path: route.path
+}));
+
+const router = new VueRouter({ routes: routesWithOutComponents });
 
 describe('RouteListing.vue', () => {
 	it('should render 2 labels', () => {
-		const router = createRouter();
-		const Constructor = Vue.extend(RouteListing);
-		const vm = new Constructor({ router }).$mount();
-		expect(vm.$el.querySelectorAll('li').length).toEqual(routes.length);
+		const wrapper = shallowMount(RouteListing, {
+			localVue,
+			router,
+		});
+		const list = wrapper.findAll('li');
+		expect(list.length).toEqual(routes.length);
 	});
 });

--- a/test/unit/specs/components/WwwFrame/TheHeader.spec.js
+++ b/test/unit/specs/components/WwwFrame/TheHeader.spec.js
@@ -2,9 +2,11 @@ import { shallowMount, createLocalVue, RouterLinkStub } from '@vue/test-utils';
 import TheHeader from '@/components/WwwFrame/TheHeader';
 import kvAnalytics from '@/plugins/kv-analytics-plugin';
 import { MockKvAuth0 } from '@/util/KvAuth0';
+import numeralFilter from '@/plugins/numeral-filter';
 
 const localVue = createLocalVue();
 localVue.use(kvAnalytics);
+localVue.filter('numeral', numeralFilter);
 
 describe('TheHeader', () => {
 	it('should hide/show the search area when the search toggle button is clicked', () => {
@@ -15,6 +17,9 @@ describe('TheHeader', () => {
 				SearchBar: {
 					template: '<div></div>',
 					methods: { focus() {} }
+				},
+				TheLendMenu: {
+					template: '<div></div>'
 				},
 			},
 			provide: {


### PR DESCRIPTION
Cleaned up the unit tests, some minor misspellings. 

The e2e tests still produce this type of error: 
ApolloMixin promotionalBanner { Invariant Violation: Invariant Violation: 8 (see https://github.com/apollographql/invariant-packages)

Which I am giving up on because I didn't really get anywhere trying to figure out what it was...
