### PR TITLE
Pass snowplow session id as header in api requests.

### DIFF
--- a/src/api/SnowplowSessionLink.js
+++ b/src/api/SnowplowSessionLink.js
@@ -1,0 +1,29 @@
+import { setContext } from 'apollo-link-context';
+import _set from 'lodash/set';
+import cookieStore from '@/util/cookieStore';
+
+function getSPCookieSession() {
+	// kiva specific sp cookie
+	const sp = cookieStore.get('_sp_id.6d5c');
+	// handle missing cookie
+	if (typeof sp === 'undefined') {
+		return '';
+	}
+	const spCookieArray = sp.split('.');
+	// get last item in the array, our session id
+	const sessionId = spCookieArray[spCookieArray.length - 1];
+	return sessionId;
+}
+
+export default () => {
+	return setContext((operation, previousContext) => {
+		// fetch session id
+		const spSessionId = getSPCookieSession();
+		// pass along existing context if no session id exists
+		if (spSessionId === '') {
+			return previousContext;
+		}
+		// add header to existing context and pass along
+		return _set(previousContext, 'headers.X-Session-Id', spSessionId);
+	});
+};

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -9,6 +9,7 @@ import {
 import Auth0LinkCreator from './Auth0Link';
 import BasketLinkCreator from './BasketLink';
 import HttpLinkCreator from './HttpLink';
+import SnowplowSessionLink from './SnowplowSessionLink';
 import initState from './localState';
 
 export default function createApolloClient({
@@ -49,6 +50,7 @@ export default function createApolloClient({
 
 	const client = new ApolloClient({
 		link: ApolloLink.from([
+			SnowplowSessionLink(),
 			Auth0LinkCreator(kvAuth0),
 			BasketLinkCreator(),
 			HttpLinkCreator({ csrfToken, uri }),


### PR DESCRIPTION
Depends on https://github.com/kiva/kiva/pull/8810 for direct calls to monolith graphql (generally only the VM at this point)