### PR TITLE
ENG-2895: checkoutId strict typing

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -72,12 +72,12 @@ export default {
 		preFetch: true,
 		preFetchVariables({ route }) {
 			return {
-				checkoutId: numeral(route.query.kiva_transaction_id, 10).value()
+				checkoutId: numeral(route.query.kiva_transaction_id).value()
 			};
 		},
 		variables() {
 			return {
-				checkoutId: numeral(this.$route.query.kiva_transaction_id, 10).value()
+				checkoutId: numeral(this.$route.query.kiva_transaction_id).value()
 			};
 		},
 		result({ data }) {

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -39,6 +39,7 @@
 
 <script>
 import confetti from 'canvas-confetti';
+import numeral from 'numeral';
 
 import CheckoutReceipt from '@/components/Checkout/CheckoutReceipt';
 import CheckoutSteps from '@/components/Checkout/CheckoutSteps';
@@ -71,12 +72,12 @@ export default {
 		preFetch: true,
 		preFetchVariables({ route }) {
 			return {
-				checkoutId: parseInt(route.query.kiva_transaction_id, 10)
+				checkoutId: numeral(route.query.kiva_transaction_id, 10).value()
 			};
 		},
 		variables() {
 			return {
-				checkoutId: parseInt(this.$route.query.kiva_transaction_id, 10)
+				checkoutId: numeral(this.$route.query.kiva_transaction_id, 10).value()
 			};
 		},
 		result({ data }) {

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -71,12 +71,12 @@ export default {
 		preFetch: true,
 		preFetchVariables({ route }) {
 			return {
-				checkoutId: route.query.kiva_transaction_id
+				checkoutId: parseInt(route.query.kiva_transaction_id, 10)
 			};
 		},
 		variables() {
 			return {
-				checkoutId: this.$route.query.kiva_transaction_id
+				checkoutId: parseInt(this.$route.query.kiva_transaction_id, 10)
 			};
 		},
 		result({ data }) {


### PR DESCRIPTION
GraphQL Federation expects strict typing, and checkoutId is defined as an Int, so we need to ensure it is provided as an integer value instead of a String.