### PR TITLE
grow-387 change for small screen size in the phoneauth.vue lightbox.

### DIFF
--- a/src/components/Settings/PhoneAuthentication.vue
+++ b/src/components/Settings/PhoneAuthentication.vue
@@ -378,6 +378,16 @@ export default {
 		color: $kiva-accent-red;
 	}
 
+	.verification-code {
+		&__input {
+			font-size: 2.15rem;
+
+			@include breakpoint(medium) {
+				font-size: 3rem;
+			}
+		}
+	}
+
 	.loading-spinner {
 		display: block;
 		margin: 2rem auto 0;


### PR DESCRIPTION
I ran into the same screen size issue with the PhoneAuthentication.vue file, so I made really similar changes in that file to get it looking better on small screen sizes: 
![Screen Shot 2021-01-15 at 2 44 28 PM](https://user-images.githubusercontent.com/1521381/104786489-e320cb00-5741-11eb-893f-ff4359b2aa87.png)


Looks the same still on larger screen sizes: 
![Screen Shot 2021-01-15 at 2 44 40 PM](https://user-images.githubusercontent.com/1521381/104786494-eae06f80-5741-11eb-836d-51213f335026.png)
