### PR TITLE
GROW-313 smoother transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33329,6 +33329,11 @@
 				}
 			}
 		},
+		"vue-smooth-reflow": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/vue-smooth-reflow/-/vue-smooth-reflow-0.1.12.tgz",
+			"integrity": "sha512-cic+dmqsBzu/lRMXf/mhUPMM0g0vancJGUyNMMGHjis0ilSFd1RjIrZYcU5B7ef+n5oshH33/zbMA8OYyRTu7Q=="
+		},
 		"vue-style-loader": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
 		"vue-progressbar": "^0.7.3",
 		"vue-router": "^3.4.9",
 		"vue-server-renderer": "^2.6.12",
+		"vue-smooth-reflow": "^0.1.12",
 		"vue2-touch-events": "^2.3.2",
 		"vuedraggable": "^2.23.0",
 		"vuelidate": "^0.7.6",

--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -1,10 +1,5 @@
 <template>
-	<transition
-		@enter="enter"
-		@leave="leave"
-		:css="false"
-		mode="out-in"
-	>
+	<div>
 		<!-- open banner -->
 		<div
 			class="appeal-banner appeal-banner--open"
@@ -125,12 +120,12 @@
 				</div>
 			</div>
 		</div>
-	</transition>
+	</div>
 </template>
 
 <script>
 // import numeral from 'numeral';
-import { expand, collapse } from '@/util/expander';
+import smoothReflow from 'vue-smooth-reflow';
 
 import KvButton from '@/components/Kv/KvButton';
 import KvIcon from '@/components/Kv/KvIcon';
@@ -142,6 +137,7 @@ export default {
 		KvIcon,
 		KvProgressCircle,
 	},
+	mixins: [smoothReflow],
 	props: {
 		targetAmount: {
 			type: Number,
@@ -203,19 +199,9 @@ export default {
 		onClickToggleBanner() {
 			this.$emit('toggle-banner', !this.isOpen);
 		},
-		// slide up / down transitions
-		enter(el, done) {
-			expand(el, {
-				easing: 'ease-in-out',
-				done
-			});
-		},
-		leave(el, done) {
-			collapse(el, {
-				easing: 'ease-in-out',
-				done
-			});
-		},
+	},
+	mounted() {
+		this.$smoothReflow();
 	},
 };
 </script>


### PR DESCRIPTION
Since we were transitioning on height on the appeal banner, we ended up with a lot of jank. This package does some interesting stuff behind the scenes to use transforms for everything instead. Ends up smooth.

Don't love throwing this in at the last second without much testing though. Adds 10k too.
https://bundlephobia.com/result?p=vue-smooth-reflow@0.1.12

Thoughts?