### PR TITLE
Additional Storybook enhancements

### DIFF
--- a/.storybook/mixins/apollo-story-mixin.js
+++ b/.storybook/mixins/apollo-story-mixin.js
@@ -17,7 +17,7 @@ export default {
 			},
 			readFragment() {
 				return {}
-			}
+			},
 		},
 	}
 };

--- a/.storybook/mock-data/loan-channels-data-mock.js
+++ b/.storybook/mock-data/loan-channels-data-mock.js
@@ -1,0 +1,40 @@
+/** Mock Data
+* Array of loan channel data
+*/
+export default [
+	{
+		"id": 52,
+		"name": "Loans to women",
+		"description": "Women around the world have less access to fair credit—while 46% of men have access to formal financial services, only 27% women do. Support women starting businesses, going to school, leading their communities and building strong families.",
+		"url": "https://dev-vm-01.kiva.org/lend/loans-to-women",
+		"__typename": "LoanChannel"
+	},
+	{
+		"id": 96,
+		"name": "Covid-19",
+		"description": "People across the world are economically impacted by the COVID-19 Coronavirus pandemic. Funding these loans will provide a financial safety net during an uncertain time, in addition to leading borrowers on a path to recovery.",
+		"url": "https://dev-vm-01.kiva.org/lend/covid-19",
+		"__typename": "LoanChannel"
+	},
+	{
+		"id": 93,
+		"name": "Shelter loans",
+		"description": "Help borrowers create safe and stable homes for their families.",
+		"url": "https://dev-vm-01.kiva.org/lend/shelter-loans",
+		"__typename": "LoanChannel"
+	},
+	{
+		"id": 89,
+		"name": "Arts loans",
+		"description": "With your support, artisans can buy more materials, grow their businesses and preserve local traditions.",
+		"url": "https://dev-vm-01.kiva.org/lend/arts-loans",
+		"__typename": "LoanChannel"
+	},
+	{
+		"id": 87,
+		"name": "Agriculture loans",
+		"description": "Farmers face many challenges like unpredictable weather and market prices, and are often forced to choose between investing in their crops and fulfilling basic needs for their families. Your support keeps their crops growing and their livelihoods stable.",
+		"url": "https://dev-vm-01.kiva.org/lend/agriculture-loans",
+		"__typename": "LoanChannel"
+	}
+]

--- a/.storybook/mock-data/loan-data-mock.js
+++ b/.storybook/mock-data/loan-data-mock.js
@@ -1,3 +1,6 @@
+/** Mock Data
+* Array of 3 distinct loans
+*/
 export default [
 		{
 			"id": 1975833,

--- a/.storybook/mock-data/receipt-data-mock.js
+++ b/.storybook/mock-data/receipt-data-mock.js
@@ -1,329 +1,302 @@
-// https://api-vm.kiva.org/graphqlgraphql?user_id=1003394&app_id=org.kiva.www&query=query%20checkoutReceipt%20%7B%20%0A%09shop%20%7B%0A%09%09receipt(checkoutId%3A%2038663432)%20%7B%0A%09%09%09credits%20%7B%0A%09%09%09%09values%20%7B%0A%09%09%09%09%09creditType%0A%09%09%09%09%09amount%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%09totals%20%7B%0A%20%20%20%20%20%20%20%20bonusAppliedTotal%0A%09%09%09%09itemTotal%0A%09%09%09%09donationTotal%0A%09%09%09%09kivaCardTotal%0A%09%09%09%09depositTotals%20%7B%0A%09%09%09%09%09depositTotal%0A%09%09%09%09%09kivaCreditAdded%0A%09%09%09%09%09kivaCreditUsed%0A%09%09%09%09%7D%0A%20%20%20%20%20%20%20%20freeTrialAppliedTotal%0A%09%09%09%09kivaCreditAppliedTotal%0A%20%20%20%20%20%20%20%20redemptionCodeAppliedTotal%0A%20%20%20%20%20%20%20%20universalCodeAppliedTotal%0A%09%09%09%7D%0A%09%09%09hasFreeCredits%0A%09%09%09items%20%7B%0A%09%09%09%09totalCount%0A%09%09%09%09values%20%7B%0A%09%09%09%09%09id%0A%09%09%09%09%09price%0A%09%09%09%09%09basketItemType%0A%09%09%09%09%09...%20on%20KivaCard%20%7B%0A%09%09%09%09%09%09individualPrice%0A%09%09%09%09%09%09basketItemType%0A%09%09%09%09%09%09kivaCardObject%20%7B%0A%09%09%09%09%09%09%09deliveryType%0A%09%09%09%09%09%09%09mailingInfo%20%7B%0A%09%09%09%09%09%09%09%09firstName%0A%09%09%09%09%09%09%09%09lastName%0A%09%09%09%09%09%09%09%09address%0A%09%09%09%09%09%09%09%09address2%0A%09%09%09%09%09%09%09%09city%0A%09%09%09%09%09%09%09%09state%0A%09%09%09%09%09%09%09%09zip%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09recipient%20%7B%0A%09%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09%09email%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%09...%20on%20LoanReservation%20%7B%0A%09%09%09%09%09%09loan%20%7B%0A%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09id%0A%09%09%09%09%09%09%09image%20%7B%0A%09%09%09%09%09%09%09%09url%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09use%0A%09%09%09%09%09%09%09geocode%20%7B%0A%09%09%09%09%09%09%09%09city%0A%09%09%09%09%09%09%09%09country%20%7B%0A%09%09%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%7D%0A%09%7D%0A%09my%20%7B%0A%09%09userAccount%20%7B%0A%09%09%09firstName%0A%09%09%09lastName%0A%09%09%09email%0A%09%09%7D%0A%09%7D%0A%7D%0A&operationName=checkoutReceipt
+/** Mock Data
+* A receipt object
+*/
 export default {
-	"data": {
-		"shop": {
-			"receipt": {
-				"transactionTime" : "2020-01-30T00:52:31Z",
-				"credits": {
-					"values": [
-						{
-							"creditType": "kiva_credit",
-							"amount": null
-						}
-					]
-				},
-				"totals": {
-					"itemTotal": "960.25",
-					"donationTotal": "125.25",
-					"kivaCardTotal": "710.00",
-					"depositTotals": {
-						"depositTotal": "960.25",
-						"kivaCreditAdded": "0.00",
-						"kivaCreditUsed": "0.00"
-					},
-					"kivaCreditAppliedTotal": "960.25"
-				},
-				"hasFreeCredits": false,
-				"items": {
-					"totalCount": 11,
-					"values": [
-						{
-							"id": 1911067,
-							"price": "25.00",
-							"basketItemType": "loan_reservation",
-							"creditsUsed": [
-								{
-									"amount": "25.00"
-								}
-							],
-							"loan": {
-								"name": "Alan",
-								"id": 1911067,
-								"image": {
-									"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/5e041e655faa305c49c13505d1c17cba.jpg"
-								},
-								"use": "to expand her business by purchasing more stock such as seed and manure for the expansion of her vegetable garden.",
-								"geocode": {
-									"city": "Chienge",
-									"country": {
-										"name": "Zambia"
-									}
-								}
-							}
-						},
-						{
-							"id": 1908530,
-							"price": "25.00",
-							"basketItemType": "loan_reservation",
-							"creditsUsed": [
-								{
-									"amount": "25.00"
-								}
-							],
-							"loan": {
-								"name": "Alan",
-								"id": 1908530,
-								"image": {
-									"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/da9ac74228e39e15cc198f8165e68c20.jpg"
-								},
-								"use": "to buy taro roots (seedlings), banana tubers (seedlings), chemicals, a bag back sprayer, and a chainsaw.",
-								"geocode": {
-									"city": "Vaiafai Savaii",
-									"country": {
-										"name": "Samoa"
-									}
-								}
-							}
-						},
-						{
-							"id": 1907517,
-							"price": "25.00",
-							"basketItemType": "loan_reservation",
-							"creditsUsed": [
-								{
-									"amount": "25.00"
-								}
-							],
-							"loan": {
-								"name": "Barrio Concepcion Group",
-								"id": 1907517,
-								"image": {
-									"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/213d4f59069e192a2a4b9ee1fb56b649.jpg"
-								},
-								"use": "to buy a stove with a grill, kitchen utensils, corn and firewood.",
-								"geocode": {
-									"city": "Retalhuleu",
-									"country": {
-										"name": "Guatemala"
-									}
-								}
-							}
-						},
-						{
-							"id": 1909791,
-							"price": "25.00",
-							"basketItemType": "loan_reservation",
-							"creditsUsed": [
-								{
-									"amount": "25.00"
-								}
-							],
-							"loan": {
-								"name": "Alan",
-								"id": 1909791,
-								"image": {
-									"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/26e15431f51b540f31cd9f011cc54f31.jpg"
-								},
-								"use": "to buy farming inputs and improve her production in 2020 for an increased income.",
-								"geocode": {
-									"city": "Kitale",
-									"country": {
-										"name": "Kenya"
-									}
-								}
-							}
-						},
-						{
-							"id": 1906824,
-							"price": "25.00",
-							"basketItemType": "loan_reservation",
-							"creditsUsed": [
-								{
-									"amount": "25.00"
-								}
-							],
-							"loan": {
-								"name": "Las Victoriosas Group",
-								"id": 1906824,
-								"image": {
-									"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/26342071330beb8309d17a5d262da2dd.jpg"
-								},
-								"use": "to buy used clothing for men, women and children in specific sizes.",
-								"geocode": {
-									"city": "Chimaltenango",
-									"country": {
-										"name": "Guatemala"
-									}
-								}
-							}
-						},
-						{
-							"id": 2118024,
-							"price": "30.00",
-							"basketItemType": "kiva_card",
-							"creditsUsed": [
-								{
-									"amount": "30.00"
-								}
-							],
-							"individualPrice": "30.00",
-							"kivaCardObject": {
-								"redemptionCode": "ABCDEFH123456789",
-								"deliveryType": "email",
-								"mailingInfo": {
-									"firstName": null,
-									"lastName": null,
-									"address": null,
-									"address2": null,
-									"city": null,
-									"state": null,
-									"zip": null
-								},
-								"recipient": {
-									"name": "Jane Doe eMail",
-									"email": "test@kiva.org"
-								}
-							}
-						},
-						{
-							"id": 2118025,
-							"price": "30.00",
-							"basketItemType": "kiva_card",
-							"creditsUsed": [
-								{
-									"amount": "30.00"
-								}
-							],
-							"individualPrice": "30.00",
-							"kivaCardObject": {
-								"redemptionCode": "ABCDEFH123456789",
-								"deliveryType": "email",
-								"mailingInfo": {
-									"firstName": null,
-									"lastName": null,
-									"address": null,
-									"address2": null,
-									"city": null,
-									"state": null,
-									"zip": null
-								},
-								"recipient": {
-									"name": "Jane Doe eMail",
-									"email": "test+123@kiva.org"
-								}
-							}
-						},
-						{
-							"id": 2118026,
-							"price": "150.00",
-							"basketItemType": "kiva_card",
-							"creditsUsed": [
-								{
-									"amount": "150.00"
-								}
-							],
-							"individualPrice": "150.00",
-							"kivaCardObject": {
-								"redemptionCode": "ABCDEFH123456789",
-								"deliveryType": "print",
-								"mailingInfo": {
-									"firstName": null,
-									"lastName": null,
-									"address": null,
-									"address2": null,
-									"city": null,
-									"state": null,
-									"zip": null
-								},
-								"recipient": {
-									"name": "Jane Doe Print",
-									"email": null
-								}
-							}
-						},
-						{
-							"id": 2118027,
-							"price": "250.00",
-							"basketItemType": "kiva_card",
-							"creditsUsed": [
-								{
-									"amount": "250.00"
-								}
-							],
-							"individualPrice": "250.00",
-							"kivaCardObject": {
-								"redemptionCode": "ABCDEFH123456789",
-								"deliveryType": "postal",
-								"mailingInfo": {
-									"firstName": "John",
-									"lastName": "Doe",
-									"address": "555 Sw 5th St",
-									"address2": "Apt. C",
-									"city": "Washington",
-									"state": "DC",
-									"zip": "55555"
-								},
-								"recipient": {
-									"name": "Jane Doe",
-									"email": null
-								}
-							}
-						},
-						{
-							"id": 2118028,
-							"price": "250.00",
-							"basketItemType": "kiva_card",
-							"creditsUsed": [
-								{
-									"amount": "250.00"
-								}
-							],
-							"individualPrice": "250.00",
-							"kivaCardObject": {
-								"redemptionCode": "ABCDEFH123456789",
-								"deliveryType": "postal",
-								"mailingInfo": {
-									"firstName": "John",
-									"lastName": "Doe",
-									"address": "555 Sw 5th St",
-									"address2": "Apt. C",
-									"city": "Washington",
-									"state": "DC",
-									"zip": "55555"
-								},
-								"recipient": {
-									"name": "Jane Doe",
-									"email": null
-								}
-							}
-						},
-						{
-							"id": 48417665,
-							"price": "125.25",
-							"basketItemType": "donation",
-							"creditsUsed": [
-								{
-									"amount": "125.25"
-								}
-							]
-						}
-					]
-				}
+	"transactionTime" : "2020-01-30T00:52:31Z",
+	"credits": {
+		"values": [
+			{
+				"creditType": "kiva_credit",
+				"amount": null
 			}
+		]
+	},
+	"totals": {
+		"itemTotal": "960.25",
+		"donationTotal": "125.25",
+		"kivaCardTotal": "710.00",
+		"depositTotals": {
+			"depositTotal": "960.25",
+			"kivaCreditAdded": "0.00",
+			"kivaCreditUsed": "0.00"
 		},
-		"my": {
-			"teams": {
-				"values": [
+		"kivaCreditAppliedTotal": "960.25"
+	},
+	"hasFreeCredits": false,
+	"items": {
+		"totalCount": 11,
+		"values": [
+			{
+				"id": 1911067,
+				"price": "25.00",
+				"basketItemType": "loan_reservation",
+				"creditsUsed": [
 					{
-						"team": {
-							"teamPublicId": 'SRT',
-							"name": "Staff Reserve Team"
-						}
+						"amount": "25.00"
+					}
+				],
+				"loan": {
+					"name": "Alan",
+					"id": 1911067,
+					"image": {
+						"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/5e041e655faa305c49c13505d1c17cba.jpg"
 					},
-					{
-						"team": {
-							"teamPublicId": 'testteam23',
-							"name": "TestTeam23"
+					"use": "to expand her business by purchasing more stock such as seed and manure for the expansion of her vegetable garden.",
+					"geocode": {
+						"city": "Chienge",
+						"country": {
+							"name": "Zambia"
 						}
 					}
-				]
+				}
 			},
-			"userAccount": {
-				"firstName": "Alan",
-				"lastName": "Smithee",
-				"email": "user_1003394@braincrave.org",
-				"inviterName": "alans"
+			{
+				"id": 1908530,
+				"price": "25.00",
+				"basketItemType": "loan_reservation",
+				"creditsUsed": [
+					{
+						"amount": "25.00"
+					}
+				],
+				"loan": {
+					"name": "Alan",
+					"id": 1908530,
+					"image": {
+						"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/da9ac74228e39e15cc198f8165e68c20.jpg"
+					},
+					"use": "to buy taro roots (seedlings), banana tubers (seedlings), chemicals, a bag back sprayer, and a chainsaw.",
+					"geocode": {
+						"city": "Vaiafai Savaii",
+						"country": {
+							"name": "Samoa"
+						}
+					}
+				}
+			},
+			{
+				"id": 1907517,
+				"price": "25.00",
+				"basketItemType": "loan_reservation",
+				"creditsUsed": [
+					{
+						"amount": "25.00"
+					}
+				],
+				"loan": {
+					"name": "Barrio Concepcion Group",
+					"id": 1907517,
+					"image": {
+						"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/213d4f59069e192a2a4b9ee1fb56b649.jpg"
+					},
+					"use": "to buy a stove with a grill, kitchen utensils, corn and firewood.",
+					"geocode": {
+						"city": "Retalhuleu",
+						"country": {
+							"name": "Guatemala"
+						}
+					}
+				}
+			},
+			{
+				"id": 1909791,
+				"price": "25.00",
+				"basketItemType": "loan_reservation",
+				"creditsUsed": [
+					{
+						"amount": "25.00"
+					}
+				],
+				"loan": {
+					"name": "Alan",
+					"id": 1909791,
+					"image": {
+						"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/26e15431f51b540f31cd9f011cc54f31.jpg"
+					},
+					"use": "to buy farming inputs and improve her production in 2020 for an increased income.",
+					"geocode": {
+						"city": "Kitale",
+						"country": {
+							"name": "Kenya"
+						}
+					}
+				}
+			},
+			{
+				"id": 1906824,
+				"price": "25.00",
+				"basketItemType": "loan_reservation",
+				"creditsUsed": [
+					{
+						"amount": "25.00"
+					}
+				],
+				"loan": {
+					"name": "Las Victoriosas Group",
+					"id": 1906824,
+					"image": {
+						"url": "https://www-dev-kiva-org.global.ssl.fastly.net/img/s100/26342071330beb8309d17a5d262da2dd.jpg"
+					},
+					"use": "to buy used clothing for men, women and children in specific sizes.",
+					"geocode": {
+						"city": "Chimaltenango",
+						"country": {
+							"name": "Guatemala"
+						}
+					}
+				}
+			},
+			{
+				"id": 2118024,
+				"price": "30.00",
+				"basketItemType": "kiva_card",
+				"creditsUsed": [
+					{
+						"amount": "30.00"
+					}
+				],
+				"individualPrice": "30.00",
+				"kivaCardObject": {
+					"redemptionCode": "ABCDEFH123456789",
+					"deliveryType": "email",
+					"mailingInfo": {
+						"firstName": null,
+						"lastName": null,
+						"address": null,
+						"address2": null,
+						"city": null,
+						"state": null,
+						"zip": null
+					},
+					"recipient": {
+						"name": "Jane Doe eMail",
+						"email": "test@kiva.org"
+					}
+				}
+			},
+			{
+				"id": 2118025,
+				"price": "30.00",
+				"basketItemType": "kiva_card",
+				"creditsUsed": [
+					{
+						"amount": "30.00"
+					}
+				],
+				"individualPrice": "30.00",
+				"kivaCardObject": {
+					"redemptionCode": "ABCDEFH123456789",
+					"deliveryType": "email",
+					"mailingInfo": {
+						"firstName": null,
+						"lastName": null,
+						"address": null,
+						"address2": null,
+						"city": null,
+						"state": null,
+						"zip": null
+					},
+					"recipient": {
+						"name": "Jane Doe eMail",
+						"email": "test+123@kiva.org"
+					}
+				}
+			},
+			{
+				"id": 2118026,
+				"price": "150.00",
+				"basketItemType": "kiva_card",
+				"creditsUsed": [
+					{
+						"amount": "150.00"
+					}
+				],
+				"individualPrice": "150.00",
+				"kivaCardObject": {
+					"redemptionCode": "ABCDEFH123456789",
+					"deliveryType": "print",
+					"mailingInfo": {
+						"firstName": null,
+						"lastName": null,
+						"address": null,
+						"address2": null,
+						"city": null,
+						"state": null,
+						"zip": null
+					},
+					"recipient": {
+						"name": "Jane Doe Print",
+						"email": null
+					}
+				}
+			},
+			{
+				"id": 2118027,
+				"price": "250.00",
+				"basketItemType": "kiva_card",
+				"creditsUsed": [
+					{
+						"amount": "250.00"
+					}
+				],
+				"individualPrice": "250.00",
+				"kivaCardObject": {
+					"redemptionCode": "ABCDEFH123456789",
+					"deliveryType": "postal",
+					"mailingInfo": {
+						"firstName": "John",
+						"lastName": "Doe",
+						"address": "555 Sw 5th St",
+						"address2": "Apt. C",
+						"city": "Washington",
+						"state": "DC",
+						"zip": "55555"
+					},
+					"recipient": {
+						"name": "Jane Doe",
+						"email": null
+					}
+				}
+			},
+			{
+				"id": 2118028,
+				"price": "250.00",
+				"basketItemType": "kiva_card",
+				"creditsUsed": [
+					{
+						"amount": "250.00"
+					}
+				],
+				"individualPrice": "250.00",
+				"kivaCardObject": {
+					"redemptionCode": "ABCDEFH123456789",
+					"deliveryType": "postal",
+					"mailingInfo": {
+						"firstName": "John",
+						"lastName": "Doe",
+						"address": "555 Sw 5th St",
+						"address2": "Apt. C",
+						"city": "Washington",
+						"state": "DC",
+						"zip": "55555"
+					},
+					"recipient": {
+						"name": "Jane Doe",
+						"email": null
+					}
+				}
+			},
+			{
+				"id": 48417665,
+				"price": "125.25",
+				"basketItemType": "donation",
+				"creditsUsed": [
+					{
+						"amount": "125.25"
+					}
+				]
 			}
-		}
+		]
 	}
 };
+

--- a/.storybook/stories/CheckoutReceipt.stories.js
+++ b/.storybook/stories/CheckoutReceipt.stories.js
@@ -2,6 +2,19 @@ import StoryRouter from 'storybook-vue-router';
 import CheckoutReceipt from '@/components/Checkout/CheckoutReceipt';
 import mockedReceiptData from '../mock-data/receipt-data-mock';
 
+// https://api-vm.kiva.org/graphqlgraphql?user_id=1003394&app_id=org.kiva.www&query=query%20checkoutReceipt%20%7B%20%0A%09shop%20%7B%0A%09%09receipt(checkoutId%3A%2038663432)%20%7B%0A%09%09%09credits%20%7B%0A%09%09%09%09values%20%7B%0A%09%09%09%09%09creditType%0A%09%09%09%09%09amount%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%09totals%20%7B%0A%20%20%20%20%20%20%20%20bonusAppliedTotal%0A%09%09%09%09itemTotal%0A%09%09%09%09donationTotal%0A%09%09%09%09kivaCardTotal%0A%09%09%09%09depositTotals%20%7B%0A%09%09%09%09%09depositTotal%0A%09%09%09%09%09kivaCreditAdded%0A%09%09%09%09%09kivaCreditUsed%0A%09%09%09%09%7D%0A%20%20%20%20%20%20%20%20freeTrialAppliedTotal%0A%09%09%09%09kivaCreditAppliedTotal%0A%20%20%20%20%20%20%20%20redemptionCodeAppliedTotal%0A%20%20%20%20%20%20%20%20universalCodeAppliedTotal%0A%09%09%09%7D%0A%09%09%09hasFreeCredits%0A%09%09%09items%20%7B%0A%09%09%09%09totalCount%0A%09%09%09%09values%20%7B%0A%09%09%09%09%09id%0A%09%09%09%09%09price%0A%09%09%09%09%09basketItemType%0A%09%09%09%09%09...%20on%20KivaCard%20%7B%0A%09%09%09%09%09%09individualPrice%0A%09%09%09%09%09%09basketItemType%0A%09%09%09%09%09%09kivaCardObject%20%7B%0A%09%09%09%09%09%09%09deliveryType%0A%09%09%09%09%09%09%09mailingInfo%20%7B%0A%09%09%09%09%09%09%09%09firstName%0A%09%09%09%09%09%09%09%09lastName%0A%09%09%09%09%09%09%09%09address%0A%09%09%09%09%09%09%09%09address2%0A%09%09%09%09%09%09%09%09city%0A%09%09%09%09%09%09%09%09state%0A%09%09%09%09%09%09%09%09zip%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09recipient%20%7B%0A%09%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09%09email%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%09...%20on%20LoanReservation%20%7B%0A%09%09%09%09%09%09loan%20%7B%0A%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09id%0A%09%09%09%09%09%09%09image%20%7B%0A%09%09%09%09%09%09%09%09url%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09use%0A%09%09%09%09%09%09%09geocode%20%7B%0A%09%09%09%09%09%09%09%09city%0A%09%09%09%09%09%09%09%09country%20%7B%0A%09%09%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%7D%0A%09%7D%0A%09my%20%7B%0A%09%09userAccount%20%7B%0A%09%09%09firstName%0A%09%09%09lastName%0A%09%09%09email%0A%09%09%7D%0A%09%7D%0A%7D%0A&operationName=checkoutReceipt
+const mockedAPIResponse = {
+	"data": {
+		"my": {
+			"userAccount": {
+				"firstName": "Alan",
+				"lastName": "Smithee",
+				"email": "user_1003394@braincrave.org",
+				"inviterName": "alans"
+			}
+		}
+	}
+}
 export default {
 	title: 'Components/CheckoutReceipt',
 	component: CheckoutReceipt,
@@ -22,13 +35,13 @@ export const Default = () => ({
 		lender: {
 			type: Object,
 			default() {
-				return mockedReceiptData.data.my.userAccount
+				return mockedAPIResponse.data.my.userAccount
 			}
 		},
 		receipt: {
 			type: Object,
 			default() {
-				return mockedReceiptData.data.shop.receipt
+				return mockedReceiptData
 			}
 		}
 	},

--- a/.storybook/stories/LendByCategoryHomepage.stories.js
+++ b/.storybook/stories/LendByCategoryHomepage.stories.js
@@ -7,7 +7,8 @@ Vue.use(kivaPlugins)
 import StoryRouter from 'storybook-vue-router';
 import LendByCategoryHomepage from '@/pages/Homepage/LendByCategoryHomepage';
 import apolloStoryMixin from '../mixins/apollo-story-mixin';
-import { returnArrayOfLoans } from '../utils';
+import { mockLoansArray } from '../utils';
+import mockedLoanChannelsData from '../mock-data/loan-channels-data-mock';
 
 const mockedAPIResponse = {
 	data: {
@@ -18,43 +19,7 @@ const mockedAPIResponse = {
 			}
 		},
 		lend: {
-			loanChannelsById:[
-				{
-					"id": 52,
-					"name": "Loans to women",
-					"description": "Women around the world have less access to fair credit—while 46% of men have access to formal financial services, only 27% women do. Support women starting businesses, going to school, leading their communities and building strong families.",
-					"url": "https://dev-vm-01.kiva.org/lend/loans-to-women",
-					"__typename": "LoanChannel"
-				},
-				{
-					"id": 96,
-					"name": "Covid-19",
-					"description": "People across the world are economically impacted by the COVID-19 Coronavirus pandemic. Funding these loans will provide a financial safety net during an uncertain time, in addition to leading borrowers on a path to recovery.",
-					"url": "https://dev-vm-01.kiva.org/lend/covid-19",
-					"__typename": "LoanChannel"
-				},
-				{
-					"id": 93,
-					"name": "Shelter loans",
-					"description": "Help borrowers create safe and stable homes for their families.",
-					"url": "https://dev-vm-01.kiva.org/lend/shelter-loans",
-					"__typename": "LoanChannel"
-				},
-				{
-					"id": 89,
-					"name": "Arts loans",
-					"description": "With your support, artisans can buy more materials, grow their businesses and preserve local traditions.",
-					"url": "https://dev-vm-01.kiva.org/lend/arts-loans",
-					"__typename": "LoanChannel"
-				},
-				{
-					"id": 87,
-					"name": "Agriculture loans",
-					"description": "Farmers face many challenges like unpredictable weather and market prices, and are often forced to choose between investing in their crops and fulfilling basic needs for their families. Your support keeps their crops growing and their livelihoods stable.",
-					"url": "https://dev-vm-01.kiva.org/lend/agriculture-loans",
-					"__typename": "LoanChannel"
-				}
-			]
+			loanChannelsById: mockedLoanChannelsData
 		},
 	}
 }
@@ -75,11 +40,10 @@ export const Default = () => ({
 				return mockedAPIResponse.data;
 			},
 			query(params) {
-				console.log(params);
-				if (params.variables && params.variables.ids) {
+				if (params.variables && params.variables.ids && params.variables.numberOfLoans) {
 					const mockedLoanChannel = mockedAPIResponse.data.lend.loanChannelsById.find(channel => channel.id === params.variables.ids[0]);
 					mockedLoanChannel.loans = {
-						values:  returnArrayOfLoans(params.variables.numberOfLoans),
+						values:  mockLoansArray(params.variables.numberOfLoans),
 					};
 					return Promise.resolve({
 						data: {
@@ -93,11 +57,6 @@ export const Default = () => ({
 					});
 				}
 				return Promise.resolve(mockedAPIResponse);
-			},
-			watchQuery() {
-				return {
-					subscribe() {}
-				}
 			},
 		},
 	},

--- a/.storybook/stories/LendHomepageLoanCard.stories.js
+++ b/.storybook/stories/LendHomepageLoanCard.stories.js
@@ -69,7 +69,7 @@ export const Default = () => ({
 			return {
 				maxWidth: '476px',
 			}
-		}
+		},
 	},
 	template: `
 		<div :style="styling">
@@ -85,6 +85,12 @@ export const Default = () => ({
 				:loan="loan"
 				:percent-raised="percentRaised"
 			/>
+			<component is="style">
+				.lend-homepage-loan-card {
+					border-radius: 0.65rem;
+					box-shadow: 0 0.65rem 0.875rem 0.4375rem hsla(0,0%,60%,.1);
+				}
+   			 </component>
 		</div>
 	`,
 });

--- a/.storybook/stories/LendHomepageLoanCard.stories.js
+++ b/.storybook/stories/LendHomepageLoanCard.stories.js
@@ -74,6 +74,7 @@ export const Default = () => ({
 	template: `
 		<div :style="styling">
 			<lend-homepage-loan-card
+				class="lend-homepage-loan-card"
 				:amount-left="amountLeft"
 				:expiring-soon-message="expiringSoonMessage"
 				:is-expired="isExpired"

--- a/.storybook/stories/SocialShare.stories.js
+++ b/.storybook/stories/SocialShare.stories.js
@@ -1,6 +1,37 @@
 import SocialShare from '@/components/Checkout/SocialShare';
 import StoryRouter from 'storybook-vue-router';
 import mockedReceiptData from '../mock-data/receipt-data-mock';
+import apolloStoryMixin from '../mixins/apollo-story-mixin';
+
+// https://api-vm.kiva.org/graphqlgraphql?user_id=1003394&app_id=org.kiva.www&query=query%20checkoutReceipt%20%7B%20%0A%09shop%20%7B%0A%09%09receipt(checkoutId%3A%2038663432)%20%7B%0A%09%09%09credits%20%7B%0A%09%09%09%09values%20%7B%0A%09%09%09%09%09creditType%0A%09%09%09%09%09amount%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%09totals%20%7B%0A%20%20%20%20%20%20%20%20bonusAppliedTotal%0A%09%09%09%09itemTotal%0A%09%09%09%09donationTotal%0A%09%09%09%09kivaCardTotal%0A%09%09%09%09depositTotals%20%7B%0A%09%09%09%09%09depositTotal%0A%09%09%09%09%09kivaCreditAdded%0A%09%09%09%09%09kivaCreditUsed%0A%09%09%09%09%7D%0A%20%20%20%20%20%20%20%20freeTrialAppliedTotal%0A%09%09%09%09kivaCreditAppliedTotal%0A%20%20%20%20%20%20%20%20redemptionCodeAppliedTotal%0A%20%20%20%20%20%20%20%20universalCodeAppliedTotal%0A%09%09%09%7D%0A%09%09%09hasFreeCredits%0A%09%09%09items%20%7B%0A%09%09%09%09totalCount%0A%09%09%09%09values%20%7B%0A%09%09%09%09%09id%0A%09%09%09%09%09price%0A%09%09%09%09%09basketItemType%0A%09%09%09%09%09...%20on%20KivaCard%20%7B%0A%09%09%09%09%09%09individualPrice%0A%09%09%09%09%09%09basketItemType%0A%09%09%09%09%09%09kivaCardObject%20%7B%0A%09%09%09%09%09%09%09deliveryType%0A%09%09%09%09%09%09%09mailingInfo%20%7B%0A%09%09%09%09%09%09%09%09firstName%0A%09%09%09%09%09%09%09%09lastName%0A%09%09%09%09%09%09%09%09address%0A%09%09%09%09%09%09%09%09address2%0A%09%09%09%09%09%09%09%09city%0A%09%09%09%09%09%09%09%09state%0A%09%09%09%09%09%09%09%09zip%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09recipient%20%7B%0A%09%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09%09email%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%09...%20on%20LoanReservation%20%7B%0A%09%09%09%09%09%09loan%20%7B%0A%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09id%0A%09%09%09%09%09%09%09image%20%7B%0A%09%09%09%09%09%09%09%09url%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09use%0A%09%09%09%09%09%09%09geocode%20%7B%0A%09%09%09%09%09%09%09%09city%0A%09%09%09%09%09%09%09%09country%20%7B%0A%09%09%09%09%09%09%09%09%09name%0A%09%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%09%7D%0A%09%09%09%09%09%09%7D%0A%09%09%09%09%09%7D%0A%09%09%09%09%7D%0A%09%09%09%7D%0A%09%09%7D%0A%09%7D%0A%09my%20%7B%0A%09%09userAccount%20%7B%0A%09%09%09firstName%0A%09%09%09lastName%0A%09%09%09email%0A%09%09%7D%0A%09%7D%0A%7D%0A&operationName=checkoutReceipt
+const mockedAPIResponse = {
+	"data": {
+		"my": {
+			"teams": {
+				"values": [
+					{
+						"team": {
+							"teamPublicId": 'SRT',
+							"name": "Staff Reserve Team"
+						}
+					},
+					{
+						"team": {
+							"teamPublicId": 'testteam23',
+							"name": "TestTeam23"
+						}
+					}
+				]
+			},
+			"userAccount": {
+				"firstName": "Alan",
+				"lastName": "Smithee",
+				"email": "user_1003394@braincrave.org",
+				"inviterName": "alans"
+			}
+		}
+	}
+}
 
 export default {
 	title: 'Components/SocialShare',
@@ -9,6 +40,7 @@ export default {
 };
 
 export const Default = () => ({
+	mixins: [apolloStoryMixin],
 	components: {
 		SocialShare,
 	},
@@ -18,27 +50,20 @@ export const Default = () => ({
 			:loans="loans"
 		/>
 	`,
-	provide: {
-		apollo: {
-			mutate() {
-				return Promise.resolve();
-			},
-		},
-	},
 	props: {
 		lender: {
 			type: Object,
 			default() {
 				return {
-					...mockedReceiptData.data.my.userAccount,
-					teams: mockedReceiptData.data.my.teams.values.map(value => value.team)
+					...mockedAPIResponse.data.my.userAccount,
+					teams: mockedAPIResponse.data.my.teams.values.map(value => value.team)
 				};
 			}
 		},
 		loans: {
 			type: Array,
 			default() {
-				return mockedReceiptData.data.shop.receipt.items.values
+				return mockedReceiptData.items.values
 					.filter(item => item.basketItemType === 'loan_reservation')
 					.map(item => item.loan);
 			}

--- a/.storybook/utils.js
+++ b/.storybook/utils.js
@@ -6,7 +6,7 @@ import loanData from './mock-data/loan-data-mock';
  * @param {number} length
  * @returns {array}
  */
-export function returnArrayOfLoans (length) {
+export function mockLoansArray (length) {
 	// returns an array of length filled with loanData
 	return [].concat(...Array(length).fill(loanData))
 }


### PR DESCRIPTION
Some functional improvements to mocking data. 

My thinking is that we can mock objects/arrays of data in the mock-data folder. Instead of mocking entire API responses.  We can then reuse these across different stories for different needs. 

For example, we can use these objects to mock apollo response. Like `.storybook/stories/LendByCategoryHomepage.stories.js`

Or we can use them to mock props, like in: `.storybook/stories/CheckoutReceipt.stories.js`

We can also then write any logic to process the data in the stories themselves or in utility functions such as the `arrayOfLoans` functions or the apollo mocks in `.storybook/stories/LendByCategoryHomepage.stories.js`
