### PR TITLE
SUBS-313 Removes braintree checkout experiment code

### DIFF
--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -27,10 +27,6 @@ query initializeCheckout($basketId: String) {
 			value
 			key
 		}
-		braintreeDropInExperimentCheckout: uiExperimentSetting(key: "braintree_dropin_checkout") {
-			key
-			value
-		}
 	}
 	shop (basketId: $basketId) {
 		basket {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -171,7 +171,6 @@ import setupBasketForUserMutation from '@/graphql/mutation/shopSetupBasketForUse
 import validatePreCheckoutMutation from '@/graphql/mutation/shopValidatePreCheckout.graphql';
 import validationErrorsFragment from '@/graphql/fragments/checkoutValidationErrors.graphql';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
-import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 import checkoutUtils from '@/plugins/checkout-utils-mixin';
 import KvCheckoutSteps from '@/components/Kv/KvCheckoutSteps';
 import KivaCreditPayment from '@/components/Checkout/KivaCreditPayment';
@@ -279,9 +278,6 @@ export default {
 					return Promise.all([
 						client.query({ query: initializeCheckout, fetchPolicy: 'network-only' })
 					]);
-				})
-				.then(() => {
-					return client.query({ query: experimentQuery, variables: { id: 'braintree_dropin_checkout' } });
 				});
 		},
 		result({ data }) {
@@ -304,19 +300,10 @@ export default {
 			// general data
 			this.activeLoginDuration = parseInt(_get(data, 'general.activeLoginDuration.value'), 10) || 3600;
 
-			// Braintree drop-in UI data
-			//
-			// This experiment is for testing the Braintree Drop in UI.
-			// It should be removed when testing is complete.
-			// It is queried in initializeCheckout
-			const braintreeDropInExp = this.apollo.readFragment({
-				id: 'Experiment:braintree_dropin_checkout',
-				fragment: experimentVersionFragment,
-			}) || {};
-
-			// if experiment and feature flag are BOTH on, show UI
+			// Braintree drop-in UI
+			// if feature flag are in ON, show drop-in UI
 			const braintreeDropInFeatureFlag = _get(data, 'general.braintreeDropInFeature.value') === 'true' || false;
-			this.showDropInPayments = braintreeDropInFeatureFlag && braintreeDropInExp.version === 'shown';
+			this.showDropInPayments = braintreeDropInFeatureFlag;
 		}
 	},
 	created() {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -241,7 +241,7 @@ export default {
 				'Payment',
 				'Thank You!'
 			],
-			showDropInPayments: false,
+			showDropInPayments: true,
 			userPrefContinueBrowsing: false,
 			addToBasketRedirectExperimentShown: false,
 		};


### PR DESCRIPTION
Will remove setting from env's after this gets pushed to production. We should NOT merge this in for the hotfix, while low risk, theres no need to get it.