### PR TITLE
Increase options for autolending loan limits

### DIFF
--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -83,7 +83,7 @@
 										<kv-expandable>
 											<div class="row" v-show="showAdvanced">
 												<div class="small-12 large-6 columns setting-column">
-													<loan-increment-radios />
+													<loan-increment-dropdown />
 												</div>
 												<div class="small-12 large-6 columns setting-column">
 													<attribute-radios
@@ -156,7 +156,7 @@ import GenderRadios from './GenderRadios';
 import GroupRadios from './GroupRadios';
 import InlineCounter from './InlineCounter';
 import KivaChoosesRadios from './KivaChoosesRadios';
-import LoanIncrementRadios from './LoanIncrementRadios';
+import LoanIncrementDropdown from './LoanIncrementDropdown';
 import LoanTermDropdown from './LoanTermDropdown';
 import PartnerDelRateDropdown from './PartnerDelRateDropdown';
 import PartnerFilter from './PartnerFilter';
@@ -182,7 +182,7 @@ export default {
 		KvExpandable,
 		KvIcon,
 		KvLightbox,
-		LoanIncrementRadios,
+		LoanIncrementDropdown,
 		LoanTermDropdown,
 		PartnerDelRateDropdown,
 		PartnerFilter,

--- a/src/pages/Autolending/LoanIncrementDropdown.vue
+++ b/src/pages/Autolending/LoanIncrementDropdown.vue
@@ -1,34 +1,46 @@
 <template>
-	<div class="loan-increment-radios">
+	<div class="loan-increment-dropdown">
 		<h3 class="filter-title">
 			Loan sizes
 		</h3>
-		<kv-radio
-			id="loan-increment-any"
-			radio-value="any"
-			v-model="loanIncrement"
-		>
-			Any amounts
-		</kv-radio>
-		<kv-radio
-			id="loan-increment-25"
-			radio-value="25"
-			v-model="loanIncrement"
-		>
-			Limit amounts to $25 per borrower
-		</kv-radio>
+		<kv-dropdown-rounded v-model="loanIncrement">
+			<option value="any">
+				Any amounts
+			</option>
+			<option value="25">
+				$25
+			</option>
+			<option value="50">
+				$50
+			</option>
+			<option value="75">
+				$75
+			</option>
+			<option value="100">
+				$100
+			</option>
+			<option value="250">
+				$250
+			</option>
+			<option value="500">
+				$500
+			</option>
+			<option value="1000">
+				$1000
+			</option>
+		</kv-dropdown-rounded>
 	</div>
 </template>
 
 <script>
 import _get from 'lodash/get';
 import gql from 'graphql-tag';
-import KvRadio from '@/components/Kv/KvRadio';
+import KvDropdownRounded from '@/components/Kv/KvDropdownRounded';
 
 export default {
 	inject: ['apollo'],
 	components: {
-		KvRadio,
+		KvDropdownRounded,
 	},
 	data() {
 		return {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/AUTO-177
https://kiva.atlassian.net/browse/AUTO-154

This switches the loan increment selector to a dropdown; having 5+ radio buttons looked cluttered.

Tested with https://github.com/kiva/kiva/pull/8878: I changed the limit on my dev VM to 25, then 100, then any, refreshing each time and verifying the previous selection appeared correctly.