### PR TITLE
AUTO-178 Autolending Opt In Cleanup

### DIFF
--- a/src/pages/Autolending/LendTimingMessaging.vue
+++ b/src/pages/Autolending/LendTimingMessaging.vue
@@ -79,30 +79,11 @@ export default {
 			const idleStartTime = Date.parse(this.cIdleStartTime);
 			const daysIdle = differenceInCalendarDays(new Date(), idleStartTime);
 			const daysUntilLend = this.lendAfterDaysIdle - daysIdle > 0 ? this.lendAfterDaysIdle - daysIdle : 0;
-			const daysUntilMay = differenceInCalendarDays(new Date('5/21/2020'), new Date());
 
 			// cash-1883
 			if (daysIdle === 0) {
 				// eslint-disable-next-line max-len
 				return `You're currently active! You'll be eligible for auto-lending if you don't make a loan yourself in the next ${this.lendAfterDaysIdle} days.`;
-			}
-
-			// TEMPORARY - Remove after 5/21/2020
-			// Special launch conditions for Autolenders with unchanged default of 90 days
-			if (this.lendAfterDaysIdle === 90 && daysUntilMay >= 0) {
-				// lender has a qualifying credit change after 2/20/2020 thus resetting their 90 days beyond 5/21/2020
-				if (daysUntilLend > daysUntilMay) {
-					// eslint-disable-next-line max-len
-					return `You haven’t made a loan yourself in ${daysIdle} days – your balance will be eligible for auto-lending in ${daysUntilLend} days.`;
-				}
-				// lender's 90 eligible window falls between now and 5/21/2020
-				if (daysUntilLend > 0 && daysUntilLend <= daysUntilMay) {
-					// eslint-disable-next-line max-len
-					return `You haven’t made a loan yourself in ${daysIdle} days – your balance will be eligible for auto-lending on May 21, 2020.`;
-				}
-				// lender is already eligible to autolend, but delayed until program launch
-				// eslint-disable-next-line max-len
-				return `Since you haven’t made a loan yourself in ${daysIdle} days, you will be eligible for auto-lending on May 21, 2020 when the first 90-day auto-loans are made.`;
 			}
 
 			// R1: User balance > $25 + the user's , # of days within dropdown - cIdleStartTime is greater than 0


### PR DESCRIPTION
* Removes some code associated with the autolending opt in before may 21.
* e2e tests had been previously removed already in hot fix.

AUTO-178