### PR TITLE
webbug-2811 router-link to anchor

### DIFF
--- a/src/components/WwwFrame/TheFooter.vue
+++ b/src/components/WwwFrame/TheFooter.vue
@@ -194,9 +194,9 @@
 							</router-link>
 						</li>
 						<li>
-							<router-link to="https://www.kivaushub.org/hubs">
+							<a href="https://www.kivaushub.org/hubs" target="_blank">
 								US Hubs
-							</router-link>
+							</a>
 						</li>
 					</ul>
 				</div>


### PR DESCRIPTION
changing router-link to anchor so this works correctly and directs outside of the kiva.org domain