### PR TITLE
GROW-203 Experiment to change checkout steps and login button text

### DIFF
--- a/src/util/experimentPreFetch.js
+++ b/src/util/experimentPreFetch.js
@@ -15,6 +15,7 @@ let activeExperiments = [
 	'expandable_loan_cards',
 	'intercom_messenger',
 	'add_to_basket_redirect',
+	'checkout_login_cta',
 ];
 
 // TODO: Enhance Error handling


### PR DESCRIPTION
https://kiva.atlassian.net/browse/GROW-203

I've already added the `uiexp.checkout_login_cta` setting to Dev, QA, Stage, and Prod. In Dev and QA it is enabled and set to 100% `b`. In Stage it is enabled and set to 100% `a` to avoid messing with any automation tests. In Prod it is not enabled and is set to 50% `a` and 50% `b`, meaning that it will have to be enabled once the code is deployed and the experiment is ready to launch.

The changes to the login method require https://github.com/kiva/auth0/pull/185

@ryan-ludwig could you please take care of making any requested changes to these PRs and getting them merged?