### PR TITLE
removing settings card's padding on small screens

### DIFF
--- a/src/pages/Settings/SecuritySettings.vue
+++ b/src/pages/Settings/SecuritySettings.vue
@@ -1,7 +1,7 @@
 <template>
 	<www-page class="security-login-page" :gray-background="true">
 		<the-my-kiva-secondary-menu slot="secondary" />
-		<div class="security-login__title-area">
+		<div class="security-login-page__title-area">
 			<div class="row column">
 				<h1>
 					Security and login

--- a/src/pages/Settings/SecuritySettings.vue
+++ b/src/pages/Settings/SecuritySettings.vue
@@ -1,22 +1,20 @@
 <template>
 	<www-page class="security-login" :gray-background="true">
 		<the-my-kiva-secondary-menu slot="secondary" />
-		<div class="title-area">
+		<div class="security-login__title-area">
 			<div class="row column">
 				<h1>
 					Security and login
 				</h1>
 			</div>
 		</div>
-		<div class="security-settings-page">
-			<div class="row">
-				<div class="columns small-12 large-8">
-					<password />
-					<two-step-verification />
-				</div>
-				<div class="columns small-12 large-4">
-					<two-step-faq />
-				</div>
+		<div class="row">
+			<div class="columns small-12 large-8 security-login__component-container">
+				<password />
+				<two-step-verification />
+			</div>
+			<div class="columns small-12 large-4 security-login__component-container">
+				<two-step-faq />
 			</div>
 		</div>
 	</www-page>
@@ -47,10 +45,18 @@ export default {
 @import 'settings';
 
 .security-login {
-	.title-area {
+	&__title-area {
 		padding: 1.625rem 0;
 		margin-bottom: 2rem;
 		background-color: $white;
+	}
+
+	&__component-container {
+		padding: 0;
+
+		@include breakpoint(medium) {
+			padding: unset;
+		}
 	}
 }
 

--- a/src/pages/Settings/SecuritySettings.vue
+++ b/src/pages/Settings/SecuritySettings.vue
@@ -1,5 +1,5 @@
 <template>
-	<www-page class="security-login" :gray-background="true">
+	<www-page class="security-login-page" :gray-background="true">
 		<the-my-kiva-secondary-menu slot="secondary" />
 		<div class="security-login__title-area">
 			<div class="row column">
@@ -9,11 +9,11 @@
 			</div>
 		</div>
 		<div class="row">
-			<div class="columns small-12 large-8 security-login__component-container">
+			<div class="columns small-12 large-8 security-login-page__component-container">
 				<password />
 				<two-step-verification />
 			</div>
-			<div class="columns small-12 large-4 security-login__component-container">
+			<div class="columns small-12 large-4 security-login-page__component-container">
 				<two-step-faq />
 			</div>
 		</div>
@@ -44,7 +44,7 @@ export default {
 <style lang="scss" scoped>
 @import 'settings';
 
-.security-login {
+.security-login-page {
 	&__title-area {
 		padding: 1.625rem 0;
 		margin-bottom: 2rem;

--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -9,7 +9,7 @@
 			</div>
 		</div>
 		<div class="row">
-			<div class="column small-12 large-8">
+			<div class="column small-12 large-8 two-step-verification__settings-card-area">
 				<!--
 					Toggle MFA off settings card
 				-->
@@ -221,6 +221,7 @@ export default {
 	},
 	methods: {
 		gatherMfaEnrollments() {
+			console.log('gatherMfaEnrollments triggered');
 			this.kvAuth0.checkSession()
 				.then(() => this.kvAuth0.getMfaManagementToken())
 				.then(token => {
@@ -261,6 +262,7 @@ export default {
 			});
 		},
 		removeMfaMethod(mfaMethod) {
+			console.log('removeMFA Method triggered', mfaMethod);
 			this.kvAuth0.checkSession()
 				.then(() => this.kvAuth0.getMfaManagementToken())
 				.then(token => {
@@ -317,6 +319,14 @@ export default {
 		padding: 1.625rem 0;
 		margin-bottom: 2rem;
 		background-color: $white;
+	}
+
+	&__settings-card-area {
+		padding: 0;
+
+		@include breakpoint(medium) {
+			padding: unset;
+		}
 	}
 
 	&__method {

--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -221,7 +221,6 @@ export default {
 	},
 	methods: {
 		gatherMfaEnrollments() {
-			console.log('gatherMfaEnrollments triggered');
 			this.kvAuth0.checkSession()
 				.then(() => this.kvAuth0.getMfaManagementToken())
 				.then(token => {
@@ -262,7 +261,6 @@ export default {
 			});
 		},
 		removeMfaMethod(mfaMethod) {
-			console.log('removeMFA Method triggered', mfaMethod);
 			this.kvAuth0.checkSession()
 				.then(() => this.kvAuth0.getMfaManagementToken())
 				.then(token => {


### PR DESCRIPTION
Removed the padding from the settings-cards on small screens for /settings/security & setting/security/mfa. 
This change makes these two pages look visually consistent with the /settings/autolend page when on a small screen.

Cards now have no padding while on small screen sizes:
<img width="371" alt="Screen Shot 2021-01-11 at 2 00 31 PM" src="https://user-images.githubusercontent.com/1521381/104243428-675b1180-5415-11eb-94bb-b167705c3bfa.png">
