### PR TITLE
VUE-431 Add ID field to every query that can have one

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,5 +89,6 @@ module.exports = {
 		'graphql/template-strings': ['warn', graphqlOptions],
 		'graphql/no-deprecated-fields': ['warn', graphqlOptions],
 		'graphql/named-operations': ['error', graphqlOptions],
+		'graphql/required-fields': ['error', { ...graphqlOptions, requiredFields: ['id', 'key'] }],
 	}
 }

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -32,8 +32,6 @@ export default function createApolloClient({
 			// Return a custom cache id for types that don't have an id field
 			dataIdFromObject: object => {
 				if (object.__typename === 'Setting' && object.key) return `Setting:${object.key}`;
-				if (object.__typename === 'Shop') return 'Shop';
-				if (object.__typename === 'ShopMutation') return 'ShopMutation';
 				return defaultDataIdFromObject(object);
 			},
 			// Use a simpler underlying cache for server renders

--- a/src/components/Homepage/LendByCategory/NoClickLoanCard.vue
+++ b/src/components/Homepage/LendByCategory/NoClickLoanCard.vue
@@ -81,6 +81,7 @@ const loanQuery = gql`query noClickLoanCard($channelId: Int!) {
 						}
 					}
 					image {
+						id
 						default: url(customSize: "w480h300")
 						retina: url(customSize: "w960h600")
 					}

--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -27,8 +27,10 @@ import LoanExpiredText from './LoanExpiredText';
 
 const freeCreditBasketCountQuery = gql`query hasFreeCreditsAndBasketCount($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		nonTrivialItemCount
 		basket {
+			id
 			hasFreeCredits
 		}
 	}

--- a/src/components/LoanCards/Buttons/LendButton2.vue
+++ b/src/components/LoanCards/Buttons/LendButton2.vue
@@ -104,6 +104,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation addToBasket($loanId: Int!, $price: Money!, $basketId: String) {
 					shop (basketId: $basketId) {
+						id
 						updateLoanReservation (loanReservation: {
 							id: $loanId
 							price: $price

--- a/src/components/LoanCards/RecommendedLoanCard.vue
+++ b/src/components/LoanCards/RecommendedLoanCard.vue
@@ -99,7 +99,9 @@ import WhySpecial from '@/components/LoanCards/WhySpecial';
 
 const loanQuery = gql`query recLoanCard($basketId: String, $loanId: Int!) {
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			# for isInBasket
 			items {
 				values {

--- a/src/graphql/.eslintrc.js
+++ b/src/graphql/.eslintrc.js
@@ -26,5 +26,6 @@ module.exports = {
 		'graphql/template-strings': ['warn', graphqlOptions],
 		'graphql/no-deprecated-fields': ['warn', graphqlOptions],
 		'graphql/named-operations': ['error', graphqlOptions],
+		'graphql/required-fields': ['error', { ...graphqlOptions, requiredFields: ['id', 'key'] }],
 	}
 }

--- a/src/graphql/fragments/checkoutValidationErrors.graphql
+++ b/src/graphql/fragments/checkoutValidationErrors.graphql
@@ -1,4 +1,5 @@
 fragment checkoutValidationErrors on ShopMutation {
+	id
 	validatePreCheckout {
 		error
 		success

--- a/src/graphql/mutation/autolending/updateServerProfile.graphql
+++ b/src/graphql/mutation/autolending/updateServerProfile.graphql
@@ -3,6 +3,7 @@
 mutation updateAutolendingProfile($profile: AutolendProfileUpdateInput!) {
 	my {
 		updateAutolendProfile(profile: $profile) {
+			id
 			...autolendProfileFragment
 		}
 	}

--- a/src/graphql/mutation/braintreeCreateAutoDepositSubscription.graphql
+++ b/src/graphql/mutation/braintreeCreateAutoDepositSubscription.graphql
@@ -8,7 +8,7 @@ mutation braintreeCreateAutoDepositSubscription($paymentMethodNonce: String!, $a
 				dayOfMonth: $dayOfMonth,
 			},
 			paymentMethodNonce:$paymentMethodNonce) {
-				amount donateAmount dayOfMonth status
+				id amount donateAmount dayOfMonth status
 			}
 	}
 }

--- a/src/graphql/mutation/braintreeDepositAndCheckout.graphql
+++ b/src/graphql/mutation/braintreeDepositAndCheckout.graphql
@@ -1,5 +1,6 @@
 mutation doNoncePaymentDepositAndCheckout($basketId: String, $amount: Money!, $nonce: String!, $savePaymentMethod: Boolean, $deviceData: String) {
 	shop (basketId: $basketId) {
+		id
 		doNoncePaymentDepositAndCheckout (amount: $amount, nonce: $nonce, savePaymentMethod: $savePaymentMethod, deviceData: $deviceData)
 	}
 }

--- a/src/graphql/mutation/checkout/startBasketVerification.graphql
+++ b/src/graphql/mutation/checkout/startBasketVerification.graphql
@@ -1,5 +1,6 @@
 mutation startBasketVerification($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		startBasketVerification
 	}
 }

--- a/src/graphql/mutation/depositAndCheckout.graphql
+++ b/src/graphql/mutation/depositAndCheckout.graphql
@@ -1,5 +1,6 @@
 mutation depositAndCheckout($amount: Money!, $token: String!, $payerId: String!, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		doPaymentDepositAndCheckout	(amount: $amount, token: $token, payerId: $payerId)
 	}
 }

--- a/src/graphql/mutation/shop/trackTransaction.graphql
+++ b/src/graphql/mutation/shop/trackTransaction.graphql
@@ -8,6 +8,7 @@ mutation trackTransaction(
 	$transactionId: Int!
 ) {
 	shop {
+		id
 		trackTransaction(
 			campaign: $campaign
 			campaignContent: $campaignContent

--- a/src/graphql/mutation/shopAddCreditByType.graphql
+++ b/src/graphql/mutation/shopAddCreditByType.graphql
@@ -1,5 +1,6 @@
 mutation addCreditByType($creditType: CreditTypeEnum!, $redemptionCode: String, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		addCreditByType	(creditType: $creditType, redemptionCode: $redemptionCode)
 	}
 }

--- a/src/graphql/mutation/shopAddOnePrintKivaCard.graphql
+++ b/src/graphql/mutation/shopAddOnePrintKivaCard.graphql
@@ -1,5 +1,6 @@
 mutation shopAddOnePrintKivaCard($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		addOnePrintKivaCard
 	}
 }

--- a/src/graphql/mutation/shopCheckout.graphql
+++ b/src/graphql/mutation/shopCheckout.graphql
@@ -1,5 +1,6 @@
 mutation checkout($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		checkout
 	}
 }

--- a/src/graphql/mutation/shopRemoveCreditByType.graphql
+++ b/src/graphql/mutation/shopRemoveCreditByType.graphql
@@ -1,5 +1,6 @@
 mutation removeCreditByType($creditType: CreditTypeEnum!, $creditId: Int, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		removeCreditByType	(creditType: $creditType, creditId: $creditId)
 	}
 }

--- a/src/graphql/mutation/shopSetupBasketForUser.graphql
+++ b/src/graphql/mutation/shopSetupBasketForUser.graphql
@@ -1,5 +1,6 @@
 mutation setupBasketForUser($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		setupBasketForUser
 	}
 }

--- a/src/graphql/mutation/shopValidateItemsAndCredits.graphql
+++ b/src/graphql/mutation/shopValidateItemsAndCredits.graphql
@@ -1,5 +1,6 @@
 mutation shopValidateItemsAndCredits($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		validateItemsAndCredits {
 			success
 			error

--- a/src/graphql/mutation/shopValidatePreCheckout.graphql
+++ b/src/graphql/mutation/shopValidatePreCheckout.graphql
@@ -1,5 +1,6 @@
 mutation validatePreCheckout($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		validatePreCheckout {
 			error
 			success

--- a/src/graphql/mutation/updateDonation.graphql
+++ b/src/graphql/mutation/updateDonation.graphql
@@ -1,5 +1,6 @@
 mutation updateDonation($price: Money!, $isTip: Boolean!, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		updateDonation (donation: {
 			price: $price,
 			isTip: $isTip

--- a/src/graphql/mutation/updateKivaCardAmount.graphql
+++ b/src/graphql/mutation/updateKivaCardAmount.graphql
@@ -1,5 +1,6 @@
 mutation updateKivaCardReservation($idsInGroup: [Int], $individualPrice: Money!, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		updateKivaCard (kivaCard: {
 			idsInGroup: $idsInGroup
 			individualPrice: $individualPrice

--- a/src/graphql/mutation/updateLoanReservation.graphql
+++ b/src/graphql/mutation/updateLoanReservation.graphql
@@ -1,5 +1,6 @@
 mutation updateLoanReservation($loanid: Int!, $price: Money!, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		updateLoanReservation (loanReservation: {
 			id: $loanid
 			price: $price

--- a/src/graphql/mutation/updateLoanReservationDonateRepayments.graphql
+++ b/src/graphql/mutation/updateLoanReservationDonateRepayments.graphql
@@ -1,5 +1,6 @@
 mutation updateLoanReservationDonateRepayments($loanid: Int!, $donateRepayments: Boolean, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		updateLoanReservationDonateRepayments (loanReservation: {
 			id: $loanid
 			donateRepayments: $donateRepayments

--- a/src/graphql/mutation/updateLoanReservationTeam.graphql
+++ b/src/graphql/mutation/updateLoanReservationTeam.graphql
@@ -1,5 +1,6 @@
 mutation updateLoanReservationTeam($loanid: Int!, $teamId: Int, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		updateLoanReservationTeam (loanReservation: {
 			id: $loanid
 			teamId: $teamId

--- a/src/graphql/query/appealBanner.graphql
+++ b/src/graphql/query/appealBanner.graphql
@@ -6,7 +6,9 @@ query appealBanner($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			hasFreeCredits
 			totals {
 				redemptionCodeAvailableTotal

--- a/src/graphql/query/autolending/bothProfiles.graphql
+++ b/src/graphql/query/autolending/bothProfiles.graphql
@@ -3,9 +3,11 @@
 query autolendingProfiles {
 	autolending @client {
 		currentProfile {
+			id
 			...autolendProfileFragment
 		}
 		savedProfile {
+			id
 			...autolendProfileFragment
 		}
 	}

--- a/src/graphql/query/autolending/countryList.graphql
+++ b/src/graphql/query/autolending/countryList.graphql
@@ -1,6 +1,7 @@
 query countryList {
 	autolending @client {
 		currentProfile {
+			id
 			loanSearchCriteria {
 				filters {
 					country

--- a/src/graphql/query/autolending/partnerList.graphql
+++ b/src/graphql/query/autolending/partnerList.graphql
@@ -1,6 +1,7 @@
 query partnerList {
 	autolending @client {
 		currentProfile {
+			id
 			loanSearchCriteria {
 				filters {
 					partner

--- a/src/graphql/query/autolending/profileFromServer.graphql
+++ b/src/graphql/query/autolending/profileFromServer.graphql
@@ -3,6 +3,7 @@
 query fullAutolendProfile {
 	my {
 		autolendProfile {
+			id
 			...autolendProfileFragment
 		}
 	}

--- a/src/graphql/query/autolending/sectorList.graphql
+++ b/src/graphql/query/autolending/sectorList.graphql
@@ -1,6 +1,7 @@
 query sectorList {
 	autolending @client {
 		currentProfile {
+			id
 			loanSearchCriteria {
 				filters {
 					sector

--- a/src/graphql/query/autolending/themeList.graphql
+++ b/src/graphql/query/autolending/themeList.graphql
@@ -1,6 +1,7 @@
 query themeList {
 	autolending @client {
 		currentProfile {
+			id
 			loanSearchCriteria {
 				filters {
 					theme
@@ -10,6 +11,7 @@ query themeList {
 	}
 	lend {
 		loanThemeFilter {
+			id
 			name
 		}
 	}

--- a/src/graphql/query/basicLoanData.graphql
+++ b/src/graphql/query/basicLoanData.graphql
@@ -15,6 +15,7 @@ query basicLoanData(
 			) {
 			totalCount
 			values {
+				id
 				...loanCardFields
 				image {
 					id

--- a/src/graphql/query/basketAddInterstitialData.graphql
+++ b/src/graphql/query/basketAddInterstitialData.graphql
@@ -6,7 +6,9 @@ query basketAddInterstitialData(
 	$imgRetinaSize: String = "w960h720",
 ) {
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				totalCount
 				values {
@@ -16,6 +18,7 @@ query basketAddInterstitialData(
 						expiryTime
 						isEndingSoon
 						loan {
+							id
 							...loanCardFields
 							image {
 								id

--- a/src/graphql/query/basketCount.graphql
+++ b/src/graphql/query/basketCount.graphql
@@ -1,5 +1,6 @@
 query basketCount($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		nonTrivialItemCount
 	}
 }

--- a/src/graphql/query/basketItems.graphql
+++ b/src/graphql/query/basketItems.graphql
@@ -2,7 +2,9 @@
 
 query basketItems($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/categoryRows.graphql
+++ b/src/graphql/query/categoryRows.graphql
@@ -6,9 +6,11 @@ query categoryRows {
 				url
 				name
 				image {
+					id
 					url (customSize: "w313h176")
 				}
 				retinaImage {
+					id
 					url (customSize: "w626h352")
 				}
 			}

--- a/src/graphql/query/checkout/basketVerificationState.graphql
+++ b/src/graphql/query/checkout/basketVerificationState.graphql
@@ -1,5 +1,6 @@
 query basketVerificationState($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		basketVerificationState
 	}
 	my {

--- a/src/graphql/query/checkout/checkoutSettings.graphql
+++ b/src/graphql/query/checkout/checkoutSettings.graphql
@@ -6,7 +6,9 @@ query checkoutSettings($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			hasFreeCredits
 		}
 		lendingRewardOffered

--- a/src/graphql/query/checkout/getClientToken.graphql
+++ b/src/graphql/query/checkout/getClientToken.graphql
@@ -1,5 +1,6 @@
 query getClientToken($useCustomerId: Boolean = false) {
 	shop {
+		id
 		getClientToken(useCustomerId: $useCustomerId)
 	}
 }

--- a/src/graphql/query/checkout/getPaymentToken.graphql
+++ b/src/graphql/query/checkout/getPaymentToken.graphql
@@ -1,5 +1,6 @@
 query getPaymentToken($amount: Money!) {
 	shop {
+		id
 		getPaymentToken(amount: $amount)
 	}
 }

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -10,6 +10,7 @@ query initializeCheckout($basketId: String) {
 			donateRepayments
 		}
 		lender {
+			id
 			teams(limit: 100){
 				values {
 					name
@@ -29,7 +30,9 @@ query initializeCheckout($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			hasFreeCredits
 			credits {
 				totalCount

--- a/src/graphql/query/checkout/shopBasketUpdate.graphql
+++ b/src/graphql/query/checkout/shopBasketUpdate.graphql
@@ -10,9 +10,11 @@ query shopBasketUpdate($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		nonTrivialItemCount
 		basketVerificationState
 		basket {
+			id
 			hasFreeCredits
 			credits {
 				totalCount

--- a/src/graphql/query/checkoutReceipt.graphql
+++ b/src/graphql/query/checkoutReceipt.graphql
@@ -1,9 +1,12 @@
 query checkoutReceipt($checkoutId: Int!) {
 	shop {
+		id
 		receipt(checkoutId: $checkoutId) {
+			id
 			transactionTime
 			credits {
 				values {
+					id
 					creditType
 					amount
 				}
@@ -56,6 +59,7 @@ query checkoutReceipt($checkoutId: Int!) {
 							name
 							id
 							image {
+								id
 								url
 							}
 							use
@@ -74,13 +78,16 @@ query checkoutReceipt($checkoutId: Int!) {
 	my {
 		teams {
 			values {
+				id
 				team {
+					id
 					teamPublicId
 					name
 				}
 			}
 		}
 		userAccount {
+			id
 			firstName
 			lastName
 			email

--- a/src/graphql/query/countriesNotLentTo.graphql
+++ b/src/graphql/query/countriesNotLentTo.graphql
@@ -10,6 +10,7 @@ query countriesNotLentTo {
 	}
 	my {
 		lendingStats {
+			id
 			countriesLentTo {
 				isoCode
 			}

--- a/src/graphql/query/featuredLoansData.graphql
+++ b/src/graphql/query/featuredLoansData.graphql
@@ -15,6 +15,7 @@ query featuredLoansData(
 			url
 			loans(limit: $numberOfLoans, offset: $offset, unique: true) {
 				values {
+					id
 					...loanCardFields
 					image {
 						id

--- a/src/graphql/query/fundedBorrowerProfile.graphql
+++ b/src/graphql/query/fundedBorrowerProfile.graphql
@@ -35,12 +35,15 @@ query fundedBorrowerProfile(
 			use
 			description
 			sector {
+				id
 				name
 			}
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/iwdLoanChannels.graphql
+++ b/src/graphql/query/iwdLoanChannels.graphql
@@ -9,9 +9,11 @@ query categoryRows(
 				name
       			url
 				image {
+					id
 					url (customSize: $imgDefaultSize)
 				}
 				retinaImage {
+					id
 					url (customSize: $imgRetinaSize)
 				}
 			}

--- a/src/graphql/query/lendByCategory/lendByCategory.graphql
+++ b/src/graphql/query/lendByCategory/lendByCategory.graphql
@@ -47,7 +47,9 @@ query lendByCategory($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/lendByCategory/recommendedLoans.graphql
+++ b/src/graphql/query/lendByCategory/recommendedLoans.graphql
@@ -14,6 +14,7 @@ query recommendedLoans(
 				id
 				loans(limit: $numberOfLoans, offset: $offset) {
 					values {
+						id
 						...loanCardFields
 						image {
 							id

--- a/src/graphql/query/lendByCategoryHomepageCategories.graphql
+++ b/src/graphql/query/lendByCategoryHomepageCategories.graphql
@@ -11,7 +11,9 @@ query lendByCategoryHomepageCategories($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/lendFilterPage.graphql
+++ b/src/graphql/query/lendFilterPage.graphql
@@ -5,7 +5,9 @@ query lendFilterPage($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/lendMenuData.graphql
+++ b/src/graphql/query/lendMenuData.graphql
@@ -2,6 +2,7 @@ query lendMenuData {
 	lend {
 		loanChannels(popular: true, applyMinLoanCount: true, limit: 50) {
 			values {
+				id
 				name
 				url
 			}

--- a/src/graphql/query/loanCardBasketed.graphql
+++ b/src/graphql/query/loanCardBasketed.graphql
@@ -1,7 +1,9 @@
 query loanCardBasketed($id: Int!, $basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		nonTrivialItemCount
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/loanCardData.graphql
+++ b/src/graphql/query/loanCardData.graphql
@@ -21,6 +21,7 @@ query loanCardData(
 			) {
 			totalCount
 			values {
+				id
 				...loanCardFields
 				image {
 					id
@@ -32,7 +33,9 @@ query loanCardData(
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/loanChannelData.graphql
+++ b/src/graphql/query/loanChannelData.graphql
@@ -15,6 +15,7 @@ query loanChannelData(
 			url
 			loans(limit: $numberOfLoans, unique: true, exclude_ids: $excludeIds) {
 				values {
+					id
 					...loanCardFields
 					image {
 						id

--- a/src/graphql/query/loanChannelDataExpanded.graphql
+++ b/src/graphql/query/loanChannelDataExpanded.graphql
@@ -24,6 +24,7 @@ query loanChannelDataExpanded (
 			) {
 				totalCount
 				values {
+					id
 					...loanCardFields
 					image {
 						id
@@ -35,7 +36,9 @@ query loanChannelDataExpanded (
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			items {
 				values {
 					id

--- a/src/graphql/query/loanDetails.graphql
+++ b/src/graphql/query/loanDetails.graphql
@@ -22,6 +22,7 @@ query loanDetails(
 				disbursalDate
 				partnerName
 				partner {
+					id
 					chargesFeesInterest
 					riskRating
 					currencyExchangeLossRate
@@ -36,7 +37,9 @@ query loanDetails(
 				disbursalDate
 				trusteeName
 				trustee {
+					id
 					stats {
+						id
 						numFundraisingLoans
 					}
 				}

--- a/src/graphql/query/loanPartner.graphql
+++ b/src/graphql/query/loanPartner.graphql
@@ -7,6 +7,7 @@ query loanPartnerTrustee(
 			name
 			... on LoanPartner {
 				partner {
+					id
 					avgBorrowerCost
 					avgBorrowerCostType
 					loansPosted
@@ -23,6 +24,7 @@ query loanPartnerTrustee(
 			... on LoanDirect {
 				endorsement
 				trustee {
+					id
 					organizationName
 					trusteeType
 					contactRecord {
@@ -30,6 +32,7 @@ query loanPartnerTrustee(
 					}
 					memberSince
 					stats {
+						id
 						numLoansEndorsedPublic
 						totalLoansValue
 						numFundraisingLoans

--- a/src/graphql/query/loansById.graphql
+++ b/src/graphql/query/loansById.graphql
@@ -10,6 +10,7 @@ query loansById(
 	lend {
 		loans(limit: $numberOfLoans, filters: {loanIds: $ids}) {
 			values {
+				id
 				...loanCardFields
 				image {
 					id

--- a/src/graphql/query/loansYouMightLike/loansYouMightLikeData.graphql
+++ b/src/graphql/query/loansYouMightLike/loansYouMightLikeData.graphql
@@ -13,6 +13,7 @@ query loansYouMightLikeData(
 	lend {
 		loans(filters: {country: $country, sector: $sector, partner: $partner, gender: $gender, status: fundraising}, limit: $limit, sortBy: $sortBy) {
 			values {
+				id
 				...loanCardFields
 				image {
 					id

--- a/src/graphql/query/loansYouMightLike/mlLoansYouMightLikeData.graphql
+++ b/src/graphql/query/loansYouMightLike/mlLoansYouMightLikeData.graphql
@@ -8,8 +8,9 @@ query mlLoansYouMightLikeData(
 	$imgRetinaSize: String = "w480h360"
 ) {
 	ml {
-    	relatedLoansByTopics(limit: $limit, loanId: $loanId, offset: $offset, topics: [story]) {
-      		values {
+		relatedLoansByTopics(limit: $limit, loanId: $loanId, offset: $offset, topics: [story]) {
+			values {
+				id
 				...loanCardFields
 				image {
 					id

--- a/src/graphql/query/myLendingStats.graphql
+++ b/src/graphql/query/myLendingStats.graphql
@@ -1,6 +1,7 @@
 query myLendingStats {
 	my {
 		lendingStats {
+			id
 			countriesLentTo {
 				isoCode
 				name

--- a/src/graphql/query/myTeams.graphql
+++ b/src/graphql/query/myTeams.graphql
@@ -2,6 +2,7 @@ query myTeams($teamIds: [Int]) {
 	my {
 		teams(teamIds:$teamIds) {
 			values {
+				id
 				team {
 	  				id
 				}

--- a/src/graphql/query/promoCampaign.graphql
+++ b/src/graphql/query/promoCampaign.graphql
@@ -2,6 +2,7 @@ query promoCampaign($basketId: String, $promoFundId: String) {
 	shop (basketId: $basketId) {
 		id
 		basket {
+			id
 			hasFreeCredits
 			items {
 				values {
@@ -22,11 +23,13 @@ query promoCampaign($basketId: String, $promoFundId: String) {
 		}
 		promoCampaign (promoFundId: $promoFundId) {
 			promoFund {
+				id
 				displayName
 				displayDescription
 				promoPrice
 			}
 			promoGroup {
+				id
 				type
 				teamId
 			}

--- a/src/graphql/query/promotionalBanner.graphql
+++ b/src/graphql/query/promotionalBanner.graphql
@@ -6,7 +6,9 @@ query promotionalBanner($basketId: String) {
 		}
 	}
 	shop (basketId: $basketId) {
+		id
 		basket {
+			id
 			hasFreeCredits
 			totals {
 				bonusAvailableTotal

--- a/src/graphql/query/teamInfoFromId.graphql
+++ b/src/graphql/query/teamInfoFromId.graphql
@@ -1,16 +1,19 @@
 query teamInfoFromId($team_id: Int, $team_recruitment_id: Int, $team_ids: [Int]) {
 	community {
 		team(id: $team_id) {
+			id
 			name
 			membershipType
 		}
 	}
 	my {
 		teamRecruitment(id: $team_recruitment_id) {
+			id
 			recruiterDisplayName
 		}
 		teams(teamIds: $team_ids) {
 			values {
+				id
 				team {
 	  				id
 				}

--- a/src/graphql/query/wwwHeader.graphql
+++ b/src/graphql/query/wwwHeader.graphql
@@ -1,5 +1,6 @@
 query wwwHeader($basketId: String) {
 	shop (basketId: $basketId) {
+		id
 		nonTrivialItemCount
 	}
 	my {
@@ -9,6 +10,7 @@ query wwwHeader($basketId: String) {
 			promoBalance
 		}
 		lender {
+			id
 			image {
 				id
 				url( presetSize:lender_default )

--- a/src/pages/AutoDeposit/AutoDepositLandingPage.vue
+++ b/src/pages/AutoDeposit/AutoDepositLandingPage.vue
@@ -105,10 +105,12 @@ const pageQuery = gql`query autoDepositLandingPage {
 	my {
 		subscriptions {
 			values {
+				id
 				subscrId
 			}
 		}
 		autoDeposit {
+			id
 			isSubscriber
 		}
 	}

--- a/src/pages/Autolending/AutolendingSettingsPage.vue
+++ b/src/pages/Autolending/AutolendingSettingsPage.vue
@@ -27,6 +27,7 @@ const pageQuery = gql`query autolendProfileEnabled {
 	autolending @client {
 		profileChanged
 		currentProfile {
+			id
 			isEnabled
 		}
 	}
@@ -57,6 +58,7 @@ export default {
 					query: gql`query userIsMonthlyGoodSubscriber {
 							my {
 								autoDeposit {
+									id
 									isSubscriber
 								}
 							}

--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -136,6 +136,7 @@ export default {
 			autolending @client {
 				profileChanged
 				currentProfile {
+					id
 					isEnabled
 					pauseUntil
 				}

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -143,6 +143,7 @@ export default {
 			autolending @client {
 				profileChanged
 				currentProfile {
+					id
 					isEnabled
 					donationPercentage
 					lendAfterDaysIdle
@@ -150,6 +151,7 @@ export default {
 			}
 			my {
 				autoDeposit {
+					id
 					donateAmount
 				}
 			}

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -199,6 +199,7 @@ export default {
 			autolending @client {
 				profileChanged
 				currentProfile {
+					id
 					isEnabled
 					kivaChooses
 				}

--- a/src/pages/Autolending/DefaultRateDropdown.vue
+++ b/src/pages/Autolending/DefaultRateDropdown.vue
@@ -54,6 +54,7 @@ export default {
 		query: gql`query autolendProfileDefaultRate {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							defaultRate {

--- a/src/pages/Autolending/GenderRadios.vue
+++ b/src/pages/Autolending/GenderRadios.vue
@@ -46,6 +46,7 @@ export default {
 		query: gql`query autolendProfileGender {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							gender

--- a/src/pages/Autolending/GroupRadios.vue
+++ b/src/pages/Autolending/GroupRadios.vue
@@ -46,6 +46,7 @@ export default {
 		query: gql`query autolendProfileIsGroup {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							isGroup

--- a/src/pages/Autolending/KivaChoosesRadios.vue
+++ b/src/pages/Autolending/KivaChoosesRadios.vue
@@ -38,6 +38,7 @@ export default {
 		query: gql`query autolendProfileKivaChooses {
 			autolending @client {
 				currentProfile {
+					id
 					kivaChooses
 				}
 			}

--- a/src/pages/Autolending/LendTimingDropdown.vue
+++ b/src/pages/Autolending/LendTimingDropdown.vue
@@ -93,6 +93,7 @@ export default {
 			}
 			autolending @client {
 				currentProfile {
+					id
 					isEnabled
 					enableAfter
 					lendAfterDaysIdle
@@ -100,6 +101,7 @@ export default {
 					donationPercentage
 				}
 				savedProfile {
+					id
 					enableAfter
 				}
 			}

--- a/src/pages/Autolending/LendTimingMessaging.vue
+++ b/src/pages/Autolending/LendTimingMessaging.vue
@@ -127,6 +127,7 @@ export default {
 			}
 			autolending @client {
 				currentProfile {
+					id
 					isEnabled
 					enableAfter
 					lendAfterDaysIdle
@@ -134,6 +135,7 @@ export default {
 					donationPercentage
 				}
 				savedProfile {
+					id
 					enableAfter
 				}
 			}

--- a/src/pages/Autolending/LoanIncrementDropdown.vue
+++ b/src/pages/Autolending/LoanIncrementDropdown.vue
@@ -51,6 +51,7 @@ export default {
 		query: gql`query autolendProfileLoanLimit {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							loanLimit

--- a/src/pages/Autolending/LoanTermDropdown.vue
+++ b/src/pages/Autolending/LoanTermDropdown.vue
@@ -42,6 +42,7 @@ export default {
 		query: gql`query autolendProfileLoanTerm {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							lenderTerm {

--- a/src/pages/Autolending/PartnerDelRateDropdown.vue
+++ b/src/pages/Autolending/PartnerDelRateDropdown.vue
@@ -45,6 +45,7 @@ export default {
 		query: gql`query autolendProfileArrearsRate {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							arrearsRate {

--- a/src/pages/Autolending/RiskRatingDropdown.vue
+++ b/src/pages/Autolending/RiskRatingDropdown.vue
@@ -42,6 +42,7 @@ export default {
 		query: gql`query autolendProfileRiskRating {
 			autolending @client {
 				currentProfile {
+					id
 					loanSearchCriteria {
 						filters {
 							riskRating {

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -89,6 +89,7 @@ export default {
 				profileChanged
 				savingProfile
 				currentProfile {
+					id
 					kivaChooses
 				}
 			}

--- a/src/pages/Autolending/WhoYoullSupportText.vue
+++ b/src/pages/Autolending/WhoYoullSupportText.vue
@@ -71,6 +71,7 @@ export default {
 		query: gql`query whoYoullSupport {
 			autolending @client {
 				currentProfile {
+					id
 					kivaChooses
 					loanSearchCriteria {
 						filters {

--- a/src/pages/GetStarted/GetStartedCauses.vue
+++ b/src/pages/GetStarted/GetStartedCauses.vue
@@ -59,6 +59,7 @@ import KvProgressBar from '@/components/Kv/KvProgressBar';
 const lendingPreferencesCauses = gql`query lendingPreferences($visitorId: String) {
 	general {
 		lendingPreferences(visitorId: $visitorId) {
+			id
 			causes {
 				values {
 					id

--- a/src/pages/GetStarted/GetStartedPlaces.vue
+++ b/src/pages/GetStarted/GetStartedPlaces.vue
@@ -171,6 +171,7 @@ import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 const lendingPreferencesPlaces = gql`query lendingPreferences($visitorId: String) {
 	general {
 		lendingPreferences(visitorId: $visitorId) {
+			id
 			countries {
 				values {
 					isoCode

--- a/src/pages/GetStarted/GetStartedResults.vue
+++ b/src/pages/GetStarted/GetStartedResults.vue
@@ -202,6 +202,7 @@ export default {
 		query: gql`query getStartedResults($limit: Int, $visitorId: String) {
 			general {
 				lendingPreferences(visitorId: $visitorId) {
+					id
 					loans(limit: $limit) {
 						totalCount
 						values {

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -142,6 +142,7 @@ const pageQuery = gql`query pageContent($basketId: String!, $contentKey: String)
 	shop(basketId: $basketId) {
 		id
 		basket {
+			id
 			hasFreeCredits
 		}
 		lendingRewardOffered
@@ -160,6 +161,7 @@ const basketItemsQuery = gql`query basketItemsQuery(
 	shop(basketId: $basketId) {
 		id
 		basket {
+			id
 			hasFreeCredits
 			items {
 				totalCount

--- a/src/pages/LandingPages/MGCovid19/MGCovidHero.vue
+++ b/src/pages/LandingPages/MGCovid19/MGCovidHero.vue
@@ -83,6 +83,7 @@ const pageQuery = gql`
     }
     my {
       autoDeposit {
+        id
         isSubscriber
       }
     }

--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -89,6 +89,7 @@ import KivaAsExpert from './KivaAsExpert';
 const pageQuery = gql`query monthlyGoodLandingPage {
 	my {
 		autoDeposit {
+			id
 			isSubscriber
 		}
 	}

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageControl.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageControl.vue
@@ -297,6 +297,7 @@ const pageQuery = gql`query monthlyGoodSetupPageControl {
 	my {
 		subscriptions {
 			values {
+				id
 				subscrId
 			}
 		}
@@ -309,6 +310,7 @@ const pageQuery = gql`query monthlyGoodSetupPageControl {
 			isSubscriber
 		}
 		autolendProfile {
+			id
 			isEnabled
 		}
 		payPalBillingAgreement {

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPageVariant.vue
@@ -236,6 +236,7 @@ const pageQuery = gql`query monthlyGoodSetupPageVariant {
 	my {
 		subscriptions {
 			values {
+				id
 				subscrId
 			}
 		}
@@ -248,6 +249,7 @@ const pageQuery = gql`query monthlyGoodSetupPageVariant {
 			isSubscriber
 		}
 		autolendProfile {
+			id
 			isEnabled
 		}
 		loans {

--- a/src/pages/PageTwo.vue
+++ b/src/pages/PageTwo.vue
@@ -96,6 +96,7 @@ import FrequentlyAskedQuestions from '@/components/MonthlyGood/FrequentlyAskedQu
 const pageQuery = gql`query pageTwo {
 		my {
 			autoDeposit {
+				id
 				isSubscriber
 			}
 		}

--- a/src/pages/Subscriptions/SubscriptionsAutoDeposit.vue
+++ b/src/pages/Subscriptions/SubscriptionsAutoDeposit.vue
@@ -215,6 +215,7 @@ import KvSettingsCard from '@/components/Kv/KvSettingsCard';
 const pageQuery = gql`query autoDepositPage {
 	my {
 		autoDeposit {
+			id
 			amount
 			donateAmount
 			dayOfMonth
@@ -326,7 +327,7 @@ export default {
 						updateAutoDeposit( autoDeposit: {
 							amount: $amount, donateAmount: $donateAmount, dayOfMonth: $dayOfMonth
 						}) {
-							amount donateAmount dayOfMonth
+							id amount donateAmount dayOfMonth
 						}
 					}
 				}`,

--- a/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
+++ b/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
@@ -181,6 +181,7 @@ import MonthlyGoodDropInPaymentWrapper from '@/components/MonthlyGood/MonthlyGoo
 const pageQuery = gql`query monthlyGoodSubscription {
 	my {
 		autoDeposit {
+			id
 			amount
 			donateAmount
 			dayOfMonth
@@ -315,7 +316,7 @@ export default {
 						updateAutoDeposit( autoDeposit: {
 							amount: $amount, donateAmount: $donateAmount, dayOfMonth: $dayOfMonth
 						}) {
-							amount donateAmount dayOfMonth
+							id amount donateAmount dayOfMonth
 						}
 					}
 				}`,

--- a/src/pages/Subscriptions/SubscriptionsOneTime.vue
+++ b/src/pages/Subscriptions/SubscriptionsOneTime.vue
@@ -159,6 +159,7 @@ import KvSettingsCard from '@/components/Kv/KvSettingsCard';
 const pageQuery = gql`query oneTimeSubscription {
 	my {
 		autoDeposit {
+			id
 			amount
 			donateAmount
 		}
@@ -247,7 +248,7 @@ export default {
 						updateAutoDeposit( autoDeposit: {
 							amount: $amount, donateAmount: $donateAmount
 						}) {
-							amount donateAmount
+							id amount donateAmount
 						}
 					}
 				}`,

--- a/src/pages/Subscriptions/SubscriptionsSettingsPage.vue
+++ b/src/pages/Subscriptions/SubscriptionsSettingsPage.vue
@@ -92,6 +92,7 @@ import SubscriptionsLegacy from './SubscriptionsLegacy';
 const pageQuery = gql`query subscriptionSettingsPage {
 	my {
 		autoDeposit {
+			id
 			isSubscriber
 			isOnetime
 		}

--- a/src/util/campaignUtils.js
+++ b/src/util/campaignUtils.js
@@ -17,6 +17,7 @@ function addCreditByType(type, code, apollo) {
 		$redemptionCode: String!
 	) {
 		shop(basketId: $basketId) {
+			id
 			addCreditByType(creditType: $creditType, redemptionCode: $redemptionCode)
 		}
 	}`;
@@ -44,6 +45,7 @@ export function applyLendingReward(promoFundId, apollo) {
 		$promoFundId: String!
 	) {
 		shop(basketId: $basketId) {
+			id
 			applyLendingReward(promoFundId: $promoFundId)
 		}
 	}`;


### PR DESCRIPTION
This adds a linting rule to require that the `id` and `key` fields are always requested in graphql queries when they are available on the type. This also adds the id field to all the queries that did not have one. And finally, this removes the custom Shop and ShopMutation id definitions. This makes it easier for Apollo to cache everything that it needs to.

The hope is that it resolves the various Invariant Violations that we've seen, especially around using the Shop basket. This solution was inspired by the fix in #2141. 

We could also remove the extra `basketId` variable definitions, as those should be set by `BasketLink`, but I think it makes sense to test that this isn't causing problems first.