### PR TITLE
Attempt to fix flaky Travis test

### DIFF
--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -252,14 +252,14 @@ describe('Autolending Page Spec', () => {
 			// Show the modal
 			cy.get('[data-test=autolending-who]').first().click();
 			// Wait for modal
-			// Select the radio
 			cy.get('.autolending-who-lightbox')
 				.should('be.visible');
-
 			// Assert that 'Let Kiva select the best loans for me' is selected
 			cy.get('[data-test=kiva-chooses-true]').should('be.checked');
 			// Select 'I want to set my own auto-lending criteria'
 			cy.get('[data-test=kiva-chooses-false] + label').click();
+			// Save button should be enabled
+			cy.get('[data-test=save-button]').first().should('be.enabled');
 			// Hit save button
 			cy.get('[data-test=save-button]').first().click();
 			// Assert that 'I want to set my own auto-lending criteria' is selected
@@ -289,14 +289,14 @@ describe('Autolending Page Spec', () => {
 			// Show the modal
 			cy.get('[data-test=autolending-who]').first().click();
 			// Wait for modal
-			// Select the radio
 			cy.get('.autolending-who-lightbox')
 				.should('be.visible');
-
 			// Assert that 'I want to set my own auto-lending criteria' is selected
 			cy.get('[data-test=kiva-chooses-false]').should('be.checked');
 			// Select 'Let Kiva select the best loans for me'
 			cy.get('[data-test=kiva-chooses-true] + label').click();
+			// Save button should be enabled
+			cy.get('[data-test=save-button]').first().should('be.enabled');
 			// Hit save button
 			cy.get('[data-test=save-button]').first().click();
 			// Assert that 'Let Kiva select the best loans for me' is selected


### PR DESCRIPTION
AutolendingPage spec fails periodically on Travis. This might be able to fix it, as cypress will retry the assertion before click.

Reference:
https://docs.cypress.io/guides/core-concepts/retry-ability.html#Commands-vs-assertions

`If the assertion that follows the cy.get() command fails, then the cy.get() command will requery the application’s DOM again. Then Cypress will try the assertion against the elements yielded from cy.get(). If the assertion still fails, cy.get() will try requerying the DOM again, and so on until the cy.get() command timeout is reached.`