### PR TITLE
Replace <input type="checkbox"> with <kv-checkbox>

### DIFF
--- a/.storybook/stories/KvCheckbox.stories.js
+++ b/.storybook/stories/KvCheckbox.stories.js
@@ -80,6 +80,21 @@ export const Checked = () => ({
 	}
 });
 
+export const CheckboxRight = () => ({
+	components: {
+		KvCheckbox
+	},
+	template: `
+		<kv-checkbox
+			id="right"
+			:checkbox-right="true"
+			:checked="true"
+		>
+			checkboxRight
+		</kv-checkbox>
+	`,
+});
+
 export const FontSized = () => ({
 	components: {
 		KvCheckbox
@@ -115,5 +130,19 @@ export const FontSized = () => ({
 				.75rem
 			</kv-checkbox>
 		</fieldset>
+	`,
+});
+
+export const MultiLine = () => ({
+	components: {
+		KvCheckbox
+	},
+	template: `
+		<kv-checkbox
+			id="multi-line"
+			:checked="true"
+		>
+			Lorem ipsum proident occaecat elit voluptate labore eu eiusmod quis elit enim commodo. Officia mollit Lorem do culpa quis consectetur deserunt sunt. Deserunt commodo non labore Lorem reprehenderit incididunt. Qui nisi nisi officia incididunt irure nostrud. Nulla laborum labore adipisicing aute anim sint ullamco adipisicing fugiat adipisicing. Ipsum elit mollit cillum aliquip irure reprehenderit ea duis. Velit duis in laborum sunt tempor adipisicing voluptate eiusmod aute.
+		</kv-checkbox>
 	`,
 });

--- a/.storybook/stories/KvRadio.stories.js
+++ b/.storybook/stories/KvRadio.stories.js
@@ -40,6 +40,45 @@ export const Default = () => ({
 	`
 });
 
+export const MultiLine = () => ({
+	components: {
+		KvRadio
+	},
+	data() {
+		return {
+			color: 'red',
+		}
+	},
+	template: `
+		<fieldset>
+			<legend>What is your favorite color?</legend>
+			<kv-radio
+				id="color-radio-red"
+				radio-value="red"
+				v-model="color"
+				disabled
+			>
+				Red
+			</kv-radio>
+			<kv-radio
+				id="color-radio-blue"
+				radio-value="blue"
+				v-model="color"
+			>
+				Blue, I mean red! Lorem ipsum proident occaecat elit voluptate labore eu eiusmod quis elit enim commodo. Officia mollit Lorem do culpa quis consectetur deserunt sunt. Deserunt commodo non labore Lorem reprehenderit incididunt. Qui nisi nisi officia incididunt irure nostrud. Nulla laborum labore adipisicing aute anim sint ullamco adipisicing fugiat adipisicing. Ipsum elit mollit cillum aliquip irure reprehenderit ea duis. Velit duis in laborum sunt tempor adipisicing voluptate eiusmod aute.
+			</kv-radio>
+			<kv-radio
+				id="color-radio-green"
+				radio-value="green"
+				v-model="color"
+			>
+				Green
+			</kv-radio>
+		</fieldset>
+	`
+});
+
+
 export const FontSized = () => ({
 	components: {
 		KvRadio

--- a/src/components/Checkout/BraintreeCheckout.vue
+++ b/src/components/Checkout/BraintreeCheckout.vue
@@ -132,13 +132,12 @@
 				class="row small-collapse"
 			>
 				<div class="small-12 columns vault-checkbox-wrapper">
-					<label for="vault-checkbox">
-						<input
-							v-model="storePaymentMethod"
-							type="checkbox"
-							id="vault-checkbox"
-						> Save payment method
-					</label>
+					<kv-checkbox
+						v-model="storePaymentMethod"
+						id="vault-checkbox"
+					>
+						Save payment method
+					</kv-checkbox>
 				</div>
 			</div>
 
@@ -201,12 +200,14 @@ import deleteBraintreeCard from '@/graphql/mutation/deleteBraintreeCard.graphql'
 import braintreeDepositAndCheckout from '@/graphql/mutation/braintreeDepositAndCheckout.graphql';
 import braintreeConfig from '@/graphql/query/checkout/braintreeConfig.graphql';
 import KvButton from '@/components/Kv/KvButton';
+import KvCheckbox from '@/components/Kv/KvCheckbox';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvLightbox from '@/components/Kv/KvLightbox';
 
 export default {
 	components: {
 		KvButton,
+		KvCheckbox,
 		KvIcon,
 		KvLightbox,
 	},

--- a/src/components/Checkout/DonateRepaymentsToggle.vue
+++ b/src/components/Checkout/DonateRepaymentsToggle.vue
@@ -1,18 +1,15 @@
 <template>
 	<div v-if="showToggle" class="donate-repayments-toggle">
-		<label v-if="!myDonateRepayments" class="donate-repayments-label">
-			<span class="donate-repayments-icon">
-				<kv-icon v-if="!donateRepayments" name="checkbox-rounded-unchecked" />
-				<kv-icon v-else name="checkbox-rounded-checked" />
-			</span>
+		<kv-checkbox
+			class="donate-repayments-label"
+			id="donate-repayments"
+			:checkbox-right="true"
+			v-if="!myDonateRepayments"
+			v-model="donateRepayments"
+			@change="toggleDonateRepayments"
+		>
 			<span id="donate-repayments-tooltip">Donate loan repayments instead?</span>
-			<input
-				class="donate-repayments-checkbox"
-				type="checkbox"
-				v-model="donateRepayments"
-				@change="toggleDonateRepayments"
-			>
-		</label>
+		</kv-checkbox>
 		<kv-tooltip controller="donate-repayments-tooltip">
 			<template slot="title">
 				Thanks for your support!
@@ -30,14 +27,14 @@ import _get from 'lodash/get';
 import _filter from 'lodash/filter';
 import _forEach from 'lodash/forEach';
 import numeral from 'numeral';
-import KvIcon from '@/components/Kv/KvIcon';
+import KvCheckbox from '@/components/Kv/KvCheckbox';
 import KvTooltip from '@/components/Kv/KvTooltip';
 import initializeCheckout from '@/graphql/query/checkout/initializeCheckout.graphql';
 import updateLoanReservationDonateRepayments from '@/graphql/mutation/updateLoanReservationDonateRepayments.graphql';
 
 export default {
 	components: {
-		KvIcon,
+		KvCheckbox,
 		KvTooltip
 	},
 	inject: ['apollo'],
@@ -144,15 +141,14 @@ export default {
 
 .donate-repayments-toggle {
 	.donate-repayments-label {
-		display: flex;
 		position: relative;
 		padding: 0.5rem 0 0 0.55rem;
-		align-items: flex-start;
-		line-height: 1.5rem;
+		line-height: 1;
+		font-size: $small-text-font-size;
 		cursor: pointer;
 
 		@include breakpoint(medium) {
-			flex-direction: row-reverse;
+			text-align: right;
 			padding: 0.05rem 0 0 0.5rem;
 		}
 	}

--- a/src/components/Kv/KvCheckbox.vue
+++ b/src/components/Kv/KvCheckbox.vue
@@ -1,5 +1,8 @@
 <template>
-	<div class="kv-checkbox">
+	<div
+		class="kv-checkbox"
+		:class="{ 'kv-checkbox--right' : checkboxRight }"
+	>
 		<input
 			class="input"
 			type="checkbox"
@@ -39,6 +42,10 @@ export default {
 			type: Boolean,
 			default: null
 		},
+		checkboxRight: {
+			type: Boolean,
+			default: false
+		}
 	},
 	methods: {
 		onChange(event) {
@@ -62,14 +69,16 @@ export default {
 
 	.label {
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 		font-size: 1em;
+		line-height: inherit;
 		margin: 0;
 	}
 
 	.square {
 		width: 1em;
 		height: 1em;
+		top: 0.125em;
 		flex-shrink: 0;
 		border-radius: 0.125em;
 		background-color: #fff;
@@ -89,6 +98,14 @@ export default {
 			border: solid transparent;
 			border-width: 0 0.125em 0.125em 0;
 			transform: rotate(45deg);
+		}
+	}
+
+	&--right {
+		.square {
+			order: 1;
+			margin-right: 0;
+			margin-left: 0.5em;
 		}
 	}
 

--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -49,8 +49,9 @@ export default {
 
 	.label {
 		display: flex;
-		align-items: center;
+		align-items: baseline;
 		font-size: 1em;
+		line-height: inherit;
 		margin: 0;
 	}
 
@@ -58,6 +59,8 @@ export default {
 		border-radius: 50%;
 		width: 1em;
 		height: 1em;
+		top: 0.125em;
+		flex-shrink: 0;
 		background-color: #fff;
 		border: 0.125em solid $subtle-gray;
 		margin-right: 0.5em;

--- a/src/pages/Lend/admin/FeaturedAdminControls.vue
+++ b/src/pages/Lend/admin/FeaturedAdminControls.vue
@@ -3,9 +3,9 @@
 		<div class="columns small-12">
 			<h2>Featured Loans admin controls</h2>
 			<div class="experiment-controls">
-				<label>
-					Enable experiment: <input type="checkbox" v-model="experimentEnabled">
-				</label>
+				<kv-checkbox v-model="experimentEnabled">
+					Enable experiment:
+				</kv-checkbox>
 				<label>
 					Start time: <input type="datetime-local" v-model="experimentStart">
 				</label>
@@ -46,11 +46,13 @@ import { readJSONSetting } from '@/util/settingsUtils';
 import expDataQuery from '@/graphql/query/featuredLoansControl.graphql';
 import setExpMutation from '@/graphql/mutation/setFeaturedLoans.graphql';
 import KvButton from '@/components/Kv/KvButton';
+import KvCheckbox from '@/components/Kv/KvCheckbox';
 import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 
 export default {
 	components: {
 		KvButton,
+		KvCheckbox,
 		KvLoadingSpinner,
 	},
 	inject: ['apollo'],


### PR DESCRIPTION
VUE-201 

DonateRepaymentsToggle.vue showed a use case for having the checkbox on the right and the label also wrapped to multiple lines. Added a new prop to kv-checkbox and tweaked styles to accommodate multi-line labels.

No rush to get this merged.