### PR TITLE
Add new Experiment Id Link to target specific experiment ids and pass…

### DIFF
--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -52,6 +52,6 @@ export default () => {
 			return previousContext;
 		}
 		// add header to existing context and pass along
-		return _set(previousContext, 'headers.X-Experiment', experimentHeader);
+		return _set(previousContext, 'headers.X-Experiments', experimentHeader);
 	});
 };

--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -5,7 +5,6 @@ import cookieStore from '@/util/cookieStore';
 // Experiment Ids from setting that will be passed in the X-Experiment Header
 const targetIds = [
 	'category_row_hillclimb',
-	'redirect_to_login',
 	'ml_loan_to_loan',
 ];
 

--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -1,0 +1,57 @@
+import { setContext } from 'apollo-link-context';
+import _set from 'lodash/set';
+import cookieStore from '@/util/cookieStore';
+
+// Experiment Ids from setting that will be passed in the X-Experiment Header
+const targetIds = [
+	'category_row_hillclimb',
+	'redirect_to_login',
+	'ml_loan_to_loan',
+];
+
+function buildExpHeaders() {
+	// kiva specific experiment cookie
+	const exps = cookieStore.get('uiab');
+	// handle missing cookie
+	if (typeof exps === 'undefined') {
+		return '';
+	}
+	const expCookieArray = exps.split('|');
+	// filter experiments to only those containing targeted ids
+	const targetExps = expCookieArray.filter(exp => {
+		let matched = false;
+		targetIds.forEach(expId => {
+			if (exp.indexOf(expId) !== -1) {
+				matched = true;
+				return true;
+			}
+		});
+		return matched;
+	});
+
+	// set experiment id:version then concatenate
+	let experimentHeader = '';
+	targetExps.forEach((target, index) => {
+		const expSegments = target.split(':');
+		if (expSegments.length && expSegments.length > 1) {
+			experimentHeader += `${expSegments[0]}:${expSegments[1]}`;
+			if (targetExps.length - 1 > index) {
+				experimentHeader += ',';
+			}
+		}
+	});
+	return experimentHeader;
+}
+
+export default () => {
+	return setContext((operation, previousContext) => {
+		// fetch experiment header
+		const experimentHeader = buildExpHeaders();
+		// pass along existing context if no session id exists
+		if (experimentHeader === '') {
+			return previousContext;
+		}
+		// add header to existing context and pass along
+		return _set(previousContext, 'headers.X-Experiment', experimentHeader);
+	});
+};

--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -34,7 +34,7 @@ function buildExpHeaders() {
 	targetExps.forEach((target, index) => {
 		const expSegments = target.split(':');
 		if (expSegments.length && expSegments.length > 1) {
-			experimentHeader += `${expSegments[0]}:${expSegments[1]}`;
+			experimentHeader += `${expSegments[0]};${expSegments[1]}`;
 			if (targetExps.length - 1 > index) {
 				experimentHeader += ',';
 			}

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -8,6 +8,7 @@ import {
 } from 'apollo-cache-inmemory';
 import Auth0LinkCreator from './Auth0Link';
 import BasketLinkCreator from './BasketLink';
+import ExperimentIdLink from './ExperimentIdLink';
 import HttpLinkCreator from './HttpLink';
 import NetworkErrorLink from './NetworkErrorLink';
 import SnowplowSessionLink from './SnowplowSessionLink';
@@ -51,6 +52,7 @@ export default function createApolloClient({
 		link: ApolloLink.from([
 			NetworkErrorLink(),
 			SnowplowSessionLink(),
+			ExperimentIdLink(),
 			Auth0LinkCreator(kvAuth0),
 			BasketLinkCreator(),
 			HttpLinkCreator({ csrfToken, uri }),


### PR DESCRIPTION
… through with a new header, X-Experiment.

ex. (legacy experiment names + versions)
`X-Experiments | redirect_to_login;b,category_row_hillclimb;variant-a,ml_loan_to_loan;shown`

ex. (new experiment name + versions)
`X-Experiments | EXP-ML-Service-Bandit;b,EXP-GROW-330-KivaLoves;a`
