### PR TITLE
AWS-DEV: try multi-node Memcache setup

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -60,6 +60,6 @@ module.exports = merge(base, {
 		graphqlUri: 'https://marketplace-api.dk1.kiva.org/graphql',
 		sessionUri: 'https://www.dev.kiva.org/start-ui-session',
 		memcachedEnabled: true,
-		memcachedServers: 'dev-memcached-01:11211',
+		memcachedServers: 'dev-kivadev-oregon-memcached.knmtma.0001.usw2.cache.amazonaws.com:11211,dev-kivadev-oregon-memcached.knmtma.0002.usw2.cache.amazonaws.com:11211',
 	}
 })


### PR DESCRIPTION
AWS-DEV: try multi-node Memcache setup
AWS-DEV: use Memcache node FQDN/ not Route53 CNAME

Related backend PR: https://github.com/kiva/kiva/pull/8408