### PR TITLE
Found out that our server-entry.js was always getting 'none' for the …

### DIFF
--- a/build/webpack.server.conf.js
+++ b/build/webpack.server.conf.js
@@ -6,6 +6,7 @@ var FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin');
 const isProd = process.env.NODE_ENV === 'production';
 
 module.exports = merge.smart(baseWebpackConfig, {
+	mode: isProd ? 'production' : baseWebpackConfig.mode,
 	entry: './src/server-entry.js',
 	target: 'node',
 	devtool: isProd ? 'source-map' : 'eval',


### PR DESCRIPTION
…NODE_ENV due to webpack overriding it at compile time. This updates the mode to set 'production' when appropriate so webpack doesn't override the process.env.NODE_ENV with the mode setting from our base webpack config.