### PR TITLE
Update borrower application link to new link

### DIFF
--- a/src/pages/Borrow/BorrowHowLong.vue
+++ b/src/pages/Borrow/BorrowHowLong.vue
@@ -27,7 +27,7 @@
 		</div>
 		<!-- eslint-disable max-len -->
 		<kv-button
-			:href="`https://kivaportal.force.com/portal/secur/CommunitiesSelfRegUi?startURL=%2Fportal%2Fs%2F%3Fref%3Dbam%26refid%3D${trusteeId}`"
+			:href="`/my/borrower/minimum-eligibility?refid=${trusteeId}`"
 			class="cta-btn"
 		>
 			I understand, let’s create an account


### PR DESCRIPTION
Updates to the new borrower application link which has moved out of Salesforce's portal and into FormAssembly forms which are embedded on kiva.org
In the main Kiva code we have this as a settings manager setting, not sure if that is possible here so just using the actual relative URL
This would ideally go out with next Kiva production release (which is when the code changes are going out in the PHP code for the new borrower application)