### PR TITLE
GROW-159 KvCarousel

### DIFF
--- a/.storybook/stories/KvCarousel.stories.js
+++ b/.storybook/stories/KvCarousel.stories.js
@@ -1,0 +1,395 @@
+import Vue from 'vue'
+import Vue2TouchEvents from 'vue2-touch-events';
+
+import KvCarousel from '@/components/Kv/KvCarousel';
+import KvCarouselSlide from '@/components/Kv/KvCarouselSlide';
+import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+
+Vue.use(Vue2TouchEvents);
+
+const defaultCarouselSlides = `
+	<template slot="default" slot-scope="props">
+		<kv-carousel-slide :transition-name="props.transitionName">
+			<img src="https://via.placeholder.com/300x220/e8f0f6/000000" style="width: 100%;">
+		</kv-carousel-slide>
+		<kv-carousel-slide :transition-name="props.transitionName">
+			<img src="https://via.placeholder.com/300x220/a87c7c/000000" style="width: 100%;">
+		</kv-carousel-slide>
+		<kv-carousel-slide :transition-name="props.transitionName">
+			<img src="https://via.placeholder.com/300x220/f6dbb8/000000" style="width: 100%;">
+		</kv-carousel-slide>
+		<kv-carousel-slide :transition-name="props.transitionName">
+			<img src="https://via.placeholder.com/300x220/b39696/000000" style="width: 100%;">
+		</kv-carousel-slide>
+	</template>
+`;
+
+export default {
+	title: 'Kv/KvCarousel',
+	component: KvCarousel,
+ };
+
+export const Default = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel style="width: 400px; height: 250px;">
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const PauseOnHoverFalse = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			:pause-on-hover="false"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const AutoplayFalse = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			:autoplay="false"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const HideArrows = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			:hide-arrows="true"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const IndicatorStyleNone = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			indicator-style="none"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const HideArrowsTrueIndicatorNone = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			:hide-arrows="true"
+			indicator-style="none"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const indicatorStyleBar = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			indicator-style="bar"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const indicatorStyleBarControlsInside = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			indicator-style="bar"
+			:controls-inside="true"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const indicatorStyleBarHideArrowsTrue = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			indicator-style="bar"
+			:hide-arrows="true"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const controlsInside = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide
+	},
+	template: `
+		<kv-carousel
+			:controls-inside="true"
+			style="width: 400px; height: 250px;"
+		>
+			${defaultCarouselSlides}
+		</kv-carousel>
+	`,
+});
+
+export const loanCardExample = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide,
+		KvLoadingSpinner
+	},
+	data() {
+		return {
+			loan2Loaded: false,
+			loan3Loaded: false,
+		}
+	},
+	template: `
+		<div class="row">
+			<div class="small-12 large-6 columns">
+				<kv-carousel
+					indicator-style="bar"
+					@change="onCarouselSlideChange"
+					style="height: 0; padding-bottom: 135%;"
+				>
+					<template slot="default" slot-scope="props">
+						<kv-carousel-slide :transition-name="props.transitionName">
+							<div>Prefetched Loan card goes here</div>
+						</kv-carousel-slide>
+						<kv-carousel-slide :transition-name="props.transitionName">
+							<div v-if="loan2Loaded">
+								Loan card goes here
+							</div>
+							<div v-else
+								style="display: flex; align-items: center; justify-content: center; position: absolute; top: 0; bottom: 0; right: 0; left: 0;"
+							>
+								<kv-loading-spinner />
+							</div>
+						</kv-carousel-slide>
+						<kv-carousel-slide :transition-name="props.transitionName">
+							<div v-if="loan3Loaded">
+								Loan card goes here
+							</div>
+							<div v-else
+								style="display: flex; align-items: center; justify-content: center; position: absolute; top: 0; bottom: 0; right: 0; left: 0;"
+							>
+								<kv-loading-spinner />
+							</div>
+						</kv-carousel-slide>
+					</template>
+				</kv-carousel>
+			</div>
+		</div>
+	`,
+	methods: {
+		onCarouselSlideChange(slideIndex) {
+			console.log(`carousel changed to slide: ${slideIndex}`);
+			console.log('start fetching the next indexes loan data now');
+		}
+	}
+});
+
+const slidesImageRequire = require.context('@/assets/images/possibilities-banners/kivan-slider', true);
+export const KivanSlider = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide,
+		KvResponsiveImage
+	},
+	props: {
+		slidesData: {
+			type: Array,
+			default() {
+				return [
+					{
+						left: [
+							['small', slidesImageRequire('./kivan-1a-std.jpg')],
+							['small retina', slidesImageRequire('./kivan-1a-retina.jpg')]
+						],
+						right: [
+							['small', slidesImageRequire('./kivan-1b-std.jpg')],
+							['small retina', slidesImageRequire('./kivan-1b-retina.jpg')],
+						]
+					},
+					{
+						left: [
+							['small', slidesImageRequire('./kivan-2a-std.jpg')],
+							['small retina', slidesImageRequire('./kivan-2a-retina.jpg')],
+						],
+						right: [
+							['small', slidesImageRequire('./kivan-2b-std.jpg')],
+							['small retina', slidesImageRequire('./kivan-2b-retina.jpg')],
+						]
+					},
+					{
+						left: [
+							['small', slidesImageRequire('./kivan-3a-std.jpg')],
+							['small retina', slidesImageRequire('./kivan-3a-retina.jpg')],
+						],
+						right: [
+							['small', slidesImageRequire('./kivan-3b-std.jpg')],
+							['small retina', slidesImageRequire('./kivan-3b-retina.jpg')]
+						]
+					}
+				]
+			}
+		}
+	},
+	template: `
+		<div class="row">
+			<kv-carousel
+				:autoplay="false"
+				:controls-inside="true"
+				style="height: 0; padding-bottom: 41%;"
+			>
+				<kv-carousel-slide
+					v-for="(slide, index) in slidesData"
+					:class="slide-index"
+				>
+					<div class="row">
+						<div class="small-12 large-6">
+							<kv-responsive-image :images="slide.left" alt="" />
+						</div>
+						<div class="small-12 large-6 show-for-large">
+							<kv-responsive-image :images="slide.right" alt="" />
+						</div>
+					</div>
+				</kv-carousel-slide>
+			</kv-carousel>
+		</div>
+	`,
+});
+
+const imageRequire = require.context('@/assets/images/hero-slideshow/', true);
+export const ImagesOnlyLazyLoadLikeHomepage = () => ({
+	components: {
+		KvCarousel,
+		KvCarouselSlide,
+		KvResponsiveImage,
+	},
+	data() {
+		return {
+			counter: 0,
+		}
+	},
+	methods: {
+		slideChange() {
+			// count the number of slides shown to use for lazy-loading images with v-if
+			if (this.counter < 5) {
+				this.counter += 1;
+			}
+			console.log(this.counter);
+		},
+		heroImages(number) {
+			return [
+				['small', imageRequire(`./hero-${number}-sm-std.jpg`)],
+				['small retina', imageRequire(`./hero-${number}-sm-retina.jpg`)],
+				['medium', imageRequire(`./hero-${number}-med-std.jpg`)],
+				['medium retina', imageRequire(`./hero-${number}-med-retina.jpg`)],
+				['large', imageRequire(`./hero-${number}-lg-std.jpg`)],
+				['large retina', imageRequire(`./hero-${number}-lg-retina.jpg`)],
+				['xga', imageRequire(`./hero-${number}-xga-std.jpg`)],
+				['xga retina', imageRequire(`./hero-${number}-xga-retina.jpg`)],
+				['wxga', imageRequire(`./hero-${number}-wxga-std.jpg`)],
+				['wxga retina', imageRequire(`./hero-${number}-wxga-retina.jpg`)],
+			];
+		},
+	},
+	template: `
+		<div>
+			<kv-carousel
+				:hide-arrows="true"
+				:slide-interval="5"
+				:pause-on-hover="false"
+				indicator-style="none"
+				@change="slideChange"
+				style="height: 0; padding-bottom: 50%;"
+			>
+				<!-- eslint-disable max-len -->
+				<kv-carousel-slide>
+					<kv-responsive-image
+						:images="heroImages(1)"
+						alt="A woman laughs while sitting on a traditional wooden boat on the waterways of Southeast Asia."
+					/>
+				</kv-carousel-slide>
+				<kv-carousel-slide>
+					<kv-responsive-image
+						:images="heroImages(2)"
+						alt="Four women wear colorful, patterned African dresses and smile."
+					/>
+				</kv-carousel-slide>
+				<kv-carousel-slide>
+					<kv-responsive-image
+						v-if="counter > 1"
+						:images="heroImages(3)"
+						alt="An older woman wearing a bright pink shirt smiles, standing in front of a tropical forest landscape."
+					/>
+				</kv-carousel-slide>
+				<kv-carousel-slide>
+					<kv-responsive-image
+						v-if="counter > 2"
+						:images="heroImages(4)"
+						alt="An older Latin American farmer with a mustache smiles. He stands in front of tropical shrubbery."
+					/>
+				</kv-carousel-slide>
+				<kv-carousel-slide>
+					<kv-responsive-image
+						v-if="counter > 3"
+						:images="heroImages(5)"
+						alt="A man wearing a light blue dashiki smiles in a workshop filled with traditional African crafts and jewelry."
+					/>
+				</kv-carousel-slide>
+				<!-- eslint-enable max-len -->
+			</kv-carousel>
+		</div>
+	`,
+
+});

--- a/.storybook/stories/KvLoadingSpinner.stories.js
+++ b/.storybook/stories/KvLoadingSpinner.stories.js
@@ -1,0 +1,12 @@
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+
+export default {
+	title: 'Kv/KvLoadingSpinner',
+	component: KvLoadingSpinner,
+};
+
+export const Default = () => ({
+	components: { KvLoadingSpinner },
+	template: '<kv-loading-spinner />'
+});
+

--- a/src/components/Kv/KvCarousel.vue
+++ b/src/components/Kv/KvCarousel.vue
@@ -1,23 +1,160 @@
 <template>
-	<div class="kv-carousel">
-		<slot></slot>
+	<div
+		class="kv-carousel"
+		:class="carouselModifierClasses"
+		ref="KvCarousel"
+	>
+		<div class="kv-carousel__slides"
+			@mouseover="pauseOnHover ? paused = true : paused = false"
+			@touchstart="pauseOnHover ? paused = true : paused = false"
+			@mouseleave="paused = false"
+			@touchend="paused = false"
+			v-touch:swipe.left="previous"
+			v-touch:swipe.right="advance"
+		>
+			<slot :transitionName="transitionName"></slot>
+		</div>
+
+		<div class="kv-carousel__arrows">
+			<button
+				class="kv-carousel__arrows-btn kv-carousel__arrows-btn--left"
+				@click="previous"
+			>
+				<kv-icon
+					class="kv-carousel__arrows-icon"
+					name="small-chevron"
+					:from-sprite="true"
+					title="Show previous slide"
+				/>
+			</button>
+			<button
+				class="kv-carousel__arrows-btn kv-carousel__arrows-btn--right"
+				@click="advance"
+			>
+				<kv-icon
+					class="kv-carousel__arrows-icon"
+					name="small-chevron"
+					:from-sprite="true"
+					title="Show next slide"
+				/>
+			</button>
+		</div>
+
+		<div
+			class="kv-carousel__indicator"
+		>
+			<button
+				v-for="(slide, index) in slides"
+				:key="`indicator-${index}`"
+				class="kv-carousel__indicator-btn"
+				:class="currentIndex === index ? 'kv-carousel__indicator-btn--active' : ''"
+				@click="goToSlide(index)"
+			>
+				<span class="show-for-sr">Show slide {{ index + 1 }}</span>
+			</button>
+		</div>
 	</div>
 </template>
 
 <script>
+import KvIcon from '@/components/Kv/KvIcon';
+
 export default {
+	components: {
+		KvIcon,
+	},
 	props: {
 		autoplay: {
 			type: Boolean,
 			default: true
+		},
+		/**
+		 * Duration in seconds between how long a slide is in view if autoplay is active
+		* */
+		autoplayInterval: {
+			type: Number,
+			default: 5,
+		},
+		/**
+		 * Pauses the carousel autoplay if the user is hovering or touching the slides
+		* */
+		pauseOnHover: {
+			type: Boolean,
+			default: true,
+		},
+		/**
+		 * Hide the left and right slide arrows
+		* */
+		hideArrows: {
+			type: Boolean,
+			default: false,
+		},
+		/**
+		 * The style of the indicator
+		 * `circle, bar, none`
+		* */
+		indicatorStyle: {
+			type: String,
+			default: 'circle'
+		},
+		/**
+		 * Cover the slide contents with the arrows and indicator
+		* */
+		controlsInside: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {
 		return {
-			currentIndex: 0,
-			interval: null,
 			slides: [],
+			currentIndex: 0,
+			paused: false,
+			intervalTimerCurrentTime: 0,
+			transitionName: 'kv-slide-left',
 		};
+	},
+	computed: {
+		nextIndex() {
+			const nextSlideIndex = this.currentIndex + 1;
+			if (nextSlideIndex < this.slides.length) {
+				return nextSlideIndex;
+			}
+			return 0;
+		},
+		previousIndex() {
+			const previousSlideIndex = this.currentIndex - 1;
+			if (previousSlideIndex >= 0) {
+				return previousSlideIndex;
+			}
+			return this.slides.length - 1;
+		},
+		carouselModifierClasses() {
+			let classes = '';
+			if (this.controlsInside) {
+				classes += 'kv-carousel--controls-inside ';
+			}
+			if (this.hideArrows) {
+				classes += 'kv-carousel--hide-arrows ';
+			}
+			if (this.indicatorStyle === 'bar') {
+				classes += 'kv-carousel--indicator-bar ';
+			}
+			if (this.indicatorStyle === 'none') {
+				classes += 'kv-carousel--indicator-none ';
+			}
+			return classes;
+		}
+	},
+	watch: {
+		paused(isPaused) {
+			if (this.indicatorStyle !== 'none') {
+				// pause the css animation on the indicator
+				this.$refs.KvCarousel.style.setProperty(
+					'--kv-carousel-play-state', `${isPaused ? 'paused' : 'running'}`
+				);
+			}
+		},
 	},
 	mounted() {
 		// get slide components
@@ -29,53 +166,287 @@ export default {
 		}
 
 		// setup autoplay
-		if (this.slides.length > 1 && this.autoplay) {
-			this.interval = setInterval(() => {
-				this.advance();
-			}, 5000);
+		if (this.autoplay && this.slides.length > 1) {
+			// init the CSS custom property for CSS animation
+			this.$refs.KvCarousel.style.setProperty(
+				'--kv-carousel-autoplay-interval', `${this.autoplayInterval}s`
+			);
+
+			const refreshRate = 0.1; // 100 milliseconds
+			this.intervalTimerCurrentTime = 0;
+			this.intervalTimer = setInterval(() => {
+				if (!this.paused) {
+					this.intervalTimerCurrentTime += refreshRate;
+				}
+				if (this.intervalTimerCurrentTime >= this.autoplayInterval) {
+					this.intervalTimerCurrentTime = 0;
+					this.advance();
+				}
+			}, refreshRate * 1000); // 100 milliseconds
 		}
 	},
 	beforeDestroy() {
-		clearInterval(this.interval);
+		if (this.autoplay) {
+			clearInterval(this.intervalTimer);
+		}
 	},
 	methods: {
+		/**
+		 * Move forward one slide
+		 *
+		 * @public This is a public method
+		 */
 		advance() {
-			this.goToSlide(this.getNextIndex());
+			this.goToSlide(this.nextIndex);
 		},
+		/**
+		 * Move backward one slide
+		 *
+		 * @public This is a public method
+		 */
 		previous() {
-			this.goToSlide(this.getPreviousIndex());
+			this.goToSlide(this.previousIndex);
 		},
+		/**
+		 * Jump to a specific slide index
+		 *
+		 * @param {Number} num Index of slide to show
+		 * @public This is a public method
+		 */
 		goToSlide(index) {
-			this.slides[this.currentIndex].hide();
-			this.currentIndex = index;
-			this.slides[this.currentIndex].show();
-			this.$emit('change', this.currentIndex);
-		},
-		getNextIndex() {
-			const nextSlideIndex = this.currentIndex + 1;
-			if (nextSlideIndex < this.slides.length) {
-				return nextSlideIndex;
+			let direction;
+			if (this.currentIndex === 0 && index === this.slides.length - 1) { // first slide to last
+				direction = 'right';
+			} else if (this.currentIndex === this.slides.length - 1 && index === 0) { // last slide to first
+				direction = 'left';
+			} else if (index < this.currentIndex) {
+				direction = 'right';
+			} else if (index > this.currentIndex) {
+				direction = 'left';
 			}
-			return 0;
+			this.transitionName = `kv-slide-${direction}`;
+
+			// wait for the transition to be applied
+			this.$nextTick(() => {
+				this.intervalTimerCurrentTime = 0;
+				this.slides[this.currentIndex].hide();
+				this.currentIndex = index;
+				this.slides[this.currentIndex].show();
+
+				/**
+				 * The index of the slide that the carousel has changed to
+				 * @event change
+				 * @type {Event}
+				 */
+				this.$emit('change', this.currentIndex);
+			});
 		},
-		getPreviousIndex() {
-			const previousSlideIndex = this.currentIndex - 1;
-			if (previousSlideIndex >= 0) {
-				return previousSlideIndex;
-			}
-			return this.slides.length - 1;
-		}
 	}
 };
 </script>
 
 <style lang="scss" scoped>
-@import 'settings';
+@import "settings";
+
+$arrow-width: rem-calc(41);
+$arrow-margin: rem-calc(8);
+$circle-indicator-height: rem-calc(16);
+$circle-indicator-margin: rem-calc(8);
+$bar-indicator-height: rem-calc(4);
+$bar-indicator-margin: rem-calc(4);
 
 .kv-carousel {
 	position: relative;
+	display: flex;
 	overflow: hidden;
 	width: 100%;
-	height: 100%;
+	// you'll aways need to add either a height: 123px; or height: 0; padding-bottom: 123% when you put it on the page.
+
+	&__slides {
+		position: absolute;
+		top: 0;
+		right: #{$arrow-width + $arrow-margin};
+		bottom: #{$circle-indicator-height + $circle-indicator-margin * 2};
+		left: #{$arrow-width + $arrow-margin};
+		flex: 1;
+		background: green; // TODO: colors
+		overflow: hidden;
+	}
+
+	&__arrows {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: #{$circle-indicator-height + $circle-indicator-margin * 2};
+		right: 0;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		pointer-events: none;
+	}
+
+	&__arrows-btn {
+		background: $kiva-text-light;
+		border-radius: 50%;
+		width: $arrow-width;
+		height: $arrow-width;
+		padding: 0.75rem;
+		pointer-events: auto;
+
+		&--right {
+			transform: rotate(270deg);
+		}
+
+		&--left {
+			transform: rotate(90deg);
+		}
+
+		&:hover,
+		&:focus {
+			background: $dark-charcoal;
+		}
+	}
+
+	&__arrows-icon {
+		fill: #fff;
+	}
+
+	&__indicator {
+		position: absolute;
+		left: #{$arrow-width + $arrow-margin};
+		right: #{$arrow-width + $arrow-margin};
+		bottom: 0;
+		display: flex;
+		justify-content: center;
+		pointer-events: none;
+	}
+
+	&__indicator-btn {
+		margin: 0.5rem;
+		margin-left: 0;
+		width: 1rem;
+		height: 1rem;
+		border-radius: 50%;
+		background: $kiva-text-dark;
+		pointer-events: auto;
+		position: relative;
+		overflow: hidden;
+
+		&:hover,
+		&:focus {
+			background: yellow; // TODO: colors
+		}
+
+		&:first-child {
+			margin-left: 0;
+		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+
+		&--active {
+			background: orange; // TODO: colors
+
+			@keyframes scaleX {
+				0% {
+					transform: scaleX(0);
+				}
+
+				100% {
+					transform: scaleX(1);
+				}
+			}
+
+			&::after {
+				display: block;
+				content: '';
+				background: purple; // TODO: colors
+				width: 100%;
+				height: 100%;
+				transform-origin: left;
+				animation-name: scaleX;
+				animation-duration: var(--kv-carousel-autoplay-interval);
+				animation-play-state: paused;
+				animation-play-state: var(--kv-carousel-play-state, 'playing');
+				animation-timing-function: linear;
+			}
+		}
+	}
+
+	// carousel modifiers
+	&--controls-inside {
+		.kv-carousel__slides {
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+		}
+
+		.kv-carousel__arrows {
+			left: $arrow-margin;
+			right: $arrow-margin;
+			top: 0;
+			bottom: 0;
+		}
+
+		.kv-carousel__indicator {
+			left: 0;
+			right: 0;
+			z-index: 2;
+		}
+	}
+
+	&--hide-arrows {
+		.kv-carousel__arrows {
+			display: none;
+		}
+
+		.kv-carousel__slides,
+		.kv-carousel__indicator {
+			left: 0;
+			right: 0;
+		}
+	}
+
+	&--indicator-bar {
+		.kv-carousel__indicator {
+			top: 0;
+			bottom: initial;
+		}
+
+		.kv-carousel__indicator-btn {
+			height: $bar-indicator-height;
+			border-radius: 0;
+			width: auto;
+			flex: 1;
+			margin: 0 ($bar-indicator-margin / 2);
+
+			&:first-child {
+				margin-left: 0;
+			}
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
+
+		.kv-carousel__slides,
+		.kv-carousel__arrows {
+			top: $bar-indicator-height + $bar-indicator-margin;
+			bottom: 0;
+		}
+	}
+
+	&--indicator-none {
+		.kv-carousel__indicator {
+			display: none;
+		}
+
+		.kv-carousel__slides,
+		.kv-carousel__arrows {
+			bottom: 0;
+		}
+	}
 }
 </style>

--- a/src/components/Kv/KvCarouselSlide.vue
+++ b/src/components/Kv/KvCarouselSlide.vue
@@ -38,6 +38,7 @@ export default {
 	position: absolute;
 	left: 0;
 	top: 0;
-	width: 100%;
+	bottom: 0;
+	right: 0;
 }
 </style>


### PR DESCRIPTION
Most of the work done to make KvCarousel able to handle what's needed for the homepage redesign as well as other carousels Kiva has done in the past (homepage hero images, KivanSlider on holiday promo).

Still have some styling todos around colors and the arrow btns but don't want to hold up Eddie. I also don't love the way the transitions are handled right with scoped slots, may work on that more tomorrow. Lotta position absolutes, wish I could use grid.

Right now none of the other implementations of KvCarousel are live so this shouldn't break anything.

@eddieferrer There's a storybook story "loanCardExample", with an idea around how to show the loans. The text above the slider isn't part of this component, but you should be able to build that using the change event on the carousel. 
![image](https://user-images.githubusercontent.com/187937/88741968-cb06b200-d0f5-11ea-92df-ac4ba4fa4967.png)
