### PR TITLE
Instead of settimeout, force a reflow to avoid timing bugs

### DIFF
--- a/src/util/expander.js
+++ b/src/util/expander.js
@@ -33,15 +33,15 @@ export function expand(el, {
 
 	el.addEventListener('transitionend', function listener() {
 		unsetStyles(el, { property });
-		el.removeEventListener('transitionend', listener, true);
 		// finally, call the done callback after the transition
 		done();
+		el.removeEventListener('transitionend', listener, true);
 	}, true);
 
+	// hack to cause the browser to reflow
+	void el.offsetWidth; // eslint-disable-line no-void
 	// ...and set the property to the measured value on the next tick so it animates w/ css
-	window.setTimeout(() => {
-		el.style[property] = propValue;
-	});
+	el.style[property] = propValue;
 }
 
 export function collapse(el, {
@@ -59,13 +59,13 @@ export function collapse(el, {
 
 	el.addEventListener('transitionend', function listener() {
 		unsetStyles(el, { property });
-		el.removeEventListener('transitionend', listener, true);
 		// finally, call the done callback after the transition
 		done();
+		el.removeEventListener('transitionend', listener, true);
 	}, true);
 
+	// hack to cause the browser to reflow
+	void el.offsetWidth; // eslint-disable-line no-void
 	// ...and set the property to the 'to' value on the next tick so it animates w/ css
-	window.setTimeout(() => {
-		el.style[property] = to;
-	});
+	el.style[property] = to;
 }


### PR DESCRIPTION
Seeing the banner sometimes get stuck in a closed position. After this change haven't seen it totally bork yet. Would like to do more browser testing once it's in dev.