### PR TITLE
Import common version of fuse build for now until https://github.com/…

### DIFF
--- a/src/util/searchEngine.js
+++ b/src/util/searchEngine.js
@@ -1,7 +1,8 @@
 import _filter from 'lodash/filter';
 import _flatten from 'lodash/flatten';
 import _map from 'lodash/map';
-import Fuse from 'fuse.js';
+import Fuse from 'fuse.js/dist/fuse.common';
+// import Fuse from 'fuse.js'; // re-enabled after https://github.com/krisk/Fuse/pull/383 is merged
 import { startsWith } from '@/util/comparators';
 
 /*


### PR DESCRIPTION
…krisk/Fuse/pull/383/files is merged to allow webpack to transpile the esm build.