### PR TITLE
Fix image width on Monthly Good page

### DIFF
--- a/src/pages/MonthlyGood/EmailPreview.vue
+++ b/src/pages/MonthlyGood/EmailPreview.vue
@@ -2,6 +2,7 @@
 	<div class="email-preview-section-wrapper row">
 		<div class="small-12 large-6 columns">
 			<kv-responsive-image
+				class="img"
 				:images="images"
 				alt="A Monthly Good email in your inbox"
 			/>
@@ -55,7 +56,7 @@ h2 {
 	padding: 4rem 1rem;
 }
 
-img {
+.img {
 	max-width: 21.88rem;
 	margin: 0 auto;
 	display: block;


### PR DESCRIPTION
Fixes max-width, since img is no longer the first child of kv-responsive-img (picture is now).