### PR TITLE
VUE-467 KvLightBox Focus

### DIFF
--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -110,6 +110,8 @@ export default {
 	watch: {
 		// Create and set our internal visibility property
 		visible() {
+			// Drop focus to avoid the focus automatically focusing close button
+			document.activeElement.blur();
 			this.isShown = this.visible;
 			if (this.isShown) {
 				document.addEventListener('keyup', this.onKeyUp);

--- a/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
+++ b/src/pages/Subscriptions/SubscriptionsMonthlyGood.vue
@@ -146,7 +146,6 @@
 					<subscriptions-monthly-good-cancellation-flow
 						:show-cancel-lightbox="showCancelLightbox"
 						:subscription-id="subscriptionId"
-						v-if="showCancelLightbox"
 						@confirm-cancel="$emit('cancel-subscription'); showCancelLightbox = false;"
 						@abort-cancel="showCancelLightbox = false"
 						@modify-cancel="showCancelLightbox = false; showEditLightbox = true"


### PR DESCRIPTION
* Fixes issue with mg settings lightbox not firing watcher
* Fixes issue with all lightboxes autofocusing close button on load

VUE-467

The focus issue was only happening on the site, not storybook. Verified that the lightbox still pops up and traps focus, but focus isn't initialized. 