### PR TITLE
GROW-303 full-screen mobile lightbox

### DIFF
--- a/.storybook/stories/KvLightbox.stories.js
+++ b/.storybook/stories/KvLightbox.stories.js
@@ -86,6 +86,31 @@ Padding.args = {
 	noPaddingSides: true,
 };
 
+export const SmallContent = (args, { argTypes }) => ({
+	components: { KvLightbox, KvButton },
+	props: Object.keys(argTypes),
+	template: `
+		<div>
+			<kv-lightbox
+				:visible="visible"
+				:inverted="inverted"
+				:full-width="fullWidth"
+				:prevent-close="preventClose"
+				:title="title"
+				:no-padding-top="noPaddingTop"
+				:no-padding-bottom="noPaddingBottom"
+				:no-padding-sides="noPaddingSides"
+			>
+				<p>Small amount of content</p>
+				<template slot="controls">
+					<kv-button>Button 1</kv-button>
+					<kv-button>Button 2</kv-button>
+				</template>
+			</kv-lightbox>
+		</div>
+	`,
+});
+
 export const WithControls = (args, { argTypes }) => ({
 	components: { KvLightbox, KvButton },
 	props: Object.keys(argTypes),

--- a/.storybook/stories/KvLightbox.stories.js
+++ b/.storybook/stories/KvLightbox.stories.js
@@ -1,4 +1,3 @@
-import { boolean } from '@storybook/addon-knobs';
 import KvLightbox from '@/components/Kv/KvLightbox';
 import KvButton from '@/components/Kv/KvButton';
 
@@ -20,10 +19,21 @@ const loremIpsum = `
 export default {
 	title: 'Kv/KvLightbox',
 	component: KvLightbox,
+	args: {
+		visible: true,
+		preventClose: false,
+		title: 'Test Title',
+		inverted: false,
+		fullWidth: false,
+		noPaddingTop: false,
+		noPaddingBottom: false,
+		noPaddingSides: false,
+	},
 };
 
-export const Default = () => ({
-	components: { KvLightbox, KvButton },
+export const Default = (args, { argTypes }) => ({
+	components: { KvLightbox },
+	props: Object.keys(argTypes),
 	data: () => ({
 		lightboxVisible: false,
 	}),
@@ -37,12 +47,15 @@ export const Default = () => ({
 	},
 	template: `
 		<div>
-			<kv-button @click.native.prevent="showLightbox">
-				Show Lightbox
-			</kv-button>
-
 			<kv-lightbox
-				:visible="lightboxVisible"
+				:visible="visible"
+				:inverted="inverted"
+				:full-width="fullWidth"
+				:prevent-close="preventClose"
+				:title="title"
+				:no-padding-top="noPaddingTop"
+				:no-padding-bottom="noPaddingBottom"
+				:no-padding-sides="noPaddingSides"
 				@lightbox-closed="hideLightbox"
 			>
 				${loremIpsum}
@@ -51,29 +64,42 @@ export const Default = () => ({
 	`,
 });
 
-export const TitleSlotControlsSlot = () => ({
+export const Inverted = Default.bind({});
+Inverted.args = {
+	inverted: true,
+};
+
+export const FullWidth = Default.bind({});
+FullWidth.args = {
+	fullWidth: true,
+};
+
+export const PreventClose = Default.bind({});
+PreventClose.args = {
+	preventClose: true,
+};
+
+export const Padding = Default.bind({});
+Padding.args = {
+	noPaddingTop: true,
+	noPaddingBottom: true,
+	noPaddingSides: true,
+};
+
+export const WithControls = (args, { argTypes }) => ({
 	components: { KvLightbox, KvButton },
-	data: () => ({
-		lightboxVisible: false,
-	}),
-	methods: {
-		showLightbox() {
-			this.lightboxVisible = true;
-		},
-		hideLightbox() {
-			this.lightboxVisible = false;
-		}
-	},
+	props: Object.keys(argTypes),
 	template: `
 		<div>
-			<kv-button @click.native.prevent="showLightbox">
-				Show Lightbox - Use Header and Controls Slot
-			</kv-button>
-
 			<kv-lightbox
-				:visible="lightboxVisible"
-				@lightbox-closed="hideLightbox"
-				title="Title"
+				:visible="visible"
+				:inverted="inverted"
+				:full-width="fullWidth"
+				:prevent-close="preventClose"
+				:title="title"
+				:no-padding-top="noPaddingTop"
+				:no-padding-bottom="noPaddingBottom"
+				:no-padding-sides="noPaddingSides"
 			>
 				${loremIpsum}
 				<template slot="controls">
@@ -85,153 +111,21 @@ export const TitleSlotControlsSlot = () => ({
 	`,
 });
 
-export const Inverted = () => ({
-	components: { KvLightbox, KvButton },
-	data: () => ({
-		lightboxVisible: false,
-	}),
-	methods: {
-		showLightbox() {
-			this.lightboxVisible = true;
-		},
-		hideLightbox() {
-			this.lightboxVisible = false;
-		}
-	},
+export const CustomTitleColor = (args, { argTypes }) => ({
+	components: { KvLightbox },
+	props: Object.keys(argTypes),
 	template: `
 		<div>
-			<kv-button @click.native.prevent="showLightbox">
-				Show Lightbox Inverted
-			</kv-button>
-
 			<kv-lightbox
-				:visible="lightboxVisible"
-				:inverted="true"
-				@lightbox-closed="hideLightbox"
-				title="Title"
-			>
-				${loremIpsum}
-				<template slot="controls">Controls Here</template>
-			</kv-lightbox>
-
-			<kv-lightbox
-				:visible="false"
-				:inverted="true"
-				@lightbox-closed="hideLightbox"
-				title="Title"
-			>
-				${loremIpsum}
-				<template slot="controls">Controls Here</template>
-			</kv-lightbox>
-		</div>
-	`,
-});
-
-export const CustomTitleColor = () => ({
-	components: { KvLightbox, KvButton },
-	data: () => ({
-		lightboxVisible: false,
-	}),
-	methods: {
-		showLightbox() {
-			this.lightboxVisible = true;
-		},
-		hideLightbox() {
-			this.lightboxVisible = false;
-		}
-	},
-	template: `
-		<div>
-			<kv-button @click.native.prevent="showLightbox">
-				Show Lightbox Custom Title Color
-			</kv-button>
-
-			<kv-lightbox
-				:visible="lightboxVisible"
-				@lightbox-closed="hideLightbox"
-				title="Custom Title Color"
-				style="--kv-lightbox-title-color: blue"
-			>
-				${loremIpsum}
-			</kv-lightbox>
-		</div>
-	`,
-});
-
-export const FullWidth = () => ({
-	components: { KvLightbox, KvButton },
-	props: {
-		fullWidth: {
-			default: boolean('fullWidth', true)
-		},
-	},
-	data: () => ({
-		lightboxVisible: false,
-	}),
-	methods: {
-		showLightbox() {
-			this.lightboxVisible = true;
-		},
-		hideLightbox() {
-			this.lightboxVisible = false;
-		}
-	},
-	template: `
-		<div>
-			<kv-button @click.native.prevent="showLightbox">
-				Show Lightbox Full Width
-			</kv-button>
-
-			<kv-lightbox
-				:visible="lightboxVisible"
+				:visible="visible"
+				:inverted="inverted"
 				:full-width="fullWidth"
-				@lightbox-closed="hideLightbox"
-				title="Title"
-			>
-				This is small content, but the lightbox takes all the space it can.
-			</kv-lightbox>
-		</div>
-	`,
-});
-
-
-export const NoPadding = () => ({
-	components: { KvLightbox, KvButton },
-	props: {
-		noPaddingTop: {
-			default: boolean('noPaddingTop', true)
-		},
-		noPaddingSides: {
-			default: boolean('noPaddingSides', true)
-		},
-		noPaddingBottom: {
-			default: boolean('noPaddingBottom', true)
-		}
-	},
-	data: () => ({
-		lightboxVisible: false,
-	}),
-	methods: {
-		showLightbox() {
-			this.lightboxVisible = true;
-		},
-		hideLightbox() {
-			this.lightboxVisible = false;
-		}
-	},
-	template: `
-		<div>
-			<kv-button @click.native.prevent="showLightbox">
-				Show Lightbox no padding
-			</kv-button>
-
-			<kv-lightbox
-				:visible="lightboxVisible"
+				:prevent-close="preventClose"
+				:title="title"
 				:no-padding-top="noPaddingTop"
 				:no-padding-bottom="noPaddingBottom"
 				:no-padding-sides="noPaddingSides"
-				@lightbox-closed="hideLightbox"
-				title="Title"
+				style="--kv-lightbox-title-color: blue"
 			>
 				${loremIpsum}
 			</kv-lightbox>

--- a/src/components/Checkout/DonationNudge/DonationNudgeLightboxImage.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeLightboxImage.vue
@@ -96,6 +96,7 @@ export default {
 			display: flex;
 			align-items: center;
 			justify-content: center;
+			width: 100%;
 
 			.no-donation-x {
 				width: 0.75rem;

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -46,7 +46,7 @@
 					>
 						<slot>Lightbox body</slot>
 					</div>
-					<div class="kv-lightbox__controls">
+					<div class="kv-lightbox__controls" v-if="this.$slots.controls">
 						<slot name="controls"></slot>
 					</div>
 				</div>

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -12,7 +12,6 @@
 					'kv-lightbox--full-width': fullWidth,
 				}"
 				ref="kvlightbox"
-				@keyup.esc="closeLightbox"
 				@click.stop.prevent="closeLightbox"
 				role="dialog"
 				:aria-labelledby="title ? 'lightbox-title' : null"
@@ -112,10 +111,12 @@ export default {
 		visible() {
 			this.isShown = this.visible;
 			if (this.isShown) {
+				document.addEventListener('keyup', this.onKeyUp);
 				this.$nextTick(() => {
 					this.lockScroll();
 				});
 			} else {
+				document.removeEventListener('keyup', this.onKeyUp);
 				this.unlockScroll();
 			}
 		}
@@ -127,6 +128,11 @@ export default {
 		this.closeLightbox();
 	},
 	methods: {
+		onKeyUp(e) {
+			if (e.key === 'Escape') {
+				this.closeLightbox();
+			}
+		},
 		closeLightbox() {
 			if (!this.preventClose) {
 				// scroll any content inside the lightbox back to top

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -11,6 +11,7 @@
 					'kv-lightbox--no-padding-sides': noPaddingSides,
 					'kv-lightbox--full-width': fullWidth,
 				}"
+				data-test="kv-lightbox"
 				ref="kvlightbox"
 				@click.stop.prevent="closeLightbox"
 				role="dialog"

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -219,6 +219,9 @@ export default {
 		position: absolute;
 		top: 0.75rem;
 		right: 0.75rem;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
 		&:hover {
 			.kv-lightbox__close-btn-icon {

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -1,6 +1,6 @@
 <template>
-	<transition name="kvfade">
-		<focus-lock :disabled="!isShown">
+	<focus-lock :disabled="!isShown">
+		<transition name="kvfade">
 			<div
 				v-show="isShown"
 				class="kv-lightbox"
@@ -51,8 +51,8 @@
 					</div>
 				</div>
 			</div>
-		</focus-lock>
-	</transition>
+		</transition>
+	</focus-lock>
 </template>
 
 <script>

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -150,7 +150,7 @@ export default {
 
 .kv-lightbox {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: center;
 	position: fixed;
 	top: 0;
@@ -176,7 +176,7 @@ export default {
 		@include breakpoint(medium) {
 			padding: 2.8125rem;
 			border-radius: rem-calc(4);
-			max-width: 61rem;
+			max-width: rem-calc(900);
 		}
 	}
 
@@ -187,6 +187,7 @@ export default {
 
 	&__body {
 		flex: 1;
+		flex: 0 1 auto; // ie11
 		overflow: auto;
 		position: relative;
 	}
@@ -204,7 +205,7 @@ export default {
 	&__title {
 		color: inherit;
 		color: var(--kv-lightbox-title-color, inherit);
-		padding-right: 1rem;
+		padding-right: 1.5rem;
 	}
 
 	&__close-btn-icon {

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -129,7 +129,7 @@ export default {
 	methods: {
 		closeLightbox() {
 			if (!this.preventClose) {
-				// scroll any body content back to top
+				// scroll any content inside the lightbox back to top
 				this.$refs.kvLightboxBody.scrollTop = 0;
 
 				// remove scroll lock class from body

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -169,6 +169,7 @@ export default {
 		flex-direction: column;
 		overflow: hidden;
 		padding: 1.5rem;
+		max-height: 100%;
 		background: $white;
 		position: relative;
 

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -165,8 +165,6 @@ export default {
 	}
 
 	&__container {
-		flex: 1;
-		height: 100%;
 		display: flex;
 		flex-direction: column;
 		overflow: hidden;

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -190,6 +190,14 @@ export default {
 		flex: 0 1 auto; // ie11
 		overflow: auto;
 		position: relative;
+		// set a negative margin + padding to push the scrollbar to edge of the dialog.
+		margin: 0 -1.5rem;
+		padding: 0 1.5rem;
+
+		@include breakpoint(medium) {
+			margin: 0 -2.8125rem;
+			padding: 0 2.8125rem;
+		}
 	}
 
 	&__controls {

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -79,7 +79,7 @@ describe('Autolending Page Spec', () => {
 
 			// Wait for modal
 			// Select the radio
-			cy.get('.autolending-status-lightbox')
+			cy.get('.autolending-status-lightbox [data-test=kv-lightbox]')
 				.should('be.visible')
 				.find('[data-test=is-autolending-off] + label')
 				.click();
@@ -111,7 +111,7 @@ describe('Autolending Page Spec', () => {
 
 			// Wait for modal
 			// Select the radio
-			cy.get('.autolending-status-lightbox')
+			cy.get('.autolending-status-lightbox [data-test=kv-lightbox]')
 				.should('be.visible')
 				.find('[data-test=is-autolending-on] + label')
 				.click();
@@ -252,7 +252,7 @@ describe('Autolending Page Spec', () => {
 			// Show the modal
 			cy.get('[data-test=autolending-who]').first().click();
 			// Wait for modal
-			cy.get('.autolending-who-lightbox')
+			cy.get('.autolending-who-lightbox [data-test=kv-lightbox]')
 				.should('be.visible');
 			// Assert that 'Let Kiva select the best loans for me' is selected
 			cy.get('[data-test=kiva-chooses-true]').should('be.checked');
@@ -289,7 +289,7 @@ describe('Autolending Page Spec', () => {
 			// Show the modal
 			cy.get('[data-test=autolending-who]').first().click();
 			// Wait for modal
-			cy.get('.autolending-who-lightbox')
+			cy.get('.autolending-who-lightbox [data-test=kv-lightbox]')
 				.should('be.visible');
 			// Assert that 'I want to set my own auto-lending criteria' is selected
 			cy.get('[data-test=kiva-chooses-false]').should('be.checked');


### PR DESCRIPTION
Refactors KvLightbox to fill the screen on mobile, while keeping the title and controls always visible.

As part of GROW-303, we've changed course a little - instead of doing special pages for mobile, we're making the lightbox work better on phones. 

I'll do some more testing on my vm tomorrow morning since KvLightbox is used in many places, but initial tests look good.

Component keeps the same props/events/slots as before.

![image](https://user-images.githubusercontent.com/187937/102433973-a8a00300-3fc8-11eb-98a1-2c39073f6137.png)
![image](https://user-images.githubusercontent.com/187937/102433988-af2e7a80-3fc8-11eb-8002-8eb6d583744b.png)
