### PR TITLE
Monthly Good & Subscriptions & BT Drop In Misc Changes

### DIFF
--- a/src/pages/Autolending/AutolendingPage.vue
+++ b/src/pages/Autolending/AutolendingPage.vue
@@ -2,7 +2,7 @@
 	<www-page class="autolending" :gray-background="true">
 		<div class="title-area">
 			<div class="row column">
-				<h2>Auto-lending preferences</h2>
+				<h2>Auto-lending settings</h2>
 				<h3>Make the impact you want even if you’re away from your account for a while</h3>
 			</div>
 		</div>

--- a/src/pages/LandingPages/MGCovid19/MGCovidHero.vue
+++ b/src/pages/LandingPages/MGCovid19/MGCovidHero.vue
@@ -44,7 +44,7 @@
 						<h4>
 							You're already signed up for Monthly Good.
 							Changes to this contribution can be made in your
-							<a href="/settings/credit">credit settings</a>.
+							<a href="/settings/subscriptions">subscription settings</a>.
 						</h4>
 					</div>
 					<div class="campaign-inactive" v-else-if="!covidLandingActive">

--- a/src/pages/MonthlyGood/AlreadySubscribedNotice.vue
+++ b/src/pages/MonthlyGood/AlreadySubscribedNotice.vue
@@ -6,7 +6,7 @@
 
 		<p class="text-center">
 			Changes to this contribution can be made in your
-			<a href="/settings/credit">credit settings</a>.
+			<a href="/settings/subscriptions">subscription settings</a>.
 		</p>
 	</div>
 	<div v-else>
@@ -16,7 +16,7 @@
 
 		<p class="text-center">
 			<!-- eslint-disable-next-line max-len -->
-			Instead, you can change your <a href="/settings/credit">credit settings</a> to direct your Monthly Good contribution to COVID-19 support loans?
+			Instead, you can change your <a href="/settings/subscriptions">subscription settings</a> to direct your Monthly Good contribution to COVID-19 support loans?
 		</p>
 	</div>
 </template>

--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -33,7 +33,7 @@
 							<h4>
 								You're already signed up for Monthly Good.
 								Changes to this contribution can be made in your
-								<a href="/settings/credit">credit settings</a>.
+								<a href="/settings/subscriptions">subscription settings</a>.
 							</h4>
 						</div>
 					</div>
@@ -57,7 +57,7 @@
 					<h4>
 						You're already signed up for Monthly Good.
 						Changes to this contribution can be made in your
-						<a href="/settings/credit">credit settings</a>.
+						<a href="/settings/subscriptions">subscription settings</a>.
 					</h4>
 				</div>
 			</template>

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
@@ -6,31 +6,12 @@
 		:onetime="onetime"
 		:source="source"
 	/>
-	<monthly-good-setup-page-variant
-		v-else
-		:amount="amount"
-		:category="category"
-		:onetime="onetime"
-		:source="source"
-	/>
 </template>
 
 <script>
-import gql from 'graphql-tag';
-import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
-import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
-
 import MonthlyGoodSetupPageControl from '@/pages/MonthlyGood/MonthlyGoodSetupPageControl';
-import MonthlyGoodSetupPageVariant from '@/pages/MonthlyGood/MonthlyGoodSetupPageVariant';
-
-const pageQuery = gql`query monthlyGoodSetupPage {
-	general {
-		uiExperimentSetting(key: "mg_setup") {
-			key
-			value
-		}
-	}
-}`;
+// Variant template driven by experiment
+// import MonthlyGoodSetupPageVariant from '@/pages/MonthlyGood/MonthlyGoodSetupPageVariant';
 
 export default {
 	props: {
@@ -53,42 +34,12 @@ export default {
 	},
 	components: {
 		MonthlyGoodSetupPageControl,
-		MonthlyGoodSetupPageVariant
 	},
 	data() {
 		return {
 			showMGSetupControl: true
 		};
 	},
-	inject: ['apollo'],
-	apollo: {
-		preFetch(config, client) {
-			return new Promise((resolve, reject) => {
-				// Get the experiment object from settings
-				client.query({
-					query: pageQuery
-				}).then(() => {
-					// Get the assigned experiment version for braintree pay with experiment
-					client.query({ query: experimentAssignmentQuery, variables: { id: 'mg_setup' } })
-						.then(resolve).catch(reject);
-				}).catch(reject);
-			});
-		}
-	},
-	created() {
-		// get experiment data from apollo cache
-		// GROW-82: Redesigned monthly good receipt page.
-		const mgSetupExp = this.apollo.readFragment({
-			id: 'Experiment:mg_setup',
-			fragment: experimentVersionFragment,
-		}) || {};
-		if (mgSetupExp.version === 'control') {
-			this.$kvTrackEvent('MonthlyGood', 'EXP-GROW-82-May2020', 'a');
-		} else if (mgSetupExp.version === 'shown') {
-			this.showMGSetupControl = false;
-			this.$kvTrackEvent('MonthlyGood', 'EXP-GROW-82-May2020', 'b');
-		}
-	}
 };
 
 </script>

--- a/src/pages/PageTwo.vue
+++ b/src/pages/PageTwo.vue
@@ -27,7 +27,7 @@
 							<h4>
 								You're already signed up for Monthly Good.
 								Changes to this contribution can be made in your
-								<a href="/settings/credit">credit settings</a>.
+								<a href="/settings/subscriptions">subscription settings</a>.
 							</h4>
 						</div>
 					</div>
@@ -55,7 +55,7 @@
 						<h4>
 							You're already signed up for Monthly Good.
 							Changes to this contribution can be made in your
-							<a href="/settings/credit">credit settings</a>.
+							<a href="/settings/subscriptions">subscription settings</a>.
 						</h4>
 					</div>
 				</template>

--- a/src/pages/Subscriptions/SubscriptionsAutoDeposit.vue
+++ b/src/pages/Subscriptions/SubscriptionsAutoDeposit.vue
@@ -28,7 +28,7 @@
 							role="button"
 							@click.prevent="showLightbox = true;"
 						>{{ totalCombinedDeposit | numeral('$0,0.00') }}</a> will be
-						transferred from PayPal.
+						transferred.
 					</p>
 					<p>
 						<a role="button" @click.prevent="$emit('cancel-subscription')">Cancel auto deposit</a>

--- a/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
+++ b/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
@@ -28,7 +28,7 @@
 							role="button"
 							@click.prevent="showLightbox = true;"
 						>{{ totalCombinedDeposit | numeral('$0,0.00') }}</a> will be
-						transferred from PayPal<a
+						transferred<a
 							role="button"
 							@click.prevent="showLightbox = true;"
 							v-if="selectedGroupDescriptor"

--- a/src/pages/Subscriptions/SubscriptionsPage.vue
+++ b/src/pages/Subscriptions/SubscriptionsPage.vue
@@ -2,7 +2,7 @@
 	<www-page class="subscriptions" :gray-background="true">
 		<div class="title-area">
 			<div class="row column">
-				<h2>Subscription preferences</h2>
+				<h2>Subscription settings</h2>
 			</div>
 		</div>
 		<router-view />

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -37,7 +37,7 @@ describe('Autolending Page Spec', () => {
 			cy.visit('/settings/autolending');
 
 			// Assert that key elements of the page are visible
-			cy.contains('Auto-lending preferences');
+			cy.contains('Auto-lending settings');
 		});
 
 		it('Redirects to credit/settings if visitor isSubscriber', () => {


### PR DESCRIPTION
* Changed /settings/subscriptions page title to be "settings"
* Changed /settings/autolending page title to be "settings"
* Removed specific 'from Paypal' copy from MG subscription status texts to allow for MG bt drop in subscriptions
* Changed links to /settings/credit to be /settings/subscriptions on MG already subscribed elements
* Removed GROW-82 MG Variant selection code page