### PR TITLE
GROW-131 Prefetch Categories And Small CSS fix

### DIFF
--- a/src/components/Homepage/LendByCategory/LoanCategoriesSection.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategoriesSection.vue
@@ -49,6 +49,7 @@ import numeral from 'numeral';
 
 import cookieStore from '@/util/cookieStore';
 import { readJSONSetting } from '@/util/settingsUtils';
+import logReadQueryError from '@/util/logReadQueryError';
 
 import lendByCategoryHomepageCategories from '@/graphql/query/lendByCategoryHomepageCategories.graphql';
 import loanChannelInfoQuery from '@/graphql/query/loanChannelInfo.graphql';
@@ -64,7 +65,6 @@ export default {
 		KvLoadingSpinner,
 		KvButton
 	},
-	inject: ['apollo'],
 	data() {
 		return {
 			categoryIds: [52, 96, 93, 89, 87], // fallback category ids
@@ -76,6 +76,23 @@ export default {
 			scrollPos: 0,
 			categoriesLoaded: false,
 		};
+	},
+	inject: ['apollo'],
+	apollo: {
+		preFetch(config, client) {
+			// Get the experiment object from settings with category ids
+			return client.query({
+				query: lendByCategoryHomepageCategories
+			}).then(({ data }) => {
+				// Get the array of channel objects from settings,
+				const categorySettingsArray = readJSONSetting(data, 'general.homepage_category_rows.value');
+				if (categorySettingsArray) {
+					// if successful set to categoryIds
+					const categoryIds = categorySettingsArray.map(setting => setting.id);
+					return client.query({ query: loanChannelInfoQuery, variables: { ids: categoryIds } });
+				}
+			});
+		},
 	},
 	computed: {
 		allFetchedLoanIds() {
@@ -213,30 +230,40 @@ export default {
 			});
 		}
 	},
-	mounted() {
-		// TODO
-		// Get these queries in preFetch without causing an invariant error.
-		this.apollo.query({
-			query: lendByCategoryHomepageCategories,
-			variables: {
-				basketId: cookieStore.get('kvbskt'),
-			},
-		}).then(({ data }) => {
-			this.processData(data);
-		}).then(() => {
-			return this.apollo.query({
+	created() {
+		// Read the page data from the cache
+		let pageData = {};
+		try {
+			pageData = this.apollo.readQuery({
+				query: lendByCategoryHomepageCategories,
+				variables: {
+					basketId: cookieStore.get('kvbskt'),
+				},
+			});
+			this.processData(pageData);
+		} catch (e) {
+			logReadQueryError(e, 'LoanCategoriesSection lendByCategoryHomepageCategories');
+		}
+
+		// Read the loanChannel info from the cache
+		let categoryInfo = {};
+		try {
+			categoryInfo = this.apollo.readQuery({
 				query: loanChannelInfoQuery,
 				variables: {
 					ids: this.categoryIds,
 				},
 			});
-		}).then(({ data }) => {
-			this.prefetchedCategoryInfo = _get(data, 'lend.loanChannelsById') || [];
-			this.categoriesLoaded = true;
-			// set initial active category
-			this.setActiveCategory(this.categoryIds[0]);
-			this.activateWatchers();
-		});
+		} catch (e) {
+			logReadQueryError(e, 'LoanCategoriesSection loanChannelInfoQuery');
+		}
+		this.prefetchedCategoryInfo = _get(categoryInfo, 'lend.loanChannelsById') || [];
+		this.categoriesLoaded = true;
+	},
+	mounted() {
+		// set initial active category
+		this.setActiveCategory(this.categoryIds[0]);
+		this.activateWatchers();
 	},
 };
 

--- a/src/components/LoanCards/LendHomepageLoanCard.vue
+++ b/src/components/LoanCards/LendHomepageLoanCard.vue
@@ -240,6 +240,7 @@ $card-half-space: rem-calc(14/2);
 	&__borrower-info {
 		text-align: left;
 		margin: 0.65rem 0;
+		min-height: rem-calc(66);
 	}
 
 	&__fundraising-status {

--- a/src/pages/LandingPages/MGCovid19/MGCovidHero.vue
+++ b/src/pages/LandingPages/MGCovid19/MGCovidHero.vue
@@ -152,6 +152,8 @@ export default {
 				['wga retina', heroImagesRequire('./hero_3840x1480.jpg')],
 			],
 			expVideoActive: true,
+			isMonthlyGoodSubscriber: false,
+			covidLandingActive: false,
 		};
 	},
 	computed: {


### PR DESCRIPTION
* Fixed CSS of category loan carousel so that loans with 2 line info align with loans with 3 line borrower info
* Prefetch categories and category infor for category loan carousel
* Unrelated fix that was throwing a vue error

GROW-131