### PR TITLE
VUE-219 KvLightbox a11y improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26406,6 +26406,21 @@
 				}
 			}
 		},
+		"vue-focus-lock": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/vue-focus-lock/-/vue-focus-lock-1.4.0.tgz",
+			"integrity": "sha512-oEIvojC3okNOlnPYJUSzqAK6M+m1VoBSieUfTUqXiaUqa8t6xXTmn3UEhVqUnk6cUgLum+p2z04Btqr6gWNn2Q==",
+			"requires": {
+				"focus-lock": "^0.5.4"
+			},
+			"dependencies": {
+				"focus-lock": {
+					"version": "0.5.4",
+					"resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.5.4.tgz",
+					"integrity": "sha512-A9ngdb0NyI6UygBQ0eD+p8SpLWTkdEDn67I3EGUUcDUfxH694mLA/xBWwhWhoj/2YLtsv2EoQdAx9UOKs8d/ZQ=="
+				}
+			}
+		},
 		"vue-hot-reload-api": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
 		"timesync": "^1.0.4",
 		"title-case": "^3.0.2",
 		"vue": "^2.6.11",
+		"vue-focus-lock": "^1.4.0",
 		"vue-instantsearch": "^2.4.0",
 		"vue-meta": "^2.3.3",
 		"vue-progressbar": "^0.7.3",

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -10,7 +10,7 @@
 			role="dialog"
 		>
 			<focus-lock>
-				<div class="kv-lightbox">
+				<div class="kv-lightbox" role="document">
 					<div class="row lightbox-row">
 						<div class="columns lightbox-columns">
 							<!-- eslint-disable max-len -->

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -112,11 +112,6 @@ export default {
 	},
 	mounted() {
 		this.isShown = this.visible;
-
-		if (this.$slots.title) {
-			this.$slots.title[0].elm.id = 'title';
-			this.$refs.kvlightbox.setAttribute('aria-labelledby', 'title');
-		}
 	},
 	beforeDestroy() {
 		this.closeLightbox();

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -115,7 +115,7 @@ export default {
 
 		if (this.$slots.title) {
 			this.$slots.title[0].elm.id = 'title';
-			this.$refs.kvlightbox.ariaLabelledby = 'title';
+			this.$refs.kvlightbox.setAttribute('aria-labelledby', 'title');
 		}
 	},
 	beforeDestroy() {

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -112,6 +112,11 @@ export default {
 	},
 	mounted() {
 		this.isShown = this.visible;
+
+		if (this.$slots.title) {
+			this.$slots.title[0].elm.id = 'title';
+			this.$refs.kvlightbox.ariaLabelledby = 'title';
+		}
 	},
 	beforeDestroy() {
 		this.closeLightbox();

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -7,44 +7,52 @@
 			ref="kvlightbox"
 			@keyup.esc="closeLightbox"
 			@click.stop.prevent="closeLightbox"
-			tabindex="500"
+			role="dialog"
 		>
-			<div class="kv-lightbox">
-				<div class="row lightbox-row">
-					<div class="columns lightbox-columns">
-						<!-- eslint-disable max-len -->
-						<div
-							class="lightbox-content"
-							:class="`${removeContentBg} ${noPaddingTop ? 'no-padding-top': ''} ${noPaddingBottom ? 'no-padding-bottom': ''} ${noPaddingSides ? 'no-padding-sides': ''}`"
-							@click.stop
-						>
-							<!-- eslint-enable max-len -->
-							<button @click.stop.prevent="closeLightbox" class="close-lightbox" aria-label="Close">
-								<kv-icon name="small-x" :from-sprite="true" />
-							</button>
-							<slot name="title"></slot>
-							<slot>Lightbox content</slot>
-							<br v-if="!noPaddingBottom">
-							<slot name="controls">
-								<kv-button v-if="showCloseButton" @click.native="closeLightbox">
-									Close
-								</kv-button>
-							</slot>
+			<focus-lock>
+				<div class="kv-lightbox">
+					<div class="row lightbox-row">
+						<div class="columns lightbox-columns">
+							<!-- eslint-disable max-len -->
+							<div
+								class="lightbox-content"
+								:class="`${removeContentBg} ${noPaddingTop ? 'no-padding-top': ''} ${noPaddingBottom ? 'no-padding-bottom': ''} ${noPaddingSides ? 'no-padding-sides': ''}`"
+								@click.stop
+							>
+								<!-- eslint-enable max-len -->
+								<button
+									@click.stop.prevent="closeLightbox"
+									class="close-lightbox"
+									aria-label="Close"
+								>
+									<kv-icon name="small-x" :from-sprite="true" />
+								</button>
+								<slot name="title"></slot>
+								<slot>Lightbox content</slot>
+								<br v-if="!noPaddingBottom">
+								<slot name="controls">
+									<kv-button v-if="showCloseButton" @click.native="closeLightbox">
+										Close
+									</kv-button>
+								</slot>
+							</div>
 						</div>
 					</div>
 				</div>
-			</div>
+			</focus-lock>
 		</div>
 	</transition>
 </template>
 
 <script>
+import FocusLock from 'vue-focus-lock';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvButton from '@/components/Kv/KvButton';
 import lockScrollUtils from '@/plugins/lock-scroll';
 
 export default {
 	components: {
+		FocusLock,
 		KvIcon,
 		KvButton
 	},
@@ -95,7 +103,6 @@ export default {
 			// this ensures the esc functionality works
 			if (this.isShown) {
 				this.$nextTick(() => {
-					this.$refs.kvlightbox.focus();
 					this.lockScroll();
 				});
 			} else {


### PR DESCRIPTION
Adds accessibility improvements following the recommendations for a dialog
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role

- [x] Adds a focus trap,
- [x] Sets the role to dialog, sets the body role to document per this bootstrap issue https://github.com/twbs/bootstrap/issues/15875

Remaining items from the ARIA dialog recommendations
- [ ] When the dialog appears on the screen, keyboard focus (whose control depends upon the dialogs purpose) should be moved to the default focusable control inside the dialog. For dialogs that only provide a basic message, it could be an "OK" button. For dialogs containing a form it could be the first field in the form.
- [ ] After the dialog is dismissed, keyboard focus should be moved back to where it was before it moved into the dialog. Otherwise the focus can be dropped to the beginning of the page.
- [ ] Add an aria-labelledby attribute if we have a title

