### PR TITLE
GROW-223: basket verification in new UI

### DIFF
--- a/src/components/Checkout/BasketVerification.vue
+++ b/src/components/Checkout/BasketVerification.vue
@@ -1,0 +1,16 @@
+<template>
+	<div>
+	</div>
+</template>
+
+<script>
+export default {
+	inject: ['apollo'],
+	data() {
+		return {
+		};
+	},
+	methods: {
+	},
+};
+</script>

--- a/src/components/Checkout/BasketVerification.vue
+++ b/src/components/Checkout/BasketVerification.vue
@@ -64,6 +64,7 @@ export default {
 		query: getVerificationState,
 		result({ data }) {
 			this.setState(data?.shop?.basketVerificationState || this.verificationState);
+			this.email = data?.my?.userAccount?.email || this.email || '';
 		},
 	},
 	computed: {
@@ -79,7 +80,6 @@ export default {
 		},
 		send() {
 			this.setState('pending');
-			// TODO: Set this.email!!!
 			this.apollo.mutate({ mutation: startBasketVerificationMutation });
 		},
 	},

--- a/src/components/Checkout/BasketVerification.vue
+++ b/src/components/Checkout/BasketVerification.vue
@@ -4,13 +4,33 @@
 </template>
 
 <script>
+import getVerificationState from '@/graphql/query/checkout/basketVerificationState.graphql';
+
 export default {
 	inject: ['apollo'],
 	data() {
 		return {
+			verificationState: '',
 		};
 	},
+	apollo: {
+		preFetch: true,
+		query: getVerificationState,
+		result({ data }) {
+			this.setState(data?.shop?.basketVerificationState || this.verificationState);
+		},
+	},
+	computed: {
+		verificationRequired() {
+			return this.verificationState === 'required' || this.verificationState === 'pending';
+		},
+	},
 	methods: {
+		setState(state) {
+			this.verificationState = state;
+			this.$emit('verification-state', this.verificationState);
+			this.$emit('verification-required', this.verificationRequired);
+		},
 	},
 };
 </script>

--- a/src/components/Checkout/BasketVerification.vue
+++ b/src/components/Checkout/BasketVerification.vue
@@ -1,15 +1,61 @@
 <template>
-	<div>
+	<!-- NB: Reusing .order-totals .forced-width styling. -->
+	<div class="basket-verification order-totals">
+		<div
+			v-if="verificationState === 'verified'"
+			class="verification-verified forced-width"
+		>
+			<div class="forced-width">
+				Basket Verified!
+			</div>
+		</div>
+
+		<kv-lightbox
+			:visible="verificationState === 'required'"
+			class="verification-required"
+			title="Verify your email"
+		>
+			<p>To ensure your safety, we added an extra layer of security.</p>
+			<p>Once we verify your account, you can continue checking out!</p>
+			<kv-button @click.native="send">
+				Send verification link
+			</kv-button>
+		</kv-lightbox>
+
+		<kv-lightbox
+			:visible="verificationState === 'pending'"
+			class="verification-pending"
+			title="Verification link sent"
+		>
+			<p>We sent a validation link <span v-if="email" class="email">to {{ email }}</span>.</p>
+			<p>After receiving the email, follow the link provided to continue checking out with your Kiva Credit.</p>
+			<kv-button @click.native="send">
+				Resend email
+			</kv-button>
+			<p>
+				<router-link to="/help/contact-us">
+					Need help? Contact us
+				</router-link>
+			</p>
+		</kv-lightbox>
 	</div>
 </template>
 
 <script>
+import KvButton from '@/components/Kv/KvButton';
+import KvLightbox from '@/components/Kv/KvLightbox';
 import getVerificationState from '@/graphql/query/checkout/basketVerificationState.graphql';
+import startBasketVerificationMutation from '@/graphql/mutation/checkout/startBasketVerification.graphql';
 
 export default {
+	components: {
+		KvButton,
+		KvLightbox,
+	},
 	inject: ['apollo'],
 	data() {
 		return {
+			email: '',
 			verificationState: '',
 		};
 	},
@@ -31,6 +77,22 @@ export default {
 			this.$emit('verification-state', this.verificationState);
 			this.$emit('verification-required', this.verificationRequired);
 		},
+		send() {
+			this.setState('pending');
+			// TODO: Set this.email!!!
+			this.apollo.mutate({ mutation: startBasketVerificationMutation });
+		},
 	},
 };
 </script>
+
+<style lang="scss" scoped>
+.verification-verified {
+	text-align: right;
+}
+
+.verification-pending,
+.verification-required {
+	text-align: center;
+}
+</style>

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -3,7 +3,7 @@
 		<div
 			v-show="isShown"
 			class="kv-lightbox-wrap"
-			:class="removeContentBg"
+			:class="{'inverted': inverted}"
 			ref="kvlightbox"
 			@keyup.esc="closeLightbox"
 			@click.stop.prevent="closeLightbox"
@@ -13,18 +13,21 @@
 			<focus-lock :disabled="!isShown">
 				<div
 					class="kv-lightbox"
-					:class="`${fullWidth ? 'full-width' : ''}`"
+					:class="{'full-width': fullWidth}"
 					role="document"
 				>
 					<div class="row lightbox-row">
 						<div class="columns lightbox-columns">
-							<!-- eslint-disable max-len -->
 							<div
 								class="lightbox-content"
-								:class="`${removeContentBg} ${noPaddingTop ? 'no-padding-top': ''} ${noPaddingBottom ? 'no-padding-bottom': ''} ${noPaddingSides ? 'no-padding-sides': ''}`"
+								:class="{
+									'inverted': inverted,
+									'no-padding-top': noPaddingTop,
+									'no-padding-bottom': noPaddingBottom,
+									'no-padding-sides': noPaddingSides,
+								}"
 								@click.stop
 							>
-								<!-- eslint-enable max-len -->
 								<h2 v-if="title"
 									class="lightbox-title"
 									id="lightbox-title"
@@ -99,11 +102,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-	},
-	computed: {
-		removeContentBg() {
-			return this.inverted ? 'inverted' : '';
-		}
 	},
 	watch: {
 		// Create and set our internal visibility property

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
@@ -69,8 +69,10 @@ export default {
 
 	width: $small-hover-card-width;
 	height: $small-hover-card-height;
+
 	// Re-enable to add card opacity transition
 	// transition: $hover-card-transition-transform, $hover-card-transition-opacity-out;
+
 	transition: $hover-card-transition-transform;
 
 	.hover-loan-card-image {

--- a/src/graphql/mutation/checkout/startBasketVerification.graphql
+++ b/src/graphql/mutation/checkout/startBasketVerification.graphql
@@ -1,0 +1,5 @@
+mutation startBasketVerification($basketId: String) {
+	shop (basketId: $basketId) {
+		startBasketVerification
+	}
+}

--- a/src/graphql/query/checkout/basketVerificationState.graphql
+++ b/src/graphql/query/checkout/basketVerificationState.graphql
@@ -1,0 +1,5 @@
+query basketVerificationState($basketId: String) {
+	shop (basketId: $basketId) {
+		basketVerificationState
+	}
+}

--- a/src/graphql/query/checkout/basketVerificationState.graphql
+++ b/src/graphql/query/checkout/basketVerificationState.graphql
@@ -2,4 +2,10 @@ query basketVerificationState($basketId: String) {
 	shop (basketId: $basketId) {
 		basketVerificationState
 	}
+	my {
+		userAccount {
+			id
+			email
+		}
+	}
 }

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -127,6 +127,7 @@ query initializeCheckout($basketId: String) {
 				...shopTotals
 			}
 		}
+		basketVerificationState
 		lendingRewardOffered
 	}
 }

--- a/src/graphql/query/checkout/shopBasketUpdate.graphql
+++ b/src/graphql/query/checkout/shopBasketUpdate.graphql
@@ -11,6 +11,7 @@ query shopBasketUpdate($basketId: String) {
 	}
 	shop (basketId: $basketId) {
 		nonTrivialItemCount
+		basketVerificationState
 		basket {
 			hasFreeCredits
 			credits {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -60,7 +60,7 @@
 						/>
 
 						<div class="checkout-actions row" :class="{'small-collapse' : showLoginContinueButton}">
-							<div v-if="isLoggedIn" class="small-12">
+							<div v-if="isLoggedIn && !verificationRequired" class="small-12">
 								<form v-if="showKivaCreditButton" action="/checkout" method="GET">
 									<input type="hidden" name="js_loaded" value="false">
 									<kiva-credit-payment
@@ -89,9 +89,8 @@
 								/>
 							</div>
 
-							<div v-else class="small-12">
+							<div v-else-if="!isActivelyLoggedIn && showLoginContinueButton" class="small-12">
 								<kv-button
-									v-if="!isActivelyLoggedIn && showLoginContinueButton"
 									class="checkout-button smallest"
 									id="login-to-continue-button"
 									v-kv-track-event="['basket', 'Login to Continue Button']"

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -55,6 +55,8 @@
 							@updating-totals="setUpdatingTotals"
 						/>
 
+						<basket-verification />
+
 						<div class="checkout-actions row" :class="{'small-collapse' : showLoginContinueButton}">
 							<div v-if="isLoggedIn" class="small-12">
 								<form v-if="showKivaCreditButton" action="/checkout" method="GET">
@@ -175,6 +177,7 @@ import KivaCreditPayment from '@/components/Checkout/KivaCreditPayment';
 import KvButton from '@/components/Kv/KvButton';
 import OrderTotals from '@/components/Checkout/OrderTotals';
 import BasketItemsList from '@/components/Checkout/BasketItemsList';
+import BasketVerification from '@/components/Checkout/BasketVerification';
 import KivaCardRedemption from '@/components/Checkout/KivaCardRedemption';
 import LoadingOverlay from '@/pages/Lend/LoadingOverlay';
 import KvLightbox from '@/components/Kv/KvLightbox';
@@ -194,6 +197,7 @@ export default {
 		KvLightbox,
 		OrderTotals,
 		BasketItemsList,
+		BasketVerification,
 		KivaCardRedemption,
 		LoadingOverlay,
 		CheckoutHolidayPromo,

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -55,7 +55,9 @@
 							@updating-totals="setUpdatingTotals"
 						/>
 
-						<basket-verification />
+						<basket-verification
+							@verification-required="verificationRequired = $event"
+						/>
 
 						<div class="checkout-actions row" :class="{'small-collapse' : showLoginContinueButton}">
 							<div v-if="isLoggedIn" class="small-12">
@@ -221,6 +223,7 @@ export default {
 			kivaCards: [],
 			redemption_credits: [],
 			hasFreeCredits: false,
+			verificationRequired: false,
 			totals: {},
 			updatingTotals: false,
 			showReg: true,


### PR DESCRIPTION
https://kiva.atlassian.net/browse/GROW-223

* Used the design and copy linked from the ticket.
* One thing I added is some text on the checkout page when the basket is verified. I'm not attached to this, but I found it helpful to differentiate the states.
* Another thing I implemented, which is not specified in the design, is hiding the checkout buttons (but not the login button) when verification is required, especially since the verification lightbox is dismissable. [GROW-243](https://kiva.atlassian.net/browse/GROW-243) tracks making verification block checkout on the backend.

<img width="1106" alt="verification-required" src="https://user-images.githubusercontent.com/234990/93011130-5d4d0300-f548-11ea-8b65-5149a6f8aa36.png">
<img width="991" alt="verification-pending" src="https://user-images.githubusercontent.com/234990/93011131-663dd480-f548-11ea-96a7-ead4a123c79b.png">
<img width="1146" alt="verification-verified" src="https://user-images.githubusercontent.com/234990/93011134-6ccc4c00-f548-11ea-818d-091bf31bc751.png">
