### PR TITLE
Stop passing route hashes as selectors unconditionally

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -4,12 +4,14 @@ import routes from './routes';
 
 Vue.use(Router);
 
+const DISALLOW_SELECTOR_REGEX = /[;=/]/;
+
 export default function createRouter() {
 	return new Router({
 		mode: 'history',
 		routes,
 		scrollBehavior(to, from, savedPosition) {
-			if (to.hash) {
+			if (to.hash && !DISALLOW_SELECTOR_REGEX.test(to.hash)) {
 				return { selector: to.hash };
 			}
 			if (savedPosition) {


### PR DESCRIPTION
Given our use of Auth0 and this scrollBehavior, we end up getting errors like:
```
	SyntaxError: Document.querySelector: '#access_token=...'
	SyntaxError: Document.querySelector: '#_=_' is not a valid selector
	SyntaxError: Document.querySelector: '#/login' is not a valid selector
	SyntaxError: Failed to execute 'querySelector' on 'Document': '#/' is not a valid selector.
```
This should fix those errors.