### PR TITLE
GROW-382 use mfaMethod.id instead of mfaMethod.authId

### DIFF
--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -268,7 +268,7 @@ export default {
 						mutation: removeOneMfaMethod,
 						variables: {
 							mfa_token: token,
-							id: mfaMethod.authId
+							id: mfaMethod.id
 						}
 					})
 						.then(() => {


### PR DESCRIPTION
I haven't actually tested this on my vm, but I came across this as the possible problem after I noticed in the network inspector that the removeOneMfaMethod query didn't have the `id` variable. I don't see `authId` used anywhere else, so I think this didn't get updated when `formatMfaMethods()` changed.