### PR TITLE
Avoid cache when initializing auto-lending settings

### DIFF
--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -95,7 +95,7 @@ export default () => {
 
 					return new Promise((resolve, reject) => {
 						// Query for all the details of the server profile
-						client.query({ query: serverProfileQuery })
+						client.query({ query: serverProfileQuery, fetchPolicy: 'network-only' })
 							.then(result => {
 								if (result.errors) {
 									// Throw the first error that is found


### PR DESCRIPTION
This fixes an issue where you aren't redirected to login when navigating to /settings/autolending on the client-side