### PR TITLE
Cert manager fixes

### DIFF
--- a/deploy/dev/values.yaml
+++ b/deploy/dev/values.yaml
@@ -25,9 +25,7 @@ ingress:
   enabled: true
   name: "kiva-ui-ingress"
   annotations:
-    certmanager.k8s.io/acme-challenge-type: dns01
-    certmanager.k8s.io/acme-dns01-provider: route53
-    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+	cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/ingress.class: nginx-ingress-external
     kubernetes.io/ingress.ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -44,4 +42,4 @@ ingress:
   tls:
     - hosts:
       - ui-dev.dk1.kiva.org
-      secretName: "kiva-ui-tls" 
+      secretName: "kiva-ui-tls"

--- a/deploy/dev/values.yaml
+++ b/deploy/dev/values.yaml
@@ -25,7 +25,7 @@ ingress:
   enabled: true
   name: "kiva-ui-ingress"
   annotations:
-	cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/ingress.class: nginx-ingress-external
     kubernetes.io/ingress.ssl-redirect: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"


### PR DESCRIPTION
As per fairwinds recommendation, the only cert manager annotation necessary is `cert-manager.io/cluster-issuer: letsencrypt-prod`