### PR TITLE
get started redirect link fix and message centering using foundation align-self-middle class

### DIFF
--- a/src/pages/Homepage/LendByCategoryHomepage.vue
+++ b/src/pages/Homepage/LendByCategoryHomepage.vue
@@ -5,7 +5,7 @@
 				<div class="small-12 large-6 columns">
 					carousel here
 				</div>
-				<div class="small-12 large-6 columns">
+				<div class="small-12 large-6 align-self-middle columns">
 					<h1 class="featured-loans__header">
 						Make a loan, <br class="so mo"> change a life.
 					</h1>
@@ -14,7 +14,7 @@
 						dreams by crowdfunding loans and unlocking capital.
 						<router-link
 							class="show-for-large featured-loans__body-link"
-							href="/lend-by-category"
+							:to="'/lend-by-category'"
 							v-kv-track-event="[
 								'homepage',
 								'click-Get started',


### PR DESCRIPTION
PR addressing these concerns: 
- this is causing an error. Should be:
:to="'/lend-by-category'" 
- The design calls for this text to be vertically centered in the section.
     - I've added the [foundation class](https://get.foundation/sites/docs/flex-grid.html#vertical-alignment-of-child-columns-individually-) .align-self-middle, which once the carousel has a height, it should correctly vertically center the text as the design shows. 