### PR TITLE
Increase max async requests for chunk splitting

### DIFF
--- a/build/webpack.client.base.conf.js
+++ b/build/webpack.client.base.conf.js
@@ -28,13 +28,13 @@ module.exports = merge.smart(baseWebpackConfig, {
 						}
 					}
 				].concat(styleLoaders),
-
 			},
 		]
 	},
 	optimization: {
 		splitChunks: {
-			chunks: 'all'
+			chunks: 'all',
+			maxAsyncRequests: 8, // default is 6
 		}
 	},
 	plugins: [

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -52,8 +52,6 @@ module.exports = function createMiddleware({
 		inject: false,
 		// don't prefetch anything
 		shouldPrefetch: () => false,
-		// only preload scripts @TODO: try to only skipping preloading of app.*.css
-		shouldPreload: (file, type) => type === 'script'
 	});
 
 	return function middleware(req, res, next) {


### PR DESCRIPTION
This addresses the issue that was causing the header and footer styles to not be included in the initial server render. The issue was caused by some components (like `TheHeader`) being duplicated into multiple chunks instead of occupying a single chunk. Once duplicated, the vue server renderer skips on including the js or css for that component in the html (https://github.com/vuejs/vue/blob/dev/src/server/webpack-plugin/client.js#L39).

See https://webpack.js.org/plugins/split-chunks-plugin/ for more details about the `maxAsyncRequests` option.