### PR TITLE
KvRadio tuneup

### DIFF
--- a/.storybook/stories/KvFormKitchenSink.stories.js
+++ b/.storybook/stories/KvFormKitchenSink.stories.js
@@ -1,0 +1,143 @@
+import KvDropdownRounded from '@/components/Kv/KvDropdownRounded';
+import KvPillToggle from '@/components/Kv/KvPillToggle';
+import KvRadio from '@/components/Kv/KvRadio';
+
+export default { title: 'Kv | Form Elements' };
+
+export const KitchenSink = () => ({
+	components: {
+		KvDropdownRounded,
+		KvPillToggle,
+		KvRadio,
+	},
+	data() {
+		return {
+			kvRadioSelected: 'female',
+			kvPillOptions: [
+				{
+					title: 'Option 1',
+					key: 'o1',
+					disabled: true
+				},
+				{
+					title: 'Option 2',
+					key: 'o2',
+				},
+				{
+					title: 'Option 3',
+					key: 'o3',
+				},
+			],
+			kvPillSelected: 'o2',
+			kvDropdownRoundedModel: 'test2'
+		}
+	},
+	template: `
+		<section id="section-form">
+			<form>
+				<fieldset>
+					<legend>Example Legend</legend>
+
+					<fieldset style="margin-bottom: 2rem;">
+						<kv-pill-toggle
+							:options="kvPillOptions"
+							:selected="kvPillSelected"
+						/>
+					</fieldset>
+
+					<fieldset style="margin-bottom: 2rem;">
+						<div>
+							<kv-radio
+								name="gender-radio"
+								radioValue="both"
+								v-model="kvRadioSelected"
+								disabled
+							>
+								Everyone
+							</kv-radio>
+						</div>
+						<div>
+							<kv-radio
+								name="gender-radio"
+								radioValue="female"
+								v-model="kvRadioSelected"
+							>
+								Women only
+							</kv-radio>
+						</div>
+						<div>
+							<kv-radio
+								name="gender-radio"
+								radioValue="male"
+								v-model="kvRadioSelected"
+							>
+								Men only
+							</kv-radio>
+						</div>
+					</fieldset>
+
+					<fieldset style="margin-bottom: 2rem;">
+						<kv-dropdown-rounded v-model="kvDropdownRoundedModel">
+							<option value="test">Test</option>
+							<option value="test2">Test2</option>
+							<option value="test3">Test3</option>
+						</kv-dropdown-rounded>
+					</fieldset>
+
+				</fieldset>
+
+				<fieldset>
+					<label for="example-select">
+						Select
+						<select
+							name="example-select"
+							id="example-select"
+						>
+							<option
+								v-for="singleOption in options"
+								:key="singleOption"
+								:value="singleOption"
+							>
+								{{ singleOption }}
+							</option>
+						</select>
+					</label>
+					<label for="example-multiple-select">
+						Multiple Select
+						<select
+							name="example-multiple-select"
+							id="example-multiple-select"
+							multiple
+						>
+							<option
+								v-for="singleOption in options"
+								:key="singleOption"
+								:value="singleOption"
+							>
+								{{ singleOption }}
+							</option>
+						</select>
+					</label>
+				</fieldset>
+
+				<fieldset>
+					<label>
+						Input Text
+						<input
+							type="text"
+							name="inputText"
+							maxlength="40"
+						>
+					</label>
+					<label>
+						Input Text Area
+						<textarea
+							name="inputTextarea"
+							rows="4"
+						></textarea>
+					</label>
+				</fieldset>
+			</form>
+		</section>
+	`
+});

--- a/.storybook/stories/KvFormKitchenSink.stories.js
+++ b/.storybook/stories/KvFormKitchenSink.stories.js
@@ -49,7 +49,6 @@ export const KitchenSink = () => ({
 						<legend>Gender</legend>
 						<kv-radio
 							id="gender-radio-both"
-							name="gender-radio"
 							radio-value="both"
 							v-model="kvRadioSelected"
 							disabled
@@ -58,7 +57,6 @@ export const KitchenSink = () => ({
 						</kv-radio>
 						<kv-radio
 							id="gender-radio-female"
-							name="gender-radio"
 							radio-value="female"
 							v-model="kvRadioSelected"
 						>
@@ -66,7 +64,6 @@ export const KitchenSink = () => ({
 						</kv-radio>
 						<kv-radio
 							id="gender-radio-male"
-							name="gender-radio"
 							radio-value="male"
 							v-model="kvRadioSelected"
 						>

--- a/.storybook/stories/KvFormKitchenSink.stories.js
+++ b/.storybook/stories/KvFormKitchenSink.stories.js
@@ -47,37 +47,31 @@ export const KitchenSink = () => ({
 
 					<fieldset style="margin-bottom: 2rem;">
 						<legend>Gender</legend>
-						<div>
-							<kv-radio
-								id="gender-radio-both"
-								name="gender-radio"
-								radioValue="both"
-								v-model="kvRadioSelected"
-								disabled
-							>
-								Everyone
-							</kv-radio>
-						</div>
-						<div>
-							<kv-radio
-								id="gender-radio-female"
-								name="gender-radio"
-								radioValue="female"
-								v-model="kvRadioSelected"
-							>
-								Women only
-							</kv-radio>
-						</div>
-						<div>
-							<kv-radio
-								id="gender-radio-male"
-								name="gender-radio"
-								radioValue="male"
-								v-model="kvRadioSelected"
-							>
-								Men only
-							</kv-radio>
-						</div>
+						<kv-radio
+							id="gender-radio-both"
+							name="gender-radio"
+							radio-value="both"
+							v-model="kvRadioSelected"
+							disabled
+						>
+							Everyone
+						</kv-radio>
+						<kv-radio
+							id="gender-radio-female"
+							name="gender-radio"
+							radio-value="female"
+							v-model="kvRadioSelected"
+						>
+							Women only
+						</kv-radio>
+						<kv-radio
+							id="gender-radio-male"
+							name="gender-radio"
+							radio-value="male"
+							v-model="kvRadioSelected"
+						>
+							Men only
+						</kv-radio>
 					</fieldset>
 
 					<fieldset style="margin-bottom: 2rem;">

--- a/.storybook/stories/KvFormKitchenSink.stories.js
+++ b/.storybook/stories/KvFormKitchenSink.stories.js
@@ -46,8 +46,10 @@ export const KitchenSink = () => ({
 					</fieldset>
 
 					<fieldset style="margin-bottom: 2rem;">
+						<legend>Gender</legend>
 						<div>
 							<kv-radio
+								id="gender-radio-both"
 								name="gender-radio"
 								radioValue="both"
 								v-model="kvRadioSelected"
@@ -58,6 +60,7 @@ export const KitchenSink = () => ({
 						</div>
 						<div>
 							<kv-radio
+								id="gender-radio-female"
 								name="gender-radio"
 								radioValue="female"
 								v-model="kvRadioSelected"
@@ -67,6 +70,7 @@ export const KitchenSink = () => ({
 						</div>
 						<div>
 							<kv-radio
+								id="gender-radio-male"
 								name="gender-radio"
 								radioValue="male"
 								v-model="kvRadioSelected"

--- a/.storybook/stories/KvRadio.stories.js
+++ b/.storybook/stories/KvRadio.stories.js
@@ -13,38 +13,39 @@ export const Default = () => ({
 	},
 	template: `
 		<div>
-			<kv-radio
-				label-set="genderRadioSetBoth"
-				name-set="genderRadio"
-				radio-value="both"
-				v-model="gender"
-				class="filter-radio"
-			>
-				Everyone
-			</kv-radio>
-			<kv-radio
-				label-set="genderRadioSetFemale"
-				name-set="genderRadio"
-				radio-value="female"
-				v-model="gender"
-				class="filter-radio"
-			>
-				Women only
-			</kv-radio>
-			<kv-radio
-				label-set="genderRadioSetMale"
-				name-set="genderRadio"
-				radio-value="male"
-				v-model="gender"
-				class="filter-radio"
-			>
-				Men only
-			</kv-radio>
+			<div>
+				<kv-radio
+					name="gender-radio"
+					radio-value="both"
+					v-model="gender"
+					disabled
+				>
+					Everyone
+				</kv-radio>
+			</div>
+			<div>
+				<kv-radio
+					name="gender-radio"
+					radio-value="female"
+					v-model="gender"
+				>
+					Women only
+				</kv-radio>
+			</div>
+			<div>
+				<kv-radio
+					name="gender-radio"
+					radio-value="male"
+					v-model="gender"
+				>
+					Men only
+				</kv-radio>
+			</div>
 		</div>
 	`
 });
 
-export const Disabled = () => ({
+export const FontSized = () => ({
 	components: {
 		KvRadio
 	},
@@ -54,17 +55,35 @@ export const Disabled = () => ({
 		}
 	},
 	template: `
-		<div>
-			<kv-radio
-				label-set="genderRadioSetBoth"
-				name-set="genderRadio"
-				radio-value="both"
-				v-model="gender"
-				class="filter-radio"
-				disabled
-			>
-				Disabled
-			</kv-radio>
+		<div style="font-size: 2rem;">
+			<div>
+				<kv-radio
+					name="gender-radio"
+					radio-value="both"
+					v-model="gender"
+					disabled
+				>
+					Everyone
+				</kv-radio>
+			</div>
+			<div>
+				<kv-radio
+					name="gender-radio"
+					radio-value="female"
+					v-model="gender"
+				>
+					Women only
+				</kv-radio>
+			</div>
+			<div>
+				<kv-radio
+					name="gender-radio"
+					radio-value="male"
+					v-model="gender"
+				>
+					Men only
+				</kv-radio>
+			</div>
 		</div>
 	`
 });

--- a/.storybook/stories/KvRadio.stories.js
+++ b/.storybook/stories/KvRadio.stories.js
@@ -14,37 +14,31 @@ export const Default = () => ({
 	template: `
 		<fieldset>
 			<legend>What is your favorite color?</legend>
-			<div>
-				<kv-radio
-					id="color-radio-red"
-					name="color-radio"
-					radio-value="red"
-					v-model="color"
-					disabled
-				>
-					Red
-				</kv-radio>
-			</div>
-			<div>
-				<kv-radio
-					id="color-radio-green"
-					name="color-radio"
-					radio-value="green"
-					v-model="color"
-				>
-					Green
-				</kv-radio>
-			</div>
-			<div>
-				<kv-radio
-					id="color-radio-blue"
-					name="color-radio-blue"
-					radio-value="blue"
-					v-model="color"
-				>
-					Blue
-				</kv-radio>
-			</div>
+			<kv-radio
+				id="color-radio-red"
+				name="color-radio"
+				radio-value="red"
+				v-model="color"
+				disabled
+			>
+				Red
+			</kv-radio>
+			<kv-radio
+				id="color-radio-green"
+				name="color-radio"
+				radio-value="green"
+				v-model="color"
+			>
+				Green
+			</kv-radio>
+			<kv-radio
+				id="color-radio-blue"
+				name="color-radio-blue"
+				radio-value="blue"
+				v-model="color"
+			>
+				Blue
+			</kv-radio>
 		</fieldset>
 	`
 });
@@ -61,37 +55,31 @@ export const FontSized = () => ({
 	template: `
 		<fieldset style="font-size: 2rem;">
 			<legend>What is your favorite color?</legend>
-			<div>
-				<kv-radio
-					id="color-radio-red"
-					name="color-radio"
-					radio-value="red"
-					v-model="color"
-					disabled
-				>
-					Red
-				</kv-radio>
-			</div>
-			<div>
-				<kv-radio
-					id="color-radio-green"
-					name="color-radio"
-					radio-value="green"
-					v-model="color"
-				>
-					Green
-				</kv-radio>
-			</div>
-			<div>
-				<kv-radio
-					id="color-radio-blue"
-					name="color-radio-blue"
-					radio-value="blue"
-					v-model="color"
-				>
-					Blue
-				</kv-radio>
-			</div>
+			<kv-radio
+				id="color-radio-red"
+				name="color-radio"
+				radio-value="red"
+				v-model="color"
+				disabled
+			>
+				Red
+			</kv-radio>
+			<kv-radio
+				id="color-radio-green"
+				name="color-radio"
+				radio-value="green"
+				v-model="color"
+			>
+				Green
+			</kv-radio>
+			<kv-radio
+				id="color-radio-blue"
+				name="color-radio-blue"
+				radio-value="blue"
+				v-model="color"
+			>
+				Blue
+			</kv-radio>
 		</fieldset>
 	`
 });

--- a/.storybook/stories/KvRadio.stories.js
+++ b/.storybook/stories/KvRadio.stories.js
@@ -8,40 +8,44 @@ export const Default = () => ({
 	},
 	data() {
 		return {
-			gender: 'female',
+			color: 'red',
 		}
 	},
 	template: `
-		<div>
+		<fieldset>
+			<legend>What is your favorite color?</legend>
 			<div>
 				<kv-radio
-					name="gender-radio"
-					radio-value="both"
-					v-model="gender"
+					id="color-radio-red"
+					name="color-radio"
+					radio-value="red"
+					v-model="color"
 					disabled
 				>
-					Everyone
+					Red
 				</kv-radio>
 			</div>
 			<div>
 				<kv-radio
-					name="gender-radio"
-					radio-value="female"
-					v-model="gender"
+					id="color-radio-green"
+					name="color-radio"
+					radio-value="green"
+					v-model="color"
 				>
-					Women only
+					Green
 				</kv-radio>
 			</div>
 			<div>
 				<kv-radio
-					name="gender-radio"
-					radio-value="male"
-					v-model="gender"
+					id="color-radio-blue"
+					name="color-radio-blue"
+					radio-value="blue"
+					v-model="color"
 				>
-					Men only
+					Blue
 				</kv-radio>
 			</div>
-		</div>
+		</fieldset>
 	`
 });
 
@@ -51,39 +55,43 @@ export const FontSized = () => ({
 	},
 	data() {
 		return {
-			gender: 'female',
+			color: 'green',
 		}
 	},
 	template: `
-		<div style="font-size: 2rem;">
+		<fieldset style="font-size: 2rem;">
+			<legend>What is your favorite color?</legend>
 			<div>
 				<kv-radio
-					name="gender-radio"
-					radio-value="both"
-					v-model="gender"
+					id="color-radio-red"
+					name="color-radio"
+					radio-value="red"
+					v-model="color"
 					disabled
 				>
-					Everyone
+					Red
 				</kv-radio>
 			</div>
 			<div>
 				<kv-radio
-					name="gender-radio"
-					radio-value="female"
-					v-model="gender"
+					id="color-radio-green"
+					name="color-radio"
+					radio-value="green"
+					v-model="color"
 				>
-					Women only
+					Green
 				</kv-radio>
 			</div>
 			<div>
 				<kv-radio
-					name="gender-radio"
-					radio-value="male"
-					v-model="gender"
+					id="color-radio-blue"
+					name="color-radio-blue"
+					radio-value="blue"
+					v-model="color"
 				>
-					Men only
+					Blue
 				</kv-radio>
 			</div>
-		</div>
+		</fieldset>
 	`
 });

--- a/.storybook/stories/KvRadio.stories.js
+++ b/.storybook/stories/KvRadio.stories.js
@@ -16,7 +16,6 @@ export const Default = () => ({
 			<legend>What is your favorite color?</legend>
 			<kv-radio
 				id="color-radio-red"
-				name="color-radio"
 				radio-value="red"
 				v-model="color"
 				disabled
@@ -25,7 +24,6 @@ export const Default = () => ({
 			</kv-radio>
 			<kv-radio
 				id="color-radio-green"
-				name="color-radio"
 				radio-value="green"
 				v-model="color"
 			>
@@ -33,7 +31,6 @@ export const Default = () => ({
 			</kv-radio>
 			<kv-radio
 				id="color-radio-blue"
-				name="color-radio-blue"
 				radio-value="blue"
 				v-model="color"
 			>
@@ -57,7 +54,6 @@ export const FontSized = () => ({
 			<legend>What is your favorite color?</legend>
 			<kv-radio
 				id="color-radio-red"
-				name="color-radio"
 				radio-value="red"
 				v-model="color"
 				disabled
@@ -66,7 +62,6 @@ export const FontSized = () => ({
 			</kv-radio>
 			<kv-radio
 				id="color-radio-green"
-				name="color-radio"
 				radio-value="green"
 				v-model="color"
 			>
@@ -74,7 +69,6 @@ export const FontSized = () => ({
 			</kv-radio>
 			<kv-radio
 				id="color-radio-blue"
-				name="color-radio-blue"
 				radio-value="blue"
 				v-model="color"
 			>

--- a/src/assets/scss/_settings.scss
+++ b/src/assets/scss/_settings.scss
@@ -498,6 +498,17 @@ $button-smaller-medium-shadow: 0 2px $button-background-hover;
 	opacity: 0.3;
 }
 
+// Hide visually, but not from screenreaders
+// https://a11yproject.com/posts/how-to-hide-content/
+@mixin visually-hidden() {
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect(1px, 1px, 1px, 1px);
+	white-space: nowrap;
+}
+
 // 11.2 Button - Foundation vars not currently used by Kiva
 // -----------
 

--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -11,11 +11,11 @@
 			v-bind="$attrs"
 		>
 		<label
-			class="wrapper"
+			class="label"
 			:for="id"
 		>
 			<div class="disc"></div>
-			<div class="label">
+			<div>
 				<slot></slot>
 			</div>
 		</label>
@@ -52,10 +52,11 @@ export default {
 	display: inline-block;
 	position: relative;
 
-	.wrapper {
+	.label {
 		display: flex;
 		align-items: center;
 		font-size: 1em;
+		margin: 0;
 	}
 
 	.disc {
@@ -84,7 +85,7 @@ export default {
 	.input {
 		@include visually-hidden();
 
-		&:checked + .wrapper {
+		&:checked + .label {
 			.disc {
 				background-color: $kiva-light-green;
 				border-color: $kiva-light-green;
@@ -98,13 +99,13 @@ export default {
 			}
 		}
 
-		&:focus + .wrapper {
+		&:focus + .label {
 			.disc {
 				box-shadow: 0 0 0 0.25em rgba(174, 225, 92, 0.4); // $kiva-accent-green TODO: break into a scss mixin
 			}
 		}
 
-		&[disabled] + .wrapper {
+		&[disabled] + .label {
 			@include disabled();
 		}
 	}

--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -5,7 +5,6 @@
 			type="radio"
 			:id="id"
 			:value="radioValue"
-			:name="name"
 			v-model="inputValue"
 			v-on="inputListeners"
 			v-bind="$attrs"
@@ -28,10 +27,6 @@ import inputWrapperMixin from '@/plugins/input-wrapper-mixin';
 export default {
 	props: {
 		id: {
-			type: String,
-			required: true
-		},
-		name: {
 			type: String,
 			required: true
 		},

--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -1,21 +1,25 @@
 <template>
-	<label class="kv-radio">
+	<div class="kv-radio">
 		<input
 			class="input"
 			type="radio"
+			:id="id"
 			:value="radioValue"
 			:name="name"
 			v-model="inputValue"
 			v-on="inputListeners"
 			v-bind="$attrs"
 		>
-		<div class="wrapper">
+		<label
+			class="wrapper"
+			:for="id"
+		>
 			<div class="disc"></div>
 			<div class="label">
 				<slot></slot>
 			</div>
-		</div>
-	</label>
+		</label>
+	</div>
 </template>
 
 <script>
@@ -23,6 +27,10 @@ import inputWrapperMixin from '@/plugins/input-wrapper-mixin';
 
 export default {
 	props: {
+		id: {
+			type: String,
+			required: true
+		},
 		name: {
 			type: String,
 			required: true
@@ -41,13 +49,13 @@ export default {
 @import 'settings';
 
 .kv-radio {
-	font-size: 1em;
 	display: inline-block;
 	position: relative;
 
 	.wrapper {
 		display: flex;
 		align-items: center;
+		font-size: 1em;
 	}
 
 	.disc {

--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -49,7 +49,7 @@ export default {
 @import 'settings';
 
 .kv-radio {
-	display: inline-block;
+	display: block;
 	position: relative;
 
 	.label {

--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -1,17 +1,21 @@
 <template>
-	<div class="styled-radio">
+	<label class="kv-radio">
 		<input
+			class="input"
 			type="radio"
-			:id="labelSet"
 			:value="radioValue"
+			:name="name"
 			v-model="inputValue"
 			v-on="inputListeners"
 			v-bind="$attrs"
 		>
-		<label :for="labelSet">
-			<slot></slot>
-		</label>
-	</div>
+		<div class="wrapper">
+			<div class="disc"></div>
+			<div class="label">
+				<slot></slot>
+			</div>
+		</div>
+	</label>
 </template>
 
 <script>
@@ -19,7 +23,7 @@ import inputWrapperMixin from '@/plugins/input-wrapper-mixin';
 
 export default {
 	props: {
-		labelSet: {
+		name: {
 			type: String,
 			required: true
 		},
@@ -36,45 +40,64 @@ export default {
 <style lang="scss" scoped>
 @import 'settings';
 
-.styled-radio {
+.kv-radio {
+	font-size: 1em;
 	display: inline-block;
 	position: relative;
-	padding: 0 rem-calc(6);
-	margin: rem-calc(10) 0 0;
 
-	input[type='radio'] {
-		// Pushing the default radio off the page instead of using
-		// display: none; for screen reader accessibilty
-		position: absolute !important;
-		left: rem-calc(-9999) !important;
+	.wrapper {
+		display: flex;
+		align-items: center;
 	}
 
-	label::before {
-		content: " ";
-		display: inline-block;
+	.disc {
+		border-radius: 50%;
+		width: 1em;
+		height: 1em;
+		background-color: #fff;
+		border: 0.125em solid $subtle-gray;
+		margin-right: 0.5em;
+		box-shadow: 0 0 0 0 rgba(79, 175, 78, 0.2);
 		position: relative;
-		top: rem-calc(2);
-		margin: 0 rem-calc(5) 0 0;
-		width: rem-calc(15);
-		height: rem-calc(15);
-		border-radius: rem-calc(11);
-		border: 1px solid $subtle-gray;
-		background-color: transparent;
-	}
-
-	input[type=radio]:checked + label {
-		font-weight: 500;
+		transition: background-color 200ms ease-in-out, border-color 100ms ease-in-out, box-shadow 300ms ease-in-out;
 
 		&::after {
-			border-radius: rem-calc(11);
-			width: rem-calc(15);
-			height: rem-calc(15);
+			content: '';
 			position: absolute;
-			top: rem-calc(10);
-			left: rem-calc(14);
-			content: " ";
-			display: block;
-			border: rem-calc(5) solid $kiva-light-green;
+			border-radius: 50%;
+			background: #fff;
+			transition: all 150ms ease-out;
+			width: 0.5em;
+			height: 0.5em;
+			transform: translate(0.125em, 0.125em);
+		}
+	}
+
+	.input {
+		@include visually-hidden();
+
+		&:checked + .wrapper {
+			.disc {
+				background-color: $kiva-light-green;
+				border-color: $kiva-light-green;
+
+				&::after {
+					transform: translate(0.25em, 0.25em);
+					width: 0.25em;
+					height: 0.25em;
+					transition: all 100ms ease-in;
+				}
+			}
+		}
+
+		&:focus + .wrapper {
+			.disc {
+				box-shadow: 0 0 0 0.25em rgba(174, 225, 92, 0.4); // $kiva-accent-green TODO: break into a scss mixin
+			}
+		}
+
+		&[disabled] + .wrapper {
+			@include disabled();
 		}
 	}
 }

--- a/src/pages/Autolending/GenderRadios.vue
+++ b/src/pages/Autolending/GenderRadios.vue
@@ -4,8 +4,7 @@
 			Gender
 		</h3>
 		<kv-radio
-			label-set="genderRadioSetBoth"
-			name-set="genderRadio"
+			name="genderRadio"
 			radio-value="both"
 			v-model="gender"
 			class="filter-radio"
@@ -13,8 +12,7 @@
 			Everyone
 		</kv-radio>
 		<kv-radio
-			label-set="genderRadioSetFemale"
-			name-set="genderRadio"
+			name="genderRadio"
 			radio-value="female"
 			v-model="gender"
 			class="filter-radio"
@@ -22,8 +20,7 @@
 			Women only
 		</kv-radio>
 		<kv-radio
-			label-set="genderRadioSetMale"
-			name-set="genderRadio"
+			name="genderRadio"
 			radio-value="male"
 			v-model="gender"
 			class="filter-radio"

--- a/src/pages/Autolending/GenderRadios.vue
+++ b/src/pages/Autolending/GenderRadios.vue
@@ -4,7 +4,8 @@
 			Gender
 		</h3>
 		<kv-radio
-			name="genderRadio"
+			id="gender-radio-both"
+			name="gender-radio"
 			radio-value="both"
 			v-model="gender"
 			class="filter-radio"
@@ -12,7 +13,8 @@
 			Everyone
 		</kv-radio>
 		<kv-radio
-			name="genderRadio"
+			id="gender-radio-female"
+			name="gender-radio"
 			radio-value="female"
 			v-model="gender"
 			class="filter-radio"
@@ -20,7 +22,8 @@
 			Women only
 		</kv-radio>
 		<kv-radio
-			name="genderRadio"
+			id="gender-radio-male"
+			name="gender-radio"
 			radio-value="male"
 			v-model="gender"
 			class="filter-radio"

--- a/src/pages/Autolending/GenderRadios.vue
+++ b/src/pages/Autolending/GenderRadios.vue
@@ -8,7 +8,6 @@
 			name="gender-radio"
 			radio-value="both"
 			v-model="gender"
-			class="filter-radio"
 		>
 			Everyone
 		</kv-radio>
@@ -17,7 +16,6 @@
 			name="gender-radio"
 			radio-value="female"
 			v-model="gender"
-			class="filter-radio"
 		>
 			Women only
 		</kv-radio>
@@ -26,7 +24,6 @@
 			name="gender-radio"
 			radio-value="male"
 			v-model="gender"
-			class="filter-radio"
 		>
 			Men only
 		</kv-radio>
@@ -93,11 +90,6 @@ export default {
 .filter-title {
 	font-size: 1rem;
 	color: $kiva-text-light;
-}
-
-.filter-radio {
-	display: block;
-	margin: 0 0 0 -0.875rem;
 }
 
 </style>

--- a/src/pages/Autolending/GenderRadios.vue
+++ b/src/pages/Autolending/GenderRadios.vue
@@ -5,7 +5,6 @@
 		</h3>
 		<kv-radio
 			id="gender-radio-both"
-			name="gender-radio"
 			radio-value="both"
 			v-model="gender"
 		>
@@ -13,7 +12,6 @@
 		</kv-radio>
 		<kv-radio
 			id="gender-radio-female"
-			name="gender-radio"
 			radio-value="female"
 			v-model="gender"
 		>
@@ -21,7 +19,6 @@
 		</kv-radio>
 		<kv-radio
 			id="gender-radio-male"
-			name="gender-radio"
 			radio-value="male"
 			v-model="gender"
 		>

--- a/src/pages/Autolending/GroupRadios.vue
+++ b/src/pages/Autolending/GroupRadios.vue
@@ -5,7 +5,6 @@
 		</h3>
 		<kv-radio
 			id="group-radio-both"
-			name="group-radio"
 			radio-value="both"
 			v-model="isGroup"
 		>
@@ -13,7 +12,6 @@
 		</kv-radio>
 		<kv-radio
 			id="group-radio-individual"
-			name="group-radio"
 			radio-value="individual-only"
 			v-model="isGroup"
 		>
@@ -21,7 +19,6 @@
 		</kv-radio>
 		<kv-radio
 			id="group-radio-groups"
-			name="group-radio"
 			radio-value="group-only"
 			v-model="isGroup"
 		>

--- a/src/pages/Autolending/GroupRadios.vue
+++ b/src/pages/Autolending/GroupRadios.vue
@@ -4,8 +4,8 @@
 			Individuals/groups
 		</h3>
 		<kv-radio
-			label-set="groupRadioSetBoth"
-			name-set="groupRadio"
+			id="group-radio-both"
+			name="group-radio"
 			radio-value="both"
 			v-model="isGroup"
 			class="filter-radio"
@@ -13,8 +13,8 @@
 			Both
 		</kv-radio>
 		<kv-radio
-			label-set="groupRadioSetMale"
-			name-set="groupRadio"
+			id="group-radio-individual"
+			name="group-radio"
 			radio-value="individual-only"
 			v-model="isGroup"
 			class="filter-radio"
@@ -22,8 +22,8 @@
 			Individuals only
 		</kv-radio>
 		<kv-radio
-			label-set="groupRadioSetFemale"
-			name-set="groupRadio"
+			id="group-radio-groups"
+			name="group-radio"
 			radio-value="group-only"
 			v-model="isGroup"
 			class="filter-radio"

--- a/src/pages/Autolending/GroupRadios.vue
+++ b/src/pages/Autolending/GroupRadios.vue
@@ -8,7 +8,6 @@
 			name="group-radio"
 			radio-value="both"
 			v-model="isGroup"
-			class="filter-radio"
 		>
 			Both
 		</kv-radio>
@@ -17,7 +16,6 @@
 			name="group-radio"
 			radio-value="individual-only"
 			v-model="isGroup"
-			class="filter-radio"
 		>
 			Individuals only
 		</kv-radio>
@@ -26,7 +24,6 @@
 			name="group-radio"
 			radio-value="group-only"
 			v-model="isGroup"
-			class="filter-radio"
 		>
 			Groups only
 		</kv-radio>
@@ -106,11 +103,6 @@ export default {
 .filter-title {
 	font-size: 1rem;
 	color: $kiva-text-light;
-}
-
-.filter-radio {
-	display: block;
-	margin: 0 0 0 -0.875rem;
 }
 
 </style>

--- a/src/pages/Autolending/LightboxFilter.vue
+++ b/src/pages/Autolending/LightboxFilter.vue
@@ -4,16 +4,14 @@
 			{{ name | changeCase('title') }}
 		</h3>
 		<kv-radio
-			:name="`filter-${name}`"
-			:id="`filter-all_${name}`"
+			:id="`filter-all-${name}`"
 			radio-value="all"
 			v-model="radio"
 		>
 			All {{ name }}
 		</kv-radio>
 		<kv-radio
-			:name="`filter-${name}`"
-			:id="`filter-some_${name}`"
+			:id="`filter-some-${name}`"
 			radio-value="some"
 			v-model="radio"
 		>

--- a/src/pages/Autolending/LightboxFilter.vue
+++ b/src/pages/Autolending/LightboxFilter.vue
@@ -5,7 +5,7 @@
 		</h3>
 		<kv-radio
 			class="filter-radio"
-			:label-set="`${name}-radio-all`"
+			name="filter"
 			radio-value="all"
 			v-model="radio"
 		>
@@ -13,7 +13,7 @@
 		</kv-radio>
 		<kv-radio
 			class="filter-radio"
-			:label-set="`${name}-radio-some`"
+			name="filter"
 			radio-value="some"
 			v-model="radio"
 		>

--- a/src/pages/Autolending/LightboxFilter.vue
+++ b/src/pages/Autolending/LightboxFilter.vue
@@ -4,7 +4,7 @@
 			{{ name | changeCase('title') }}
 		</h3>
 		<kv-radio
-			:name="`filter_${name}`"
+			:name="`filter-${name}`"
 			:id="`filter-all_${name}`"
 			radio-value="all"
 			v-model="radio"
@@ -12,7 +12,7 @@
 			All {{ name }}
 		</kv-radio>
 		<kv-radio
-			:name="`filter_${name}`"
+			:name="`filter-${name}`"
 			:id="`filter-some_${name}`"
 			radio-value="some"
 			v-model="radio"

--- a/src/pages/Autolending/LightboxFilter.vue
+++ b/src/pages/Autolending/LightboxFilter.vue
@@ -4,7 +4,6 @@
 			{{ name | changeCase('title') }}
 		</h3>
 		<kv-radio
-			class="filter-radio"
 			:name="`filter_${name}`"
 			:id="`filter-all_${name}`"
 			radio-value="all"
@@ -13,7 +12,6 @@
 			All {{ name }}
 		</kv-radio>
 		<kv-radio
-			class="filter-radio"
 			:name="`filter_${name}`"
 			:id="`filter-some_${name}`"
 			radio-value="some"
@@ -181,11 +179,6 @@ export default {
 	.filter-title {
 		font-size: 1rem;
 		color: $kiva-text-light;
-	}
-
-	.filter-radio {
-		display: block;
-		margin: 0 0 0 -0.875rem;
 	}
 
 	.edit-button {

--- a/src/pages/Autolending/LightboxFilter.vue
+++ b/src/pages/Autolending/LightboxFilter.vue
@@ -5,7 +5,8 @@
 		</h3>
 		<kv-radio
 			class="filter-radio"
-			name="filter"
+			:name="`filter_${name}`"
+			:id="`filter-all_${name}`"
 			radio-value="all"
 			v-model="radio"
 		>
@@ -13,7 +14,8 @@
 		</kv-radio>
 		<kv-radio
 			class="filter-radio"
-			name="filter"
+			:name="`filter_${name}`"
+			:id="`filter-some_${name}`"
 			radio-value="some"
 			v-model="radio"
 		>

--- a/src/pages/Autolending/LoanIncrementRadios.vue
+++ b/src/pages/Autolending/LoanIncrementRadios.vue
@@ -4,16 +4,14 @@
 			Loan increment
 		</h3>
 		<kv-radio
-			id="loan-imcrement-any"
-			name="loan-increment-radio"
+			id="loan-increment-any"
 			radio-value="any"
 			v-model="loanIncrement"
 		>
 			Any amount
 		</kv-radio>
 		<kv-radio
-			id="loan-imcrement-25"
-			name="loan-increment-radio"
+			id="loan-increment-25"
 			radio-value="25"
 			v-model="loanIncrement"
 		>

--- a/src/pages/Autolending/LoanIncrementRadios.vue
+++ b/src/pages/Autolending/LoanIncrementRadios.vue
@@ -4,8 +4,7 @@
 			Loan increment
 		</h3>
 		<kv-radio
-			label-set="loanIncrementRadioSetAny"
-			name-set="loanIncrementRadio"
+			name="loanIncrementRadio"
 			radio-value="any"
 			v-model="loanIncrement"
 			class="filter-radio"
@@ -13,8 +12,7 @@
 			Any amount
 		</kv-radio>
 		<kv-radio
-			label-set="LoanIncrementRadioSet25"
-			name-set="LoanIncrementRadio"
+			name="LoanIncrementRadio"
 			radio-value="25"
 			v-model="loanIncrement"
 			class="filter-radio"

--- a/src/pages/Autolending/LoanIncrementRadios.vue
+++ b/src/pages/Autolending/LoanIncrementRadios.vue
@@ -4,7 +4,8 @@
 			Loan increment
 		</h3>
 		<kv-radio
-			name="loanIncrementRadio"
+			id="loan-imcrement-any"
+			name="loan-increment-radio"
 			radio-value="any"
 			v-model="loanIncrement"
 			class="filter-radio"
@@ -12,7 +13,8 @@
 			Any amount
 		</kv-radio>
 		<kv-radio
-			name="LoanIncrementRadio"
+			id="loan-imcrement-25"
+			name="loan-increment-radio"
 			radio-value="25"
 			v-model="loanIncrement"
 			class="filter-radio"

--- a/src/pages/Autolending/LoanIncrementRadios.vue
+++ b/src/pages/Autolending/LoanIncrementRadios.vue
@@ -8,7 +8,6 @@
 			name="loan-increment-radio"
 			radio-value="any"
 			v-model="loanIncrement"
-			class="filter-radio"
 		>
 			Any amount
 		</kv-radio>
@@ -17,7 +16,6 @@
 			name="loan-increment-radio"
 			radio-value="25"
 			v-model="loanIncrement"
-			class="filter-radio"
 		>
 			Limit my loans to $25 increments
 		</kv-radio>
@@ -84,11 +82,6 @@ export default {
 .filter-title {
 	font-size: 1rem;
 	color: $kiva-text-light;
-}
-
-.filter-radio {
-	display: block;
-	margin: 0 0 0 -0.875rem;
 }
 
 </style>


### PR DESCRIPTION
- Use name property instead of name-set and label-set. 
- Add focus and disabled styles. 
- Wrap component in label el instead of using ids.
- Allow font-size to scale label without reaching inside the component styles. i.e., `<kv-radio style="font-size: 100px;">`Will scale both the circle and the label up
- Start the kitchen sink file.

VUE-192
