### PR TITLE
Render newlines as line breaks in the appeal banner body

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -309,6 +309,7 @@ export default {
 
 	&__body {
 		margin-bottom: 1rem;
+		white-space: pre-wrap;
 	}
 
 	&--open {


### PR DESCRIPTION
I was looking into how to get line breaks created in contentful rich text (using `Shift + Enter`) to be rendered as `<br />`, and found [a comment](https://github.com/contentful/rich-text/issues/69#issuecomment-479790401) pointing me in the direction of this whitespace value `pre-wrap` that works like this: "Sequences of white space are preserved. Lines are broken at newline characters, at `<br>`, and as necessary to fill line boxes."

So I added a line break into the rich text for the appeal banner and tried `pre-wrap` and it worked:
![Screen Shot 2020-11-25 at 12 40 26 PM](https://user-images.githubusercontent.com/4149025/100280143-8f9db800-2f1c-11eb-9214-259b6df9f74b.png)