### PR TITLE
GROW-416 Fix being redirected to the email verification page on the client side when MFA authenticated

### DIFF
--- a/src/pages/StartVerification.vue
+++ b/src/pages/StartVerification.vue
@@ -83,17 +83,12 @@ export default {
 	},
 	apollo: {
 		preFetch(config, client, { route, kvAuth0 }) {
-			if (kvAuth0.isMfaAuthenticated()) {
-				return Promise.reject({
-					url: getFullPath(route.query.doneUrl || '/')
-				});
-			}
-			return client.query({ query: getVerificationState })
+			return client.query({ query: getVerificationState, fetchPolicy: 'network-only' })
 				.then(result => {
 					// Redirect to doneUrl if email has already been verified recently
-					if (result?.data?.my?.emailVerifiedRecently) {
+					if (kvAuth0.isMfaAuthenticated() || result?.data?.my?.emailVerifiedRecently) {
 						return Promise.reject({
-							url: getFullPath(route.query.doneUrl || '/')
+							path: getFullPath(route.query.doneUrl || '/')
 						});
 					}
 					return result;

--- a/src/pages/StartVerification.vue
+++ b/src/pages/StartVerification.vue
@@ -82,7 +82,12 @@ export default {
 		};
 	},
 	apollo: {
-		preFetch(config, client, { route }) {
+		preFetch(config, client, { route, kvAuth0 }) {
+			if (kvAuth0.isMfaAuthenticated()) {
+				return Promise.reject({
+					url: getFullPath(route.query.doneUrl || '/')
+				});
+			}
 			return client.query({ query: getVerificationState })
 				.then(result => {
 					// Redirect to doneUrl if email has already been verified recently

--- a/src/util/authenticationGuard.js
+++ b/src/util/authenticationGuard.js
@@ -81,7 +81,8 @@ export function authenticationGuard({ route, apolloClient, kvAuth0 }) {
 		// Route requires some sort of authentication
 		if (activeRequired || authRequired || mfaRequired || recentRequired) {
 			return apolloClient.query({
-				query: authenticationQuery
+				query: authenticationQuery,
+				fetchPolicy: 'network-only',
 			}).then(({ data }) => {
 				if (!data.my) {
 					throw new Error('api.authenticationRequired');


### PR DESCRIPTION
It possible for these methods to be called on the client before an auth token has been fetched, meaning that it would appear that the user was not MFA authenticated even when they actually were. This fixes that by ensuring their graphql queries don't use the cache, forcing a checkSession call to be made (via src/api/Auth0link.js).
Also, the email verification page wasn't checking if a user was MFA authenticated and therefore didn't need to verify their email.