### PR TITLE
lend by category homepage loan not donation flourish z-index update

### DIFF
--- a/src/pages/Homepage/LendByCategoryHomepage.vue
+++ b/src/pages/Homepage/LendByCategoryHomepage.vue
@@ -394,6 +394,7 @@ export default {
 		top: 0;
 		left: -3%;
 		pointer-events: none;
+		z-index: -1;
 
 		@include breakpoint(large) {
 			left: 0;


### PR DESCRIPTION
Found a small overlap issue on specific screen size. Added a z-index to the loans-not-donation__flourish and fixed it up. 

**Before fix:** 
![Screen Shot 2020-07-30 at 11 04 49 AM](https://user-images.githubusercontent.com/1521381/88959355-b5f56480-d256-11ea-988c-25134b30fd44.png)


**After fix:**
![Screen Shot 2020-07-30 at 11 14 14 AM](https://user-images.githubusercontent.com/1521381/88959371-bdb50900-d256-11ea-93de-1b80eb478717.png)

