### PR TITLE
Attempt to fix svg sprite loading in github pages

### DIFF
--- a/src/assets/iconLoader.js
+++ b/src/assets/iconLoader.js
@@ -2,5 +2,5 @@ import svgXhr from 'webpack-svgstore-plugin/src/helpers/svgxhr';
 
 // inject svg icons as a sprite sheet
 // eslint-disable-next-line no-underscore-dangle
-const __svgsprite__ = { path: './icons/sprite/*.svg', name: 'static/icons.[hash].svg' };
+const __svgsprite__ = { path: './icons/sprite/*.svg', name: './static/icons.[hash].svg' };
 svgXhr(__svgsprite__);


### PR DESCRIPTION
Works OK on my VM, and seemed like it works in my local storybook export. But... I feel like I've tried this before without success 🤔. May revert after github actions runs its thing post merge.