### PR TITLE
Only show app banners on certain routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -89,15 +89,7 @@ export default {
 					name: 'twitter:image',
 					content: 'https://www-kiva-org.freetls.fastly.net/cms/kiva-ogtwitter-image.jpg'
 				},
-			])
-				.concat([
-					// Apple specific meta tag to show native app install banner
-					{
-						name: 'apple-itunes-app',
-						content: 'app-id=1453093374'
-					},
-
-				]),
+			]),
 			link: [
 				// apple icons
 				{

--- a/src/components/WwwFrame/TheAppInstallBanner.vue
+++ b/src/components/WwwFrame/TheAppInstallBanner.vue
@@ -8,6 +8,47 @@
 
 <script>
 export default {
+	metaInfo() {
+		return {
+			meta: this.isAppInstallPage ? [
+				// Apple specific meta tag to show native app install banner
+				// This is all that we need to do for iOS
+				{
+					name: 'apple-itunes-app',
+					content: 'app-id=1453093374',
+				}
+			] : []
+		};
+	},
+	computed: {
+		isAppInstallPage() {
+			const route = this.$route;
+			const baseUrlsToInclude = [
+				'start',
+				'portfolio',
+				'login',
+				'register',
+				'lend',
+				'lend-by-category',
+				'about'
+			];
+			const queryParamsToExlude = [
+				'upc',
+				'promo_code',
+				'lending_reward',
+			];
+
+			let isPromoUrl = false;
+			Object.keys(route.query).forEach(key => {
+				if (queryParamsToExlude.includes(key)) {
+					isPromoUrl = true;
+				}
+			});
+			const isGoodRoute = baseUrlsToInclude.includes(route.path.split('/')[1]) || route.path === '/';
+
+			return isGoodRoute && !isPromoUrl;
+		}
+	},
 	data() {
 		return {
 			deferredPrompt: null,
@@ -33,21 +74,23 @@ export default {
 		}
 	},
 	mounted() {
-		// https://developers.google.com/web/fundamentals/app-install-banners/native#prefer_related
-		window.addEventListener('beforeinstallprompt', e => {
-			console.log('beforeinstallprompt fired');
-			console.log(e);
-			// Prevent Chrome 67 and earlier from automatically showing the prompt
-			e.preventDefault();
-			// Stash the event so it can be triggered later.
-			this.deferredPrompt = e;
-			// Update UI notify the user they can add to home screen
-			this.isPromptVisible = true;
-		});
+		if (this.isAppInstallPage) {
+			// Chrome on Android specific code.
+			// https://developers.google.com/web/fundamentals/app-install-banners/native#prefer_related
+			window.addEventListener('beforeinstallprompt', e => {
+				console.log('beforeinstallprompt fired');
+				console.log(e);
+				// Prevent Chrome 67 and earlier from automatically showing the prompt
+				e.preventDefault();
+				// Stash the event so it can be triggered later.
+				this.deferredPrompt = e;
+				// Update UI notify the user they can add to home screen
+				this.isPromptVisible = true;
+			});
+		}
 	}
 };
 </script>
 
 <style lang="scss" scoped>
-
 </style>

--- a/src/components/WwwFrame/TheAppInstallBanner.vue
+++ b/src/components/WwwFrame/TheAppInstallBanner.vue
@@ -32,7 +32,7 @@ export default {
 				'lend-by-category',
 				'about'
 			];
-			const queryParamsToExlude = [
+			const queryParamsToExclude = [
 				'upc',
 				'promo_code',
 				'lending_reward',
@@ -40,7 +40,7 @@ export default {
 
 			let isPromoUrl = false;
 			Object.keys(route.query).forEach(key => {
-				if (queryParamsToExlude.includes(key)) {
+				if (queryParamsToExclude.includes(key)) {
 					isPromoUrl = true;
 				}
 			});

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -1,23 +1,25 @@
 {
-    "short_name": "Kiva",
-    "name": "Kiva",
-    "icons": [
-        {
-            "src": "/assets/images/favicons/favicon-192x192.png",
-            "type": "image/png",
-            "sizes": "192x192"
-        },
-        {
-            "src": "/assets/images/favicons/favicon-512x512.png",
-            "type": "image/png",
-            "sizes": "512x512"
-        }
-    ],
-    "prefer_related_applications": true,
-    "related_applications": [
-        {
-            "platform": "play",
-            "id": "org.kiva.lendin"
-        }
-    ]
+	"short_name": "Kiva",
+	"name": "Kiva",
+	"display": "browser",
+	"start_url": "https://www.kiva.org",
+	"icons": [
+		{
+			"src": "/assets/images/favicons/favicon-192x192.png",
+			"type": "image/png",
+			"sizes": "192x192"
+		},
+		{
+			"src": "/assets/images/favicons/favicon-512x512.png",
+			"type": "image/png",
+			"sizes": "512x512"
+		}
+	],
+	"prefer_related_applications": true,
+	"related_applications": [
+		{
+			"platform": "play",
+			"id": "org.kiva.lendin"
+		}
+	]
 }


### PR DESCRIPTION
Also continue loading webmanifest on all pages, but move app banner logic into TheAppInstallBanner.vue.

GROW58, GROW-59



