### PR TITLE
I've added an example of the preventClose lightbox to storybook.

### DIFF
--- a/.storybook/stories/KvLightbox.stories.js
+++ b/.storybook/stories/KvLightbox.stories.js
@@ -195,8 +195,53 @@ export const FullWidth = () => ({
 });
 
 
-export const NoPadding = () => ({
+export const preventClose = () => ({
 	components: { KvLightbox, KvButton },
+	props: {
+		preventClose: {
+			default: boolean('preventClose', true)
+		},
+	},
+	data: () => ({
+		lightboxVisible: false,
+	}),
+	methods: {
+		showLightbox() {
+			this.lightboxVisible = true;
+		},
+		hideLightbox() {
+			this.lightboxVisible = false;
+		}
+	},
+	template:`
+		<div>
+			<kv-button @click.native.prevent="showLightbox">
+				Show Lightbox prevent close
+			</kv-button>
+
+			<kv-lightbox
+				:visible="lightboxVisible"
+				:prevent-close="preventClose"
+				@lightbox-closed="hideLightbox"
+				title="Title"
+			>
+				${loremIpsum}
+
+				<kv-button
+					@click.native.prevent="hideLightbox"
+				>
+					Close lightbox
+				</kv-button>
+			</kv-lightbox>
+		</div>
+	`,
+});
+
+export const NoPadding = () => ({
+	components: {
+		KvLightbox,
+		KvButton
+	},
 	props: {
 		noPaddingTop: {
 			default: boolean('noPaddingTop', true)


### PR DESCRIPTION
During my work on grow-301 I added the preventClose prop to KvLightbox.vue. This gets an example of the prevent close lightbox into storybook. 

The preventClose lightbox: 
- Hides the x in the upper right corner of the lightbox
- Disables closing the lightbox on a click of the opaque background

In this version of the lightbox we're only giving the user 1 method of closure.

For grow-301 this closure method is disabled until a user clicks a KvCheckbox, at which point, the close button become enabled and user is able to close the lightbox. 