### PR TITLE
CategoryGrid Vue Warn Fix

### DIFF
--- a/src/components/Homepage/CategoryGrid.vue
+++ b/src/components/Homepage/CategoryGrid.vue
@@ -85,6 +85,11 @@ export default {
 		KvResponsiveImage,
 	},
 	inject: ['apollo'],
+	data() {
+		return {
+			loanChannels: []
+		};
+	},
 	apollo: {
 		query: categoryRowsQuery,
 		preFetch: true,


### PR DESCRIPTION
* Fixed - [Vue warn]: Property or method "loanChannels" is not defined on the instance but referenced during render.