### PR TITLE
Fixes redirect on dev environment for autolend settings page

### DIFF
--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -174,7 +174,7 @@ export default () => {
 									// back to using apollo-link-state, which handles errors from client
 									// resolvers as actual graphql errors. More discussion here
 									// https://github.com/apollographql/apollo-client/issues/4575
-									throw new Error(result.errors[0].code || result.errors[0].message);
+									throw new Error(result.errors[0].extensions.code || result.errors[0].message);
 								}
 								return result;
 							})


### PR DESCRIPTION
Possibly fixes the issue with the autolend settings page not redirecting non logged in users.

The GQL Federation error response does not include `errors[0].code`, but instead includes `errors[0].extensions.code`.

On the VM we have both, hence why it was working locally. This local resolver is a unique case and we arent doing this anywhere else. 

Discovered testing the refactor of components in CASH-1205, I dont think its actually a cause of that change, but just the move to federation. 

thanks @emuvente for the help