### PR TITLE
VUE-336 Promo Banner Border Bug

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/PromoBannerSmall.vue
+++ b/src/components/WwwFrame/PromotionalBanner/PromoBannerSmall.vue
@@ -19,8 +19,6 @@ export default {
 .promo-banner-small {
 	text-align: center;
 	font-size: $small-text-font-size;
-	border-top: 1px solid $kiva-navdivider-green;
-	border-bottom: 1px solid $divider-green;
 
 	a {
 		text-decoration: none;
@@ -29,6 +27,8 @@ export default {
 	.content {
 		line-height: 1.25;
 		padding: rem-calc(3) 0;
+		border-top: 1px solid $kiva-navdivider-green;
+		border-bottom: 1px solid $divider-green;
 	}
 
 	.call-to-action-text {

--- a/src/components/WwwFrame/PromotionalBanner/PromotionalBanner.vue
+++ b/src/components/WwwFrame/PromotionalBanner/PromotionalBanner.vue
@@ -1,5 +1,5 @@
 <template>
-	<component :is="currentActivePromo" :bonus-balance="bonusBalance" class="legacy-promo" />
+	<component :is="currentActivePromo" :bonus-balance="bonusBalance" />
 </template>
 
 <script>


### PR DESCRIPTION
* Moved CSS for promo banner small border so that border is not visible if banner is not visible. (It creates a problem for homepage takeovers with white headers)

VUE-336