### PR TITLE
Limit for loan query must be positive rather than 0.

### DIFF
--- a/src/graphql/query/lendMenuPrivateData.graphql
+++ b/src/graphql/query/lendMenuPrivateData.graphql
@@ -1,6 +1,6 @@
 query lendMenuPrivateData($userId: Int) {
 	lend {
-		loans(limit: 0, filters: {
+		loans(limit: 1, filters: {
 			lenderFavorite: $userId
 		}) {
 			totalCount


### PR DESCRIPTION
Fixes minor error due to validation in GraphQL API
`query: "query ($userId: Int) {↵  lend {↵    loans(limit: 0, filters: {lenderFavorite: $userId}) {↵      totalCount↵      __typename↵    }↵    __typename↵  }↵  my {↵    savedSearches(limit: 10) {↵      values {↵        id↵        name↵        url↵        __typename↵      }↵      __typename↵    }↵    __typename↵  }↵}"
`

`0: "GraphQLError: Limit must be positive."`