### PR TITLE
Update flag-icon-css for IE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18834,7 +18834,7 @@
 			}
 		},
 		"flag-icon-css": {
-			"version": "github:kiva/flag-icon-css#27aa8b90236e0860dc7ec2e63fc0f878bec60d9f",
+			"version": "github:kiva/flag-icon-css#ef40e9a52246b15dd59b55409c55eb3edc72fb10",
 			"from": "github:kiva/flag-icon-css#sprite"
 		},
 		"flat-cache": {


### PR DESCRIPTION
This brings in this update: https://github.com/kiva/flag-icon-css/pull/2