### PR TITLE
FOUC: try moving inline styles off of the root element

### DIFF
--- a/src/components/WwwFrame/TheFooter.vue
+++ b/src/components/WwwFrame/TheFooter.vue
@@ -1,276 +1,278 @@
 <template>
-	<footer class="www-footer" :style="cssVars">
-		<nav class="small-footer hide-for-large" aria-label="Footer navigation">
-			<ul class="hide-for-print">
-				<li>
-					<router-link :to="applyUrl">
-						Borrow
+	<footer class="www-footer">
+		<div :style="cssVars">
+			<nav class="small-footer hide-for-large" aria-label="Footer navigation">
+				<ul class="hide-for-print">
+					<li>
+						<router-link :to="applyUrl">
+							Borrow
+						</router-link>
+					</li>
+					<li>
+						<router-link :to="aboutUrl">
+							About
+						</router-link>
+					</li>
+					<li>
+						<router-link :to="helpUrl">
+							Help
+						</router-link>
+					</li>
+					<li>
+						<a :href="careersUrl" target="_blank">
+							Careers
+						</a>
+					</li>
+					<li>
+						<router-link :to="sitemapUrl">
+							Site map
+						</router-link>
+					</li>
+				</ul>
+				<div class="hide-for-print">
+					<router-link :to="privacyUrl">
+						Privacy policy
+					</router-link> |
+					<router-link :to="termsUrl">
+						Terms of use
 					</router-link>
-				</li>
-				<li>
-					<router-link :to="aboutUrl">
-						About
-					</router-link>
-				</li>
-				<li>
-					<router-link :to="helpUrl">
-						Help
-					</router-link>
-				</li>
-				<li>
-					<a :href="careersUrl" target="_blank">
-						Careers
-					</a>
-				</li>
-				<li>
-					<router-link :to="sitemapUrl">
-						Site map
-					</router-link>
-				</li>
-			</ul>
-			<div class="hide-for-print">
-				<router-link :to="privacyUrl">
-					Privacy policy
-				</router-link> |
-				<router-link :to="termsUrl">
-					Terms of use
-				</router-link>
-			</div>
-			<ul class="hide-for-print download-app-icons">
-				<li>
-					<a
-						:href="appStoreUrl"
-						target="_blank"
-						rel="noopener"
-						v-kv-track-event="['global', 'click-app-badge-footer', 'App Store']"
-					>
-						<img
-							src="@/assets/icons/app-store.svg"
-							loading="lazy"
-							alt="Check out our new app on the App Store"
+				</div>
+				<ul class="hide-for-print download-app-icons">
+					<li>
+						<a
+							:href="appStoreUrl"
+							target="_blank"
+							rel="noopener"
+							v-kv-track-event="['global', 'click-app-badge-footer', 'App Store']"
 						>
-					</a>
-				</li>
-				<li>
-					<a
-						:href="playStoreUrl"
-						target="_blank"
-						rel="noopener"
-						v-kv-track-event="['global', 'click-app-badge-footer', 'Google Store']"
-					>
-						<img
-							src="@/assets/icons/play-store.svg"
-							loading="lazy"
-							alt="Check out our new app on the Play Store"
+							<img
+								src="@/assets/icons/app-store.svg"
+								loading="lazy"
+								alt="Check out our new app on the App Store"
+							>
+						</a>
+					</li>
+					<li>
+						<a
+							:href="playStoreUrl"
+							target="_blank"
+							rel="noopener"
+							v-kv-track-event="['global', 'click-app-badge-footer', 'Google Store']"
 						>
-					</a>
-				</li>
-			</ul>
-			<p>
-				Lending through Kiva involves risk of principal loss.
-				Kiva does not guarantee repayment or offer a financial return on your loan.
-				<br><br>
-				&copy; {{ year }} Kiva. All rights reserved.
-			</p>
-		</nav>
-		<nav class="large-footer show-for-large row" aria-label="Footer navigation">
-			<div class="groups">
-				<div class="narrow hide-for-print">
-					<h2>Borrow</h2>
-					<p>Loans for entrepreneurs doing amazing things.</p>
-					<ul>
-						<li>
-							<router-link :to="applyUrl">
-								Apply now
-							</router-link>
-						</li>
-					</ul>
-				</div>
-				<div class="narrow hide-for-print">
-					<h2>Explore</h2>
-					<ul>
-						<li>
-							<router-link to="/protocol">
-								Protocol
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/gifts">
-								Gifts
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/live">
-								Happening now
-							</router-link>
-						</li>
-						<li>
-							<router-link :to="sitemapUrl">
-								Site map
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/build">
-								Developer API
-							</router-link>
-						</li>
-						<li>
-							<router-link :to="privacyUrl">
-								Privacy policy
-							</router-link>
-						</li>
-						<li>
-							<router-link :to="termsUrl">
-								Terms of use
-							</router-link>
-						</li>
-					</ul>
-				</div>
-				<div class="narrow hide-for-print">
-					<h2>Get to know us</h2>
-					<ul>
-						<li>
-							<router-link :to="aboutUrl">
-								About us
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/about/how">
-								How Kiva works
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/about/how#faq-hkw-section">
-								FAQs
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/about/where-kiva-works">
-								Where Kiva works
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/blog">
-								Blog
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/partner-with-us">
-								Partner with us
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/help/contact-us">
-								Contact us
-							</router-link>
-						</li>
-						<li>
-							<router-link :to="helpUrl">
-								Help
-							</router-link>
-						</li>
-					</ul>
-				</div>
-				<div class="narrow hide-for-print">
-					<h2>Community</h2>
-					<ul>
-						<li>
-							<router-link to="/teams">
-								Teams
-							</router-link>
-						</li>
-						<li>
-							<router-link to="/kivau/intro">
-								Students and educators
-							</router-link>
-						</li>
-					</ul>
-				</div>
-				<div class="wide">
-					<div>
-						Kiva is a 501(c)3 U.S. nonprofit fueled by passionate people.
-						Founded in 2005, and based in San Francisco, with offices in Bangkok, Nairobi,
-						Portland and staff around the globe.
+							<img
+								src="@/assets/icons/play-store.svg"
+								loading="lazy"
+								alt="Check out our new app on the Play Store"
+							>
+						</a>
+					</li>
+				</ul>
+				<p>
+					Lending through Kiva involves risk of principal loss.
+					Kiva does not guarantee repayment or offer a financial return on your loan.
+					<br><br>
+					&copy; {{ year }} Kiva. All rights reserved.
+				</p>
+			</nav>
+			<nav class="large-footer show-for-large row" aria-label="Footer navigation">
+				<div class="groups">
+					<div class="narrow hide-for-print">
+						<h2>Borrow</h2>
+						<p>Loans for entrepreneurs doing amazing things.</p>
+						<ul>
+							<li>
+								<router-link :to="applyUrl">
+									Apply now
+								</router-link>
+							</li>
+						</ul>
 					</div>
-					<ul class="siteFooter-links hide-for-print">
-						<li>
-							<router-link to="/donate/supportus">
-								Donate to Kiva here.
-							</router-link>
-						</li>
-					</ul>
-				</div>
-				<div class="wide">
-					<ul class="siteFooter-links hide-for-print download-app-icons">
-						<li>
-							<a
-								:href="appStoreUrl"
-								target="_blank" rel="noopener"
-								v-kv-track-event="['global', 'click-app-badge-footer', 'App Store']"
-							>
-								<img
-									src="@/assets/icons/app-store.svg"
-									loading="lazy"
-									alt="Check out our new app on the App Store"
+					<div class="narrow hide-for-print">
+						<h2>Explore</h2>
+						<ul>
+							<li>
+								<router-link to="/protocol">
+									Protocol
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/gifts">
+									Gifts
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/live">
+									Happening now
+								</router-link>
+							</li>
+							<li>
+								<router-link :to="sitemapUrl">
+									Site map
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/build">
+									Developer API
+								</router-link>
+							</li>
+							<li>
+								<router-link :to="privacyUrl">
+									Privacy policy
+								</router-link>
+							</li>
+							<li>
+								<router-link :to="termsUrl">
+									Terms of use
+								</router-link>
+							</li>
+						</ul>
+					</div>
+					<div class="narrow hide-for-print">
+						<h2>Get to know us</h2>
+						<ul>
+							<li>
+								<router-link :to="aboutUrl">
+									About us
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/about/how">
+									How Kiva works
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/about/how#faq-hkw-section">
+									FAQs
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/about/where-kiva-works">
+									Where Kiva works
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/blog">
+									Blog
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/partner-with-us">
+									Partner with us
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/help/contact-us">
+									Contact us
+								</router-link>
+							</li>
+							<li>
+								<router-link :to="helpUrl">
+									Help
+								</router-link>
+							</li>
+						</ul>
+					</div>
+					<div class="narrow hide-for-print">
+						<h2>Community</h2>
+						<ul>
+							<li>
+								<router-link to="/teams">
+									Teams
+								</router-link>
+							</li>
+							<li>
+								<router-link to="/kivau/intro">
+									Students and educators
+								</router-link>
+							</li>
+						</ul>
+					</div>
+					<div class="wide">
+						<div>
+							Kiva is a 501(c)3 U.S. nonprofit fueled by passionate people.
+							Founded in 2005, and based in San Francisco, with offices in Bangkok, Nairobi,
+							Portland and staff around the globe.
+						</div>
+						<ul class="siteFooter-links hide-for-print">
+							<li>
+								<router-link to="/donate/supportus">
+									Donate to Kiva here.
+								</router-link>
+							</li>
+						</ul>
+					</div>
+					<div class="wide">
+						<ul class="siteFooter-links hide-for-print download-app-icons">
+							<li>
+								<a
+									:href="appStoreUrl"
+									target="_blank" rel="noopener"
+									v-kv-track-event="['global', 'click-app-badge-footer', 'App Store']"
 								>
-							</a>
-						</li>
-						<li>
-							<a
-								:href="playStoreUrl"
-								target="_blank"
-								rel="noopener"
-								v-kv-track-event="['global', 'click-app-badge-footer', 'Google Store']"
-							>
-								<img
-									src="@/assets/icons/play-store.svg"
-									loading="lazy"
-									alt="Check out our new app on the Play Store"
+									<img
+										src="@/assets/icons/app-store.svg"
+										loading="lazy"
+										alt="Check out our new app on the App Store"
+									>
+								</a>
+							</li>
+							<li>
+								<a
+									:href="playStoreUrl"
+									target="_blank"
+									rel="noopener"
+									v-kv-track-event="['global', 'click-app-badge-footer', 'Google Store']"
 								>
-							</a>
-						</li>
-					</ul>
+									<img
+										src="@/assets/icons/play-store.svg"
+										loading="lazy"
+										alt="Check out our new app on the Play Store"
+									>
+								</a>
+							</li>
+						</ul>
+					</div>
+					<div class="work-with-us wide hide-for-print">
+						<h2>Work with us</h2>
+						<ul>
+							<li>
+								<a :href="careersUrl" target="_blank">
+									Careers
+								</a>
+							</li>
+							<li>
+								<router-link to="/work-with-us/internvolunteers">
+									Volunteer internships
+								</router-link>
+							</li>
+							<li>
+								<a href="https://www.careers.kiva.org/fellowships" target="_blank">
+									Kiva fellows
+								</a>
+							</li>
+							<li>
+								<router-link to="/work-with-us/reviewers">
+									Review and translation
+								</router-link>
+							</li>
+							<li>
+								<a href="https://www.kivaushub.org/hubs" target="_blank">
+									US Hubs
+								</a>
+							</li>
+						</ul>
+					</div>
+					<div class="wide">
+						<p>
+							Lending through Kiva involves risk of principal loss.
+							Kiva does not guarantee repayment or offer a financial return on your loan.
+							<br><br>
+							&copy; {{ year }} Kiva. All rights reserved.
+						</p>
+					</div>
 				</div>
-				<div class="work-with-us wide hide-for-print">
-					<h2>Work with us</h2>
-					<ul>
-						<li>
-							<a :href="careersUrl" target="_blank">
-								Careers
-							</a>
-						</li>
-						<li>
-							<router-link to="/work-with-us/internvolunteers">
-								Volunteer internships
-							</router-link>
-						</li>
-						<li>
-							<a href="https://www.careers.kiva.org/fellowships" target="_blank">
-								Kiva fellows
-							</a>
-						</li>
-						<li>
-							<router-link to="/work-with-us/reviewers">
-								Review and translation
-							</router-link>
-						</li>
-						<li>
-							<a href="https://www.kivaushub.org/hubs" target="_blank">
-								US Hubs
-							</a>
-						</li>
-					</ul>
-				</div>
-				<div class="wide">
-					<p>
-						Lending through Kiva involves risk of principal loss.
-						Kiva does not guarantee repayment or offer a financial return on your loan.
-						<br><br>
-						&copy; {{ year }} Kiva. All rights reserved.
-					</p>
-				</div>
-			</div>
-		</nav>
+			</nav>
+		</div>
 	</footer>
 </template>
 

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -1,6 +1,6 @@
 <template>
-	<header class="top-nav" :style="cssVars">
-		<nav aria-label="Primary navigation">
+	<header class="top-nav">
+		<nav aria-label="Primary navigation" :style="cssVars">
 			<div class="header-row row">
 				<router-link class="header-logo header-button" to="/" v-kv-track-event="['TopNav','click-Logo']">
 					<kiva-logo class="icon" />


### PR DESCRIPTION
It's a shot in the dark, but since the delayed styles are for TheHeader and TheFooter I thought I'd try moving the inline styles which we use for theming off of their root elements. Maybe webpack/vue is getting hung up on that, and it's a recent change related to those elements.

Thought we could see if it helped in dev. If not, will roll it back. 