### PR TITLE
Improve cypress mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"report": "webpack-bundle-analyzer dist/client-bundle-stats.json",
 		"unit": "jest --config test/unit/jest.conf.js --coverage",
 		"test": "npm run lint && npm run unit && npm run build && npm run test:e2e",
-		"test:dev": "npm run dev -- --mock --config=local.vm & wait-on tcp:8888 && npm run e2e:dev",
+		"test:dev": "npm run dev -- --mock --config=local.vm & wait-on http-get://localhost:8888/ui-site-map && npm run e2e:dev",
 		"test:e2e": "npm start -- --mock --config=local & wait-on tcp:8888 && npm run e2e:headless",
 		"lint": "npm run lint:js && npm run lint:css && npm run fetchSchema && npm run lint:graphql",
 		"lint:js": "eslint --ext .js,.vue src test/unit/specs",

--- a/src/components/Kv/KvTipMessage.vue
+++ b/src/components/Kv/KvTipMessage.vue
@@ -1,11 +1,11 @@
 <template>
 	<transition name="kvfade">
-		<div v-if="visible" class="tip-message message-text text-center small-12" :class="typeClass">
+		<div v-if="visible" class="message-text text-center small-12" :class="typeClass">
 			<span class="message-content">
 				<div class="icon-wrapper">
 					<kv-icon :name="iconName" />
 				</div>
-				<p class="message" v-html="safeMessage"></p>
+				<p data-test="tip-message" class="message" v-html="safeMessage"></p>
 			</span>
 			<button @click="close" class="close-tip-message" aria-label="Close">
 				<kv-icon name="x" />

--- a/src/components/Kv/KvTipMessage.vue
+++ b/src/components/Kv/KvTipMessage.vue
@@ -1,6 +1,6 @@
 <template>
 	<transition name="kvfade">
-		<div v-if="visible" class="message-text text-center small-12" :class="typeClass">
+		<div v-if="visible" class="tip-message message-text text-center small-12" :class="typeClass">
 			<span class="message-content">
 				<div class="icon-wrapper">
 					<kv-icon :name="iconName" />

--- a/src/pages/Autolending/AutolendingOptOutPage.vue
+++ b/src/pages/Autolending/AutolendingOptOutPage.vue
@@ -7,7 +7,7 @@
 			</div>
 		</div>
 		<div class="row autolending-opt-out-content">
-			<div class="small-12 medium-10 columns" v-if="success" id="autolending-opt-out-success">
+			<div data-test="opt-out-success" class="small-12 medium-10 columns" v-if="success">
 				<!-- Success -->
 				<p>You’re successfully opted out of auto-lending.</p>
 				<p>
@@ -17,7 +17,7 @@
 				</p>
 			</div>
 
-			<div class="small-12 medium-10 columns" v-if="!success" id="autolending-opt-out-failure">
+			<div data-test="opt-out-failure" class="small-12 medium-10 columns" v-if="!success">
 				<!-- Failure -->
 				<p>Oops - this link no longer works.</p>
 				<p>

--- a/src/pages/Autolending/LendTimingDropdown.vue
+++ b/src/pages/Autolending/LendTimingDropdown.vue
@@ -21,7 +21,7 @@
 			</option>
 		</kv-dropdown-rounded>
 		<span class="text-notice" v-if="legacyAutoLender">{{ autoLendNotice }}</span>
-		<div class="autolend-explanation-text" v-if="isEnabled">
+		<div data-test="timing-explanation" class="autolend-explanation-text" v-if="isEnabled">
 			{{ autolendExplanationText }}
 		</div>
 	</div>
@@ -90,7 +90,7 @@ export default {
 			const loanAndDonationAmount = numeral((1 + this.donationPercentage / 100) * 25).value();
 			const loanAndDonationAmountFormatted = numeral((1 + this.donationPercentage / 100) * 25).format('0,0.00');
 
-			if (this.cIdleStartTime === null || userBalance < loanAndDonationAmount) {
+			if (!this.cIdleStartTime || userBalance < loanAndDonationAmount) {
 				// eslint-disable-next-line max-len
 				return `Your current balance is lower than the minimum loan share amount. The auto-lending timer will begin once your balance reaches $${loanAndDonationAmountFormatted} through repayments or additional deposits.`;
 			}

--- a/src/pages/Autolending/MainToggle.vue
+++ b/src/pages/Autolending/MainToggle.vue
@@ -1,5 +1,6 @@
 <template>
 	<kv-toggle
+		data-test="main-toggle"
 		class="main-toggle"
 		id="auto-lending-enabled-toggle"
 		v-model="isEnabled"

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="save-button-wrapper" v-show="isChanged">
-		<kv-button class="smaller" v-if="!saving" @click.native="checkSave">
+		<kv-button class="save-button smaller" v-if="!saving" @click.native="checkSave">
 			Save settings
 		</kv-button>
-		<kv-button class="smaller" v-else>
+		<kv-button class="save-button smaller" v-else>
 			Saving settings <kv-loading-spinner />
 		</kv-button>
 		<kv-lightbox

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -1,9 +1,9 @@
 <template>
 	<div class="save-button-wrapper" v-show="isChanged">
-		<kv-button class="save-button smaller" v-if="!saving" @click.native="checkSave">
+		<kv-button data-test="save-button" class="smaller" v-if="!saving" @click.native="checkSave">
 			Save settings
 		</kv-button>
-		<kv-button class="save-button smaller" v-else>
+		<kv-button data-test="save-button" class="smaller" v-else>
 			Saving settings <kv-loading-spinner />
 		</kv-button>
 		<kv-lightbox

--- a/test/e2e/fixtures/wwwPageMock.js
+++ b/test/e2e/fixtures/wwwPageMock.js
@@ -1,30 +1,28 @@
-export default function wwwPageMock() {
+export default function wwwPageMock({ UserAccount = null } = {}) {
 	return {
-		AutoDeposit: () => ({
+		AutoDeposit: {
 			isSubscriber: false
-		}),
-		Date: () => '',
-		LatestDonationCampaign: () => ({
+		},
+		Date: '',
+		LatestDonationCampaign: {
 			amount_raised: 0,
 			target_amount: 0,
-		}),
-		Manifest: () => ({
+		},
+		Manifest: {
 			hasFreeCredits: false,
-		}),
+		},
 		Setting: (parent, args) => ({
 			key: args.key,
 			value: '',
 		}),
-		Shop: () => ({
+		Shop: {
 			lendingRewardOffered: false,
 			nonTrivialItemCount: 0,
-		}),
-		ShopTotals: () => ({
+		},
+		ShopTotals: {
 			redemptionCodeAvailableTotal: '0.00',
-		}),
-		UserAccount: () => ({
-			id: 42
-		}),
+		},
+		UserAccount,
 		UserSession: (parent, args) => ({
 			sessionKey: args.sessionKey,
 			data: '',

--- a/test/e2e/specs/AutolendingOptOutPage.spec.js
+++ b/test/e2e/specs/AutolendingOptOutPage.spec.js
@@ -11,27 +11,27 @@ describe('Autolending Opt Out Spec', () => {
 			cy.visit('/settings/autolending/opt-out');
 
 			// Assert that key elements of the page are visible
-			cy.get('#autolending-opt-out-failure').should('exist');
-			cy.get('#autolending-opt-out-failure').contains('Oops - this link no longer works');
-			cy.get('#autolending-opt-out-success').should('not.exist');
+			cy.get('[data-test=opt-out-failure]').should('exist');
+			cy.get('[data-test=opt-out-failure]').contains('Oops - this link no longer works');
+			cy.get('[data-test=opt-out-success]').should('not.exist');
 		});
 		it('Opt-out page should display success message when success param is true', () => {
 			// Visit autolending settings
 			cy.visit('/settings/autolending/opt-out?success=true');
 
 			// Assert that key elements of the page are visible
-			cy.get('#autolending-opt-out-success').should('exist');
-			cy.get('#autolending-opt-out-success').contains('You’re successfully opted out of auto-lending');
-			cy.get('#autolending-opt-out-failure').should('not.exist');
+			cy.get('[data-test=opt-out-success]').should('exist');
+			cy.get('[data-test=opt-out-success]').contains('You’re successfully opted out of auto-lending');
+			cy.get('[data-test=opt-out-failure]').should('not.exist');
 		});
 		it('Opt-out page should display failure message when success param is false', () => {
 			// Visit autolending settings
 			cy.visit('/settings/autolending/opt-out?success=false');
 
 			// Assert that key elements of the page are visible
-			cy.get('#autolending-opt-out-failure').should('exist');
-			cy.get('#autolending-opt-out-failure').contains('Oops - this link no longer works');
-			cy.get('#autolending-opt-out-success').should('not.exist');
+			cy.get('[data-test=opt-out-failure]').should('exist');
+			cy.get('[data-test=opt-out-failure]').contains('Oops - this link no longer works');
+			cy.get('[data-test=opt-out-success]').should('not.exist');
 		});
 	});
 });

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -2,10 +2,12 @@ import { subDays } from 'date-fns';
 import wwwPageMock from '../fixtures/wwwPageMock';
 
 describe('Autolending Page Spec', () => {
-	// const userId = 42;
-
 	beforeEach(() => {
-		cy.mock(wwwPageMock());
+		cy.mock(wwwPageMock({
+			UserAccount: {
+				id: 42,
+			}
+		}));
 		// Prevents the window beforeunload event from getting added
 		// which blocks Cypress from exiting test correctly
 		cy.on('window:before:load', window => {
@@ -32,9 +34,9 @@ describe('Autolending Page Spec', () => {
 		it('Redirects to credit/settings if visitor isSubscriber', () => {
 			// Mock autolending as enabled
 			cy.mock({
-				AutoDeposit: () => ({
+				AutoDeposit: {
 					isSubscriber: true,
-				}),
+				},
 			});
 
 			// Attempt to Visit autolending settings
@@ -49,9 +51,9 @@ describe('Autolending Page Spec', () => {
 		it('Can be turned from on to off', () => {
 			// Mock autolending as enabled
 			cy.mock({
-				AutolendProfile: () => ({
+				AutolendProfile: {
 					isEnabled: true,
-				}),
+				},
 			});
 
 			// Visit autolending settings
@@ -70,9 +72,9 @@ describe('Autolending Page Spec', () => {
 		it('Can be turned from off to on', () => {
 			// Mock autolending as disabled
 			cy.mock({
-				AutolendProfile: () => ({
+				AutolendProfile: {
 					isEnabled: false,
-				}),
+				},
 			});
 
 			// Visit autolending settings
@@ -96,10 +98,10 @@ describe('Autolending Page Spec', () => {
 	describe('Autolend explanation text', () => {
 		it('Explains no autolending because balance is low', () => {
 			cy.mock({
-				AutolendProfile: () => ({
+				AutolendProfile: {
 					isEnabled: true,
 					enableAfter: 0,
-				}),
+				},
 				// This is setting the user's balance
 				Money: () => '3.00'
 			});
@@ -115,11 +117,11 @@ describe('Autolending Page Spec', () => {
 
 		it('Explains no autolending because idle start time is null', () => {
 			cy.mock({
-				AutolendProfile: () => ({
+				AutolendProfile: {
 					isEnabled: true,
 					enableAfter: 0,
 					cIdleStartTime: null,
-				}),
+				},
 			});
 
 			// Visit autolending settings
@@ -134,23 +136,16 @@ describe('Autolending Page Spec', () => {
 		it('Explains that autolending will start in x days if user eligible and not idle', () => {
 			const now = new Date();
 
-			// Had to pass in data this way, because I had to run a function
-			// to dynamically calculate a cIdleStartTime 4 days from 'now'
-			// eslint-disable-next-line no-new-func
-			const AutolendProfile = new Function(`
-				return {
+			cy.mock({
+				AutolendProfile: {
 					isEnabled: true,
 					enableAfter: 0,
-					cIdleStartTime: '${subDays(now, 4)}',
+					cIdleStartTime: subDays(now, 4),
 					lendAfterDaysIdle: 7,
 					donationPercentage: 5
-				};
-			`);
-
-			cy.mock({
-				AutolendProfile,
+				},
 				// This is setting the user's balance
-				Money: () => '40.05'
+				Money: '40.05'
 			});
 			// Visit autolending settings
 			cy.visit('/settings/autolending');
@@ -162,23 +157,16 @@ describe('Autolending Page Spec', () => {
 		it('Explains that autolending will start immediately if user eligible and idle', () => {
 			const now = new Date();
 
-			// Had to pass in data this way, because I had to run a function
-			// to dynamically calculate a cIdleStartTime 4 days from 'now'
-			// eslint-disable-next-line no-new-func
-			const AutolendProfile = new Function(`
-				return {
+			cy.mock({
+				AutolendProfile: {
 					isEnabled: true,
 					enableAfter: 0,
-					cIdleStartTime: '${subDays(now, 95)}',
+					cIdleStartTime: subDays(now, 95),
 					lendAfterDaysIdle: 90,
 					donationPercentage: 15
-				};
-			`);
-
-			cy.mock({
-				AutolendProfile,
+				},
 				// This is setting the user's balance
-				Money: () => '40.90'
+				Money: '40.90'
 			});
 
 			// Visit autolending settings

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -1,6 +1,11 @@
 import { subDays } from 'date-fns';
 import wwwPageMock from '../fixtures/wwwPageMock';
 
+function saveSettings() {
+	cy.get('.show-for-large .save-button').click();
+	cy.get('.tip-message').contains('have been saved');
+}
+
 describe('Autolending Page Spec', () => {
 	beforeEach(() => {
 		cy.mock(wwwPageMock({
@@ -8,6 +13,12 @@ describe('Autolending Page Spec', () => {
 				id: 42,
 			}
 		}));
+		// Mock loan count
+		cy.mock({
+			LoanBasicCollection: {
+				totalCount: 2500,
+			}
+		});
 		// Prevents the window beforeunload event from getting added
 		// which blocks Cypress from exiting test correctly
 		cy.on('window:before:load', window => {
@@ -49,45 +60,51 @@ describe('Autolending Page Spec', () => {
 
 	describe('Main toggle', () => {
 		it('Can be turned from on to off', () => {
-			// Mock autolending as enabled
 			cy.mock({
-				AutolendProfile: {
-					isEnabled: true,
+				AutolendProfile: (obj, args) => {
+					// When arguments are provided, mock isEnabled with the same value that is passed in
+					if (args && args.profile && typeof args.profile.isEnabled === 'boolean') {
+						return { isEnabled: args.profile.isEnabled };
+					}
+					// Mock autolending as enabled when no arguments are provided
+					return { isEnabled: true };
 				},
 			});
 
 			// Visit autolending settings
 			cy.visit('/settings/autolending');
-
 			// Assert that toggle displays 'on'
 			cy.get('.main-toggle').contains('Auto-lending on');
-
-			// hit toggle
-			// save
-			// assert success banner?
-			// assert save not visible?
-			// assert toggle says off
+			// Flip the toggle
+			cy.get('.main-toggle').click();
+			// Save the profile settings
+			saveSettings();
+			// Assert that toggle displays 'off'
+			cy.get('.main-toggle').contains('Auto-lending off');
 		});
 
 		it('Can be turned from off to on', () => {
-			// Mock autolending as disabled
 			cy.mock({
-				AutolendProfile: {
-					isEnabled: false,
+				AutolendProfile: (obj, args) => {
+					// When arguments are provided, mock isEnabled with the same value that is passed in
+					if (args && args.profile && typeof args.profile.isEnabled === 'boolean') {
+						return { isEnabled: args.profile.isEnabled };
+					}
+					// Mock autolending as disabled when no arguments are provided
+					return { isEnabled: false };
 				},
 			});
 
 			// Visit autolending settings
 			cy.visit('/settings/autolending');
-
 			// Assert that toggle displays 'off'
 			cy.get('.main-toggle').contains('Auto-lending off');
-
-			// hit toggle
-			// save
-			// assert success banner?
-			// assert save not visible?
-			// assert toggle says on
+			// Flip the toggle
+			cy.get('.main-toggle').click();
+			// Save the profile settings
+			saveSettings();
+			// Assert that toggle displays 'on'
+			cy.get('.main-toggle').contains('Auto-lending on');
 		});
 	});
 

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -120,7 +120,7 @@ describe('Autolending Page Spec', () => {
 					enableAfter: 0,
 				},
 				// This is setting the user's balance
-				Money: () => '3.00'
+				Money: '3.00'
 			});
 
 			// Visit autolending settings

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -2,8 +2,8 @@ import { subDays } from 'date-fns';
 import wwwPageMock from '../fixtures/wwwPageMock';
 
 function saveSettings() {
-	cy.get('.show-for-large .save-button').click();
-	cy.get('.tip-message').contains('have been saved');
+	cy.get('[data-test=save-button]').first().click();
+	cy.get('[data-test=tip-message]').contains('have been saved');
 }
 
 describe('Autolending Page Spec', () => {
@@ -74,13 +74,13 @@ describe('Autolending Page Spec', () => {
 			// Visit autolending settings
 			cy.visit('/settings/autolending');
 			// Assert that toggle displays 'on'
-			cy.get('.main-toggle').contains('Auto-lending on');
+			cy.get('[data-test=main-toggle]').contains('Auto-lending on');
 			// Flip the toggle
-			cy.get('.main-toggle').click();
+			cy.get('[data-test=main-toggle]').click();
 			// Save the profile settings
 			saveSettings();
 			// Assert that toggle displays 'off'
-			cy.get('.main-toggle').contains('Auto-lending off');
+			cy.get('[data-test=main-toggle]').contains('Auto-lending off');
 		});
 
 		it('Can be turned from off to on', () => {
@@ -98,13 +98,13 @@ describe('Autolending Page Spec', () => {
 			// Visit autolending settings
 			cy.visit('/settings/autolending');
 			// Assert that toggle displays 'off'
-			cy.get('.main-toggle').contains('Auto-lending off');
+			cy.get('[data-test=main-toggle]').contains('Auto-lending off');
 			// Flip the toggle
-			cy.get('.main-toggle').click();
+			cy.get('[data-test=main-toggle]').click();
 			// Save the profile settings
 			saveSettings();
 			// Assert that toggle displays 'on'
-			cy.get('.main-toggle').contains('Auto-lending on');
+			cy.get('[data-test=main-toggle]').contains('Auto-lending on');
 		});
 	});
 
@@ -127,7 +127,7 @@ describe('Autolending Page Spec', () => {
 			cy.visit('/settings/autolending');
 
 			// Assert that message about the auto-lend timer not starting until balance is eligible
-			cy.get('.autolend-explanation-text').contains(
+			cy.get('[data-test=timing-explanation]').contains(
 				'Your current balance is lower'
 			);
 		});
@@ -145,7 +145,7 @@ describe('Autolending Page Spec', () => {
 			cy.visit('/settings/autolending');
 
 			// Assert that message about the auto-lend timer not starting until balance is eligible
-			cy.get('.autolend-explanation-text').contains(
+			cy.get('[data-test=timing-explanation]').contains(
 				'Your current balance is lower'
 			);
 		});
@@ -168,7 +168,7 @@ describe('Autolending Page Spec', () => {
 			cy.visit('/settings/autolending');
 
 			// Assert the message says the user has been idle for 4 days and lending will start in 3 days
-			cy.get('.autolend-explanation-text').contains('for 4 days').contains('after 3 days');
+			cy.get('[data-test=timing-explanation]').contains('for 4 days').contains('after 3 days');
 		});
 
 		it('Explains that autolending will start immediately if user eligible and idle', () => {
@@ -190,7 +190,7 @@ describe('Autolending Page Spec', () => {
 			cy.visit('/settings/autolending');
 
 			// Assert the message says the user has been idle over 95 days and lending will start immediately
-			cy.get('.autolend-explanation-text').contains('over 95 days').contains('immediately');
+			cy.get('[data-test=timing-explanation]').contains('over 95 days').contains('immediately');
 		});
 	});
 });

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -10,7 +10,14 @@ Cypress.Commands.add('lunar', method => {
 
 Cypress.Commands.add('mock', mocks => {
 	const serializedMocks = Object.keys(mocks).reduce(
-		(packet, key) => Object.assign(packet, { [key]: mocks[key].toString() }),
+		(packet, key) => {
+			let mock = mocks[key];
+			if (typeof mock !== 'function') {
+				// eslint-disable-next-line no-new-func
+				mock = new Function(`return ${JSON.stringify(mocks[key])};`);
+			}
+			return Object.assign(packet, { [key]: mock.toString() });
+		},
 		{}
 	);
 


### PR DESCRIPTION
This changes the serialization method for the mocks so that simple primitive values and variable values can be used, which makes mocking simple responses much easier. This also includes an example test involving a mutation, where the mock returns a different value based on the request arguments.