### PR TITLE
Settings area semantic tweaks

### DIFF
--- a/src/pages/Autolending/AutolendingPage.vue
+++ b/src/pages/Autolending/AutolendingPage.vue
@@ -2,7 +2,7 @@
 	<www-page class="autolending" :gray-background="true">
 		<div class="title-area">
 			<div class="row column">
-				<h2>Auto-lending settings</h2>
+				<h1>Auto-lending settings</h1>
 				<h3>Make the impact you want even if you’re away from your account for a while</h3>
 			</div>
 		</div>
@@ -17,10 +17,13 @@ export default {
 	components: {
 		WwwPage,
 	},
+	metaInfo: {
+		title: 'Auto-lending settings',
+	},
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 
 .autolending {

--- a/src/pages/Settings/SecuritySettings.vue
+++ b/src/pages/Settings/SecuritySettings.vue
@@ -2,9 +2,9 @@
 	<www-page class="security-login" :gray-background="true">
 		<div class="title-area">
 			<div class="row column">
-				<h2 class="strong">
+				<h1>
 					Security and login
-				</h2>
+				</h1>
 			</div>
 		</div>
 		<div class="security-settings-page">
@@ -24,6 +24,9 @@ export default {
 		WwwPage,
 		Password,
 		TwoStepVerification,
+	},
+	metaInfo: {
+		title: 'Security and login',
 	},
 };
 </script>

--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -2,9 +2,9 @@
 	<www-page class="two-step-verification" :gray-background="true">
 		<div class="title-area">
 			<div class="row column">
-				<h2 class="strong">
+				<h1>
 					2-step verification
-				</h2>
+				</h1>
 			</div>
 		</div>
 		<div class="row">
@@ -46,6 +46,9 @@ export default {
 		WwwPage,
 		KvSettingsCard,
 		KvIcon,
+	},
+	metaInfo: {
+		title: '2-step verification',
 	},
 };
 </script>

--- a/src/pages/Subscriptions/SubscriptionsPage.vue
+++ b/src/pages/Subscriptions/SubscriptionsPage.vue
@@ -2,7 +2,7 @@
 	<www-page class="subscriptions" :gray-background="true">
 		<div class="title-area">
 			<div class="row column">
-				<h2>Subscription settings</h2>
+				<h1>Subscription settings</h1>
 			</div>
 		</div>
 		<router-view />
@@ -15,6 +15,9 @@ import WwwPage from '@/components/WwwFrame/WwwPage';
 export default {
 	components: {
 		WwwPage,
+	},
+	metaInfo: {
+		title: 'Subscription settings',
 	},
 };
 </script>


### PR DESCRIPTION
Sets page titles, use h1s.

This changes the appearance of the headings on these pages. If we want to keep the old appearance, we can do something like `<h1 class="h2">` but we should keep the `<h1>` for semantics and screenreaders. 

My personal opinion is to use a raw h1 here, and really on nearly all pages for consistency. If design wants to change the typography of what a page header look like, we change it in our global styles and all pages with a raw h1 will get the update, rather than more and more one-off designs that we'll have to go through when design updates to a new look.

Raw h1 on the left, h2 on the right:
![image](https://user-images.githubusercontent.com/187937/97339422-cd38f380-183f-11eb-9792-0e0cf528ffe1.png)
