### PR TITLE
PNG Dev Cache Fix

### DIFF
--- a/build/webpack.client.base.conf.js
+++ b/build/webpack.client.base.conf.js
@@ -53,9 +53,12 @@ module.exports = merge.smart(baseWebpackConfig, {
 				// mini-css and hard-source together. Ignoring the mini-css loader
 				// modules, but not the other css loader modules, excludes the modules
 				// that mini-css needs rebuilt to output assets every time.
-				// The above is also true for .woff font files and the SVG sprite
-				// created by svgXhr
+				// The above is also true for .woff font files, pngs in css, and the
+				// SVG sprite created by svgXhr
 				test: /mini-css-extract-plugin[\\/]dist[\\/]loader/,
+			},
+			{
+				test: /png/,
 			},
 			{
 				test: /woff/,


### PR DESCRIPTION
* Png assets referenced in the css of Vue single file components are not being referenced correctly when
 read from cache. This excludes them from the cache. Issue can be seen with background image on KvDropdownRounded.vue