### PR TITLE
SUBS-582: Use a configurable note size rather than a hardcoded share price

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -32,8 +32,9 @@
 			<loan-price
 				:price="loan.price"
 				:loan-id="loan.id"
-				:loan-amount="loan.loan.loanAmount"
 				type="loan"
+				:loan-amount="loan.loan.loanAmount"
+				:min-amount="loan.loan.minNoteSize"
 				:funded-amount="loan.loan.loanFundraisingInfo.fundedAmount"
 				:reserved-amount="loan.loan.loanFundraisingInfo.reservedAmount"
 				:is-expiring-soon="loan.loan.loanFundraisingInfo.isExpiringSoon"

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -29,6 +29,7 @@ import _forEach from 'lodash/forEach';
 import updateLoanReservation from '@/graphql/mutation/updateLoanReservation.graphql';
 import updateKivaCardAmount from '@/graphql/mutation/updateKivaCardAmount.graphql';
 import KvIcon from '@/components/Kv/KvIcon';
+import { buildPriceArray } from '@/util/loanUtils';
 
 export default {
 	components: {
@@ -97,16 +98,8 @@ export default {
 				// if we've met reserve ensure at least this loan share is set
 				remainingAmount = Math.max(remainingAmount, parseFloat(this.price, 10));
 
-				// convert this to formatted array for our select element
 				const minAmount = parseFloat(this.minAmount || 25, 10); // 25_hard_coded
-				const numShares = remainingAmount / minAmount;
-				const priceArray = [];	// ex. priceArray = ['25', '50', '75']
-				// loop and build formatted array
-				// eslint-disable-next-line no-plusplus
-				for (let i = 1; i <= numShares; i++) {
-					priceArray.push(numeral(minAmount * i).format('0,0'));
-				}
-				return priceArray;
+				return buildPriceArray(remainingAmount, minAmount);
 			}
 			if (this.type === 'kivaCard') {
 				// convert this to formatted array for our select element

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -52,6 +52,10 @@ export default {
 			type: String,
 			default: ''
 		},
+		minAmount: {
+			type: String,
+			default: '',
+		},
 		loanId: {
 			type: Number,
 			default: null
@@ -67,7 +71,7 @@ export default {
 		idsInGroup: {
 			type: Array,
 			default: () => []
-		}
+		},
 	},
 	data() {
 		return {
@@ -81,24 +85,28 @@ export default {
 		prices() {
 			if (this.type === 'loan') {
 				// determine how many (if any) overall additional shares are remaining
-				let remainingShares = parseFloat(this.loanAmount) - parseFloat(this.fundedAmount);
+				let remainingAmount = parseFloat(this.loanAmount) - parseFloat(this.fundedAmount);
 
 				// subtract reservedAmount shares (minus our own reserved shares)
 				// - only do this for loans that are not ending soon
 				// - for loans ending soon we just show remaining shares which are all un-reserved
 				if (!this.isExpiringSoon) {
-					remainingShares -= (parseFloat(this.reservedAmount) - parseInt(this.price, 10));
+					remainingAmount -= (parseFloat(this.reservedAmount) - parseFloat(this.price, 10));
 				}
 
-				// if we've met reserve ensure atleast this loan share is set
-				if (remainingShares < parseInt(this.price, 10)) remainingShares = parseInt(this.price, 10);
+				// if we've met reserve ensure at least this loan share is set
+				remainingAmount = Math.max(remainingAmount, parseFloat(this.price, 10));
 
-				// get count of shares based on available remaining shares
-				const sharesBelowReserve = parseInt(remainingShares, 10) / 25;
 				// convert this to formatted array for our select element
-				const reservePriceArray = this.buildShareArray(sharesBelowReserve);
-
-				return reservePriceArray;
+				const minAmount = parseFloat(this.minAmount || 25, 10); // 25_hard_coded
+				const numShares = remainingAmount / minAmount;
+				const priceArray = [];	// ex. priceArray = ['25', '50', '75']
+				// loop and build formatted array
+				// eslint-disable-next-line no-plusplus
+				for (let i = 1; i <= numShares; i++) {
+					priceArray.push(numeral(minAmount * i).format('0,0'));
+				}
+				return priceArray;
 			}
 			if (this.type === 'kivaCard') {
 				// convert this to formatted array for our select element
@@ -206,15 +214,6 @@ export default {
 				}
 			}
 		},
-		buildShareArray(shares) {
-			// loop and build formatted array
-			const priceArray = [];
-			// ex. priceArray = ['25.00', '50.00', '75.00']
-			for (let i = 0; i < shares; i++) { // eslint-disable-line
-				priceArray.push(numeral(25 * (i + 1)).format('0,0'));
-			}
-			return priceArray;
-		}
 	}
 };
 

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -85,10 +85,8 @@ export default {
 	computed: {
 		prices() {
 			if (this.type === 'loan') {
-				// determine how many (if any) overall additional shares are remaining
 				let remainingAmount = parseFloat(this.loanAmount) - parseFloat(this.fundedAmount);
-
-				// subtract reservedAmount shares (minus our own reserved shares)
+				// subtract reservedAmount (minus our own reserved amount)
 				// - only do this for loans that are not ending soon
 				// - for loans ending soon we just show remaining shares which are all un-reserved
 				if (!this.isExpiringSoon) {

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -90,13 +90,13 @@ export default {
 				// - only do this for loans that are not ending soon
 				// - for loans ending soon we just show remaining shares which are all un-reserved
 				if (!this.isExpiringSoon) {
-					remainingAmount -= (parseFloat(this.reservedAmount) - parseFloat(this.price, 10));
+					remainingAmount -= (parseFloat(this.reservedAmount) - parseFloat(this.price));
 				}
 
 				// if we've met reserve ensure at least this loan share is set
-				remainingAmount = Math.max(remainingAmount, parseFloat(this.price, 10));
+				remainingAmount = Math.max(remainingAmount, parseFloat(this.price));
 
-				const minAmount = parseFloat(this.minAmount || 25, 10); // 25_hard_coded
+				const minAmount = parseFloat(this.minAmount || 25); // 25_hard_coded
 				return buildPriceArray(remainingAmount, minAmount);
 			}
 			if (this.type === 'kivaCard') {

--- a/src/components/Forms/MultiAmountSelector.vue
+++ b/src/components/Forms/MultiAmountSelector.vue
@@ -92,7 +92,7 @@ export default {
 		},
 		minCustomAmount: {
 			type: Number,
-			default: 25,
+			default: 25, // 25_hard_coded
 		},
 		maxCustomAmount: {
 			type: Number,

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -57,17 +57,15 @@ export default {
 			const { loanAmount, loanFundraisingInfo } = this.loan;
 			const { isExpiringSoon, fundedAmount, reservedAmount } = loanFundraisingInfo;
 
-			// determine how many (if any) overall additional shares are remaining
-			let remainingShares = parseFloat(loanAmount) - parseFloat(fundedAmount);
-
-			// subtract reservedAmount shares
+			let remainingAmount = parseFloat(loanAmount) - parseFloat(fundedAmount);
+			// subtract reservedAmount
 			// - only do this for loans that are not ending soon
 			// - for loans ending soon we just show remaining shares which are all un-reserved
 			if (!isExpiringSoon) {
-				remainingShares -= parseFloat(reservedAmount);
+				remainingAmount -= parseFloat(reservedAmount);
 			}
 
-			return parseInt(remainingShares, 10);
+			return parseInt(remainingAmount, 10);
 		},
 		prices() {
 			const minAmount = this.loan.minNoteSize || 25; // 25_hard_coded

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -26,8 +26,8 @@
 </template>
 
 <script>
-import numeral from 'numeral';
 import LendButton from '@/components/LoanCards/Buttons/LendButton';
+import { buildPriceArray } from '@/util/loanUtils';
 
 export default {
 	components: {
@@ -70,23 +70,10 @@ export default {
 			return parseInt(remainingShares, 10);
 		},
 		prices() {
-			// get count of shares based on available remaining shares
-			const sharesBelowReserve = this.amountLeft / 25;
-			// convert this to formatted array for our select element
-			return this.buildShareArray(sharesBelowReserve);
+			const minAmount = this.loan.minNoteSize || 25; // 25_hard_coded
+			// cap at 20 prices
+			return buildPriceArray(this.amountLeft, minAmount).slice(0, 20);
 		}
-	},
-	methods: {
-		buildShareArray(shares) {
-			// loop and build formatted array
-			const priceArray = [];
-			// ex. priceArray = ['25.00', '50.00', '75.00']
-			for (let i = 0; i < Math.min(shares, 20); i++) { // eslint-disable-line
-				priceArray.push(numeral(25 * (i + 1)).format('0,0'));
-			}
-
-			return priceArray;
-		},
 	},
 	watch: {
 		loan: {

--- a/src/graphql/fragments/detailedLoanCard.graphql
+++ b/src/graphql/fragments/detailedLoanCard.graphql
@@ -23,6 +23,7 @@ fragment detailedLoanCard on LoanBasic {
 	whySpecial
 	lenderRepaymentTerm
 	loanAmount
+	minNoteSize
 	loanFundraisingInfo {
 		fundedAmount
 		reservedAmount

--- a/src/graphql/fragments/loanCardFields.graphql
+++ b/src/graphql/fragments/loanCardFields.graphql
@@ -26,6 +26,7 @@ fragment loanCardFields on LoanBasic {
 	whySpecial
 	lenderRepaymentTerm
 	loanAmount
+	minNoteSize
 	loanFundraisingInfo {
 		fundedAmount
 		reservedAmount

--- a/src/graphql/query/algoliaLoanStatus.graphql
+++ b/src/graphql/query/algoliaLoanStatus.graphql
@@ -9,6 +9,7 @@ query algoliaLoanStatus(
 				id
 				status
 				matchingText
+				minNoteSize
 				loanFundraisingInfo {
 					fundedAmount
 					reservedAmount

--- a/src/graphql/query/checkout/emptyBasketData.graphql
+++ b/src/graphql/query/checkout/emptyBasketData.graphql
@@ -8,6 +8,7 @@ query emptyBasketData(
 				id
 				name
 				loanAmount
+				minNoteSize
 				loanFundraisingInfo {
 					fundedAmount
 					reservedAmount

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -56,6 +56,7 @@ query initializeCheckout($basketId: String) {
 							status
 							matchingText
 							loanAmount
+							minNoteSize
 							plannedExpirationDate
 							sector {
 								id

--- a/src/graphql/query/checkout/shopBasketUpdate.graphql
+++ b/src/graphql/query/checkout/shopBasketUpdate.graphql
@@ -42,6 +42,7 @@ query shopBasketUpdate($basketId: String) {
 							status
 							matchingText
 							loanAmount
+							minNoteSize
 							plannedExpirationDate
 							sector {
 								id

--- a/src/graphql/query/loanCardBasketed.graphql
+++ b/src/graphql/query/loanCardBasketed.graphql
@@ -14,6 +14,7 @@ query loanCardBasketed($id: Int!, $basketId: String) {
 	lend {
 		loan(id: $id) {
 			id
+			minNoteSize
 			loanFundraisingInfo {
 				fundedAmount
 				reservedAmount

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -30,3 +30,12 @@ export function isLoanFundraising(loan) {
 	// all clear
 	return true;
 }
+
+export function buildPriceArray(amountLeft, minAmount) {
+	// get count of shares based on available remaining amount.
+	const N = amountLeft / minAmount;
+	// convert this to formatted array for our select element
+	const priceArray = Array(N).map((_, i) => numeral(minAmount * (i + 1).format('0,0')));
+	// ex. priceArray = ['25', '50', '75']
+	return priceArray;
+}


### PR DESCRIPTION
Uses the GraphQL field defined in https://github.com/kiva/kiva/pull/9463 but defaults to $25 without it. Also adds a couple of `25_hard_coded` tags.

Screenshot below. See [SUBS-582](https://kiva.atlassian.net/browse/SUBS-582) for before picture.

<img width="1009" alt="$5-in-new-UI" src="https://user-images.githubusercontent.com/234990/100079847-01c9ac00-2dfa-11eb-96e0-1f38f92d40af.png">


