### PR TITLE
Optional cta checkout redirect

### DIFF
--- a/src/components/Homepage/LendByCategory/FeaturedLoansCarousel.vue
+++ b/src/components/Homepage/LendByCategory/FeaturedLoansCarousel.vue
@@ -37,6 +37,7 @@
 							:enable-tracking="true"
 							:is-visitor="!isLoggedIn"
 							:show-view-loan-cta="showViewLoanCta"
+							@add-to-basket="handleAddToBasket"
 						/>
 					</div>
 					<div v-else class="featured-loans-carousel__loading-div">
@@ -339,7 +340,10 @@ export default {
 		getLoanPosition(categoryId) {
 			const categoryRowIndex = this.categoryIds.indexOf(categoryId);
 			return categoryRowIndex !== -1 ? categoryRowIndex + 1 : null;
-		}
+		},
+		handleAddToBasket(payload) {
+			this.$emit('add-to-basket', payload);
+		},
 	}
 };
 </script>

--- a/src/components/Homepage/LendByCategory/FeaturedLoansCarousel.vue
+++ b/src/components/Homepage/LendByCategory/FeaturedLoansCarousel.vue
@@ -31,10 +31,12 @@
 							:items-in-basket="itemsInBasket"
 							:category-id="category.id"
 							category-set-id="lbc-hp-v1-featured-loans"
+							:disable-redirects="disableRedirects"
 							:row-number="0"
 							:card-number="index + 1"
 							:enable-tracking="true"
 							:is-visitor="!isLoggedIn"
+							:show-view-loan-cta="showViewLoanCta"
 						/>
 					</div>
 					<div v-else class="featured-loans-carousel__loading-div">
@@ -72,6 +74,14 @@ export default {
 		LoanCardController
 	},
 	props: {
+		disableRedirects: {
+			type: Boolean,
+			default: false,
+		},
+		showViewLoanCta: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {

--- a/src/components/Homepage/LendByCategory/LoanCategory.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategory.vue
@@ -52,6 +52,7 @@
 							:card-number="index + 1"
 							:enable-tracking="true"
 							:is-visitor="!isLoggedIn"
+							:show-view-loan-cta="true"
 						/>
 					</div>
 					<!--

--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -2,6 +2,7 @@
 	<component
 		:is="currentButtonState"
 		class="action-button smaller"
+		:disable-redirects="disableRedirects"
 		:loan-id="loanId"
 		:loan="loan"
 		:hide-adding-to-basket-text="hideAddingToBasketText"
@@ -42,6 +43,10 @@ export default {
 	],
 	inject: ['apollo'],
 	props: {
+		disableRedirects: {
+			type: Boolean,
+			default: false,
+		},
 		loan: {
 			type: Object,
 			default: () => {}

--- a/src/components/LoanCards/Buttons/CheckoutNowButton.vue
+++ b/src/components/LoanCards/Buttons/CheckoutNowButton.vue
@@ -2,7 +2,8 @@
 	<kv-button
 		class="checkout-now-button secondary"
 		v-kv-track-event="['Lending', 'click-Read more', 'checkout-now-button-click', loanId, loanId]"
-		to="/basket"
+		:to="disableRedirects ? null : '/basket'"
+		@click.native="checkoutBtnAction"
 	>
 		<kv-icon class="icon" name="checkmark" v-if="!minimalCheckoutButton" />
 		Checkout<span v-if="!minimalCheckoutButton"> now</span>
@@ -19,6 +20,10 @@ export default {
 		KvButton,
 	},
 	props: {
+		disableRedirects: {
+			type: Boolean,
+			default: false,
+		},
 		loanId: {
 			type: Number,
 			default: null
@@ -28,6 +33,16 @@ export default {
 			default: false,
 		},
 	},
+	methods: {
+		checkoutBtnAction() {
+			this.$emit(
+				'add-to-basket',
+				{
+					eventSource: 'checkoutBtnClick'
+				}
+			);
+		}
+	}
 };
 
 </script>

--- a/src/components/LoanCards/LendHomepageLoanCard.vue
+++ b/src/components/LoanCards/LendHomepageLoanCard.vue
@@ -53,6 +53,7 @@
 					:class="{'full-width': isFunded || isExpired}"
 				>
 					<kv-button
+						v-if="showViewLoanCta"
 						class="action-button"
 						:to="`/lend/${loan.id}`"
 						v-kv-track-event="[
@@ -64,7 +65,8 @@
 					>
 						View loan
 					</kv-button>
-					<!-- <action-button
+					<action-button
+						v-else
 						class="action-button"
 						:loan-id="loan.id"
 						:loan="loan"
@@ -83,7 +85,7 @@
 						})"
 
 						@add-to-basket="handleAddToBasket"
-					/> -->
+					/>
 				</div>
 				<div class="lend-homepage-loan-card__matching-text-container" :class="{hide: isFunded || isExpired}">
 					<matching-text
@@ -104,7 +106,7 @@ import KvFlag from '@/components/Kv/KvFlag';
 import LoanCardImage from '@/components/LoanCards/LoanCardImage';
 import FundraisingStatus from '@/components/LoanCards/FundraisingStatus/FundraisingStatus';
 import BorrowerInfoBody from '@/components/LoanCards/BorrowerInfo/BorrowerInfoBody';
-// import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
+import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import MatchingText from '@/components/LoanCards/MatchingText';
 import BorrowerInfoName from '@/components/LoanCards/BorrowerInfo/BorrowerInfoName';
 
@@ -120,7 +122,7 @@ export default {
 		KvFlag,
 		LoanCardImage,
 		FundraisingStatus,
-		// ActionButton,
+		ActionButton,
 		KvButton,
 		MatchingText,
 		BorrowerInfoName,
@@ -130,9 +132,17 @@ export default {
 			type: Number,
 			default: 0,
 		},
+		disableRedirects: {
+			type: Boolean,
+			default: false,
+		},
 		expiringSoonMessage: {
 			type: String,
 			default: ''
+		},
+		showViewLoanCta: {
+			type: Boolean,
+			default: false,
 		},
 		isFavorite: {
 			type: Boolean,

--- a/src/components/LoanCards/LendHomepageLoanCard.vue
+++ b/src/components/LoanCards/LendHomepageLoanCard.vue
@@ -68,6 +68,7 @@
 					<action-button
 						v-else
 						class="action-button"
+						:disable-redirects="disableRedirects"
 						:loan-id="loan.id"
 						:loan="loan"
 						:items-in-basket="itemsInBasket"

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -302,6 +302,7 @@ export default {
 		},
 		// the final outcome of adding a loan to basket
 		// payload is { loanId: ######, success: true/false }
+		// optionally payload may also contain an eventSource identifier
 		handleAddToBasket(payload) {
 			this.$emit('add-to-basket', payload);
 		},

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -3,6 +3,7 @@
 		class="loan-card-controller"
 		:amount-left="amountLeft"
 		:card-number="cardNumber"
+		:disable-redirects="disableRedirects"
 		:experiment-data="experimentData"
 		:expiring-soon-message="expiringSoonMessage"
 		:is-favorite="isFavorite"
@@ -13,6 +14,7 @@
 		:key="loan.id"
 		:loan="loan"
 		:percent-raised="percentRaised"
+		:show-view-loan-cta="showViewLoanCta"
 		:title="title"
 		:is="loanCardType"
 
@@ -82,6 +84,10 @@ export default {
 		ListLoanCard,
 	},
 	props: {
+		disableRedirects: {
+			type: Boolean,
+			default: false,
+		},
 		loanCardType: {
 			type: String,
 			required: true,
@@ -160,6 +166,10 @@ export default {
 			default: 0,
 		},
 		preventUpdatingDetailedCard: {
+			type: Boolean,
+			default: false,
+		},
+		showViewLoanCta: {
 			type: Boolean,
 			default: false,
 		},

--- a/src/pages/Homepage/LendByCategoryHomepage.vue
+++ b/src/pages/Homepage/LendByCategoryHomepage.vue
@@ -11,7 +11,7 @@
 		>
 			<div class="row align-center">
 				<div class="small-12 medium-10 large-6 xlarge-5 small-order-2 large-order-1 columns">
-					<!-- <featured-loans-carousel /> -->
+					<!-- <featured-loans-carousel :show-view-loan-cta="true" /> -->
 					<no-click-loan-card />
 				</div>
 				<!-- eslint-disable-next-line max-len -->


### PR DESCRIPTION
Introduces the option to showViewLoanCta (link to loan detail) for the LendHomepageLoanCard which will now also be used on landing pages.

Also, introduces the option to not automatically redirect when clicking the Checkout button and to respond to the bubbled `add-to-cart` event instead.

I've verified the alternate/default states for both of these in the homepage context. These changes are required and included in some landing page work that is forthcoming.