### PR TITLE
Fixed TheHeader unit test

### DIFF
--- a/test/unit/specs/components/WwwFrame/TheHeader.spec.js
+++ b/test/unit/specs/components/WwwFrame/TheHeader.spec.js
@@ -9,14 +9,17 @@ localVue.use(kvAnalytics);
 localVue.filter('numeral', numeralFilter);
 
 describe('TheHeader', () => {
-	it('should hide/show the search area when the search toggle button is clicked', () => {
+	it('should hide/show the search area when the search toggle button is clicked', async () => {
+		const focusMethod = jest.fn();
 		const wrapper = shallowMount(TheHeader, {
 			localVue,
 			stubs: {
 				RouterLink: RouterLinkStub,
 				SearchBar: {
 					template: '<div></div>',
-					methods: { focus() {} }
+					methods: {
+						focus: focusMethod
+					}
 				},
 				TheLendMenu: {
 					template: '<div></div>'
@@ -31,9 +34,15 @@ describe('TheHeader', () => {
 		const area = wrapper.find('#top-nav-search-area');
 
 		expect(area.attributes()['aria-hidden']).toBe('true');
+
 		toggle.trigger('click');
+		await localVue.nextTick();
+		expect(focusMethod).toHaveBeenCalled();
 		expect(area.attributes()['aria-hidden']).toBe('false');
+
 		toggle.trigger('click');
+		await localVue.nextTick();
+		expect(focusMethod).not.toHaveBeenCalled();
 		expect(area.attributes()['aria-hidden']).toBe('true');
 	});
 });

--- a/test/unit/specs/components/WwwFrame/TheHeader.spec.js
+++ b/test/unit/specs/components/WwwFrame/TheHeader.spec.js
@@ -42,7 +42,6 @@ describe('TheHeader', () => {
 
 		toggle.trigger('click');
 		await localVue.nextTick();
-		expect(focusMethod).not.toHaveBeenCalled();
 		expect(area.attributes()['aria-hidden']).toBe('true');
 	});
 });


### PR DESCRIPTION
Travis and 'npm run test' are throwing a console error on the unit test for the header component due to the changes made to make the search box keyboard accessible. 

See https://travis-ci.org/github/kiva/ui/builds/668990621#L455 for the console error. 

This fixes that