### PR TITLE
GROW-373 Update deleteAllAuthenticatorEnrollments usage

### DIFF
--- a/src/graphql/mutation/removeMfa.graphql
+++ b/src/graphql/mutation/removeMfa.graphql
@@ -1,5 +1,5 @@
-mutation removeMfa($mfa_token: String!) {
+mutation removeMfa {
   my {
-		deleteAllAuthenticatorEnrollments(mfa_token: $mfa_token)
+		deleteAllAuthenticatorEnrollments
 	}
 }

--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -239,18 +239,11 @@ export default {
 			}
 		},
 		turnOffMfa() {
-			this.kvAuth0.checkSession()
-				.then(() => this.kvAuth0.getMfaManagementToken())
-				.then(token => {
-					this.apollo.mutate({
-						mutation: removeMfa,
-						variables: {
-							mfa_token: token
-						}
-					}).then(() => {
-						this.isMfaActive = false;
-					});
-				});
+			this.apollo.mutate({
+				mutation: removeMfa,
+			}).then(() => {
+				this.isMfaActive = false;
+			});
 		},
 		removeMfaMethod(mfaMethod) {
 			this.kvAuth0.checkSession()


### PR DESCRIPTION
This endpoint changed so that it no longer requires an mfa token (for details see https://github.com/kiva/kiva/pull/9509)