### PR TITLE
KvFlag expansion / specificity fix

### DIFF
--- a/src/components/Kv/KvFlag.vue
+++ b/src/components/Kv/KvFlag.vue
@@ -84,7 +84,6 @@ export default {
 @import 'settings';
 
 .kv-flag {
-	width: 100%;
 	border: 1px solid $kiva-bg-darkgray;
 
 	&__wrapper {


### PR DESCRIPTION
Width is set on the .wrapper one div deep, so we don't need it on the top level where it can cause problems.