### PR TITLE
SUBS-9 Braintree MonthlyGood Setup One Time Fix

### DIFF
--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageControl.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageControl.vue
@@ -227,7 +227,7 @@
 									:donate-amount="this.donation"
 									:day-of-month="this.dayOfMonth"
 									:category="this.selectedGroup"
-									:is-onetime="this.isOnetime"
+									:is-one-time="this.isOnetime"
 									@complete-transaction="completeMGBraintree()"
 								/>
 							</div>


### PR DESCRIPTION
* Fixes typo in prop causing oneTime boolean not to be passed correctly to mutation

SUBS-9