### PR TITLE
Fixed issue with auth pop up login not redirecting on preFetch rejection

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -427,7 +427,9 @@ export default {
 							route: this.$route,
 							kvAuth0: this.kvAuth0,
 						}).catch(error => {
-							this.$router.push(error);
+							if (error.path) {
+								this.$router.push(error);
+							}
 						});
 					}
 				});

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -426,6 +426,8 @@ export default {
 						return preFetchAll(matched, this.apollo, {
 							route: this.$route,
 							kvAuth0: this.kvAuth0,
+						}).catch(error => {
+							this.$router.push(error);
 						});
 					}
 				});

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -407,7 +407,9 @@ export default {
 							route: this.$route,
 							kvAuth0: this.kvAuth0,
 						}).catch(error => {
-							this.$router.push(error);
+							if (error.path) {
+								this.$router.push(error);
+							}
 						});
 					}
 					return false;

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -406,6 +406,8 @@ export default {
 						return preFetchAll(matched, this.apollo, {
 							route: this.$route,
 							kvAuth0: this.kvAuth0,
+						}).catch(error => {
+							this.$router.push(error);
 						});
 					}
 					return false;


### PR DESCRIPTION
When preFetchAll is used outside of apollo mixin (by component methods) we need to send the rejection to the router. 