### PR TITLE
VUE-318 lightbox improvements

### DIFF
--- a/.storybook/stories/KvLightbox.stories.js
+++ b/.storybook/stories/KvLightbox.stories.js
@@ -1,5 +1,6 @@
 import { boolean } from '@storybook/addon-knobs';
 import KvLightbox from '@/components/Kv/KvLightbox';
+import KvButton from '@/components/Kv/KvButton';
 
 const loremIpsum = `
 	<p>
@@ -22,7 +23,7 @@ export default {
 };
 
 export const Default = () => ({
-	components: { KvLightbox },
+	components: { KvLightbox, KvButton },
 	data: () => ({
 		lightboxVisible: false,
 	}),
@@ -36,9 +37,9 @@ export const Default = () => ({
 	},
 	template: `
 		<div>
-			<button @click="showLightbox">
+			<kv-button @click.native.prevent="showLightbox">
 				Show Lightbox
-			</button>
+			</kv-button>
 
 			<kv-lightbox
 				:visible="lightboxVisible"
@@ -51,7 +52,7 @@ export const Default = () => ({
 });
 
 export const TitleSlotControlsSlot = () => ({
-	components: { KvLightbox },
+	components: { KvLightbox, KvButton },
 	data: () => ({
 		lightboxVisible: false,
 	}),
@@ -65,24 +66,27 @@ export const TitleSlotControlsSlot = () => ({
 	},
 	template: `
 		<div>
-			<button @click="showLightbox">
-				Show Lightbox - Use Title and Controls Slots
-			</button>
+			<kv-button @click.native.prevent="showLightbox">
+				Show Lightbox - Use Header and Controls Slot
+			</kv-button>
 
 			<kv-lightbox
 				:visible="lightboxVisible"
 				@lightbox-closed="hideLightbox"
+				title="Title"
 			>
-				<h2 slot="title">Title</h2>
 				${loremIpsum}
-				<template slot="controls">Controls Here</template>
+				<template slot="controls">
+					<kv-button>Button 1</kv-button>
+					<kv-button>Button 2</kv-button>
+				</template>
 			</kv-lightbox>
 		</div>
 	`,
 });
 
 export const Inverted = () => ({
-	components: { KvLightbox },
+	components: { KvLightbox, KvButton },
 	data: () => ({
 		lightboxVisible: false,
 	}),
@@ -96,16 +100,26 @@ export const Inverted = () => ({
 	},
 	template: `
 		<div>
-			<button @click="showLightbox">
-				Show Lightbox - Inverted
-			</button>
+			<kv-button @click.native.prevent="showLightbox">
+				Show Lightbox Inverted
+			</kv-button>
 
 			<kv-lightbox
 				:visible="lightboxVisible"
 				:inverted="true"
 				@lightbox-closed="hideLightbox"
+				title="Title"
 			>
-				<h2 slot="title">Title</h2>
+				${loremIpsum}
+				<template slot="controls">Controls Here</template>
+			</kv-lightbox>
+
+			<kv-lightbox
+				:visible="false"
+				:inverted="true"
+				@lightbox-closed="hideLightbox"
+				title="Title"
+			>
 				${loremIpsum}
 				<template slot="controls">Controls Here</template>
 			</kv-lightbox>
@@ -113,8 +127,8 @@ export const Inverted = () => ({
 	`,
 });
 
-export const ShowCloseButton = () => ({
-	components: { KvLightbox },
+export const CustomTitleColor = () => ({
+	components: { KvLightbox, KvButton },
 	data: () => ({
 		lightboxVisible: false,
 	}),
@@ -128,16 +142,16 @@ export const ShowCloseButton = () => ({
 	},
 	template: `
 		<div>
-			<button @click="showLightbox">
-				Show Lightbox - showCloseButton = true
-			</button>
+			<kv-button @click.native.prevent="showLightbox">
+				Show Lightbox Custom Title Color
+			</kv-button>
 
 			<kv-lightbox
 				:visible="lightboxVisible"
-				:show-close-button="true"
 				@lightbox-closed="hideLightbox"
+				title="Custom Title Color"
+				style="--kv-lightbox-title-color: blue"
 			>
-				<h2 slot="title">Title</h2>
 				${loremIpsum}
 			</kv-lightbox>
 		</div>
@@ -145,7 +159,7 @@ export const ShowCloseButton = () => ({
 });
 
 export const NoPadding = () => ({
-	components: { KvLightbox },
+	components: { KvLightbox, KvButton },
 	props: {
 		noPaddingTop: {
 			default: boolean('noPaddingTop', true)
@@ -170,9 +184,9 @@ export const NoPadding = () => ({
 	},
 	template: `
 		<div>
-			<button @click="showLightbox">
-				Show Lightbox - noPadding
-			</button>
+			<kv-button @click.native.prevent="showLightbox">
+				Show Lightbox no padding
+			</kv-button>
 
 			<kv-lightbox
 				:visible="lightboxVisible"
@@ -180,8 +194,8 @@ export const NoPadding = () => ({
 				:no-padding-bottom="noPaddingBottom"
 				:no-padding-sides="noPaddingSides"
 				@lightbox-closed="hideLightbox"
+				title="Title"
 			>
-				<h2 slot="title">Title</h2>
 				${loremIpsum}
 			</kv-lightbox>
 		</div>

--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -102,24 +102,24 @@
 		<kv-lightbox
 			:visible="defaultLbVisible"
 			@lightbox-closed="lightboxClosed"
+			title="How does Kiva use donations?"
 		>
-			<h2 slot="title">
-				How does Kiva use donations?
-			</h2>
-			<div>
+			<p>
 				100% of every dollar you lend on Kiva goes directly to funding loans.
 				We rely on small optional donations from you and others to keep Kiva running.
 				Every $1 donated to Kiva makes $8 in loans possible around the world.
 				Your donation will enable us to:
-				<ul style="list-style-type: disc;">
-					<li>Send expert staff to over 60 countries to vet and monitor loans and partners.</li>
-					<li>Build and maintain a website that facilitates over $1 million in loans each week.</li>
-					<li>Provide comprehensive customer support to thousands of lenders worldwide.</li>
-					<li>Train and support hundreds of volunteers -- 4 for every 1 staff member at Kiva.</li>
-				</ul>
+			</p>
+			<ul style="margin-bottom: 1rem;">
+				<li>Send expert staff to over 60 countries to vet and monitor loans and partners.</li>
+				<li>Build and maintain a website that facilitates over $1 million in loans each week.</li>
+				<li>Provide comprehensive customer support to thousands of lenders worldwide.</li>
+				<li>Train and support hundreds of volunteers -- 4 for every 1 staff member at Kiva.</li>
+			</ul>
+			<p>
 				If you live in the United States, your donation is tax-deductible.
 				Thank you for considering a donation to Kiva.
-			</div>
+			</p>
 		</kv-lightbox>
 	</div>
 </template>

--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -48,10 +48,8 @@
 							<kv-lightbox
 								:visible="defaultLbVisible"
 								@lightbox-closed="lightboxClosed"
+								title="Where can I find my Kiva Card code?"
 							>
-								<h2 slot="title">
-									Where can I find my Kiva Card code?
-								</h2>
 								<p>
 									Kiva issues three types of Kiva Cards: print-it-yourself cards,
 									email delivery and postal delivery.

--- a/src/components/Checkout/LoanReservation.vue
+++ b/src/components/Checkout/LoanReservation.vue
@@ -25,14 +25,14 @@
 				class="loanNotReservedLightbox"
 				:visible="defaultLbVisible"
 				@lightbox-closed="lightboxClosed"
+				title="What does it mean that my loan is not reserved?"
 			>
-				<h2 slot="title">What does it mean that my loan is not reserved?</h2>
-				<div>
+				<p>
 					Loans will not be reserved if they've been in your basket for more than 45
 					minutes or have less than 6 hours left to fundraise. This means there's a chance this loan may be
 					funded by other lenders even though it's in your basket. To make this loan, please proceed through
 					the checkout process.
-				</div>
+				</p>
 			</kv-lightbox>
 		</span>
 	</div>

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -8,8 +8,9 @@
 			@keyup.esc="closeLightbox"
 			@click.stop.prevent="closeLightbox"
 			role="dialog"
+			:aria-labelledby="title ? 'lightbox-title' : null"
 		>
-			<focus-lock>
+			<focus-lock :disabled="!isShown">
 				<div class="kv-lightbox" role="document">
 					<div class="row lightbox-row">
 						<div class="columns lightbox-columns">
@@ -20,21 +21,24 @@
 								@click.stop
 							>
 								<!-- eslint-enable max-len -->
+								<h2 v-if="title"
+									class="lightbox-title"
+									id="lightbox-title"
+								>
+									{{ title }}
+								</h2>
 								<button
 									@click.stop.prevent="closeLightbox"
 									class="close-lightbox"
 									aria-label="Close"
 								>
-									<kv-icon name="small-x" :from-sprite="true" />
+									<kv-icon class="icon-small-x" name="small-x" :from-sprite="true" />
 								</button>
-								<slot name="title"></slot>
 								<slot>Lightbox content</slot>
-								<br v-if="!noPaddingBottom">
-								<slot name="controls">
-									<kv-button v-if="showCloseButton" @click.native="closeLightbox">
-										Close
-									</kv-button>
-								</slot>
+
+								<div class="lightbox-controls">
+									<slot name="controls"></slot>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -47,14 +51,12 @@
 <script>
 import FocusLock from 'vue-focus-lock';
 import KvIcon from '@/components/Kv/KvIcon';
-import KvButton from '@/components/Kv/KvButton';
 import lockScrollUtils from '@/plugins/lock-scroll';
 
 export default {
 	components: {
 		FocusLock,
 		KvIcon,
-		KvButton
 	},
 	mixins: [
 		lockScrollUtils,
@@ -69,11 +71,11 @@ export default {
 			type: Boolean,
 			default: false
 		},
-		inverted: {
-			type: Boolean,
-			default: false
+		title: {
+			type: String,
+			default: '',
 		},
-		showCloseButton: {
+		inverted: {
 			type: Boolean,
 			default: false
 		},
@@ -99,8 +101,6 @@ export default {
 		// Create and set our internal visibility property
 		visible() {
 			this.isShown = this.visible;
-			// if the lightbox is shown give it focus
-			// this ensures the esc functionality works
 			if (this.isShown) {
 				this.$nextTick(() => {
 					this.lockScroll();
@@ -129,10 +129,9 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 
-/* Background, Structure + Close Button Styles */
 .kv-lightbox-wrap {
 	display: block;
 	position: fixed;
@@ -161,13 +160,10 @@ export default {
 			padding: 0;
 			align-items: center;
 			flex-direction: column;
-			margin-right: -0.0625rem;
-			margin-left: -0.0625rem;
 
 			.lightbox-columns {
 				position: relative;
-				width: 100%;
-				max-width: 900px;
+				max-width: rem-calc(900);
 				padding-right: 0.0625rem;
 				padding-left: 0.0625rem;
 			}
@@ -177,23 +173,35 @@ export default {
 		.lightbox-content {
 			display: block;
 			position: relative;
-			padding: 2.625rem 1.5rem 1.5rem 1.5rem;
+			padding: 1.5rem;
+			margin: 1rem;
 			max-width: 61rem;
 			background: $white;
 			border-radius: rem-calc(4);
 
 			@include breakpoint(medium) {
-				padding: 4rem 2.8125rem 2.8125rem 2.8125rem;
+				padding: 2.8125rem;
+				margin: 1.5rem;
 			}
 
 			@include breakpoint(large) {
-				padding: 4.75rem 2.8125rem 2.8125rem 2.8125rem;
+				padding: 2.8125rem;
+			}
+
+			.lightbox-title {
+				color: inherit;
+				color: var(--kv-lightbox-title-color, inherit);
+				padding-right: 1rem;
 			}
 
 			.close-lightbox {
+				width: 2.5rem;
+				height: 2.5rem;
+				padding-left: 0.25rem;
+				padding-top: 0.375rem;
 				position: absolute;
-				top: 1rem;
-				right: 1rem;
+				top: 0.75rem;
+				right: 0.75rem;
 
 				.icon-small-x {
 					height: 1.5rem;
@@ -206,16 +214,6 @@ export default {
 					.icon-small-x {
 						fill: $charcoal;
 					}
-				}
-
-				@include breakpoint(medium) {
-					top: 1.5rem;
-					right: 1.5rem;
-				}
-
-				@include breakpoint(large) {
-					top: 2rem;
-					right: 2rem;
 				}
 			}
 
@@ -257,6 +255,10 @@ export default {
 				}
 			}
 		}
+	}
+
+	.lightbox-controls ::v-deep button {
+		margin-bottom: 0;
 	}
 }
 </style>

--- a/src/components/Lightboxes/AddToBasketInterstitial.vue
+++ b/src/components/Lightboxes/AddToBasketInterstitial.vue
@@ -7,7 +7,7 @@
 			:no-padding-bottom="true"
 			@lightbox-closed="closeLightbox"
 		>
-			<h1 class="lightbox-title" slot="title">
+			<h1 class="lightbox-title">
 				Thanks for your commitment to make an impact
 			</h1>
 			<div class="lightbox-loan-wrapper">

--- a/src/components/Lightboxes/ContentfulLightbox.vue
+++ b/src/components/Lightboxes/ContentfulLightbox.vue
@@ -47,10 +47,3 @@ export default {
 	}
 };
 </script>
-
-<style lang="scss" scoped>
-// allows narrower lightboxes that aren't necessarily the full width of the page
-.kv-lightbox-wrap ::v-deep .kv-lightbox .lightbox-row .lightbox-columns {
-	width: auto;
-}
-</style>

--- a/src/pages/Autolending/AutolendingSettingsPage.vue
+++ b/src/pages/Autolending/AutolendingSettingsPage.vue
@@ -140,8 +140,6 @@ export default {
 <style lang="scss" scoped>
 @import 'settings';
 
-$autolending-font-size: rem-calc(18.8);
-
 ::v-deep .obscure {
 	opacity: 0.4;
 	pointer-events: none;

--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -37,17 +37,10 @@
 
 				<kv-lightbox
 					class="autolending-status-lightbox"
-					:no-padding-bottom="true"
-					:no-padding-top="true"
 					:visible="showLightbox"
+					title="Change your auto-lending status"
 					@lightbox-closed="showLightbox = false"
 				>
-					<template slot="title">
-						<h3>
-							Change your auto-lending status
-						</h3>
-						<hr>
-					</template>
 					<div class="status-radio-wrapper">
 						<kv-radio
 							data-test="is-autolending-on"
@@ -86,7 +79,6 @@
 						</kv-radio>
 					</div>
 					<template slot="controls">
-						<hr>
 						<kv-button
 							data-test="status-save-button"
 							class="smaller button"
@@ -266,22 +258,8 @@ export default {
 @import 'settings';
 
 .autolending-status-lightbox {
-	::v-deep .kv-lightbox {
-		max-width: 520px;
-	}
-
-	h3 {
-		margin-top: 1.75rem;
-		display: inline-block;
-		font-weight: $global-weight-bold;
-	}
-
 	.status-radio-wrapper {
 		padding: 1.5rem 0;
-	}
-
-	.button {
-		margin-bottom: 1.75rem;
 	}
 
 	.dropdown-wrapper {

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -30,17 +30,10 @@
 
 				<kv-lightbox
 					class="autolending-when-lightbox"
-					:no-padding-bottom="true"
-					:no-padding-top="true"
 					:visible="showLightbox"
+					title="Choose when your balance will be auto-lent"
 					@lightbox-closed="showLightbox = false"
 				>
-					<template slot="title">
-						<h3>
-							Choose when your balance will be auto-lent
-						</h3>
-						<hr>
-					</template>
 					<div class="when-inputs-wrapper">
 						<lend-timing-dropdown />
 						<kv-radio
@@ -78,7 +71,6 @@
 						</kv-radio>
 					</div>
 					<template slot="controls">
-						<hr>
 						<kv-button
 							data-test="when-save-button"
 							class="smaller button"
@@ -216,22 +208,8 @@ export default {
 @import 'settings';
 
 .autolending-when-lightbox {
-	::v-deep .kv-lightbox {
-		max-width: 680px;
-	}
-
-	h3 {
-		margin-top: 1.75rem;
-		display: inline-block;
-		font-weight: $global-weight-bold;
-	}
-
 	.when-inputs-wrapper {
 		padding: 1.5rem 0;
-	}
-
-	.button {
-		margin-bottom: 1.75rem;
 	}
 
 	.dropdown-wrapper {

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -17,30 +17,22 @@
 
 				<kv-lightbox
 					class="autolending-who-lightbox"
-					:no-padding-bottom="true"
-					:no-padding-top="true"
 					:visible="showLightbox"
+					title="Choose who you’ll support"
 					@lightbox-closed="showLightbox = false; showSelectedFilterOptions = false;"
 				>
-					<template slot="title">
-						<div class="who-titles-wrapper">
-							<transition :name="slideTransition" mode="out-in">
-								<h3 v-if="!showSelectedFilterOptions">
-									Choose who you’ll support
-								</h3>
-								<a
-									v-if="showSelectedFilterOptions"
-									role="button"
-									class="back-to-options"
-									@click.prevent="backToAllOptions"
-								>
-									<kv-icon class="arrow back-arrow" name="small-chevron" :from-sprite="true" />
-									Back to all options</a>
-							</transition>
-							<hr>
-						</div>
-					</template>
 					<div class="who-inputs-wrapper">
+						<transition :name="slideTransition" mode="out-in">
+							<span v-if="!showSelectedFilterOptions"></span>
+							<a
+								v-if="showSelectedFilterOptions"
+								role="button"
+								class="back-to-options"
+								@click.prevent="backToAllOptions"
+							>
+								<kv-icon class="arrow back-arrow" name="small-chevron" :from-sprite="true" />
+								Back to all options</a>
+						</transition>
 						<transition
 							:name="slideTransition"
 							mode="out-in"
@@ -123,7 +115,6 @@
 						</transition>
 					</div>
 					<template slot="controls">
-						<hr>
 						<div class="row">
 							<div class="columns shrink">
 								<save-button @autolendingSaved="settingsSaved" />
@@ -246,33 +237,37 @@ export default {
 @import 'settings';
 
 .autolending-who-lightbox {
-	::v-deep .kv-lightbox {
-		max-width: 680px;
-
-		.filter-title {
-			font-size: 1rem;
-			margin: 1rem auto 0.5rem auto;
-			font-weight: $global-weight-highlight;
-		}
-	}
-
 	h3 {
-		margin-top: 1.75rem;
-		display: inline-block;
 		font-weight: $global-weight-bold;
 	}
 
 	.who-inputs-wrapper {
 		padding: 1.5rem 0 1.5rem 0.15rem;
 		overflow: hidden;
+
+		span, // placeholder span and a set to same width so animation is smoother
+		a {
+			width: 100%;
+		}
 	}
 
-	.who-titles-wrapper {
-		overflow: hidden;
+	::v-deep .kv-lightbox {
+		.who-inputs-wrapper {
+			max-width: 100%;
 
-		h3,
-		a {
-			width: 80%; // sets h3 and a to same width so animation is smoother
+			@include breakpoint('large') {
+				width: rem-calc(530);
+			}
+
+			@include breakpoint('xxlarge') {
+				width: rem-calc(680);
+			}
+		}
+
+		.filter-title {
+			font-size: 1rem;
+			margin: 1rem auto 0.5rem auto;
+			font-weight: $global-weight-highlight;
 		}
 	}
 
@@ -285,9 +280,8 @@ export default {
 	}
 
 	.back-to-options {
-		margin-top: 1.75rem;
-		line-height: rem-calc(32);
-		display: inline-block;
+		margin-bottom: 1.75rem;
+		display: block;
 	}
 
 	.arrow {

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -14,27 +14,23 @@
 		</kv-button>
 		<kv-lightbox
 			:visible="warningVisible"
-			:no-padding-top="true"
-			:no-padding-sides="true"
-			:no-padding-bottom="true"
 			@lightbox-closed="closeWarning"
+			title="Criteria too narrow"
+			class="lightbox"
 		>
-			<template #title>
-				<h2 class="warning-title">
-					Criteria too narrow
-				</h2>
-			</template>
 			<p class="warning-text">
 				There {{ beVerb }} {{ loansLeft }} that {{ matchVerb }} your criteria -
 				we may not be able to lend your funds.
 			</p>
-			<template #controls>
-				<kv-button class="smallest warning-button" @click.native="closeWarning">
-					Add more categories
-				</kv-button>
-				<kv-button class="smallest secondary warning-button" @click.native="save">
-					Continue anyway
-				</kv-button>
+			<template v-slot:controls>
+				<div class="warning-buttons">
+					<kv-button class="smallest secondary" @click.native="save">
+						Continue anyway
+					</kv-button>
+					<kv-button class="smallest" @click.native="closeWarning">
+						Add more categories
+					</kv-button>
+				</div>
 			</template>
 		</kv-lightbox>
 	</div>
@@ -154,29 +150,24 @@ export default {
 		}
 	}
 
-	.kv-lightbox-wrap .kv-lightbox .lightbox-row .lightbox-columns {
-		max-width: rem-calc(524);
-
-		.lightbox-content {
-			text-align: center;
-			padding: 1rem 1.5rem 0.5rem;
-		}
-	}
-
-	.warning-title {
-		color: $kiva-accent-red;
-		font-weight: 500;
-		margin-bottom: 1rem;
-	}
-
 	.warning-text {
 		font-size: rem-calc(18);
 		margin-bottom: 1.5rem;
 	}
 
-	.warning-button {
-		display: block;
-		margin: 0 auto 1rem;
+	.warning-buttons {
+		display: grid;
+		grid-gap: 1rem;
+		grid-template-rows: auto auto;
+
+		@include breakpoint('large') {
+			grid-template-rows: auto;
+			grid-template-columns: max-content max-content;
+		}
 	}
+}
+
+.lightbox {
+	--kv-lightbox-title-color: #{$kiva-accent-red};
 }
 </style>

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -88,30 +88,24 @@
 
 				<kv-lightbox
 					:visible="redirectLightboxVisible"
+					title="This checkout is being tested right now, but doesn't support some functions yet."
 					@lightbox-closed="redirectLightboxClosed"
 				>
-					<section>
-						<h1>
-							This checkout is being tested right now, but doesn't support some functions yet.
-						</h1>
-
-						<p>
-							We'll redirect you so you can get back to changing lives, or click here if you aren't
-							automatically redirected.
-						</p>
-
-						<p>Thank you for minding our dust.</p>
-					</section>
-
-					<kv-button slot="controls"
-						class="smaller checkout-button"
-						id="Continue-to-legacy-button"
-						v-kv-track-event="['basket', 'Redirect Continue Button', 'exit to legacy']"
-						title="Continue"
-						@click.prevent.native="redirectToLegacy"
-					>
-						Continue
-					</kv-button>
+					<p>
+						We'll redirect you so you can get back to changing lives, or click here if you aren't
+						automatically redirected.
+					</p>
+					<p>Thank you for minding our dust.</p>
+					<template v-slot:controls>
+						<kv-button
+							class="smaller checkout-button"
+							id="Continue-to-legacy-button"
+							v-kv-track-event="['basket', 'Redirect Continue Button', 'exit to legacy']"
+							@click.prevent.native="redirectToLegacy"
+						>
+							Continue
+						</kv-button>
+					</template>
 				</kv-lightbox>
 			</div>
 		</div>

--- a/src/pages/ComponentDemo/ComponentDemo.vue
+++ b/src/pages/ComponentDemo/ComponentDemo.vue
@@ -25,11 +25,9 @@
 
 				<kv-lightbox
 					:visible="defaultLbVisible"
+					title="What is an Experimental Field Partner?"
 					@lightbox-closed="lightboxClosed"
 				>
-					<h2 slot="title">
-						What is an Experimental Field Partner?
-					</h2>
 					<p>
 						If a Field Partner is labeled as Experimental, this means that Kiva has required
 						only a comparatively light level of due diligence and monitoring, in exchange for
@@ -54,12 +52,9 @@
 				<kv-lightbox
 					:visible="invertedLbVisible"
 					:inverted="true"
-					:show-close-button="true"
+					title="What is an Experimental Field Partner?"
 					@lightbox-closed="lightboxClosed"
 				>
-					<h2 slot="title">
-						What is an Experimental Field Partner?
-					</h2>
 					<p>
 						If a Field Partner is labeled as Experimental, this means that Kiva has required
 						only a comparatively light level of due diligence and monitoring, in exchange for

--- a/src/pages/LandingPages/MGCovid19/MGCovidFAQ.vue
+++ b/src/pages/LandingPages/MGCovid19/MGCovidFAQ.vue
@@ -56,6 +56,7 @@
 
 		<kv-lightbox
 			:visible="isLightboxVisible"
+			title="Contribute"
 			@lightbox-closed="hideLightbox"
 		>
 			<covid-landing-form

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
@@ -158,10 +158,8 @@
 						<kv-lightbox
 							:visible="donationLbVisible"
 							@lightbox-closed="lightboxClosed"
+							title="How does Kiva use donations?"
 						>
-							<h2 slot="title">
-								How does Kiva use donations?
-							</h2>
 							<p>
 								100% of every dollar you lend on Kiva goes directly to funding loans.
 								We rely on small optional donations from you and others to keep Kiva running.


### PR DESCRIPTION
- Use prop to set title for consistency. 
- Add aria-labelledby and fix focus-lock for a11y. 
- Remove fixed width from lightboxes to allow narrower content without overrides. 
- Add a css custom property for overriding the title color.
- Remove unused "showCloseButton" property
- Scope lightbox styles 