### PR TITLE
The opt-out controls become obsolete once we fully turn on autolendin…

### DIFF
--- a/src/pages/Autolending/OptInStatusControls.vue
+++ b/src/pages/Autolending/OptInStatusControls.vue
@@ -8,7 +8,10 @@
 				</em>
 			</blockquote><br>
 		</div>
-		<div class="columns large-10" v-show="idleCreditOptIn && !isEnabled && inactiveCreditEligible">
+		<div
+			class="columns large-10"
+			v-show="showOptOutControls && idleCreditOptIn && !isEnabled && inactiveCreditEligible"
+		>
 			<blockquote>
 				<em>
 					You're scheduled to be enrolled in 90-day auto-lending starting Feb 20, 2020.
@@ -43,6 +46,10 @@ export default {
 		isEnabled: {
 			type: Boolean,
 			required: true
+		},
+		showOptOutControls: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {


### PR DESCRIPTION
…g. Thus we will stop showing it after the launch

We will use a contentful setting to turn this on and off so we can easily time the shift.