### PR TITLE
Ensure we pass an int to the sector variable when present

### DIFF
--- a/src/components/LoansByCategory/FeaturedHeroLoanWrapper.vue
+++ b/src/components/LoansByCategory/FeaturedHeroLoanWrapper.vue
@@ -121,7 +121,7 @@ export default {
 				variables: {
 					ids: featuredCategoryIds,
 					numberOfLoans: initialLoanCount,
-					sector: this.favoriteSectorId ? [this.favoriteSectorId] : null,
+					sector: this.favoriteSectorId ? [numeral(this.favoriteSectorId).value()] : null,
 				}
 			});
 		} catch (e) {

--- a/src/components/LoansByCategory/FeaturedHeroLoanWrapper.vue
+++ b/src/components/LoansByCategory/FeaturedHeroLoanWrapper.vue
@@ -232,7 +232,7 @@ export default {
 				variables: {
 					ids: featuredCategoryIds,
 					offset: this.queryOffset,
-					sector: this.favoriteSectorId ? [this.favoriteSectorId] : null,
+					sector: this.favoriteSectorId ? [numeral(this.favoriteSectorId).value()] : null,
 				}
 			}).then(({ data }) => {
 				if (this.favoriteSectorId !== null && this.featuredSectorExpVersion === 'shown') {


### PR DESCRIPTION
We'd seen some errors where the sector id went through as a string.