### PR TITLE
grow-387 adjustments to KvVerficationCodeInput for small screens.

### DIFF
--- a/src/components/Kv/KvVerificationCodeInput.vue
+++ b/src/components/Kv/KvVerificationCodeInput.vue
@@ -89,15 +89,9 @@ export default {
 	&__input {
 		font-size: 1em;
 		font-variant-numeric: tabular-nums;
-		letter-spacing: 0.2em;
-		padding: 0.7em 0 0.7em 0;
-		text-align: center;
-
-		@include breakpoint(medium) {
-			letter-spacing: 0.5em;
-			padding: 1em 0 1em 0;
-			width: calc(var(--kv-verification-code-input-maxlength) * 1.1125em + 1.25em);
-		}
+		letter-spacing: 0.5em;
+		padding: 1em 0 1em 1em;
+		width: calc(var(--kv-verification-code-input-maxlength) * 1.1125em + 1.25em);
 	}
 }
 </style>

--- a/src/components/Kv/KvVerificationCodeInput.vue
+++ b/src/components/Kv/KvVerificationCodeInput.vue
@@ -89,9 +89,15 @@ export default {
 	&__input {
 		font-size: 1em;
 		font-variant-numeric: tabular-nums;
-		letter-spacing: 0.5em;
-		padding: 1em 0 1em 1em;
-		width: calc(var(--kv-verification-code-input-maxlength) * 1.1125em + 1.25em);
+		letter-spacing: 0.2em;
+		padding: 0.7em 0 0.7em 0;
+		text-align: center;
+
+		@include breakpoint(medium) {
+			letter-spacing: 0.5em;
+			padding: 1em 0 1em 0;
+			width: calc(var(--kv-verification-code-input-maxlength) * 1.1125em + 1.25em);
+		}
 	}
 }
 </style>

--- a/src/components/Settings/AppAuthentication.vue
+++ b/src/components/Settings/AppAuthentication.vue
@@ -288,6 +288,11 @@ export default {
 		font-weight: bold;
 		padding: 0.5rem;
 		margin-bottom: 1rem;
+		font-size: 0.75rem;
+
+		@include breakpoint(medium) {
+			font-size: 1rem;
+		}
 	}
 
 	.verification-code {

--- a/src/components/Settings/AppAuthentication.vue
+++ b/src/components/Settings/AppAuthentication.vue
@@ -302,6 +302,11 @@ export default {
 
 		&__input {
 			margin-bottom: 2rem;
+			font-size: 2.2rem;
+
+			@include breakpoint(medium) {
+				font-size: 3rem;
+			}
 		}
 	}
 


### PR DESCRIPTION
On small screen, the Auth App Code, and the 6 digit input didn't fit on our smallest support screen size 320px
![TheIssue](https://user-images.githubusercontent.com/1521381/104662015-b22b9200-567e-11eb-8123-d29aec032bfa.png)

Just for reference, this is the same lightbox on large screens (looking good)
<img width="1074" alt="Lg screen before my changes" src="https://user-images.githubusercontent.com/1521381/104662049-c96a7f80-567e-11eb-91bb-d46e575f7cd6.png">

I made adjustments to:
AppAuthentication.vue - Updated the font size of the returned code
-- The one thing I'm worried about with my fix, is this font-size being too small, setting it to 12px

KvVerificationCodeInput.vue - added a few style adjustments that I was hoping to get your eyes on @ryan-ludwig, I just made a couple style adjustments for small screens and reimplement most of your original styles at the medium breakpoint.

**My Fix** 
_small screen_
<img width="343" alt="fixed small screen" src="https://user-images.githubusercontent.com/1521381/104662298-5f9ea580-567f-11eb-97a6-c6a9ce5f604b.png">

_large screen_ 
<img width="1051" alt="Lfg screen after my changes" src="https://user-images.githubusercontent.com/1521381/104662310-6a593a80-567f-11eb-8a01-5323cff41bfc.png">

I think this looks good across screen sizes, but my one concern is that the App Auth code that you manually input into your auth app is too small (renders as 12px bolded). What do you two think? 

