### PR TITLE
CASH-1538 CASH-1539 Fixes for autolending settings data layer

### DIFF
--- a/src/api/fixtures/AutolendProfile.js
+++ b/src/api/fixtures/AutolendProfile.js
@@ -13,6 +13,7 @@ export default function AutolendProfile() {
 		isEnabled: false,
 		donationPercentage: 15,
 		lendAfterDaysIdle: 90,
+		idleCreditOptIn: true,
 		enableAfter: 0,
 		loanSearchCriteria: LoanSearchCriteria(),
 	};
@@ -48,6 +49,7 @@ export function profilesAreEqual(a, b) {
 	if (!a || !b) return false; // if only one is undefined, return false
 	if (a.isEnabled !== b.isEnabled) return false;
 	if (a.enableAfter !== b.enableAfter) return false;
+	if (a.idleCreditOptIn !== b.idleCreditOptIn) return false;
 	if (a.donationPercentage !== b.donationPercentage) return false;
 	if (a.lendAfterDaysIdle !== b.lendAfterDaysIdle) return false;
 	if (!criteriaAreEqual(a.loanSearchCriteria, b.loanSearchCriteria)) return false;

--- a/src/api/fixtures/LoanSearchFilters.js
+++ b/src/api/fixtures/LoanSearchFilters.js
@@ -1,36 +1,29 @@
 import _isEqual from 'lodash/isEqual';
-import _omit from 'lodash/omit';
+import _pick from 'lodash/pick';
+import MinMaxRange, {
+	getCacheableRange,
+	getInputRange,
+	getSearchableRange,
+} from './MinMaxRange';
 
 // Return a LoanSearchFilters object with default values
 export default function LoanSearchFilters() {
+	const riskRating = MinMaxRange();
+	riskRating.min = 0;
+	riskRating.max = 5;
+
 	return {
 		__typename: 'LoanSearchFilters',
-		arrearsRate: {
-			__typename: 'MinMaxRange',
-			min: null,
-			max: null,
-		},
+		arrearsRate: MinMaxRange(),
 		theme: null,
 		country: [],
-		defaultRate: {
-			__typename: 'MinMaxRange',
-			min: null,
-			max: null,
-		},
+		defaultRate: MinMaxRange(),
 		gender: null,
 		isGroup: null,
-		lenderTerm: {
-			__typename: 'MinMaxRange',
-			min: null,
-			max: null,
-		},
+		lenderTerm: MinMaxRange(),
 		loanLimit: null,
 		partner: null,
-		riskRating: {
-			__typename: 'MinMaxRange',
-			min: 0,
-			max: 5,
-		},
+		riskRating,
 		sector: null,
 	};
 }
@@ -42,48 +35,69 @@ export function getCacheableFilters(filters) {
 		__typename: 'LoanSearchFilters',
 	};
 	if (filters.arrearsRate) {
-		result.arrearsRate = {
-			...filters.arrearsRate,
-			__typename: 'MinMaxRange',
-		};
+		result.arrearsRate = getCacheableRange(filters.arrearsRate);
 	}
 	if (filters.defaultRate) {
-		result.defaultRate = {
-			...filters.defaultRate,
-			__typename: 'MinMaxRange',
-		};
+		result.defaultRate = getCacheableRange(filters.defaultRate);
 	}
 	if (filters.lenderTerm) {
-		result.lenderTerm = {
-			...filters.lenderTerm,
-			__typename: 'MinMaxRange',
-		};
+		result.lenderTerm = getCacheableRange(filters.lenderTerm);
 	}
 	if (filters.riskRating) {
-		result.riskRating = {
-			...filters.riskRating,
-			__typename: 'MinMaxRange',
-		};
+		result.riskRating = getCacheableRange(filters.riskRating);
 	}
 	return result;
 }
 
 // Return a cleaned filters object suitable for a query variable
 export function getInputFilters(filters) {
-	return _omit(filters, [
-		'__typename',
-		'arrearsRate.__typename',
-		'defaultRate.__typename',
-		'lenderTerm.__typename',
-		'riskRating.__typename',
-	]);
+	return {
+		..._pick(filters, [
+			'theme',
+			'country',
+			'gender',
+			'isGroup',
+			'loanLimit',
+			'partner',
+			'sector',
+		]),
+		arrearsRate: getInputRange(filters.arrearsRate),
+		defaultRate: getInputRange(filters.defaultRate),
+		lenderTerm: getInputRange(filters.lenderTerm),
+		riskRating: getInputRange(filters.riskRating),
+	};
 }
 
 // Return filters that can be used in a loan search
 export function getSearchableFilters(filters) {
-	return _omit(getInputFilters(filters), [
-		'loanLimit',
+	const result = _pick(filters, [
+		'theme',
+		'country',
+		'gender',
+		'isGroup',
+		'partner',
+		'sector',
 	]);
+	if (filters) {
+		const arrearsRate = getSearchableRange(filters.arrearsRate);
+		if (arrearsRate) {
+			result.arrearsRate = arrearsRate;
+		}
+		const defaultRate = getSearchableRange(filters.defaultRate);
+		if (defaultRate) {
+			result.defaultRate = defaultRate;
+		}
+		const lenderTerm = getSearchableRange(filters.lenderTerm);
+		if (lenderTerm) {
+			result.lenderTerm = lenderTerm;
+		}
+		const riskRating = getSearchableRange(filters.riskRating);
+		if (riskRating) {
+			result.riskRating = riskRating;
+		}
+	}
+
+	return result;
 }
 
 // Return true if the two given loan search filters objects are the same

--- a/src/api/fixtures/LoanSearchFilters.js
+++ b/src/api/fixtures/LoanSearchFilters.js
@@ -10,7 +10,7 @@ export default function LoanSearchFilters() {
 			min: null,
 			max: null,
 		},
-		theme: [],
+		theme: null,
 		country: [],
 		defaultRate: {
 			__typename: 'MinMaxRange',
@@ -24,14 +24,14 @@ export default function LoanSearchFilters() {
 			min: null,
 			max: null,
 		},
-		// loanLimit
-		partner: [],
+		loanLimit: null,
+		partner: null,
 		riskRating: {
 			__typename: 'MinMaxRange',
 			min: 0,
 			max: 5,
 		},
-		sector: [],
+		sector: null,
 	};
 }
 

--- a/src/api/fixtures/MinMaxRange.js
+++ b/src/api/fixtures/MinMaxRange.js
@@ -1,0 +1,51 @@
+import _isNumber from 'lodash/isNumber';
+import _pick from 'lodash/pick';
+
+// Return a MinMaxRange object with default values
+export default function MinMaxRange() {
+	return {
+		__typename: 'MinMaxRange',
+		min: null,
+		max: null,
+	};
+}
+
+// Return a range object suitable to write to the cache
+export function getCacheableRange(range) {
+	return {
+		...range,
+		__typename: 'MinMaxRange',
+	};
+}
+
+// Return a cleaned range object suitable for a query variable
+export function getInputRange(range) {
+	return _pick(range, ['min', 'max']);
+}
+
+// Return range that can be used in a loan search
+export function getSearchableRange(range) {
+	let result;
+
+	// only set min if it is defined
+	if (range && _isNumber(range.min)) {
+		result = result || {};
+		result.min = range.min;
+	}
+	// only set max if it is defined
+	if (range && _isNumber(range.max)) {
+		result = result || {};
+		result.max = range.max;
+	}
+
+	return result;
+}
+
+// Return true if the two given min max range objects are the same
+export function rangesAreEqual(a, b) {
+	if (!a && !b) return true;
+	if (!a || !b) return false;
+	if (a.min !== b.min) return false;
+	if (a.max !== b.max) return false;
+	return true;
+}

--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -9,7 +9,10 @@ import AutolendProfile, {
 	getInputProfile,
 	profilesAreEqual,
 } from '@/api/fixtures/AutolendProfile';
-import { criteriaAreEqual, getSearchableCriteria } from '@/api/fixtures/LoanSearchCriteria';
+import LoanSearchCriteria, {
+	criteriaAreEqual,
+	getSearchableCriteria,
+} from '@/api/fixtures/LoanSearchCriteria';
 
 // Helper function for writing autolending data to the cache
 function writeAutolendingData(cache, { currentProfile, savedProfile, ...data }) {
@@ -109,8 +112,14 @@ export default () => {
 								}
 								return result;
 							})
-							// Return default profile if non is defined on the server
-							.then(result => _get(result, 'data.my.autolendProfile') || AutolendProfile())
+							// Return default profile/loan search criteria if none is defined on the server
+							.then(result => {
+								const profile = _get(result, 'data.my.autolendProfile') || AutolendProfile();
+								return {
+									...profile,
+									loanSearchCriteria: profile.loanSearchCriteria || LoanSearchCriteria(),
+								};
+							})
 							// Write the fetched profile to the cache as both the current and saved profiles
 							.then(profile => {
 								writeAutolendingData(cache, {

--- a/src/pages/Autolending/AutolendingPage.vue
+++ b/src/pages/Autolending/AutolendingPage.vue
@@ -66,7 +66,7 @@
 						<risk-rating-dropdown />
 					</div>
 					<div class="small-12 large-6 columns setting-column">
-						<!-- <default-rate-dropdown /> -->
+						<default-rate-dropdown />
 					</div>
 				</div>
 			</kv-expandable>
@@ -105,7 +105,7 @@ import LoanTermDropdown from './LoanTermDropdown';
 import GroupRadios from './GroupRadios';
 import PartnerDelRateDropdown from './PartnerDelRateDropdown';
 import LoanIncrementRadios from './LoanIncrementRadios';
-// import DefaultRateDropdown from './DefaultRateDropdown';
+import DefaultRateDropdown from './DefaultRateDropdown';
 
 export default {
 	inject: ['apollo'],
@@ -127,7 +127,7 @@ export default {
 		LoanTermDropdown,
 		PartnerDelRateDropdown,
 		LoanIncrementRadios,
-		// DefaultRateDropdown,
+		DefaultRateDropdown,
 		WwwPage,
 	},
 	data() {

--- a/src/pages/Autolending/DefaultRateDropdown.vue
+++ b/src/pages/Autolending/DefaultRateDropdown.vue
@@ -7,28 +7,28 @@
 			<option value="0">
 				All
 			</option>
-			<option value="1">
+			<option value="0.01">
 				1% or less
 			</option>
-			<option value="2">
+			<option value="0.02">
 				2% or less
 			</option>
-			<option value="3">
+			<option value="0.03">
 				3% or less
 			</option>
-			<option value="4">
+			<option value="0.04">
 				4% or less
 			</option>
-			<option value="5">
+			<option value="0.05">
 				5% or less
 			</option>
-			<option value="6">
+			<option value="0.06">
 				6% or less
 			</option>
-			<option value="7">
+			<option value="0.07">
 				7% or less
 			</option>
-			<option value="8">
+			<option value="0.08">
 				8% or less
 			</option>
 		</kv-dropdown-rounded>

--- a/src/pages/Autolending/PartnerDelRateDropdown.vue
+++ b/src/pages/Autolending/PartnerDelRateDropdown.vue
@@ -7,19 +7,19 @@
 			<option value="0">
 				All delinquency rates
 			</option>
-			<option value="5">
+			<option value="0.05">
 				5% or less
 			</option>
-			<option value="10">
+			<option value="0.1">
 				10% or less
 			</option>
-			<option value="15">
+			<option value="0.15">
 				15% or less
 			</option>
-			<option value="20">
+			<option value="0.2">
 				20% or less
 			</option>
-			<option value="25">
+			<option value="0.25">
 				25% or less
 			</option>
 		</kv-dropdown-rounded>


### PR DESCRIPTION
Fixes problems with range filters (CASH-1538, CASH-1539) and also addresses unticketed issue of page having trouble loading when autolend profile and/or loan search criteria are not defined.