### PR TITLE
SUBS-373 MG Update Payment Method

### DIFF
--- a/src/components/Forms/MonthlyGoodUpdateForm.vue
+++ b/src/components/Forms/MonthlyGoodUpdateForm.vue
@@ -46,102 +46,108 @@
 					</small>
 				</div>
 			</div>
+			<div class="middle-wrapper">
+				<div class="row align-middle">
+					<div class="columns">
+						<span>
+							Deposit for lending
+						</span>
+					</div>
+
+					<div class="small-6 medium-4 columns">
+						<label
+							class="show-for-sr"
+							:class="{ 'error': $v.form.mgAmount.$invalid }"
+							for="amount"
+						>
+							Amount
+						</label>
+						<kv-currency-input
+							class="text-input"
+							id="amount"
+							v-model="form.mgAmount"
+						/>
+					</div>
+				</div>
+				<div class="row columns align-middle">
+					<ul class="text-right validation-errors" v-if="$v.form.mgAmount.$invalid">
+						<li v-if="!$v.form.mgAmount.required">
+							Field is required
+						</li>
+						<li v-if="!$v.form.mgAmount.minValue || !$v.form.mgAmount.maxValue">
+							Enter an amount of $5-$10,000
+						</li>
+					</ul>
+				</div>
+				<div class="row align-middle">
+					<div class="columns">
+						<span>
+							Optional donation to support Kiva
+						</span>
+					</div>
+
+					<div class="small-6 medium-4 columns">
+						<label
+							class="show-for-sr"
+							:class="{ 'error': $v.form.donation.$invalid }"
+							for="amount"
+						>
+							Donation
+						</label>
+						<kv-currency-input
+							class="text-input"
+							id="donation"
+							v-model="form.donation"
+						/>
+					</div>
+				</div>
+				<div class="row column align-middle">
+					<ul class="text-right validation-errors" v-if="$v.form.donation.$invalid">
+						<li v-if="!$v.form.donation.minValue || !$v.form.donation.maxValue">
+							Enter an amount of $0-$10,000
+						</li>
+					</ul>
+				</div>
+				<div class="row">
+					<div class="columns">
+						<strong>Total/month</strong>
+					</div>
+
+					<div class="small-6 medium-4 columns">
+						<strong
+							class="additional-left-pad-currency"
+						>{{ totalCombinedDeposit | numeral('$0,0.00') }}</strong>
+					</div>
+				</div>
+				<div class="row column">
+					<ul class="text-center validation-errors"
+						v-if="!$v.form.mgAmount.maxTotal || !$v.form.donation.maxTotal"
+					>
+						<li>
+							The maximum Monthly Good total is $10,000.<br>
+							Please try again by entering in a smaller amount.
+						</li>
+					</ul>
+				</div>
+			</div>
 			<div class="row align-middle">
-				<div class="columns">
-					<span>
-						Deposit for lending
-					</span>
+				<div class="column">
+					<strong>Your contribution will:</strong>
 				</div>
-
-				<div class="small-6 medium-4 columns">
-					<label
-						class="show-for-sr"
-						:class="{ 'error': $v.form.mgAmount.$invalid }"
-						for="amount"
+				<div class="column">
+					<kv-dropdown-rounded
+						v-model="form.category"
+						class="group-dropdown"
 					>
-						Amount
-					</label>
-					<kv-currency-input
-						class="text-input"
-						id="amount"
-						v-model="form.mgAmount"
-					/>
+						<option
+							v-for="(option, index) in lendingCategories"
+							:value="option.value"
+							:key="index"
+						>
+							{{ option.label }}
+						</option>
+					</kv-dropdown-rounded>
 				</div>
-			</div>
-			<div class="row columns align-middle">
-				<ul class="text-right validation-errors" v-if="$v.form.mgAmount.$invalid">
-					<li v-if="!$v.form.mgAmount.required">
-						Field is required
-					</li>
-					<li v-if="!$v.form.mgAmount.minValue || !$v.form.mgAmount.maxValue">
-						Enter an amount of $5-$10,000
-					</li>
-				</ul>
-			</div>
-			<div class="row align-middle">
-				<div class="columns">
-					<span>
-						Optional donation to support Kiva
-					</span>
-				</div>
-
-				<div class="small-6 medium-4 columns">
-					<label
-						class="show-for-sr"
-						:class="{ 'error': $v.form.donation.$invalid }"
-						for="amount"
-					>
-						Donation
-					</label>
-					<kv-currency-input
-						class="text-input"
-						id="donation"
-						v-model="form.donation"
-					/>
-				</div>
-			</div>
-			<div class="row column align-middle">
-				<ul class="text-right validation-errors" v-if="$v.form.donation.$invalid">
-					<li v-if="!$v.form.donation.minValue || !$v.form.donation.maxValue">
-						Enter an amount of $0-$10,000
-					</li>
-				</ul>
-			</div>
-			<div class="row">
-				<div class="columns">
-					<strong>Total/month</strong>
-				</div>
-
-				<div class="small-6 medium-4 columns">
-					<strong
-						class="additional-left-pad-currency"
-					>{{ totalCombinedDeposit | numeral('$0,0.00') }}</strong>
-				</div>
-			</div>
-			<div class="row column">
-				<ul class="text-center validation-errors"
-					v-if="!$v.form.mgAmount.maxTotal || !$v.form.donation.maxTotal"
-				>
-					<li>
-						The maximum Monthly Good total is $10,000.<br>
-						Please try again by entering in a smaller amount.
-					</li>
-				</ul>
-			</div>
-			<div class="row column text-center">
-				Select a category to focus your lending
-				<kv-dropdown-rounded
-					v-model="form.category"
-					class="group-dropdown"
-				>
-					<option
-						v-for="(option, index) in lendingCategories"
-						:value="option.value"
-						:key="index"
-					>
-						{{ option.label }}
-					</option>
-				</kv-dropdown-rounded>
 			</div>
 		</fieldset>
 	</form>
@@ -294,8 +300,6 @@ export default {
 @import 'settings';
 
 form {
-	margin: 1rem 0;
-
 	.row {
 		margin-bottom: 0.25em;
 	}
@@ -358,6 +362,16 @@ form {
 
 	::v-deep .dropdown-wrapper.group-dropdown .dropdown {
 		margin-top: 0.65rem;
+		margin-bottom: 0;
+	}
+
+	.middle-wrapper {
+		padding-left: 2rem;
+		padding-right: 2rem;
+	}
+
+	.group-dropdown {
+		margin-right: 2rem;
 	}
 }
 </style>

--- a/src/components/MonthlyGood/MonthlyGoodDropInPaymentWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodDropInPaymentWrapper.vue
@@ -66,6 +66,14 @@ export default {
 		isOneTime: {
 			type: Boolean,
 			default: false
+		},
+		/**
+		 * Context that this payment wrapper is used in:
+		 * Must be one of 2 strings 'Registration' or 'Update'
+		* */
+		action: {
+			type: String,
+			default: 'Registration'
 		}
 	},
 	data() {
@@ -124,7 +132,7 @@ export default {
 					this.$showTipMsg(standardError, 'error');
 
 					// Fire specific exception to Snowplow
-					this.$kvTrackEvent('Registration', 'DropIn Payment Error', `${errorCode}: ${errorMessage}`);
+					this.$kvTrackEvent(this.action, 'DropIn Payment Error', `${errorCode}: ${errorMessage}`);
 
 					// exit
 					return kivaBraintreeResponse;
@@ -135,13 +143,13 @@ export default {
 					kivaBraintreeResponse,
 					'data.my.createMonthlyGoodSubscription'
 				);
-				// redirect to thanks with KIVA transaction id
+
 				if (subscriptionCreatedSuccessfully) {
 					// fire BT Success event
 					this.$kvTrackEvent(
-						'Registration',
+						this.action,
 						`${paymentType} Braintree DropIn Subscription Payment`,
-						'register-monthly-good-submit'
+						`${this.action.toLowerCase()}-monthly-good-submit`
 					);
 
 					// Complete transaction handles additional analytics + redirect

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -304,6 +304,7 @@ export default {
 	.advanced-options-toggle {
 		color: $kiva-textlink;
 		font-weight: 300;
+		padding: 0.5rem;
 	}
 }
 

--- a/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
+++ b/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
@@ -263,13 +263,6 @@ export default {
 			this.showDropInPaymentUpdate = braintreeDropInFeatureFlag && braintreeDropInExp.version === 'shown';
 		},
 	},
-	mounted() {
-		// Check route params (string) for payment method reset case
-		if (this.$route.query.updatePayment === 'true' && this.showDropInPaymentUpdate) {
-			this.settingsOpen = false;
-			this.showLightbox = true;
-		}
-	},
 	computed: {
 		selectedGroupDescriptor() {
 			const selectedCategory = this.lendingCategories.find(category => category.value === this.category);


### PR DESCRIPTION
* Adds ability to modify MG payment method.

![Screen Shot 2020-08-24 at 3 10 34 PM](https://user-images.githubusercontent.com/4371888/91101472-fd83cc00-e61b-11ea-9a9b-cc1c39d8e8f6.png)
![Screen Shot 2020-08-24 at 3 05 04 PM](https://user-images.githubusercontent.com/4371888/91101535-260bc600-e61c-11ea-979c-9d3e5cd240d6.png)


**Behavior**

For users who are not opted in to experiment:
Current behavior, minor styling updates on form

Users opted in:

- If user has a BT vaulted card, they will see current payment method and link to update payment method which will take them to the drop in screen to update. On clicking confirm a new MG subscription will be created with new payment method. 

- If user has legacy paypal agreement. They will not see current payment method details, but will see update payment method link. On clicking this link, and going through the drop in interface, they will cancel their paypal auto deposit and create a new one with braintree. 

~~If a user's card expires and they're MG becomes inactive, they will see the same interface, as if they were active. If they are taken to the drop in via the updatePayment=true link, presumably the braintree drop in will handle creating a new MG subscription with a valid payment method.~~

Possible improvements:
- Change behavior to modify autodeposit instead of recreate
- Display messaging or indicator for inactive/expired, etc subscriptions?