### PR TITLE
Fixes issue preventing users with a billing agreement from submitting…

### DIFF
--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
@@ -126,10 +126,10 @@
 							</ul>
 							<div v-if="hasBillingAgreement">
 								<kv-button
-									type="submit"
 									data-test="confirm-monthly-good-button"
 									class="subscribe-btn"
 									:disabled="$v.$invalid || submitting"
+									@click.native="submitMonthlyGood()"
 								>
 									Subscribe <kv-loading-spinner v-if="submitting" />
 								</kv-button>


### PR DESCRIPTION
… MG variant form

Users who have a billing agreement are unable to submit the variant MG setup form because the button does nothing. 

Go to the variant form with a user who has a billing agreement. They are unable to sign up for MG
/monthlygood/setup?amount=10&category=education&setuiab=mg_setup.shown

Things to note: 

- Button is outside of form element, so type="submit" will not submit the form. 
- KvButton MUST use the @click.native variant of the click handler or else it does nothing