### PR TITLE
Use content group type instead of key when creating and accessing the…

### DIFF
--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -32,8 +32,9 @@
 							Support causes you care about.
 						</h2>
 
+						<!-- :applied-filters="filters" -->
 						<campaign-loan-filters
-							v-if="showTestFilters"
+							v-show="showTestFilters"
 							:initial-filters="initialFilters"
 							@updated-filters="handleUpdatedFilters"
 						/>
@@ -473,12 +474,12 @@ export default {
 		heroAreaContent() {
 			const contentGroups = this.pageData?.page?.contentGroups;
 			// Expects a content group with key = `campaign-hero-cg`
-			const heroArea = contentGroups.campaignHeroCg;
+			const heroArea = contentGroups.mlCampaignHero;
 			return heroArea;
 		},
 		partnerAreaContent() {
 			const contentGroups = this.pageData?.page?.contentGroups;
-			const partnerArea = contentGroups?.partnerAreaCg;
+			const partnerArea = contentGroups?.mlCampaignPartnerCopy;
 			return partnerArea;
 		},
 		promoAmount() {

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -208,7 +208,13 @@ export function formatContentGroupsFlat(contentfulContent) {
 				contentGroupFields.media = formatMediaAssetArray(entry.fields?.media);
 			}
 			cleanedContentGroups.push(contentGroupFields);
-			contentGroupsFlat[camelCase(entry.fields?.key) || `cg${index}`] = contentGroupFields;
+
+			const cgType = entry.fields?.type ? camelCase(entry.fields?.type) : null;
+			contentGroupsFlat[
+				cgType
+				|| camelCase(entry.fields?.key)
+				|| `cg${index}`
+			] = contentGroupFields;
 		}
 	});
 

--- a/test/unit/specs/util/contentfulUtils.spec.js
+++ b/test/unit/specs/util/contentfulUtils.spec.js
@@ -193,7 +193,7 @@ describe('contentfulUtils.js', () => {
 				},
 				settings: expect.any(Array),
 				contentGroups: {
-					promoCampaignTestCg: {
+					mlCampaignHero: {
 						key: 'promo-campaign-test-cg',
 						name: 'Promo Campaign Test Content Groups',
 						contents: [{
@@ -266,7 +266,7 @@ describe('contentfulUtils.js', () => {
 				}),
 				settings: expect.any(Array),
 				contentGroups: expect.objectContaining({
-					promoCampaignTestCg: expect.objectContaining({
+					mlCampaignHero: expect.objectContaining({
 						key: expect.any(String),
 						name: expect.any(String),
 						contents: [{


### PR DESCRIPTION
… processed content group data from a page.