### PR TITLE
SUBS-489 Removed setting braintree_dropin_mg_update

### DIFF
--- a/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
+++ b/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
@@ -166,9 +166,6 @@ import gql from 'graphql-tag';
 
 import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
 
-import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
-import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
-
 import KvButton from '@/components/Kv/KvButton';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvLightbox from '@/components/Kv/KvLightbox';
@@ -200,10 +197,6 @@ const pageQuery = gql`query monthlyGoodSubscription {
 			value
 			key
 		}
-		uiExperimentSetting(key: "braintree_dropin_mg_update") {
-			key
-			value
-		}
 	}
 }`;
 
@@ -231,7 +224,7 @@ export default {
 			settingsOpen: true, // if settingsOpen is false, payment update section is shown
 			isChanged: false,
 			isFormValid: true,
-			showDropInPaymentUpdate: false,
+			showDropInPaymentUpdate: true,
 		};
 	},
 	mixins: [
@@ -239,15 +232,7 @@ export default {
 	],
 	apollo: {
 		query: pageQuery,
-		preFetch(config, client) {
-			return client.query({
-				query: pageQuery
-			}).then(() => {
-				return client.query({
-					query: experimentAssignmentQuery, variables: { id: 'braintree_dropin_mg_update' }
-				});
-			});
-		},
+		preFetch: true,
 		result({ data }) {
 			this.isMonthlyGoodSubscriber = _get(data, 'my.autoDeposit.isSubscriber', false);
 			if (this.isMonthlyGoodSubscriber) {
@@ -259,15 +244,9 @@ export default {
 				this.paymentMethod = _get(data, 'my.autoDeposit.paymentMethod', {});
 			}
 
-			// Braintree drop-in UI data
-			const braintreeDropInExp = this.apollo.readFragment({
-				id: 'Experiment:braintree_dropin_mg_update',
-				fragment: experimentVersionFragment,
-			}) || {};
-
 			// if experiment and feature flag are BOTH on, show UI
 			const braintreeDropInFeatureFlag = _get(data, 'general.braintreeDropInFeature.value') === 'true' || false;
-			this.showDropInPaymentUpdate = braintreeDropInFeatureFlag && braintreeDropInExp.version === 'shown';
+			this.showDropInPaymentUpdate = braintreeDropInFeatureFlag;
 		},
 	},
 	computed: {


### PR DESCRIPTION
Removed setting based toggle for mg_update

This was flipped on this release to 100%. Assuming there are no issues, we can remove this for next release. I will remove the setting from admin at that point. 