### PR TITLE
Fixed link on borrower pre-application/how-long page

### DIFF
--- a/src/pages/Borrow/BorrowHowLong.vue
+++ b/src/pages/Borrow/BorrowHowLong.vue
@@ -21,7 +21,7 @@
 				</p>
 				<p>
 					Need help getting started?
-					<a href="https://www.kivaushub.org/borrowers">Check out this useful guide</a>.
+					<a href="https://www.kivaushub.org/borrower">Check out this useful guide</a>.
 				</p>
 			</div>
 		</div>


### PR DESCRIPTION
Removed s from check out this useful guide link at /borrow/pre-applic…ation/how-long.
Tested locally and this appears to work as expected.