### PR TITLE
GROW-314 Add method to fetch MFA management access token

### DIFF
--- a/config/audit.js
+++ b/config/audit.js
@@ -39,6 +39,7 @@ module.exports = merge(base, {
 			},
 			enable: true,
 			apiAudience: 'https://api.audit.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-audit.auth0.com/mfa/',
 			browserClientID: 'ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF',
 			serverClientID: 'KIzjUBQjKZwMRgYSn6NvMxsUwNppwnLH',
 			browserCallbackUri: 'https://www.audit.kiva.org/process-browser-auth',

--- a/config/dev-vm.js
+++ b/config/dev-vm.js
@@ -45,6 +45,7 @@ module.exports = merge(base, {
 			},
 			enable: true,
 			apiAudience: 'https://api.dev.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-dev.auth0.com/mfa/',
 			browserClientID: 'ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF',
 			serverClientID: 'KIzjUBQjKZwMRgYSn6NvMxsUwNppwnLH',
 			browserCallbackUri: 'https://dev-vm-01.kiva.org/process-browser-auth',

--- a/config/dev.js
+++ b/config/dev.js
@@ -39,6 +39,7 @@ module.exports = merge(base, {
 			},
 			enable: true,
 			apiAudience: 'https://api.dev.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-dev.auth0.com/mfa/',
 			browserClientID: 'ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF',
 			serverClientID: 'KIzjUBQjKZwMRgYSn6NvMxsUwNppwnLH',
 			browserCallbackUri: 'https://www.dev.kiva.org/process-browser-auth',

--- a/config/index.js
+++ b/config/index.js
@@ -38,6 +38,7 @@ module.exports = {
 			},
 			enable: true,
 			apiAudience: 'https://api.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-prod.auth0.com/mfa/',
 			browserClientID: 'AEnMbebwn6LBvxg1iMYczZKoAgdUt37K',
 			serverClientID: 'xRbi3nkuYZ2B8rjYg4VdyZb2EaI1fhPd',
 			browserCallbackUri: 'https://www.kiva.org/process-browser-auth',

--- a/config/qa.js
+++ b/config/qa.js
@@ -39,6 +39,7 @@ module.exports = merge(base, {
 			},
 			enable: true,
 			apiAudience: 'https://api.qa.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-qa.auth0.com/mfa/',
 			browserClientID: 'D4nisXFEuifQ8Am1WoJJpuneCBTBle3Q',
 			serverClientID: 'tZuDW6xKBP5WYgP8FEwNsl41T4fhjWhF',
 			browserCallbackUri: 'https://www.qa.kiva.org/process-browser-auth',

--- a/config/stage.js
+++ b/config/stage.js
@@ -38,6 +38,7 @@ module.exports = merge(base, {
 			},
 			enable: true,
 			apiAudience: 'https://api.stage.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-stage.auth0.com/mfa/',
 			browserClientID: 'pK7XVUBouUjPEFm9bz5MN7sjU5HACqqe',
 			serverClientID: 'Ch7rwGop9lctGpm5KfEl6VTVMrqKoWZ4',
 			browserCallbackUri: 'https://www.stage.kiva.org/process-browser-auth',

--- a/config/test.js
+++ b/config/test.js
@@ -39,6 +39,7 @@ module.exports = merge(base, {
 			},
 			enable: true,
 			apiAudience: 'https://api.test.kivaws.org/graphql',
+			mfaAudience: 'https://kiva-test.auth0.com/mfa/',
 			browserClientID: 'DgnxRxp8t0ei27KpwCkQDj6hMrHPheFr',
 			serverClientID: 'm0gkCWRIS0kiu2q0oFNRijUVPgY1MjCn',
 			browserCallbackUri: 'https://www.test.kiva.org/process-browser-auth',

--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -25,6 +25,7 @@ let kvAuth0;
 if (config.auth0.enable) {
 	kvAuth0 = new KvAuth0({
 		audience: config.auth0.apiAudience,
+		mfaAudience: config.auth0.mfaAudience,
 		clientID: config.auth0.browserClientID,
 		domain: config.auth0.domain,
 		redirectUri: config.auth0.browserCallbackUri,


### PR DESCRIPTION
This adds the means for the client-side portion of the app to fetch an access token to use with the auth0 MFA api.

To use in a component, first include `inject: ['kvAuth0']` in the component definition. You can then call `this.kvAuth0.getMfaManagementToken()` which returns a promise that will resolve with the token or reject with an error. That method will fetch a new token if one doesn't exist already, or it will resolve the promise with the current token.

After the token is fetched, you can also access it synchronously via `this.kvAuth0.mfaManagementToken`