### PR TITLE
GROW-82 New MG setup design experiment

### DIFF
--- a/src/components/Kv/KvCheckoutSteps.vue
+++ b/src/components/Kv/KvCheckoutSteps.vue
@@ -63,8 +63,7 @@ export default {
 		list-style: none;
 		display: flex;
 		align-items: center;
-		max-width: 40rem;
-		margin: 0 auto 2rem;
+		margin: 0 auto;
 	}
 
 	.step {

--- a/src/components/Kv/KvCheckoutSteps.vue
+++ b/src/components/Kv/KvCheckoutSteps.vue
@@ -18,7 +18,7 @@
 					{{ index + 1 }}
 				</span>
 				<span v-else class="step-icon checkmark">
-					<kv-icon name="confirmation" />
+					<kv-icon class="checkmark-icon" name="confirmation" />
 				</span>
 			</li>
 		</ul>
@@ -36,7 +36,10 @@ export default {
 		},
 		currentStepIndex: {
 			type: Number,
-			default: 0
+			default: 0,
+			validator(value) {
+				return value >= 0 && Number.isInteger(value);
+			}
 		}
 	},
 	components: {
@@ -50,7 +53,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 
 .kv-checkout-steps {
@@ -99,40 +102,38 @@ export default {
 			margin: 0 auto;
 			width: 1.5rem;
 			height: 1.5rem;
+			border-radius: 50%;
 
 			&.number-icon {
 				background: $kiva-bg-lightgray;
 				color: $kiva-stroke-gray;
 				border: 1px solid $kiva-stroke-gray;
-				border-radius: 0.8rem;
 				font-size: 1rem;
 				text-align: center;
 				line-height: 1.325rem;
 				font-weight: 700;
 			}
 
-			.icon {
-				width: 1.4rem;
-				height: 1.4rem;
-				fill: $kiva-bg-lightgray;
+			&.checkmark {
+				width: 1.5rem;
+				height: 1.5rem;
+				background: #fff;
+				border: 1px solid $kiva-stroke-gray;
+				overflow: hidden;
 			}
-		}
 
-		.checkmark {
-			background: $kiva-stroke-gray;
-			border-radius: 1.5rem;
-			border: 1px solid $kiva-stroke-gray;
+			.checkmark-icon {
+				background: $kiva-stroke-gray;
+				fill: $kiva-bg-lightgray;
+				width: 100%;
+			}
 		}
 
 		&.active {
 			color: $kiva-green;
 
 			.step-icon {
-				.icon {
-					width: 2rem;
-					height: 2rem;
-					fill: $kiva-green;
-				}
+				fill: $kiva-green;
 
 				&.number-icon {
 					background: $kiva-green;
@@ -141,13 +142,12 @@ export default {
 				}
 
 				&.checkmark {
-					background: #fff;
 					border: 0;
+				}
 
-					.icon {
-						width: 1.5rem;
-						height: 1.5rem;
-					}
+				.checkmark-icon {
+					background: #fff;
+					fill: $kiva-green;
 				}
 			}
 		}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -5,7 +5,11 @@
 				<div v-if="!emptyBasket" class="basket-wrap" :class="{'pre-login': !preCheckoutStep}">
 					<div>
 						<div class="checkout-steps-wrapper hide-for-print">
-							<kv-checkout-steps :steps="checkoutSteps" :current-step-index="currentStep" />
+							<kv-checkout-steps
+								class="checkout-steps"
+								:steps="checkoutSteps"
+								:current-step-index="currentStep"
+							/>
 							<hr>
 						</div>
 
@@ -595,6 +599,11 @@ export default {
 
 .checkout-steps-wrapper {
 	padding-bottom: 1.2rem;
+}
+
+.checkout-steps {
+	margin: 0 auto 2rem;
+	max-width: 40rem;
 }
 
 .display-align {

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
@@ -1,301 +1,38 @@
 <template>
-	<www-page>
-		<div class="row align-center monthly-good-setup-page">
-			<div class="small-12 medium-11 large-10 column" v-if="!isMonthlyGoodSubscriber && !hasLegacySubscription">
-				<h1 class="text-center impact-text">
-					Confirm your Good
-				</h1>
-				<h3 class="text-center featured-text" v-if="!isOnetime">
-					Review and set up your monthly contribution
-				</h3>
-				<form
-					class="monthly-good-form"
-					@submit.prevent="hasBillingAgreement ? submitMonthlyGood : null"
-					novalidate
-				>
-					<div class="panel zigzag-bottom">
-						<div class="row align-center text-center">
-							<div class="medium-10 small-12 columns">
-								<div class="row column" v-if="!fromCovidLanding">
-									<strong>Each month on the</strong>
-									<label class="show-for-sr" :class="{ 'error': $v.$invalid }" :for="dayOfMonth">
-										Day of the Month
-									</label>
-									<input v-if="isDayInputShown"
-										@blur="hideDayInput()"
-										class="text-input__day"
-										id="dayOfMonth"
-										type="number"
-										placeholder=""
-										required
-										min="1"
-										max="31"
-										v-model="dayOfMonth"
-									>
-									<button
-										class="button--ordinal-day"
-										@click="isDayInputShown = true"
-										v-if="!isDayInputShown"
-									>
-										<strong>{{ dayOfMonth | numeral('Oo') }}</strong>
-										<icon-pencil class="icon-pencil" />
-									</button>
-									<ul class="validation-errors" v-if="$v.dayOfMonth.$invalid">
-										<li v-if="!$v.dayOfMonth.required">
-											Field is required
-										</li>
-										<li v-if="!$v.dayOfMonth.minValue || !$v.dayOfMonth.maxValue">
-											Enter day of month - 1 to 31
-										</li>
-									</ul>
-									<div class="additional-day-info">
-										<strong>we'll process the following:</strong>
-										<small v-if="dayOfMonth > 28">
-											(note - may be processed on the last day of the month)</small>
-									</div>
-								</div>
-
-								<div class="row text-left align-middle">
-									<div class="columns">
-										<span class="additional-left-pad-spans strong">
-											Deposit for lending
-										</span>
-									</div>
-
-									<div class="medium-5 small-6 columns">
-										<label
-											class="show-for-sr"
-											:class="{ 'error': $v.mgAmount.$invalid }"
-											for="amount"
-										>
-											Amount
-										</label>
-										<kv-currency-input class="text-input" id="amount" v-model="mgAmount" />
-									</div>
-
-									<div class="small-12 columns">
-										<ul class="text-right validation-errors" v-if="$v.mgAmount.$invalid">
-											<li v-if="!$v.mgAmount.required">
-												Field is required
-											</li>
-											<li v-if="!$v.mgAmount.minValue || !$v.mgAmount.maxValue">
-												Enter an amount of $5-$10,000
-											</li>
-										</ul>
-									</div>
-								</div>
-
-								<div class="row text-left align-middle">
-									<div class="columns">
-										<kv-checkbox
-											id="donation-checkbox"
-											v-model="donationCheckbox"
-											@change="donationCheckboxChange()"
-										/>
-										<div class="additional-left-pad-spans display-inline-block">
-											<span class="strong">
-												Monthly donation to Kiva (optional)
-											</span>
-											<!-- eslint-disable-next-line max-len -->
-											<div class="small-text" v-if="isMGTaglineActive">Every $25 loan costs more than $3 to facilitate, and our generous supporters are donating $1 for every $3 you donate.</div>
-										</div>
-									</div>
-
-									<div class="medium-5 small-6 columns">
-										<label
-											class="show-for-sr"
-											:class="{ 'error': $v.donation.$invalid }"
-											for="donation"
-										>
-											Donation
-										</label>
-										<kv-dropdown-rounded
-											class="donation-dropdown"
-											v-model="donationOptionSelected"
-											v-if="donationOptionSelected !== 'other'"
-										>
-											<option
-												v-for="(option, index) in dropdownOptions"
-												:value="option.value"
-												:key="index"
-											>
-												{{ option.label }}
-											</option>
-										</kv-dropdown-rounded>
-										<kv-currency-input
-											class="text-input"
-											id="donation"
-											v-model="donation"
-											v-if="donationOptionSelected === 'other'"
-										/>
-									</div>
-
-									<div class="small-12 columns">
-										<ul class="text-right validation-errors" v-if="$v.donation.$invalid">
-											<li v-if="!$v.donation.minValue || !$v.donation.maxValue">
-												Enter an amount of $0-$10,000
-											</li>
-										</ul>
-									</div>
-								</div>
-
-								<div class="row text-left">
-									<div class="columns">
-										<strong v-if="!onetime" class="additional-left-pad-spans">Total/month</strong>
-										<strong v-else class="additional-left-pad-spans">Total</strong>
-									</div>
-
-									<div class="medium-5 small-6 columns">
-										<strong
-											class="additional-left-pad-currency"
-										>{{ totalCombinedDeposit | numeral('$0,0.00') }}</strong>
-									</div>
-
-									<div class="small-12 columns">
-										<ul class="text-center validation-errors"
-											v-if="!$v.mgAmount.maxTotal || !$v.donation.maxTotal"
-										>
-											<li>
-												The maximum Monthly Good total is $10,000.<br>
-												Please try again by entering in a smaller amount.
-											</li>
-										</ul>
-									</div>
-								</div>
-
-								<div class="row text-left" v-if="!fromCovidLanding">
-									<div class="small-12 columns">
-										<div class="additional-left-pad-spans">
-											Select a category to focus your lending
-											<kv-dropdown-rounded v-model="selectedGroup" class="group-dropdown">
-												<option
-													v-for="(option, index) in lendingCategories"
-													:value="option.value"
-													:key="index"
-												>
-													{{ option.label }}
-												</option>
-											</kv-dropdown-rounded>
-										</div>
-									</div>
-								</div>
-
-								<div class="row small-collapse" v-if="!isOnetime">
-									<div class="small-12 columns">
-										<em class="text-center">Rest easy, you can cancel anytime.</em>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-					<div class="row align-center text-center">
-						<div class="large-9 medium-10 small-12 columns">
-							<p>
-								<!-- eslint-disable-next-line max-len -->
-								<strong><em>We'll charge your PayPal account{{ isOnetime ? '' : ' each month' }}, and any credit in your Kiva account will be automatically re-lent for you.</em></strong>
-							</p>
-							<p v-if="hasAutoDeposits">
-								<!-- eslint-disable-next-line max-len -->
-								<em>* Your {{ isOnetime ? '' : 'new Monthly Good ' }}contribution will replace your existing auto deposit.</em>
-							</p>
-							<p v-if="hasAutoLending">
-								<!-- eslint-disable-next-line max-len -->
-								<em>* {{ isOnetime ? 'This contribution' : 'Enrolling in Monthly Good' }} will also disable your current auto lending settings.</em>
-							</p>
-							<div v-if="hasBillingAgreement">
-								<kv-button
-									type="submit"
-									data-test="confirm-monthly-good-button"
-									class="smaller"
-									:disabled="$v.$invalid || submitting"
-									@click.native="submitMonthlyGood()"
-								>
-									Confirm <kv-loading-spinner v-if="submitting" />
-								</kv-button>
-								<p>
-									<!-- eslint-disable-next-line max-len -->
-									<em>We'll charge your PayPal account for your {{ isOnetime ? 'Contribution' : 'Monthly Good' }}</em>
-								</p>
-							</div>
-
-							<div v-if="!hasBillingAgreement">
-								<div class="paypal-wrapper">
-									<div class="paypal-cover" v-if="$v.$invalid"></div>
-									<pay-pal-mg
-										:amount="totalCombinedDeposit"
-										@complete-transaction="submitMonthlyGood()"
-									/>
-									<p class="small-text">
-										Thanks to PayPal, Kiva receives free payment processing.
-									</p>
-								</div>
-							</div>
-						</div>
-					</div>
-				</form>
-			</div>
-			<already-subscribed-notice class="small-12 medium-11 large-8 column" v-if="isMonthlyGoodSubscriber" />
-			<legacy-subscriber-notice
-				class="small-12 medium-11 large-8 column"
-				:legacy-subscriptions="legacySubs"
-				v-if="hasLegacySubscription"
-			/>
-		</div>
-	</www-page>
+	<div>
+		<monthly-good-setup-page-control
+			v-if="showMGSetupControl"
+			:amount="amount"
+			:category="category"
+			:onetime="onetime"
+			:source="source"
+		/>
+		<monthly-good-setup-page-variant
+			v-else
+			:amount="amount"
+			:category="category"
+			:onetime="onetime"
+			:source="source"
+		/>
+	</div>
 </template>
 
 <script>
-import numeral from 'numeral';
-import _get from 'lodash/get';
 import gql from 'graphql-tag';
-import { validationMixin } from 'vuelidate';
-import { required, minValue, maxValue } from 'vuelidate/lib/validators';
+import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
+import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 
-import AlreadySubscribedNotice from './AlreadySubscribedNotice';
-import LegacySubscriberNotice from './LegacySubscriberNotice';
-import PayPalMg from './PayPalMG';
-
-import IconPencil from '@/assets/icons/inline/pencil.svg';
-import WwwPage from '@/components/WwwFrame/WwwPage';
-import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
-import KvCurrencyInput from '@/components/Kv/KvCurrencyInput';
-import KvDropdownRounded from '@/components/Kv/KvDropdownRounded';
-import KvCheckbox from '@/components/Kv/KvCheckbox';
-import KvButton from '@/components/Kv/KvButton';
-import userInfoQuery from '@/graphql/query/userInfo.graphql';
-import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
+import MonthlyGoodSetupPageControl from '@/pages/MonthlyGood/MonthlyGoodSetupPageControl';
+import MonthlyGoodSetupPageVariant from '@/pages/MonthlyGood/MonthlyGoodSetupPageVariant';
 
 const pageQuery = gql`{
-    general {
-      mgDonationTaglineActive: uiConfigSetting(key: "mg_donationtagline_active") {
-        key
-        value
-      }
-    }
-	my {
-		subscriptions {
-			values {
-				subscrId
-			}
-		}
-		autoDeposit {
-			id
-			amount
-			donateAmount
-			dayOfMonth
-			status
-			isSubscriber
-		}
-		autolendProfile {
-			isEnabled
-		}
-		payPalBillingAgreement {
-			hasPayPalBillingAgreement
+	general {
+		uiExperimentSetting(key: "mg_setup") {
+			key
+			value
 		}
 	}
 }`;
-
-let frozenDropdownOptions;
 
 export default {
 	props: {
@@ -317,442 +54,43 @@ export default {
 		}
 	},
 	components: {
-		AlreadySubscribedNotice,
-		IconPencil,
-		KvButton,
-		KvCheckbox,
-		KvCurrencyInput,
-		KvDropdownRounded,
-		KvLoadingSpinner,
-		LegacySubscriberNotice,
-		PayPalMg,
-		WwwPage,
+		MonthlyGoodSetupPageControl,
+		MonthlyGoodSetupPageVariant
 	},
 	data() {
 		return {
-			selectedGroup: 'default',
-			mgAmount: 25,
-			isDayInputShown: false,
-			dayOfMonth: new Date().getDate(),
-			donation: 25 * 0.15,
-			donationCheckbox: true,
-			donationOptionSelected: '15',
-			isDonationOptionsDirty: false,
-			submitting: false,
-			legacySubs: [],
-			// user flags
-			isMonthlyGoodSubscriber: false,
-			hasAutoDeposits: false,
-			hasAutoLending: false,
-			hasBillingAgreement: false,
-			hasLegacySubscription: false,
-			isMGTaglineActive: false,
+			showMGSetupControl: true
 		};
-	},
-	mixins: [
-		validationMixin,
-		loanGroupCategoriesMixin
-	],
-	validations: {
-		mgAmount: {
-			required,
-			minValue: minValue(5),
-			maxValue: maxValue(10000),
-			maxTotal(value) {
-				return value + this.donation < 10000;
-			}
-		},
-		donation: {
-			minValue: minValue(0),
-			maxValue: maxValue(10000),
-			maxTotal(value) {
-				return value + this.mgAmount < 10000;
-			}
-		},
-		dayOfMonth: {
-			required,
-			minValue: minValue(1),
-			maxValue: maxValue(31)
-		},
-
 	},
 	inject: ['apollo'],
 	apollo: {
-		query: pageQuery,
-		preFetch(config, client, { route }) {
-			return client.query({ query: userInfoQuery })
-				.then(({ data }) => {
-					const userId = _get(data, 'my.userAccount.id');
-					if (!userId) {
-						throw new Error('activeLoginRequired');
-					}
-				})
-				.then(() => {
-					return client.query({ query: pageQuery });
-				})
-				.catch(e => {
-					if (e.message.indexOf('activeLoginRequired') > -1) {
-						// Force a login when active login is required
-						return Promise.reject({
-							path: '/ui-login',
-							query: { doneUrl: route.fullPath }
-						});
-					}
-					// Log other errors
-					console.error(e);
-				});
-		},
-		result({ data }) {
-			this.isMGTaglineActive = _get(data, 'general.mgDonationTaglineActive.value') === 'true' || false;
-			this.isMonthlyGoodSubscriber = _get(data, 'my.autoDeposit.isSubscriber', false);
-			this.hasAutoDeposits = _get(data, 'my.autoDeposit', false);
-			this.hasAutoLending = _get(data, 'my.autolendProfile.isEnabled', false);
-			this.hasBillingAgreement = _get(data,
-				'my.payPalBillingAgreement.hasPayPalBillingAgreement', false);
-			this.legacySubs = _get(data, 'my.subscriptions.values', []);
-			this.hasLegacySubscription = this.legacySubs.length > 0;
-		},
+		preFetch(config, client) {
+			return new Promise((resolve, reject) => {
+				// Get the experiment object from settings
+				client.query({
+					query: pageQuery
+				}).then(() => {
+					// Get the assigned experiment version for braintree pay with experiment
+					client.query({ query: experimentAssignmentQuery, variables: { id: 'mg_setup' } })
+						.then(resolve).catch(reject);
+				}).catch(reject);
+			});
+		}
 	},
 	created() {
-		// Sanitize and set initial form values.
-		if (this.lendingCategories.find(category => category.value === this.category)) {
-			this.selectedGroup = this.category;
+		// get experiment data from apollo cache
+		// GROW-82: Redesigned monthly good receipt page.
+		const mgSetupExp = this.apollo.readFragment({
+			id: 'Experiment:mg_setup',
+			fragment: experimentVersionFragment,
+		}) || {};
+		if (mgSetupExp.version === 'control') {
+			this.$kvTrackEvent('MonthlyGood', 'EXP-GROW-82-May2020', 'a');
+		} else if (mgSetupExp.version === 'shown') {
+			this.showMGSetupControl = false;
+			this.$kvTrackEvent('MonthlyGood', 'EXP-GROW-82-May2020', 'b');
 		}
-
-		if (!Number.isNaN(Number(this.amount))) {
-			this.mgAmount = this.amount;
-			this.donation = this.amount * 0.15;
-		}
-		// Fire snowplow events
-		if (this.isMonthlyGoodSubscriber) {
-			this.$kvTrackEvent('Registration', 'unsuccessful-monthly-good-reg', 'has-mg');
-		}
-		if (this.hasLegacySubscription) {
-			this.$kvTrackEvent('Registration', 'unsuccessful-monthly-good-reg', 'has-legacy-subscription');
-		}
-	},
-	watch: {
-		donation(newVal) {
-			if (newVal !== 0) {
-				this.donationCheckbox = true;
-			}
-			if (newVal === 0) {
-				this.donationOptionSelected = '0';
-			}
-		},
-		donationOptionSelected(newVal) {
-			// flag donation options as dirty, which stops the recalculation of the drop down values.
-			this.isDonationOptionsDirty = true;
-			if (newVal !== 'other') {
-				// handle pre-computed donation options based update
-				if (!this.isDonationOptionsDirty) {
-					// get selected amount in donation
-					const selectedDonationAmount = this.calculatedDonationOptions.find(
-						donationSelect => donationSelect.value === newVal
-					);
-					this.donation = selectedDonationAmount.monetaryValue;
-				} else if (this.isDonationOptionsDirty) {
-					// handle user selected donation options based update
-					this.$nextTick(() => {
-						const selectedFrozenOption = frozenDropdownOptions.find(
-							donationSelect => donationSelect.value === newVal
-						);
-						if (selectedFrozenOption) {
-							this.donation = selectedFrozenOption.monetaryValue;
-						}
-					});
-				}
-
-				// sync the checkbox with the dropdown.
-				if (newVal !== '0') {
-					this.donationCheckbox = true;
-				} else {
-					this.donationCheckbox = false;
-				}
-			}
-		},
-		// monitor mgAmount for changes
-		mgAmount() {
-			// handle pre-computed donation options based update
-			if (this.donationOptionSelected !== 'other' && !this.isDonationOptionsDirty) {
-				// get selected amount in donation
-				const selectedDonationAmount = this.calculatedDonationOptions.find(
-					donationSelect => donationSelect.value === this.donationOptionSelected
-				);
-				this.donation = selectedDonationAmount.monetaryValue;
-			} else if (this.donationOptionSelected !== 'other' && this.isDonationOptionsDirty) {
-				// handle user selected donation options based update
-				const selectedFrozenOption = frozenDropdownOptions.find(
-					donationSelect => donationSelect.value === this.donationOptionSelected
-				);
-				if (selectedFrozenOption) {
-					this.donation = selectedFrozenOption.monetaryValue;
-				}
-			}
-		},
-	},
-	methods: {
-		hideDayInput() {
-			if (!this.$v.dayOfMonth.$invalid) {
-				this.isDayInputShown = false;
-			}
-		},
-		donationCheckboxChange() {
-			if (!this.donationCheckbox) {
-				// when box is unchecked, change donation amount to zero.
-				this.donationOptionSelected = '0';
-			}
-		},
-		submitMonthlyGood() {
-			this.submitting = true;
-			this.$kvTrackEvent('Registration', 'click-confirm-monthly-good', 'register-monthly-good');
-
-			this.apollo.mutate({
-				mutation: gql`
-					mutation (
-						$amount: Money!,
-						$donateAmount: Money!,
-						$dayOfMonth: Int!,
-						$category: MonthlyGoodCategoryEnum,
-						$isOnetime: Boolean
-					) {
-						my {
-							createMonthlyGoodSubscription( autoDeposit: {
-								amount: $amount,
-								donateAmount:
-								$donateAmount,
-								dayOfMonth: $dayOfMonth,
-								isOnetime: $isOnetime
-							},
-							category: $category)
-						}
-					}`,
-				variables: {
-					amount: numeral(this.totalCombinedDeposit).format('0.00'),
-					donateAmount: numeral(this.donation).format('0.00'),
-					dayOfMonth: numeral(this.dayOfMonth).value(),
-					category: this.selectedGroup,
-					isOnetime: this.isOnetime
-				}
-			}).then(data => {
-				if (data.errors) {
-					const errorMessage = _get(data, 'errors[0].message');
-					this.$showTipMsg(errorMessage, 'error');
-				} else {
-					this.$kvTrackEvent('Registration', 'successful-monthly-good-reg', 'register-monthly-good');
-					// Send to thanks page
-					this.$router.push({
-						path: '/monthlygood/thanks',
-						query: {
-							onetime: this.isOnetime,
-							source: this.source,
-						}
-					});
-				}
-			}).catch(error => {
-				this.$showTipMsg(error, 'error');
-			}).finally(() => {
-				this.submitting = false;
-			});
-		},
-	},
-	computed: {
-		totalCombinedDeposit() {
-			return this.donation + this.mgAmount;
-		},
-		dropdownOptions() {
-			if (this.isDonationOptionsDirty) {
-				if (!frozenDropdownOptions) {
-					// make a copy of calculatedDonationOptions to freeze the values
-					frozenDropdownOptions = this.calculatedDonationOptions.map(selectItem => ({ ...selectItem }));
-				}
-				return frozenDropdownOptions;
-			}
-			return this.calculatedDonationOptions;
-		},
-		calculatedDonationOptions() {
-			// If mgAmount isn't valid, just set these values on the amount prop.
-			const amountToBasePercentageOn = this.$v.mgAmount.$invalid ? this.amount : this.mgAmount;
-			return [
-				{
-					value: '20',
-					label: `${numeral(amountToBasePercentageOn * 0.20).format('$0,0.00')}`,
-					monetaryValue: Math.round(amountToBasePercentageOn * 0.20 * 100) / 100
-				},
-				{
-					value: '15',
-					label: `${numeral(amountToBasePercentageOn * 0.15).format('$0,0.00')}`,
-					monetaryValue: Math.round(amountToBasePercentageOn * 0.15 * 100) / 100
-
-				},
-				{
-					value: '8',
-					label: `${numeral(amountToBasePercentageOn * 0.08).format('$0,0.00')}`,
-					monetaryValue: Math.round(amountToBasePercentageOn * 0.08 * 100) / 100
-				},
-				{
-					value: '0',
-					label: '$0.00',
-					monetaryValue: 0
-
-				},
-				{
-					value: 'other',
-					label: 'Other'
-				}
-			];
-		},
-		isOnetime() {
-			// ensure this is cast to a bool for use in Graphql mutation
-			return this.onetime === 'true';
-		},
-		fromCovidLanding() {
-			return this.source === 'covid19response';
-		}
-	},
+	}
 };
 
 </script>
-
-<style lang="scss" scoped>
-@import 'settings';
-
-.monthly-good-setup-page {
-	margin: 2rem auto 2rem;
-
-	h1 { color: $kiva-green; }
-
-	h3 { padding: 0 2rem; }
-
-	form.monthly-good-form {
-		margin-top: 2rem;
-
-		.panel.zigzag-bottom {
-			margin-bottom: 1.5rem;
-			position: relative;
-			background-color: $kiva-bg-darkgray;
-			padding: 1rem;
-
-			& > .row .row {
-				margin-bottom: 1rem;
-			}
-
-			@include breakpoint(large) {
-				padding: 1rem 2rem;
-			}
-		}
-
-		.panel.zigzag-bottom::after {
-			background:
-				linear-gradient(-45deg, $white 12px, transparent 0),
-				linear-gradient(45deg, $white 12px, transparent 0);
-			background-size: 24px 24px;
-			content: " ";
-			position: absolute;
-			bottom: 0;
-			left: 0;
-			width: 100%;
-			height: 24px;
-		}
-
-		//aligns numbers with input
-		.additional-left-pad-currency {
-			padding-left: 0.55rem;
-		}
-
-		//aligns other rows to make room for checkbox
-		.additional-left-pad-spans {
-			padding-left: 1.55rem;
-			display: inline-block;
-		}
-
-		// styles to match KvDropDownRounded
-		input.text-input {
-			border: 1px solid $charcoal;
-			border-radius: $button-radius;
-			color: $charcoal;
-			font-size: $medium-text-font-size;
-			font-weight: $global-weight-highlight;
-			margin: 0;
-		}
-
-		.button--ordinal-day {
-			color: $kiva-accent-blue;
-			fill: $kiva-accent-blue;
-			cursor: pointer;
-		}
-
-		.icon-pencil {
-			height: 1rem;
-		}
-
-		.text-input__day {
-			display: inline-block;
-			width: 3.5rem;
-			padding: 0.25rem 0.5rem;
-			margin: 0 0 0 0.25rem;
-			height: 2rem;
-		}
-
-		.text-input,
-		.validation-errors {
-			margin: 0;
-		}
-
-		.additional-day-info {
-			margin-bottom: 1.25rem;
-
-			small,
-			strong {
-				display: block;
-			}
-		}
-
-		.display-inline-block {
-			display: inline-block;
-		}
-
-		::v-deep .loading-spinner {
-			vertical-align: middle;
-			width: 1rem;
-			height: 1rem;
-		}
-
-		::v-deep .loading-spinner .line {
-			background-color: $white;
-		}
-
-		::v-deep .dropdown-wrapper.donation-dropdown .dropdown {
-			margin-bottom: 0;
-			width: 100%;
-		}
-
-		::v-deep .dropdown-wrapper.group-dropdown .dropdown {
-			margin-top: 0.65rem;
-		}
-
-		::v-deep .kv-checkbox {
-			position: absolute;
-			padding-top: 0.15rem;
-		}
-	}
-
-	// cover and disallow clicking if form is invalid
-	.paypal-wrapper { position: relative; }
-
-	.paypal-cover {
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		background: rgba(255, 255, 255, 0.8);
-		z-index: 10000;
-	}
-}
-
-// Hide global promo bar (this is the promo landing page!!!)
-::v-deep .generic-banner {
-	display: none;
-}
-</style>

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
@@ -1,20 +1,18 @@
 <template>
-	<div>
-		<monthly-good-setup-page-control
-			v-if="showMGSetupControl"
-			:amount="amount"
-			:category="category"
-			:onetime="onetime"
-			:source="source"
-		/>
-		<monthly-good-setup-page-variant
-			v-else
-			:amount="amount"
-			:category="category"
-			:onetime="onetime"
-			:source="source"
-		/>
-	</div>
+	<monthly-good-setup-page-control
+		v-if="showMGSetupControl"
+		:amount="amount"
+		:category="category"
+		:onetime="onetime"
+		:source="source"
+	/>
+	<monthly-good-setup-page-variant
+		v-else
+		:amount="amount"
+		:category="category"
+		:onetime="onetime"
+		:source="source"
+	/>
 </template>
 
 <script>

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageControl.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageControl.vue
@@ -1,0 +1,760 @@
+<template>
+	<www-page>
+		<div class="row align-center monthly-good-setup-page">
+			<div class="small-12 medium-11 large-10 column" v-if="!isMonthlyGoodSubscriber && !hasLegacySubscription">
+				<h1 class="text-center impact-text">
+					Confirm your Good
+				</h1>
+				<h3 class="text-center featured-text" v-if="!isOnetime">
+					Review and set up your monthly contribution
+				</h3>
+				<form
+					class="monthly-good-form"
+					@submit.prevent="hasBillingAgreement ? submitMonthlyGood : null"
+					novalidate
+				>
+					<div class="panel zigzag-bottom">
+						<div class="row align-center text-center">
+							<div class="medium-10 small-12 columns">
+								<div class="row column" v-if="!fromCovidLanding">
+									<strong>Each month on the</strong>
+									<label class="show-for-sr" :class="{ 'error': $v.$invalid }" :for="dayOfMonth">
+										Day of the Month
+									</label>
+									<input v-if="isDayInputShown"
+										@blur="hideDayInput()"
+										class="text-input__day"
+										id="dayOfMonth"
+										type="number"
+										placeholder=""
+										required
+										min="1"
+										max="31"
+										v-model="dayOfMonth"
+									>
+									<button
+										class="button--ordinal-day"
+										@click="isDayInputShown = true"
+										v-if="!isDayInputShown"
+									>
+										<strong>{{ dayOfMonth | numeral('Oo') }}</strong>
+										<icon-pencil class="icon-pencil" />
+									</button>
+									<ul class="validation-errors" v-if="$v.dayOfMonth.$invalid">
+										<li v-if="!$v.dayOfMonth.required">
+											Field is required
+										</li>
+										<li v-if="!$v.dayOfMonth.minValue || !$v.dayOfMonth.maxValue">
+											Enter day of month - 1 to 31
+										</li>
+									</ul>
+									<div class="additional-day-info">
+										<strong>we'll process the following:</strong>
+										<small v-if="dayOfMonth > 28">
+											(note - may be processed on the last day of the month)</small>
+									</div>
+								</div>
+
+								<div class="row text-left align-middle">
+									<div class="columns">
+										<span class="additional-left-pad-spans strong">
+											Deposit for lending
+										</span>
+									</div>
+
+									<div class="medium-5 small-6 columns">
+										<label
+											class="show-for-sr"
+											:class="{ 'error': $v.mgAmount.$invalid }"
+											for="amount"
+										>
+											Amount
+										</label>
+										<kv-currency-input class="text-input" id="amount" v-model="mgAmount" />
+									</div>
+
+									<div class="small-12 columns">
+										<ul class="text-right validation-errors" v-if="$v.mgAmount.$invalid">
+											<li v-if="!$v.mgAmount.required">
+												Field is required
+											</li>
+											<li v-if="!$v.mgAmount.minValue || !$v.mgAmount.maxValue">
+												Enter an amount of $5-$10,000
+											</li>
+										</ul>
+									</div>
+								</div>
+
+								<div class="row text-left align-middle">
+									<div class="columns">
+										<kv-checkbox
+											id="donation-checkbox"
+											v-model="donationCheckbox"
+											@change="donationCheckboxChange()"
+										/>
+										<div class="additional-left-pad-spans display-inline-block">
+											<span class="strong">
+												Monthly donation to Kiva (optional)
+											</span>
+											<div class="small-text" v-if="isMGTaglineActive">
+												<!-- eslint-disable-next-line max-len -->
+												Every $25 loan costs more than $3 to facilitate, and our generous supporters are donating $1 for every $3 you donate.
+											</div>
+										</div>
+									</div>
+
+									<div class="medium-5 small-6 columns">
+										<label
+											class="show-for-sr"
+											:class="{ 'error': $v.donation.$invalid }"
+											for="donation"
+										>
+											Donation
+										</label>
+										<kv-dropdown-rounded
+											class="donation-dropdown"
+											v-model="donationOptionSelected"
+											v-if="donationOptionSelected !== 'other'"
+										>
+											<option
+												v-for="(option, index) in dropdownOptions"
+												:value="option.value"
+												:key="index"
+											>
+												{{ option.label }}
+											</option>
+										</kv-dropdown-rounded>
+										<kv-currency-input
+											class="text-input"
+											id="donation"
+											v-model="donation"
+											v-if="donationOptionSelected === 'other'"
+										/>
+									</div>
+
+									<div class="small-12 columns">
+										<ul class="text-right validation-errors" v-if="$v.donation.$invalid">
+											<li v-if="!$v.donation.minValue || !$v.donation.maxValue">
+												Enter an amount of $0-$10,000
+											</li>
+										</ul>
+									</div>
+								</div>
+
+								<div class="row text-left">
+									<div class="columns">
+										<strong v-if="!onetime" class="additional-left-pad-spans">Total/month</strong>
+										<strong v-else class="additional-left-pad-spans">Total</strong>
+									</div>
+
+									<div class="medium-5 small-6 columns">
+										<strong
+											class="additional-left-pad-currency"
+										>{{ totalCombinedDeposit | numeral('$0,0.00') }}</strong>
+									</div>
+
+									<div class="small-12 columns">
+										<ul class="text-center validation-errors"
+											v-if="!$v.mgAmount.maxTotal || !$v.donation.maxTotal"
+										>
+											<li>
+												The maximum Monthly Good total is $10,000.<br>
+												Please try again by entering in a smaller amount.
+											</li>
+										</ul>
+									</div>
+								</div>
+
+								<div class="row text-left" v-if="!fromCovidLanding">
+									<div class="small-12 columns">
+										<div class="additional-left-pad-spans">
+											Select a category to focus your lending
+											<kv-dropdown-rounded v-model="selectedGroup" class="group-dropdown">
+												<option
+													v-for="(option, index) in lendingCategories"
+													:value="option.value"
+													:key="index"
+												>
+													{{ option.label }}
+												</option>
+											</kv-dropdown-rounded>
+										</div>
+									</div>
+								</div>
+
+								<div class="row small-collapse" v-if="!isOnetime">
+									<div class="small-12 columns">
+										<em class="text-center">Rest easy, you can cancel anytime.</em>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
+					<div class="row align-center text-center">
+						<div class="large-9 medium-10 small-12 columns">
+							<p>
+								<!-- eslint-disable-next-line max-len -->
+								<strong><em>We'll charge your PayPal account{{ isOnetime ? '' : ' each month' }}, and any credit in your Kiva account will be automatically re-lent for you.</em></strong>
+							</p>
+							<p v-if="hasAutoDeposits">
+								<!-- eslint-disable-next-line max-len -->
+								<em>* Your {{ isOnetime ? '' : 'new Monthly Good ' }}contribution will replace your existing auto deposit.</em>
+							</p>
+							<p v-if="hasAutoLending">
+								<!-- eslint-disable-next-line max-len -->
+								<em>* {{ isOnetime ? 'This contribution' : 'Enrolling in Monthly Good' }} will also disable your current auto lending settings.</em>
+							</p>
+							<div v-if="hasBillingAgreement">
+								<kv-button
+									type="submit"
+									data-test="confirm-monthly-good-button"
+									class="smaller"
+									:disabled="$v.$invalid || submitting"
+									@click.native="submitMonthlyGood()"
+								>
+									Confirm <kv-loading-spinner v-if="submitting" />
+								</kv-button>
+								<p>
+									<!-- eslint-disable-next-line max-len -->
+									<em>We'll charge your PayPal account for your {{ isOnetime ? 'Contribution' : 'Monthly Good' }}</em>
+								</p>
+							</div>
+
+							<div v-if="!hasBillingAgreement">
+								<div class="paypal-wrapper">
+									<div class="paypal-cover" v-if="$v.$invalid"></div>
+									<pay-pal-mg
+										:amount="totalCombinedDeposit"
+										@complete-transaction="submitMonthlyGood()"
+									/>
+									<p class="small-text">
+										Thanks to PayPal, Kiva receives free payment processing.
+									</p>
+								</div>
+							</div>
+						</div>
+					</div>
+				</form>
+			</div>
+			<already-subscribed-notice class="small-12 medium-11 large-8 column" v-if="isMonthlyGoodSubscriber" />
+			<legacy-subscriber-notice
+				class="small-12 medium-11 large-8 column"
+				:legacy-subscriptions="legacySubs"
+				v-if="hasLegacySubscription"
+			/>
+		</div>
+	</www-page>
+</template>
+
+<script>
+import numeral from 'numeral';
+import _get from 'lodash/get';
+import gql from 'graphql-tag';
+import { validationMixin } from 'vuelidate';
+import { required, minValue, maxValue } from 'vuelidate/lib/validators';
+
+import AlreadySubscribedNotice from './AlreadySubscribedNotice';
+import LegacySubscriberNotice from './LegacySubscriberNotice';
+import PayPalMg from './PayPalMG';
+
+import IconPencil from '@/assets/icons/inline/pencil.svg';
+import WwwPage from '@/components/WwwFrame/WwwPage';
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+import KvCurrencyInput from '@/components/Kv/KvCurrencyInput';
+import KvDropdownRounded from '@/components/Kv/KvDropdownRounded';
+import KvCheckbox from '@/components/Kv/KvCheckbox';
+import KvButton from '@/components/Kv/KvButton';
+import userInfoQuery from '@/graphql/query/userInfo.graphql';
+import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
+
+const pageQuery = gql`{
+    general {
+      mgDonationTaglineActive: uiConfigSetting(key: "mg_donationtagline_active") {
+        key
+        value
+      }
+    }
+	my {
+		subscriptions {
+			values {
+				subscrId
+			}
+		}
+		autoDeposit {
+			id
+			amount
+			donateAmount
+			dayOfMonth
+			status
+			isSubscriber
+		}
+		autolendProfile {
+			isEnabled
+		}
+		payPalBillingAgreement {
+			hasPayPalBillingAgreement
+		}
+	}
+}`;
+
+let frozenDropdownOptions;
+
+export default {
+	props: {
+		amount: {
+			type: Number,
+			default: 25
+		},
+		category: {
+			type: String,
+			default: 'default'
+		},
+		onetime: {
+			type: String,
+			default: 'false'
+		},
+		source: {
+			type: String,
+			default: ''
+		}
+	},
+	components: {
+		AlreadySubscribedNotice,
+		IconPencil,
+		KvButton,
+		KvCheckbox,
+		KvCurrencyInput,
+		KvDropdownRounded,
+		KvLoadingSpinner,
+		LegacySubscriberNotice,
+		PayPalMg,
+		WwwPage,
+	},
+	data() {
+		return {
+			selectedGroup: 'default',
+			mgAmount: 25,
+			isDayInputShown: false,
+			dayOfMonth: new Date().getDate(),
+			donation: 25 * 0.15,
+			donationCheckbox: true,
+			donationOptionSelected: '15',
+			isDonationOptionsDirty: false,
+			submitting: false,
+			legacySubs: [],
+			// user flags
+			isMonthlyGoodSubscriber: false,
+			hasAutoDeposits: false,
+			hasAutoLending: false,
+			hasBillingAgreement: false,
+			hasLegacySubscription: false,
+			isMGTaglineActive: false,
+		};
+	},
+	mixins: [
+		validationMixin,
+		loanGroupCategoriesMixin
+	],
+	validations: {
+		mgAmount: {
+			required,
+			minValue: minValue(5),
+			maxValue: maxValue(10000),
+			maxTotal(value) {
+				return value + this.donation < 10000;
+			}
+		},
+		donation: {
+			minValue: minValue(0),
+			maxValue: maxValue(10000),
+			maxTotal(value) {
+				return value + this.mgAmount < 10000;
+			}
+		},
+		dayOfMonth: {
+			required,
+			minValue: minValue(1),
+			maxValue: maxValue(31)
+		},
+
+	},
+	inject: ['apollo'],
+	apollo: {
+		query: pageQuery,
+		preFetch(config, client, { route }) {
+			return client.query({ query: userInfoQuery })
+				.then(({ data }) => {
+					const userId = _get(data, 'my.userAccount.id');
+					if (!userId) {
+						throw new Error('activeLoginRequired');
+					}
+				})
+				.then(() => {
+					return client.query({ query: pageQuery });
+				})
+				.catch(e => {
+					if (e.message.indexOf('activeLoginRequired') > -1) {
+						// Force a login when active login is required
+						return Promise.reject({
+							path: '/ui-login',
+							query: { doneUrl: route.fullPath }
+						});
+					}
+					// Log other errors
+					console.error(e);
+				});
+		},
+		result({ data }) {
+			this.isMGTaglineActive = _get(data, 'general.mgDonationTaglineActive.value') === 'true' || false;
+			this.isMonthlyGoodSubscriber = _get(data, 'my.autoDeposit.isSubscriber', false);
+			this.hasAutoDeposits = _get(data, 'my.autoDeposit', false);
+			this.hasAutoLending = _get(data, 'my.autolendProfile.isEnabled', false);
+			this.hasBillingAgreement = _get(data,
+				'my.payPalBillingAgreement.hasPayPalBillingAgreement', false);
+			this.legacySubs = _get(data, 'my.subscriptions.values', []);
+			this.hasLegacySubscription = this.legacySubs.length > 0;
+		},
+	},
+	created() {
+		// Sanitize and set initial form values.
+		if (this.lendingCategories.find(category => category.value === this.category)) {
+			this.selectedGroup = this.category;
+		}
+
+		if (!Number.isNaN(Number(this.amount))) {
+			this.mgAmount = this.amount;
+			this.donation = this.amount * 0.15;
+		}
+		// Fire snowplow events
+		if (this.isMonthlyGoodSubscriber) {
+			this.$kvTrackEvent('Registration', 'unsuccessful-monthly-good-reg', 'has-mg');
+		}
+		if (this.hasLegacySubscription) {
+			this.$kvTrackEvent('Registration', 'unsuccessful-monthly-good-reg', 'has-legacy-subscription');
+		}
+	},
+	watch: {
+		donation(newVal) {
+			if (newVal !== 0) {
+				this.donationCheckbox = true;
+			}
+			if (newVal === 0) {
+				this.donationOptionSelected = '0';
+			}
+		},
+		donationOptionSelected(newVal) {
+			// flag donation options as dirty, which stops the recalculation of the drop down values.
+			this.isDonationOptionsDirty = true;
+			if (newVal !== 'other') {
+				// handle pre-computed donation options based update
+				if (!this.isDonationOptionsDirty) {
+					// get selected amount in donation
+					const selectedDonationAmount = this.calculatedDonationOptions.find(
+						donationSelect => donationSelect.value === newVal
+					);
+					this.donation = selectedDonationAmount.monetaryValue;
+				} else if (this.isDonationOptionsDirty) {
+					// handle user selected donation options based update
+					this.$nextTick(() => {
+						const selectedFrozenOption = frozenDropdownOptions.find(
+							donationSelect => donationSelect.value === newVal
+						);
+						if (selectedFrozenOption) {
+							this.donation = selectedFrozenOption.monetaryValue;
+						}
+					});
+				}
+
+				// sync the checkbox with the dropdown.
+				if (newVal !== '0') {
+					this.donationCheckbox = true;
+				} else {
+					this.donationCheckbox = false;
+				}
+			}
+		},
+		// monitor mgAmount for changes
+		mgAmount() {
+			// handle pre-computed donation options based update
+			if (this.donationOptionSelected !== 'other' && !this.isDonationOptionsDirty) {
+				// get selected amount in donation
+				const selectedDonationAmount = this.calculatedDonationOptions.find(
+					donationSelect => donationSelect.value === this.donationOptionSelected
+				);
+				this.donation = selectedDonationAmount.monetaryValue;
+			} else if (this.donationOptionSelected !== 'other' && this.isDonationOptionsDirty) {
+				// handle user selected donation options based update
+				const selectedFrozenOption = frozenDropdownOptions.find(
+					donationSelect => donationSelect.value === this.donationOptionSelected
+				);
+				if (selectedFrozenOption) {
+					this.donation = selectedFrozenOption.monetaryValue;
+				}
+			}
+		},
+	},
+	methods: {
+		hideDayInput() {
+			if (!this.$v.dayOfMonth.$invalid) {
+				this.isDayInputShown = false;
+			}
+		},
+		donationCheckboxChange() {
+			if (!this.donationCheckbox) {
+				// when box is unchecked, change donation amount to zero.
+				this.donationOptionSelected = '0';
+			}
+		},
+		submitMonthlyGood() {
+			this.submitting = true;
+			this.$kvTrackEvent('Registration', 'click-confirm-monthly-good', 'register-monthly-good');
+
+			this.apollo.mutate({
+				mutation: gql`
+					mutation (
+						$amount: Money!,
+						$donateAmount: Money!,
+						$dayOfMonth: Int!,
+						$category: MonthlyGoodCategoryEnum,
+						$isOnetime: Boolean
+					) {
+						my {
+							createMonthlyGoodSubscription( autoDeposit: {
+								amount: $amount,
+								donateAmount:
+								$donateAmount,
+								dayOfMonth: $dayOfMonth,
+								isOnetime: $isOnetime
+							},
+							category: $category)
+						}
+					}`,
+				variables: {
+					amount: numeral(this.totalCombinedDeposit).format('0.00'),
+					donateAmount: numeral(this.donation).format('0.00'),
+					dayOfMonth: numeral(this.dayOfMonth).value(),
+					category: this.selectedGroup,
+					isOnetime: this.isOnetime
+				}
+			}).then(data => {
+				if (data.errors) {
+					const errorMessage = _get(data, 'errors[0].message');
+					this.$showTipMsg(errorMessage, 'error');
+				} else {
+					this.$kvTrackEvent('Registration', 'successful-monthly-good-reg', 'register-monthly-good');
+					// Send to thanks page
+					this.$router.push({
+						path: '/monthlygood/thanks',
+						query: {
+							onetime: this.isOnetime,
+							source: this.source,
+						}
+					});
+				}
+			}).catch(error => {
+				this.$showTipMsg(error, 'error');
+			}).finally(() => {
+				this.submitting = false;
+			});
+		},
+	},
+	computed: {
+		totalCombinedDeposit() {
+			return this.donation + this.mgAmount;
+		},
+		dropdownOptions() {
+			if (this.isDonationOptionsDirty) {
+				if (!frozenDropdownOptions) {
+					// make a copy of calculatedDonationOptions to freeze the values
+					frozenDropdownOptions = this.calculatedDonationOptions.map(selectItem => ({ ...selectItem }));
+				}
+				return frozenDropdownOptions;
+			}
+			return this.calculatedDonationOptions;
+		},
+		calculatedDonationOptions() {
+			// If mgAmount isn't valid, just set these values on the amount prop.
+			const amountToBasePercentageOn = this.$v.mgAmount.$invalid ? this.amount : this.mgAmount;
+			return [
+				{
+					value: '20',
+					label: `${numeral(amountToBasePercentageOn * 0.20).format('$0,0.00')}`,
+					monetaryValue: Math.round(amountToBasePercentageOn * 0.20 * 100) / 100
+				},
+				{
+					value: '15',
+					label: `${numeral(amountToBasePercentageOn * 0.15).format('$0,0.00')}`,
+					monetaryValue: Math.round(amountToBasePercentageOn * 0.15 * 100) / 100
+
+				},
+				{
+					value: '8',
+					label: `${numeral(amountToBasePercentageOn * 0.08).format('$0,0.00')}`,
+					monetaryValue: Math.round(amountToBasePercentageOn * 0.08 * 100) / 100
+				},
+				{
+					value: '0',
+					label: '$0.00',
+					monetaryValue: 0
+
+				},
+				{
+					value: 'other',
+					label: 'Other'
+				}
+			];
+		},
+		isOnetime() {
+			// ensure this is cast to a bool for use in Graphql mutation
+			return this.onetime === 'true';
+		},
+		fromCovidLanding() {
+			return this.source === 'covid19response';
+		}
+	},
+};
+
+</script>
+
+<style lang="scss" scoped>
+@import 'settings';
+
+.monthly-good-setup-page {
+	margin: 2rem auto 2rem;
+
+	h1 { color: $kiva-green; }
+
+	h3 { padding: 0 2rem; }
+
+	form.monthly-good-form {
+		margin-top: 2rem;
+
+		.panel.zigzag-bottom {
+			margin-bottom: 1.5rem;
+			position: relative;
+			background-color: $kiva-bg-darkgray;
+			padding: 1rem;
+
+			& > .row .row {
+				margin-bottom: 1rem;
+			}
+
+			@include breakpoint(large) {
+				padding: 1rem 2rem;
+			}
+		}
+
+		.panel.zigzag-bottom::after {
+			background:
+				linear-gradient(-45deg, $white 12px, transparent 0),
+				linear-gradient(45deg, $white 12px, transparent 0);
+			background-size: 24px 24px;
+			content: " ";
+			position: absolute;
+			bottom: 0;
+			left: 0;
+			width: 100%;
+			height: 24px;
+		}
+
+		//aligns numbers with input
+		.additional-left-pad-currency {
+			padding-left: 0.55rem;
+		}
+
+		//aligns other rows to make room for checkbox
+		.additional-left-pad-spans {
+			padding-left: 1.55rem;
+			display: inline-block;
+		}
+
+		// styles to match KvDropDownRounded
+		input.text-input {
+			border: 1px solid $charcoal;
+			border-radius: $button-radius;
+			color: $charcoal;
+			font-size: $medium-text-font-size;
+			font-weight: $global-weight-highlight;
+			margin: 0;
+		}
+
+		.button--ordinal-day {
+			color: $kiva-accent-blue;
+			fill: $kiva-accent-blue;
+			cursor: pointer;
+		}
+
+		.icon-pencil {
+			height: 1rem;
+		}
+
+		.text-input__day {
+			display: inline-block;
+			width: 3.5rem;
+			padding: 0.25rem 0.5rem;
+			margin: 0 0 0 0.25rem;
+			height: 2rem;
+		}
+
+		.text-input,
+		.validation-errors {
+			margin: 0;
+		}
+
+		.additional-day-info {
+			margin-bottom: 1.25rem;
+
+			small,
+			strong {
+				display: block;
+			}
+		}
+
+		.display-inline-block {
+			display: inline-block;
+		}
+
+		::v-deep .loading-spinner {
+			vertical-align: middle;
+			width: 1rem;
+			height: 1rem;
+		}
+
+		::v-deep .loading-spinner .line {
+			background-color: $white;
+		}
+
+		::v-deep .dropdown-wrapper.donation-dropdown .dropdown {
+			margin-bottom: 0;
+			width: 100%;
+		}
+
+		::v-deep .dropdown-wrapper.group-dropdown .dropdown {
+			margin-top: 0.65rem;
+		}
+
+		::v-deep .kv-checkbox {
+			position: absolute;
+			padding-top: 0.15rem;
+		}
+	}
+
+	// cover and disallow clicking if form is invalid
+	.paypal-wrapper { position: relative; }
+
+	.paypal-cover {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		background: rgba(255, 255, 255, 0.8);
+		z-index: 10000;
+	}
+}
+
+// Hide global promo bar (this is the promo landing page!!!)
+::v-deep .generic-banner {
+	display: none;
+}
+</style>

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
@@ -2,6 +2,7 @@
 	<www-page>
 		<div v-if="!isMonthlyGoodSubscriber && !hasLegacySubscription">
 			<kv-responsive-image
+				class="hero-images"
 				:images="heroImages"
 				alt="A woman in a yellow dress with a look of pride and satisfaction on her face "
 			/>
@@ -552,6 +553,27 @@ export default {
 
 <style lang="scss" scoped>
 @import 'settings';
+
+.hero-images {
+	height: 0;
+	padding-bottom: 540/480 * 100%;
+
+	@include breakpoint(medium) {
+		padding-bottom: 372/680 * 100%;
+	}
+
+	@include breakpoint(large) {
+		padding-bottom: 441/1024 * 100%;
+	}
+
+	@include breakpoint(xga) {
+		padding-bottom: 620/1440 * 100%;
+	}
+
+	@include breakpoint(wxga) {
+		padding-bottom: 750/1920 * 100%;
+	}
+}
 
 .section {
 	padding-bottom: 2rem;

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
@@ -1,0 +1,711 @@
+<template>
+	<www-page>
+		<div v-if="!isMonthlyGoodSubscriber && !hasLegacySubscription">
+			<kv-responsive-image
+				:images="heroImages"
+				alt="A woman in a yellow dress with a look of pride and satisfaction on her face "
+			/>
+			<div class="row">
+				<div class="small-12 columns monthly-good-setup">
+					<div class="large-10 large-offset-1 columns ">
+						<div class="section">
+							<kv-checkout-steps
+								class="step-indicator"
+								:steps="['Review', 'Thank You!']"
+								:current-step-index="0"
+							/>
+						</div>
+						<div class="section">
+							<h1 class="h2">
+								Monthly Good
+							</h1>
+							<div class="row">
+								<div class="small-12 large-7 xlarge-8 xxlarge-9 columns">
+									<p>
+										{{ selectedCategory }} on Kiva.<br>
+										Deposits every  month on the {{ dayOfMonth }}th, cancel any time.
+									</p>
+								</div>
+								<div class="small-12 large-4 xlarge-3 xxlarge-2 large-offset-1 columns text-right">
+									<span class="h2 strong">${{ mgAmount }}</span>
+								</div>
+							</div>
+						</div>
+						<form
+							class="section donation"
+							:disabled="$v.$invalid || submitting"
+							@submit.prevent="hasBillingAgreement ? submitMonthlyGood() : null"
+							novalidate
+						>
+							<div class="donation__description">
+								<label for="donation" class="h2">
+									Monthly Donation to Kiva (optional)
+								</label>
+								<p class="inline">
+									{{ donationTagLine }}
+								</p>
+								<!-- TODO: What is the correct tracking event? -->
+								<button
+									class="small-text donation__info-btn inline"
+									@click="triggerDefaultLightbox"
+									type="button"
+									v-kv-track-event="['basket', 'Donation Info Lightbox', 'Open Lightbox']"
+								>
+									How Kiva uses donations
+								</button>
+							</div>
+							<div class="donation__pricing">
+								<kv-dropdown-rounded
+									class="donation__pricing-dropdown"
+									v-model="donationOptionSelected"
+									id="donation"
+								>
+									<option
+										v-for="(option, index) in dropdownOptions"
+										:value="option.value"
+										:key="index"
+									>
+										{{ option.label }}
+									</option>
+								</kv-dropdown-rounded>
+								<div
+									class="donation__pricing-other"
+									v-if="donationOptionSelected === 'other'"
+								>
+									<label for="other-donation" class="show-for-sr">Other Donation Amount</label>
+									<kv-currency-input
+										id="other-donation"
+										v-model="donation"
+										ref="donationOtherInput"
+									/>
+									<ul class="text-right validation-errors" v-if="$v.donation.$invalid">
+										<li v-if="!$v.donation.minValue || !$v.donation.maxValue">
+											Enter an amount of $0-$10,000
+										</li>
+									</ul>
+								</div>
+							</div>
+						</form>
+
+						<div class="section notice" v-if="!isNewUserRegistration">
+							<kv-icon name="bell" class="notice__icon" />
+							<div>
+								<p>
+									Your current auto lending settings will be
+									updated to the <strong>Monthly Good Lending Setting</strong>
+								</p>
+								<p>
+									We'll charge your PayPal account{{ isOnetime ? '' : ' each month' }}, and any credit
+									in your Kiva account will be automatically re-lent for you.
+								</p>
+								<p v-if="hasAutoDeposits">
+									<em>
+										* Your {{ isOnetime ? '' : 'new Monthly Good ' }}contribution
+										will replace your existing auto deposit.
+									</em>
+								</p>
+								<p v-if="hasAutoLending">
+									<em>
+										* {{ isOnetime ? 'This contribution' : 'Enrolling in Monthly Good' }} will
+										also disable your current auto lending settings.
+									</em>
+								</p>
+							</div>
+						</div>
+
+						<div class="section section--last text-right">
+							<div class="h2 strong">
+								<span v-if="!isOnetime">Total/month:</span>
+								<span v-else>Total:</span>
+								{{ totalCombinedDeposit | numeral('$0,0.00') }}
+							</div>
+							<ul class="text-right validation-errors"
+								v-if="!$v.mgAmount.maxTotal || !$v.donation.maxTotal"
+							>
+								<li>
+									The maximum Monthly Good total is $10,000.<br>
+									Please try again by entering in a smaller amount.
+								</li>
+							</ul>
+							<div v-if="hasBillingAgreement">
+								<kv-button
+									type="submit"
+									data-test="confirm-monthly-good-button"
+									class="subscribe-btn"
+									:disabled="$v.$invalid || submitting"
+								>
+									Subscribe <kv-loading-spinner v-if="submitting" />
+								</kv-button>
+								<p>
+									<!-- TODO: This is not in the comp, do we want it still? -->
+									<em>
+										We'll charge your PayPal account for your
+										{{ isOnetime ? 'Contribution' : 'Monthly Good' }}
+									</em>
+								</p>
+							</div>
+
+							<div v-if="!hasBillingAgreement" class="paypal">
+								<div class="paypal__wrapper">
+									<div class="paypal__cover" v-if="$v.$invalid"></div>
+									<pay-pal-mg
+										class="paypal__btn"
+										:amount="totalCombinedDeposit"
+										@complete-transaction="submitMonthlyGood()"
+									/>
+									<p class="small-text">
+										<!-- TODO: This is not in the comp, do we want it still? -->
+										Thanks to PayPal, Kiva receives free payment processing.
+									</p>
+								</div>
+							</div>
+						</div>
+						<kv-lightbox
+							:visible="donationLbVisible"
+							@lightbox-closed="lightboxClosed"
+						>
+							<h2 slot="title">
+								How does Kiva use donations?
+							</h2>
+							<p>
+								100% of every dollar you lend on Kiva goes directly to funding loans.
+								We rely on small optional donations from you and others to keep Kiva running.
+								Every $1 donated to Kiva makes $8 in loans possible around the world.
+								Your donation will enable us to:
+							</p>
+							<ul>
+								<li>Send expert staff to over 60 countries to vet and monitor loans and partners.</li>
+								<li>
+									Build and maintain a website that facilitates over
+									$1 million in loans each week.
+								</li>
+								<li>Provide comprehensive customer support to thousands of lenders worldwide.</li>
+								<li>Train and support hundreds of volunteers -- 4 for every 1 staff member at Kiva.</li>
+							</ul>
+							<p>
+								If you live in the United States, your donation is tax-deductible.
+								Thank you for considering a donation to Kiva.
+							</p>
+						</kv-lightbox>
+					</div>
+				</div>
+			</div>
+		</div>
+		<div
+			v-else
+			class="row align-center other-notices"
+		>
+			<already-subscribed-notice
+				v-if="isMonthlyGoodSubscriber"
+				class="small-12 medium-11 large-8 columns"
+			/>
+			<legacy-subscriber-notice
+				v-if="hasLegacySubscription"
+				class="small-12 medium-11 large-8 columns"
+				:legacy-subscriptions="legacySubs"
+			/>
+		</div>
+	</www-page>
+</template>
+
+<script>
+import numeral from 'numeral';
+import _get from 'lodash/get';
+import gql from 'graphql-tag';
+import { validationMixin } from 'vuelidate';
+import { required, minValue, maxValue } from 'vuelidate/lib/validators';
+
+import AlreadySubscribedNotice from './AlreadySubscribedNotice';
+import LegacySubscriberNotice from './LegacySubscriberNotice';
+import PayPalMg from './PayPalMG';
+
+import WwwPage from '@/components/WwwFrame/WwwPage';
+import KvButton from '@/components/Kv/KvButton';
+import KvCheckoutSteps from '@/components/Kv/KvCheckoutSteps';
+import KvCurrencyInput from '@/components/Kv/KvCurrencyInput';
+import KvDropdownRounded from '@/components/Kv/KvDropdownRounded';
+import KvIcon from '@/components/Kv/KvIcon';
+import KvLightbox from '@/components/Kv/KvLightbox';
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
+import userInfoQuery from '@/graphql/query/userInfo.graphql';
+import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
+
+const heroImagesRequire = require.context('@/assets/images/mg-landing-hero', true);
+
+const pageQuery = gql`{
+    general {
+      mgDonationTaglineActive: uiConfigSetting(key: "mg_donationtagline_active") {
+        key
+        value
+      }
+    }
+	my {
+		subscriptions {
+			values {
+				subscrId
+			}
+		}
+		autoDeposit {
+			id
+			amount
+			donateAmount
+			dayOfMonth
+			status
+			isSubscriber
+		}
+		autolendProfile {
+			isEnabled
+		}
+		loans {
+			totalCount
+		}
+		payPalBillingAgreement {
+			hasPayPalBillingAgreement
+		}
+	}
+}`;
+
+export default {
+	props: {
+		amount: {
+			type: Number,
+			default: 25
+		},
+		category: {
+			type: String,
+			default: 'default'
+		},
+		onetime: {
+			type: String,
+			default: 'false'
+		},
+		source: {
+			type: String,
+			default: ''
+		}
+	},
+	components: {
+		AlreadySubscribedNotice,
+		KvButton,
+		KvCheckoutSteps,
+		KvCurrencyInput,
+		KvDropdownRounded,
+		KvIcon,
+		KvLightbox,
+		KvLoadingSpinner,
+		KvResponsiveImage,
+		LegacySubscriberNotice,
+		PayPalMg,
+		WwwPage,
+	},
+	data() {
+		return {
+			donationLbVisible: false,
+			heroImages: [
+				['small', heroImagesRequire('./monthlygood-banner-sm-std.jpg')],
+				['small retina', heroImagesRequire('./monthlygood-banner-sm-retina.jpg')],
+				['medium', heroImagesRequire('./monthlygood-banner-med-std_0.jpg')],
+				['medium retina', heroImagesRequire('./monthlygood-banner-med-retina_0.jpg')],
+				['large', heroImagesRequire('./monthlygood-banner-lg-std_0.jpg')],
+				['large retina', heroImagesRequire('./monthlygood-banner-lg-retina_0.jpg')],
+				['xga', heroImagesRequire('./monthlygood-banner-xl-std_0.jpg')],
+				['xga retina', heroImagesRequire('./monthlygood-banner-xl-retina_0.jpg')],
+				['wxga', heroImagesRequire('./monthlygood-banner-xxl-std.jpg')],
+				['wxga retina', heroImagesRequire('./monthlygood-banner-xxl-retina.jpg')],
+			],
+			selectedGroup: 'default',
+			mgAmount: 25,
+			dayOfMonth: 20,
+			donation: 25 * 0.15,
+			donationOptionSelected: '15',
+			submitting: false,
+			legacySubs: [],
+			// user flags
+			isNewUserRegistration: true,
+			isMonthlyGoodSubscriber: false,
+			hasAutoDeposits: false,
+			hasAutoLending: false,
+			hasBillingAgreement: false,
+			hasLegacySubscription: false,
+			isMGTaglineActive: false,
+		};
+	},
+	mixins: [
+		validationMixin,
+		loanGroupCategoriesMixin
+	],
+	validations: {
+		mgAmount: {
+			required,
+			minValue: minValue(5),
+			maxValue: maxValue(10000),
+			maxTotal(value) {
+				return value + this.donation < 10000;
+			}
+		},
+		donation: {
+			minValue: minValue(0),
+			maxValue: maxValue(10000),
+			maxTotal(value) {
+				return value + this.mgAmount < 10000;
+			}
+		},
+	},
+	inject: ['apollo'],
+	apollo: {
+		query: pageQuery,
+		preFetch(config, client, { route }) {
+			return client.query({ query: userInfoQuery })
+				.then(({ data }) => {
+					const userId = _get(data, 'my.userAccount.id');
+					if (!userId) {
+						throw new Error('activeLoginRequired');
+					}
+				})
+				.then(() => {
+					return client.query({ query: pageQuery });
+				})
+				.catch(e => {
+					if (e.message.indexOf('activeLoginRequired') > -1) {
+						// Force a login when active login is required
+						return Promise.reject({
+							path: '/ui-login',
+							query: { doneUrl: route.fullPath }
+						});
+					}
+					// Log other errors
+					console.error(e);
+				});
+		},
+		result({ data }) {
+			this.isMGTaglineActive = _get(data, 'general.mgDonationTaglineActive.value') === 'true' || false;
+			this.isMonthlyGoodSubscriber = _get(data, 'my.autoDeposit.isSubscriber', false);
+			this.hasAutoDeposits = _get(data, 'my.autoDeposit', false);
+			this.hasAutoLending = _get(data, 'my.autolendProfile.isEnabled', false);
+			this.hasBillingAgreement = _get(data,
+				'my.payPalBillingAgreement.hasPayPalBillingAgreement', false);
+			this.legacySubs = _get(data, 'my.subscriptions.values', []);
+			this.hasLegacySubscription = this.legacySubs.length > 0;
+			this.isNewUserRegistration = _get(data, 'my.loans.totalCount') === 0;
+		},
+	},
+	created() {
+		// Sanitize and set initial form values.
+		if (this.lendingCategories.find(category => category.value === this.category)) {
+			this.selectedGroup = this.category;
+		}
+
+		if (!Number.isNaN(Number(this.amount))) {
+			this.mgAmount = this.amount;
+			this.donation = this.amount * 0.15;
+		}
+		// Fire snowplow events
+		if (this.isMonthlyGoodSubscriber) {
+			this.$kvTrackEvent('Registration', 'unsuccessful-monthly-good-reg', 'has-mg');
+		}
+		if (this.hasLegacySubscription) {
+			this.$kvTrackEvent('Registration', 'unsuccessful-monthly-good-reg', 'has-legacy-subscription');
+		}
+	},
+	watch: {
+		async donationOptionSelected(newVal) {
+			// flag donation options as dirty, which stops the recalculation of the drop down values.
+			if (newVal !== 'other') {
+				// handle pre-computed donation options based update
+				const selectedDonationAmount = this.calculatedDonationOptions.find(
+					donationSelect => donationSelect.value === newVal
+				);
+				this.donation = selectedDonationAmount.monetaryValue;
+			} else {
+				await this.$nextTick();
+				try {
+					this.$refs.donationOtherInput.$el.focus();
+				} catch (err) {
+					console.error(err);
+				}
+			}
+		}
+	},
+	methods: {
+		triggerDefaultLightbox() {
+			this.donationLbVisible = !this.donationLbVisible;
+		},
+		lightboxClosed() {
+			this.donationLbVisible = false;
+		},
+		focusDonationOtherInput() {
+			this.$refs.donationOtherInput.focus();
+		},
+		submitMonthlyGood() {
+			this.submitting = true;
+			this.$kvTrackEvent('Registration', 'click-confirm-monthly-good', 'register-monthly-good');
+
+			this.apollo.mutate({
+				mutation: gql`
+					mutation (
+						$amount: Money!,
+						$donateAmount: Money!,
+						$dayOfMonth: Int!,
+						$category: MonthlyGoodCategoryEnum,
+						$isOnetime: Boolean
+					) {
+						my {
+							createMonthlyGoodSubscription( autoDeposit: {
+								amount: $amount,
+								donateAmount: $donateAmount,
+								dayOfMonth: $dayOfMonth,
+								isOnetime: $isOnetime
+							},
+							category: $category)
+						}
+					}`,
+				variables: {
+					amount: numeral(this.totalCombinedDeposit).format('0.00'),
+					donateAmount: numeral(this.donation).format('0.00'),
+					dayOfMonth: numeral(this.dayOfMonth).value(),
+					category: this.selectedGroup,
+					isOnetime: this.isOnetime
+				}
+			}).then(data => {
+				if (data.errors) {
+					const errorMessage = _get(data, 'errors[0].message');
+					this.$showTipMsg(errorMessage, 'error');
+				} else {
+					this.$kvTrackEvent('Registration', 'successful-monthly-good-reg', 'register-monthly-good');
+					// Send to thanks page
+					this.$router.push({
+						path: '/monthlygood/thanks',
+						query: {
+							onetime: this.isOnetime,
+							source: this.source,
+						}
+					});
+				}
+			}).catch(error => {
+				this.$showTipMsg(error, 'error');
+			}).finally(() => {
+				this.submitting = false;
+			});
+		},
+	},
+	computed: {
+		totalCombinedDeposit() {
+			return this.donation + this.mgAmount;
+		},
+		donationTagLine() {
+			if (!this.isMGTaglineActive) {
+				// return 'Each $25 loan costs Kiva more than $3 to facilitate. Will you help us cover our costs?';
+				return 'Optional donation to support Kiva.';
+			}
+			return 'Every $25 loan costs more than $3 to facilitate, and our generous supporters are donating $1 for every $3 you donate.'; // eslint-disable-line max-len
+		},
+		selectedCategory() {
+			return this.lendingCategories.find(category => category.value === this.category).label;
+		},
+		dropdownOptions() {
+			return this.calculatedDonationOptions;
+		},
+		calculatedDonationOptions() {
+			// If mgAmount isn't valid, just set these values on the amount prop.
+			const amountToBasePercentageOn = this.$v.mgAmount.$invalid ? this.amount : this.mgAmount;
+			return [
+				{
+					value: '20',
+					label: `${numeral(amountToBasePercentageOn * 0.20).format('$0,0.00')}`,
+					monetaryValue: Math.round(amountToBasePercentageOn * 0.20 * 100) / 100
+				},
+				{
+					value: '15',
+					label: `${numeral(amountToBasePercentageOn * 0.15).format('$0,0.00')}`,
+					monetaryValue: Math.round(amountToBasePercentageOn * 0.15 * 100) / 100
+
+				},
+				{
+					value: '8',
+					label: `${numeral(amountToBasePercentageOn * 0.08).format('$0,0.00')}`,
+					monetaryValue: Math.round(amountToBasePercentageOn * 0.08 * 100) / 100
+				},
+				{
+					value: '0',
+					label: '$0.00',
+					monetaryValue: 0
+
+				},
+				{
+					value: 'other',
+					label: 'Other'
+				}
+			];
+		},
+		isOnetime() {
+			// ensure this is cast to a bool for use in Graphql mutation
+			return this.onetime === 'true';
+		},
+		fromCovidLanding() {
+			return this.source === 'covid19response';
+		}
+	},
+};
+
+</script>
+
+<style lang="scss" scoped>
+@import 'settings';
+
+.section {
+	padding-bottom: 2rem;
+	margin-bottom: 2rem;
+	border-bottom: 1px solid $kiva-stroke-gray;
+
+	&--last {
+		margin-bottom: 0;
+		border-bottom: 0;
+	}
+}
+
+.step-indicator {
+	max-width: 20rem;
+	margin: 0 auto;
+}
+
+.monthly-good-setup {
+	background: #fff;
+	padding-bottom: 2rem;
+	padding-top: 2rem;
+
+	@include breakpoint(large) {
+		margin-top: -20%;
+		margin-bottom: 4rem;
+		border-radius: rem-calc(8);
+		box-shadow: 0 0 rem-calc(24) rem-calc(1) rgba(0, 0, 0, 0.2);
+	}
+
+	@include breakpoint(xga) {
+		margin-top: -30%;
+	}
+
+	@include breakpoint(wxga) {
+		margin-top: -38%;
+	}
+
+	p {
+		margin-bottom: 0;
+	}
+}
+
+.donation {
+	@include breakpoint(large) {
+		display: flex;
+	}
+
+	&__description {
+		@include breakpoint(large) {
+			flex: 1;
+			margin-right: 1rem;
+		}
+	}
+
+	&__pricing {
+		display: flex;
+		text-align: right;
+		margin-top: 1rem;
+	}
+
+	&__pricing-other {
+		margin-left: 1rem;
+		width: 7rem;
+	}
+
+	&__info-btn {
+		font-size: $normal-text-font-size;
+		color: $kiva-textlink;
+		text-decoration: underline;
+
+		&:hover {
+			color: $kiva-textlink-hover;
+			text-decoration: underline;
+		}
+	}
+}
+
+.notice {
+	display: flex;
+
+	&__icon {
+		width: 3rem;
+		height: 3rem;
+		flex-shrink: 0;
+		margin-right: 1rem;
+		padding: 0.66rem;
+		background: $kiva-green;
+		fill: #fff;
+		border-radius: 50%;
+	}
+}
+
+.subscribe-btn {
+	width: 100%;
+	margin: 1.5rem auto;
+
+	@include breakpoint(large) {
+		width: 16rem;
+	}
+}
+
+.paypal {
+	&__wrapper {
+		position: relative;
+	}
+
+	// cover and disallow clicking if form is invalid
+	&__cover {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		background: rgba(255, 255, 255, 0.8);
+		z-index: 10000;
+	}
+
+	&__btn {
+		width: fit-content;
+		margin: 1.5rem 0 1.5rem auto;
+	}
+}
+
+.other-notices {
+	margin: 5rem auto;
+	text-align: center;
+}
+
+// utility classes
+.h1 {
+	@include large-text();
+}
+
+.h2 {
+	font-size: 1.75rem;
+}
+
+.inline {
+	display: inline;
+}
+
+// overrides
+::v-deep .loading-spinner {
+	vertical-align: middle;
+	width: 1rem;
+	height: 1rem;
+}
+
+::v-deep .loading-spinner .line {
+	background-color: $white;
+}
+
+// Hide global promo bar (this is the promo landing page!!!)
+::v-deep .generic-banner {
+	display: none;
+}
+</style>

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
@@ -17,13 +17,16 @@
 						</div>
 						<div class="section">
 							<h1 class="h2">
-								Monthly Good
+								{{ pageTitle }}
 							</h1>
 							<div class="row">
 								<div class="small-12 large-7 xlarge-8 xxlarge-9 columns">
 									<p>
-										{{ selectedCategory }} on Kiva.<br>
-										Deposits every  month on the {{ dayOfMonth }}th, cancel any time.
+										<span class="quiet">
+											Your subscription will support {{ selectedCategory }} on Kiva.
+										</span><br>
+										It will deposit every month on the {{ dayOfMonth }}th,
+										and you can cancel any time.
 									</p>
 								</div>
 								<div class="small-12 large-4 xlarge-3 xxlarge-2 large-offset-1 columns text-right">
@@ -41,7 +44,7 @@
 								<label for="donation" class="h2">
 									Monthly Donation to Kiva (optional)
 								</label>
-								<p class="inline">
+								<p class="inline quiet">
 									{{ donationTagLine }}
 								</p>
 								<!-- TODO: What is the correct tracking event? -->
@@ -92,22 +95,16 @@
 							<div>
 								<p>
 									Your current auto lending settings will be
-									updated to the <strong>Monthly Good Lending Setting</strong>
+									updated to the <strong>Monthly Good Lending Setting</strong>.
 								</p>
-								<p>
-									We'll charge your PayPal account{{ isOnetime ? '' : ' each month' }}, and any credit
-									in your Kiva account will be automatically re-lent for you.
+								<p class="quiet">
+									Eligible credit in your Kiva account will be automatically re-lent
+									for you to support {{ selectedCategory }} on Kiva.
 								</p>
-								<p v-if="hasAutoDeposits">
+								<p v-if="hasAutoDeposits" class="quiet">
 									<em>
 										* Your {{ isOnetime ? '' : 'new Monthly Good ' }}contribution
 										will replace your existing auto deposit.
-									</em>
-								</p>
-								<p v-if="hasAutoLending">
-									<em>
-										* {{ isOnetime ? 'This contribution' : 'Enrolling in Monthly Good' }} will
-										also disable your current auto lending settings.
 									</em>
 								</p>
 							</div>
@@ -137,7 +134,6 @@
 									Subscribe <kv-loading-spinner v-if="submitting" />
 								</kv-button>
 								<p>
-									<!-- TODO: This is not in the comp, do we want it still? -->
 									<em>
 										We'll charge your PayPal account for your
 										{{ isOnetime ? 'Contribution' : 'Monthly Good' }}
@@ -154,7 +150,6 @@
 										@complete-transaction="submitMonthlyGood()"
 									/>
 									<p class="small-text">
-										<!-- TODO: This is not in the comp, do we want it still? -->
 										Thanks to PayPal, Kiva receives free payment processing.
 									</p>
 								</div>
@@ -325,10 +320,9 @@ export default {
 			isNewUserRegistration: true,
 			isMonthlyGoodSubscriber: false,
 			hasAutoDeposits: false,
-			hasAutoLending: false,
 			hasBillingAgreement: false,
 			hasLegacySubscription: false,
-			isMGTaglineActive: false,
+			isMGDonationTaglineActive: false,
 		};
 	},
 	mixins: [
@@ -379,10 +373,9 @@ export default {
 				});
 		},
 		result({ data }) {
-			this.isMGTaglineActive = _get(data, 'general.mgDonationTaglineActive.value') === 'true' || false;
+			this.isMGDonationTaglineActive = _get(data, 'general.mgDonationTaglineActive.value') === 'true' || false;
 			this.isMonthlyGoodSubscriber = _get(data, 'my.autoDeposit.isSubscriber', false);
 			this.hasAutoDeposits = _get(data, 'my.autoDeposit', false);
-			this.hasAutoLending = _get(data, 'my.autolendProfile.isEnabled', false);
 			this.hasBillingAgreement = _get(data,
 				'my.payPalBillingAgreement.hasPayPalBillingAgreement', false);
 			this.legacySubs = _get(data, 'my.subscriptions.values', []);
@@ -426,6 +419,11 @@ export default {
 				}
 			}
 		}
+	},
+	metaInfo() {
+		return {
+			title: `${this.pageTitle} - Review`,
+		};
 	},
 	methods: {
 		triggerDefaultLightbox() {
@@ -490,18 +488,20 @@ export default {
 		},
 	},
 	computed: {
+		pageTitle() {
+			return this.category === 'disaster_relief_covid' ? 'COVID-19 relief' : 'Monthly Good';
+		},
 		totalCombinedDeposit() {
 			return this.donation + this.mgAmount;
 		},
 		donationTagLine() {
-			if (!this.isMGTaglineActive) {
-				// return 'Each $25 loan costs Kiva more than $3 to facilitate. Will you help us cover our costs?';
-				return 'Optional donation to support Kiva.';
+			if (!this.isMGDonationTaglineActive) {
+				return 'Each $25 loan costs Kiva more than $3 to facilitate. Will you help us cover our costs?';
 			}
 			return 'Every $25 loan costs more than $3 to facilitate, and our generous supporters are donating $1 for every $3 you donate.'; // eslint-disable-line max-len
 		},
 		selectedCategory() {
-			return this.lendingCategories.find(category => category.value === this.category).label;
+			return this.lendingCategories.find(category => category.value === this.category).shortName;
 		},
 		dropdownOptions() {
 			return this.calculatedDonationOptions;
@@ -691,6 +691,10 @@ export default {
 
 .inline {
 	display: inline;
+}
+
+.quiet {
+	color: $kiva-text-light;
 }
 
 // overrides

--- a/src/plugins/loan-group-categories.js
+++ b/src/plugins/loan-group-categories.js
@@ -4,36 +4,44 @@ export default {
 			lendingCategories: [
 				{
 					value: 'default',
-					label: 'Support all borrowers'
+					label: 'Support all borrowers',
+					shortName: 'all borrowers',
 				},
 				{
 					value: 'women',
-					label: 'Support women'
+					label: 'Support women',
+					shortName: 'women',
 				},
 
 				{
 					value: 'agriculture',
-					label: 'Support farmers'
+					label: 'Support farmers',
+					shortName: 'farmers',
 				},
 				{
 					value: 'refugees',
-					label: 'Support refugees'
+					label: 'Support refugees',
+					shortName: 'refugees'
 				},
 				{
 					value: 'education',
-					label: 'Support students'
+					label: 'Support students',
+					shortName: 'students',
 				},
 				{
 					value: 'eco_friendly',
-					label: 'Support eco-friendly loans'
+					label: 'Support eco-friendly loans',
+					shortName: 'eco-friendly loans',
 				},
 				{
 					value: 'us_borrowers',
-					label: 'Support US borrowers'
+					label: 'Support US borrowers',
+					shortName: 'US borrowers',
 				},
 				{
 					value: 'disaster_relief_covid',
-					label: 'COVID-19 Coronavirus'
+					label: 'COVID-19 Coronavirus',
+					shortName: 'the global COVID—19 response',
 				},
 			],
 		};


### PR DESCRIPTION
Sorry for the giant PR, it might be easier to view the files whole instead of as diffs. 
Overview:

- Renames MonthlyGoodSetupPage.vue to MonthlyGoodSetupPage**Control**.vue 
- Builds the new design from GROW-82 to MonthlyGoodSetupPage**Variant**.vue
- MonthlyGoodSetupPage.vue now checks the uiexperiment and determines which component (control or variant) to show.
- Some tweaks to KvCheckoutSteps to make it work well in this scenario and the checkout.

- To test:
  - add a setting named `uiexp.mg_setup` to your vm admin settings manager with this data:
`{ "name": "MonthlyGoodSetup", "enabled": true, "startTime": "2020-05-01T00:00", "endTime": "2021-05-01T00:00", "control": { "key": "control", "name": "Control" }, "distribution": { "control": 0.5, "shown": 0.5 } }`

  - To see the new design go to:
  /monthlygood/setup?amount=25&category=eco_friendly&setuiab=mg_setup.shown
  or the control:
  /monthlygood/setup?amount=25&category=eco_friendly&setuiab=mg_setup.control

  - You can now go to /monthlygood and choose different amounts and categories. Try the covid fund please.








