### PR TITLE
CASH-1844 Require login for thanks page

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -80,6 +80,14 @@ export default {
 				checkoutId: numeral(this.$route.query.kiva_transaction_id).value()
 			};
 		},
+		errorHandlers: {
+			'api.authenticationRequired': ({ route }) => {
+				return Promise.reject({
+					path: '/ui-login',
+					query: { doneUrl: route.fullPath }
+				});
+			}
+		},
 		result({ data }) {
 			this.lender = {
 				...data.my.userAccount,


### PR DESCRIPTION
This prevents 500 errors when the page is loaded when the user is not logged in (i.e. a couple days after they checkout and they open the browser again)