### PR TITLE
GROW-249 fix CORS headers for binary and wasm files

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -36,9 +36,9 @@ const port = argv.port || config.server.port;
 // Set sensible security headers for express
 app.use(helmet());
 
-// Set headers for fonts
+// Set headers for static files
 function setHeaders(res, path) {
-	if (path.indexOf('/fonts/') > -1) {
+	if (/\/fonts\/|\/binary\/|\/wasm\//.test(path)) {
 		res.header('Access-Control-Allow-Origin', '*');
 		res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
 	}


### PR DESCRIPTION
This is to fix these console errors on /15:
```
Access to fetch at 'https://www-dev-kiva-org.freetls.fastly.net/static/wasm/gkweb_bg.caff18f.wasm' from origin 'https://www.dev.kiva.org' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
```