### PR TITLE
Hide auto-lending donation controls and zero out donation if there is an auto-deposit donation

### DIFF
--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -36,39 +36,44 @@
 				>
 					<div class="when-inputs-wrapper">
 						<lend-timing-dropdown />
-						<kv-radio
-							data-test="is-autolending-donation-on"
-							id="is-autolending-donation-on"
-							radio-value="on"
-							v-model="donationToggle"
-						>
-							Include a donation to Kiva of
-							<kv-dropdown-rounded v-model="donation">
-								<option :value="0">
-									0%
-								</option>
-								<option :value="5">
-									5%
-								</option>
-								<option :value="10">
-									10%
-								</option>
-								<option :value="15">
-									15%
-								</option>
-								<option :value="20">
-									20%
-								</option>
-							</kv-dropdown-rounded>
-						</kv-radio>
-						<kv-radio
-							data-test="is-autolending-donation-off"
-							id="is-autolending-donation-off"
-							radio-value="off"
-							v-model="donationToggle"
-						>
-							No donation to Kiva
-						</kv-radio>
+						<p v-if="hasAutoDepositDonation && donation === 0">
+							Your auto-deposit includes a donation, so auto-lending donations are disabled.
+						</p>
+						<div v-else>
+							<kv-radio
+								data-test="is-autolending-donation-on"
+								id="is-autolending-donation-on"
+								radio-value="on"
+								v-model="donationToggle"
+							>
+								Include a donation to Kiva of
+								<kv-dropdown-rounded v-model="donation">
+									<option :value="0">
+										0%
+									</option>
+									<option :value="5">
+										5%
+									</option>
+									<option :value="10">
+										10%
+									</option>
+									<option :value="15">
+										15%
+									</option>
+									<option :value="20">
+										20%
+									</option>
+								</kv-dropdown-rounded>
+							</kv-radio>
+							<kv-radio
+								data-test="is-autolending-donation-off"
+								id="is-autolending-donation-off"
+								radio-value="off"
+								v-model="donationToggle"
+							>
+								No donation to Kiva.
+							</kv-radio>
+						</div>
 					</div>
 					<template slot="controls">
 						<kv-button
@@ -128,6 +133,7 @@ export default {
 			lendAfterDaysIdle: 0,
 			donation: 15,
 			donationToggle: 'on',
+			hasAutoDepositDonation: false,
 		};
 	},
 	apollo: {
@@ -140,15 +146,21 @@ export default {
 					lendAfterDaysIdle
 				}
 			}
+			my {
+				autoDeposit {
+					donateAmount
+				}
+			}
 		}`,
 		preFetch: true,
 		result({ data }) {
 			this.isEnabled = !!_get(data, 'autolending.currentProfile.isEnabled');
-			const donationPercentage = _get(data, 'autolending.currentProfile.donationPercentage');
 			this.lendAfterDaysIdle = _get(data, 'autolending.currentProfile.lendAfterDaysIdle');
 			this.isChanged = !!_get(data, 'autolending.profileChanged');
+			const donationPercentage = _get(data, 'autolending.currentProfile.donationPercentage');
 			this.donation = _isFinite(donationPercentage) ? donationPercentage : 15;
 			this.donationToggle = this.donation !== 0 ? 'on' : 'off';
+			this.hasAutoDepositDonation = _get(data, 'my.autoDeposit.donateAmount') > 0;
 		},
 	},
 	mounted() {

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -36,6 +36,11 @@
 				>
 					<div class="when-inputs-wrapper">
 						<lend-timing-dropdown />
+						<!--
+							While lenders with an auto-deposit donation should not have an auto-lending donation after
+							the fixes for AUTO-44 and AUTO-206, the check below includes donation===0
+							for graceful degradation, so that users with both donations still see the actual value.
+						-->
 						<p v-if="hasAutoDepositDonation && donation === 0">
 							Your auto-deposit includes a donation, so auto-lending donations are disabled.
 						</p>


### PR DESCRIPTION
Resolves https://kiva.atlassian.net/browse/AUTO-207

I couldn't tell why this component makes a direct mutation to update the `donationPercentage` (rather than go through the local resolver), but IIUC this change will pre-empt that code path, as the controls that modify `this.donation` are not rendered.

<img width="701" alt="Screen Shot 2020-07-07 at 11 06 03 PM" src="https://user-images.githubusercontent.com/234990/86883235-777ce780-c0a6-11ea-974a-4af6a781c3fa.png">