### PR TITLE
VUE-405 giant flag fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19109,7 +19109,7 @@
 			}
 		},
 		"flag-icon-css": {
-			"version": "github:kiva/flag-icon-css#021ea59466146a2005bea5c5586a3568d602cd77",
+			"version": "github:kiva/flag-icon-css#27aa8b90236e0860dc7ec2e63fc0f878bec60d9f",
 			"from": "github:kiva/flag-icon-css#sprite"
 		},
 		"flat-cache": {

--- a/src/pages/BorrowerProfile/fundedBorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/fundedBorrowerProfile.vue
@@ -33,7 +33,9 @@
 					<h1> {{ loan.name }} </h1>
 					<!-- Borrower location -->
 					<div>
-						<kv-flag class="loan-location-flag" :country="`${ loan.geocode.country.isoCode }`" />
+						<div class="loan-location-flag">
+							<kv-flag :country="`${ loan.geocode.country.isoCode }`" />
+						</div>
 						<span class="loan-location-text">
 							{{ loan.geocode.city }}, {{ loan.geocode.state }}, {{ loan.geocode.country.name }}
 							/ {{ loan.sector.name }}


### PR DESCRIPTION
On the funded loan page KvFlag's default 100% width was overriding the 1rem width set on the fundedBorrowerProfile.vue page.
The order the CSS is bundled can cause this. I feel like we don't usually see it in prod bundles though :/
![image](https://user-images.githubusercontent.com/187937/92339467-215aff00-f06b-11ea-83d7-0a255187142e.png)

I also noticed the country names in assistive text were coming in as undefined so fixed that in the flag-icon-css repo and bumped the package-lock here.