### PR TITLE
Provide config through a single $appConfig instance property

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
 		<router-view />
 		<vue-progress-bar />
 		<the-tip-message />
-		<intercom-messenger :app-config="appConfig" />
+		<intercom-messenger />
 	</div>
 </template>
 
@@ -13,9 +13,6 @@ import IntercomMessenger from '@/components/WwwFrame/IntercomMessenger';
 
 export default {
 	name: 'App',
-	props: {
-		appConfig: { type: Object, default: () => {} }
-	},
 	components: {
 		TheTipMessage,
 		IntercomMessenger
@@ -33,7 +30,7 @@ export default {
 					// eslint-disable-next-line max-len
 					content: 'Make a loan to an entrepreneur across the globe for as little as $25. Kiva is the world\'s first online lending platform connecting online lenders to entrepreneurs across the globe.'
 				}
-			].concat(this.appConfig.enableFB ? [
+			].concat(this.$appConfig.enableFB ? [
 				// Facebook Specific Tags
 				// TODO: We should consider omitting these on protected pages
 				{
@@ -44,7 +41,7 @@ export default {
 				{
 					vmid: 'fb:app_id',
 					property: 'fb:app_id',
-					content: this.appConfig.fbApplicationId
+					content: this.$appConfig.fbApplicationId
 				}
 			] : []).concat([
 				// Open Graph Tags

--- a/src/components/WwwFrame/IntercomMessenger.vue
+++ b/src/components/WwwFrame/IntercomMessenger.vue
@@ -7,9 +7,6 @@ export default {
 	render() {
 		return '<div></div>';
 	},
-	props: {
-		appConfig: { type: Object, default: () => {} }
-	},
 	inject: ['apollo'],
 	apollo: {
 		preFetch(config, client) {
@@ -17,7 +14,7 @@ export default {
 		},
 	},
 	mounted() {
-		if (this.appConfig.intercom.enable) {
+		if (this.$appConfig.intercom.enable) {
 			const intercomMessenger = this.apollo.readFragment({
 				id: 'Experiment:intercom_messenger',
 				fragment: experimentVersionFragment,
@@ -44,7 +41,7 @@ export default {
 					const userEmail = _get(data, 'my.userAccount.email');
 
 					const intercomSettings = {
-						app_id: this.appConfig.intercom.appId
+						app_id: this.$appConfig.intercom.appId
 					};
 					if (userId) {
 						intercomSettings.user_id = userId;

--- a/src/main.js
+++ b/src/main.js
@@ -46,13 +46,14 @@ export default function createApp({
 		});
 	}
 
+	// Provide application config to all components
+	Vue.prototype.$appConfig = appConfig;
+
 	const app = new Vue({
 		router,
-		render: h => h(App, { props: { appConfig } }),
+		render: h => h(App),
 		provide: {
 			apollo: apolloClient,
-			algoliaConfig: appConfig.algoliaConfig,
-			auth0Config: appConfig.auth0,
 			kvAuth0,
 		}
 	});

--- a/src/pages/Error.vue
+++ b/src/pages/Error.vue
@@ -23,7 +23,6 @@ import WwwPage from '@/components/WwwFrame/WwwPage';
 
 export default {
 	components: { WwwPage },
-	inject: ['auth0Config'],
 	metaInfo: {
 		title: 'Error'
 	},
@@ -42,7 +41,7 @@ export default {
 			return this.errorDescription;
 		},
 		loginRedirectUrl() {
-			return this.auth0Config.loginRedirectUrls[this.clientId];
+			return this.$appConfig.auth0.loginRedirectUrls[this.clientId];
 		},
 	},
 	created() {

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -39,7 +39,7 @@
 				</KvButton>
 			</form>
 			<div class="small-12">
-				<a :href="`https://${auth0Config.domain}/v2/logout`">Cancel registration</a>
+				<a :href="`https://${$appConfig.auth0.domain}/v2/logout`">Cancel registration</a>
 			</div>
 		</div>
 	</www-page>
@@ -54,21 +54,17 @@ export default {
 		WwwPage,
 		KvButton,
 	},
-	inject: ['auth0Config'],
-
 	data() {
 		return {
 			newAcctTerms: false,
 			showNewAcctTermsError: false,
 		};
 	},
-
 	mounted() {
 		if (!this.$route.query.state) {
 			this.$router.push('/error');
 		}
 	},
-
 	methods: {
 		validateTerms() {
 			return this.newAcctTerms;
@@ -80,7 +76,7 @@ export default {
 				// show error here
 				this.showNewAcctTermsError = true;
 			} else {
-				window.location = `https://${this.auth0Config.domain}`
+				window.location = `https://${this.$appConfig.auth0.domain}`
 				+ `/continue?agree=yes&state=${this.$route.query.state}`;
 			}
 		},

--- a/src/plugins/algolia-init-mixin.js
+++ b/src/plugins/algolia-init-mixin.js
@@ -13,9 +13,6 @@ const routing = {
 };
 
 export default {
-	inject: [
-		'algoliaConfig'
-	],
 	data() {
 		return {
 			routing,
@@ -24,11 +21,11 @@ export default {
 			// Utility instance of default index
 			defaultIndexInstance: null,
 			// These are required in each instance of the plugin
-			algoliaAppId: this.algoliaConfig.appId,
-			algoliaApiKey: this.algoliaConfig.apiKey,
+			algoliaAppId: this.$appConfig.algoliaConfig.appId,
+			algoliaApiKey: this.$appConfig.algoliaConfig.apiKey,
 			// environment + index config
-			algoliaDefaultIndex: this.algoliaConfig.defaultIndex,
-			algoliaGroup: this.algoliaConfig.group,
+			algoliaDefaultIndex: this.$appConfig.algoliaConfig.defaultIndex,
+			algoliaGroup: this.$appConfig.algoliaConfig.group,
 			// all locationFacets.lvl1 facet values
 			allLocationsLvl1: [],
 			// all sector.name facet values


### PR DESCRIPTION
As I'm working on the social share buttons, I've found a need to access the application config to be able to get our facebook application id. Accessing it through a prop didn't seem worth the effort, as I would have to pass that down through WwwPage and ThanksPage. I was considering using provide/inject to make the config available, but that seems like overkill for a static object that we could access through an instance property instead: https://vuejs.org/v2/cookbook/adding-instance-properties.html
For this pr I converted everything over to using that so that there wouldn't be differing examples of how to access the app config.