### PR TITLE
Fix fastly url for k8s dev configuration

### DIFF
--- a/config/k8sdev.js
+++ b/config/k8sdev.js
@@ -4,7 +4,7 @@ var dev  = require('./dev.js')
 module.exports = merge(dev, {
 	app: {
 		// removes 'ui' path segment
-		publicPath: 'https://ui-dev.dk1.kiva.org.global.prod.fastly.net/',
+		publicPath: 'https://ui-dev-dk1-kiva-org.freetls.fastly.net/',
 	},
 	server: {
 		memcachedServers: 'k8sdev-elasticache.bu9ifv.0001.usw1.cache.amazonaws.com:11211',


### PR DESCRIPTION
This change matches up with a change I made to the fastly configuration where I removed the invalid `ui-dev.dk1.kiva.org` domain (see [valid domain name guide](https://docs.fastly.com/en/guides/adding-cname-records#choosing-the-right-fastly-hostname-for-your-cname-record)) and replaced it with the `ui-dev-dk1-kiva-org.global.ssl.fastly.net` domain. Adding this domain also automatically makes the `https://ui-dev-dk1-kiva-org.freetls.fastly.net` domain, which has HTTP/2 support and TLS 1.2 (see [tls support guide](https://docs.fastly.com/en/guides/setting-up-free-tls#support-for-http2-ipv6-and-tls-12))