### PR TITLE
SUBS-334 Auth Guard and Query Params

### DIFF
--- a/src/util/authenticationGuard.js
+++ b/src/util/authenticationGuard.js
@@ -9,7 +9,7 @@ const processErrors = (error, route) => {
 		// Force a login when active login is required
 		return {
 			path: '/ui-login',
-			query: { force: true, doneUrl: route.path }
+			query: { force: true, doneUrl: route.fullPath }
 		};
 	}
 
@@ -17,7 +17,7 @@ const processErrors = (error, route) => {
 		// Redirect to login upon authentication error
 		return {
 			path: '/ui-login',
-			query: { doneUrl: route.path }
+			query: { doneUrl: route.fullPath }
 		};
 	}
 	// Log other errors to Sentry
@@ -30,7 +30,7 @@ const processErrors = (error, route) => {
 	// catch all redirect to login
 	return {
 		path: '/ui-login',
-		query: { doneUrl: route.path }
+		query: { doneUrl: route.fullPath }
 	};
 };
 


### PR DESCRIPTION
* Changed doneUrl param in auth guard to use route.fullPath, which will keep the query params when redirecting. This was causing some issues, see SUBS-334