### PR TITLE
ML2-167 improve checkout styles

### DIFF
--- a/.storybook/stories/KvLightbox.stories.js
+++ b/.storybook/stories/KvLightbox.stories.js
@@ -127,6 +127,48 @@ export const WithControls = (args, { argTypes }) => ({
 	`,
 });
 
+export const WithFoundationGrid = (args, { argTypes }) => ({
+	components: { KvLightbox, KvButton },
+	props: Object.keys(argTypes),
+	template: `
+		<div>
+			<kv-lightbox
+				:visible="visible"
+				:inverted="inverted"
+				:prevent-close="preventClose"
+				:title="title"
+				:no-padding-top="noPaddingTop"
+				:no-padding-bottom="noPaddingBottom"
+				:no-padding-sides="noPaddingSides"
+			>
+				<p>Hi, I'm outside the grid</p>
+				<div class="row">
+					<div class="small-12 large-6 columns">
+						<b>Grid, Full mobile, half large</b>
+					</div>
+					<div class="small-12 large-6 columns">
+						<b>Grid, Full mobile, half large</b>
+
+						<div class="row">
+							<div class="small-12 large-6 columns">
+								<b>Nested Grid, Full mobile, half large</b>
+							</div>
+							<div class="small-12 large-6 columns">
+								<b>Nested Grid, Full mobile, half large</b>
+							</div>
+						</div>
+					</div>
+				</div>
+				${loremIpsum}
+				<template slot="controls">
+					<kv-button>Button 1</kv-button>
+					<kv-button>Button 2</kv-button>
+				</template>
+			</kv-lightbox>
+		</div>
+	`,
+});
+
 export const CustomTitleColor = (args, { argTypes }) => ({
 	components: { KvLightbox },
 	props: Object.keys(argTypes),

--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -1,15 +1,15 @@
 <template>
 	<div v-show="loanVisible" class="basket-item-wrapper row">
-		<span class="hide-for-small-only medium-3 large-2">
+		<div class="hide-for-small-only medium-3 large-2 columns">
 			<checkout-item-img
 				:loan-id="loan.id"
 				:name="loan.loan.name"
 				:image-url="loan.loan.image.url"
 			/>
-		</span>
+		</div>
 
-		<span class="small-12 medium-5 large-7 borrower-info-wrapper">
-			<span class="borrower-info featured-text">
+		<div class="small-12 medium-5 large-7 columns borrower-info-wrapper">
+			<div class="borrower-info featured-text">
 				{{ loan.loan.name }} in {{ loan.loan.geocode.country.name }}
 				<loan-matcher
 					v-if="loan.loan.matchingText"
@@ -26,9 +26,9 @@
 					:loan-id="loan.id"
 					:team-id="loan.team ? loan.team.id : null"
 				/>
-			</span>
-		</span>
-		<span class="small-12 medium-4 large-3 loan-res-price-wrapper">
+			</div>
+		</div>
+		<div class="small-12 medium-4 large-3 columns loan-res-price-wrapper">
 			<loan-price
 				:price="loan.price"
 				:loan-id="loan.id"
@@ -41,7 +41,7 @@
 				@refreshtotals="onLoanUpdate($event)"
 				@updating-totals="$emit('updating-totals', $event)"
 			/>
-		</span>
+		</div>
 	</div>
 </template>
 
@@ -102,14 +102,8 @@ export default {
 	margin-bottom: rem-calc(30);
 }
 
-.borrower-info-wrapper {
-	text-align: left;
-	padding: 0;
-
-	.borrower-info {
-		text-align: left;
-		line-height: 0.8;
-		font-weight: $global-weight-highlight;
-	}
+.borrower-info {
+	line-height: 1.25;
+	font-weight: $global-weight-highlight;
 }
 </style>

--- a/src/components/Checkout/BasketItemsList.vue
+++ b/src/components/Checkout/BasketItemsList.vue
@@ -77,13 +77,8 @@ export default {
 <style lang="scss" scoped>
 @import 'settings';
 
-.basket-items-list {
-	max-width: 800px;
-	margin: 0 auto;
-}
-
 .basket-items-list ul {
+	margin: 0;
 	list-style-type: none;
-	margin-right: 1.25rem;
 }
 </style>

--- a/src/components/Checkout/BasketVerification.vue
+++ b/src/components/Checkout/BasketVerification.vue
@@ -1,13 +1,10 @@
 <template>
-	<!-- NB: Reusing .order-totals .forced-width styling. -->
-	<div class="basket-verification order-totals">
+	<div class="basket-verification">
 		<div
 			v-if="verificationState === 'verified'"
-			class="verification-verified forced-width"
+			class="verification-verified"
 		>
-			<div class="forced-width">
-				Basket Verified!
-			</div>
+			Basket Verified!
 		</div>
 
 		<kv-lightbox

--- a/src/components/Checkout/CheckoutHolidayPromo.vue
+++ b/src/components/Checkout/CheckoutHolidayPromo.vue
@@ -50,12 +50,9 @@ export default {
 .checkout-holiday-promo {
 	display: flex;
 	align-items: center;
-	padding-left: 1.25rem;
-	padding-right: 1.25rem;
 
 	@include breakpoint(medium) {
-		margin: $list-side-margin $list-side-margin 2rem;
-		padding-left: rem-calc(90);
+		margin-bottom: 2rem;
 	}
 
 	.holiday-present-icon {

--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -1,14 +1,14 @@
 <template>
 	<div class="basket-donation-item row">
-		<span class="hide-for-small-only medium-3 large-2">
-			<span class="donation-icon">
+		<div class="hide-for-small-only medium-3 large-2 columns">
+			<div class="donation-icon">
 				<kv-icon class="dedicate-heart" name="dedicate-heart" />
-			</span>
-		</span>
-		<span class="small-12 medium-5 large-7 donation-info-wrapper">
-			<span class="donation-info featured-text">
+			</div>
+		</div>
+		<div class="small-12 medium-5 large-7 columns donation-info-wrapper">
+			<div class="donation-info featured-text">
 				{{ donationTitle }}
-			</span>
+			</div>
 			<div v-if="hasLoans">
 				<div class="donation-tagline small-text" v-html="donationTagLine">
 				</div>
@@ -20,9 +20,8 @@
 					{{ donationDetailsLink }}
 				</button>
 			</div>
-		</span>
-		<!-- <span class="small-3 show-for-small-only"></span> -->
-		<span class="small-12 medium-4 large-3 medium-text-font-size">
+		</div>
+		<div class="small-12 medium-4 large-3 columns medium-text-font-size">
 			<div
 				v-show="!editDonation"
 				class="donation-amount-wrapper"
@@ -32,7 +31,8 @@
 					v-kv-track-event="['basket', 'Edit Donation']"
 					@click="enterEditDonation"
 					title="Edit Donation"
-				>{{ formattedAmount }}
+				>
+					{{ formattedAmount }}
 					<kv-icon
 						role="img"
 						aria-label="Edit Donation"
@@ -42,7 +42,7 @@
 					/>
 				</button>
 			</div>
-			<div v-show="editDonation" class="small-12 donation-amount-input-wrapper">
+			<div v-show="editDonation" class="small-12 columns donation-amount-input-wrapper">
 				<input
 					type="input"
 					class="donation-amount-input"
@@ -55,7 +55,9 @@
 				<kv-button
 					class="secondary update-donation-inline-button"
 					@click.native.prevent.stop="updateDonation()"
-				>Update</kv-button>
+				>
+					Update
+				</kv-button>
 				<button
 					class="show-for-medium remove-wrapper"
 					@click="updateLoanAmount('remove')"
@@ -68,7 +70,7 @@
 				@updating-totals="$emit('updating-totals', $event)"
 				@refreshtotals="$emit('refreshtotals')"
 			/>
-		</span>
+		</div>
 		<donation-nudge-lightbox
 			v-if="!donationNudgeFellows"
 			ref="nudgeLightbox"
@@ -427,7 +429,7 @@ export default {
 }
 
 .donation-info {
-	line-height: 0.8;
+	line-height: 1.25;
 	font-weight: $global-weight-highlight;
 }
 

--- a/src/components/Checkout/InContext/InContextCheckout.vue
+++ b/src/components/Checkout/InContext/InContextCheckout.vue
@@ -153,13 +153,6 @@ export default {
 
 .in-context-checkout {
 	&__basket-items {
-		@include breakpoint(large) {
-			::v-deep .borrower-info-wrapper {
-				margin-top: 0;
-				padding: 0 0.25rem;
-			}
-		}
-
 		&--hide-donation {
 			::v-deep .basket-donation-item {
 				display: none;

--- a/src/components/Checkout/KivaCardItem.vue
+++ b/src/components/Checkout/KivaCardItem.vue
@@ -1,33 +1,33 @@
 <template>
 	<div class="basket-item-wrapper row">
-		<span class="hide-for-small-only medium-3 large-2">
-			<span class="kiva-card-icon">
+		<div class="hide-for-small-only medium-3 large-2 columns">
+			<div class="kiva-card-icon">
 				<!-- Print Kiva Card -->
-				<span v-if="cardType == 'print'">
-					<img alt="print-kiva-card"
-						class="card-preview"
-						src="~@/assets/images/checkout/kiva_card_print_preview.jpg"
-					>
-				</span>
+				<img
+					v-if="cardType == 'print'"
+					alt="print-kiva-card"
+					class="card-preview"
+					src="~@/assets/images/checkout/kiva_card_print_preview.jpg"
+				>
 				<!-- Postal Kiva Card -->
-				<span v-if="cardType == 'postal'">
-					<img alt="postal-kiva-card"
-						class="card-preview"
-						src="~@/assets/images/checkout/kiva_card_postal_preview.jpg"
-					>
-				</span>
+				<img
+					v-if="cardType == 'postal'"
+					alt="postal-kiva-card"
+					class="card-preview"
+					src="~@/assets/images/checkout/kiva_card_postal_preview.jpg"
+				>
 				<!-- Email Kiva Card -->
-				<span v-if="cardType == 'email'">
-					<img alt="email-kiva-card"
-						class="card-preview"
-						src="~@/assets/images/checkout/kiva_card_email_preview.jpg"
-					>
-				</span>
-			</span>
-		</span>
-		<span class="small-12 medium-5 large-7 kiva-card-info-wrapper">
+				<img
+					v-if="cardType == 'email'"
+					alt="email-kiva-card"
+					class="card-preview"
+					src="~@/assets/images/checkout/kiva_card_email_preview.jpg"
+				>
+			</div>
+		</div>
+		<div class="small-12 medium-5 large-7 columns kiva-card-info-wrapper">
 			<!-- Main line text -->
-			<span class="kiva-card-info featured-text">
+			<div class="kiva-card-info featured-text">
 				<!-- Print Kiva Card -->
 				<span v-if="cardType == 'print'">Print-it-yourself Kiva Card
 					<span v-if="quantity > 1">({{ quantity }})</span>
@@ -71,9 +71,9 @@
 						<div class="small-text">For {{ recipientName }} {{ recipientEmail }}</div>
 					</span>
 				</div>
-			</span>
-		</span>
-		<span class="small-12 medium-4 large-3 price-wrapper medium-text-font-size">
+			</div>
+		</div>
+		<div class="small-12 medium-4 large-3 columns price-wrapper medium-text-font-size">
 			<!-- Kiva card amount dropdown section -->
 			<loan-price
 				:ids-in-group="kivaCard.idsInGroup"
@@ -82,7 +82,7 @@
 				@refreshtotals="onLoanUpdate($event)"
 				@updating-totals="$emit('updating-totals', $event)"
 			/>
-		</span>
+		</div>
 	</div>
 </template>
 
@@ -152,7 +152,7 @@ export default {
 }
 
 .kiva-card-info {
-	line-height: 0.8;
+	line-height: 1.25;
 	font-weight: $global-weight-highlight;
 }
 

--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -1,9 +1,9 @@
 <template>
-	<div class="columns">
+	<div>
 		<div
 			class="kiva-card-entry-wrapper row"
 		>
-			<span class="small-3 large-2">
+			<div class="small-3 large-2 columns">
 				<button @click="toggleAccordion">
 					<kv-icon
 						:class="{ flipped: open }"
@@ -12,9 +12,9 @@
 						:from-sprite="true"
 					/>
 				</button>
-			</span>
+			</div>
 			<button
-				class="featured-text accordion-title small-9 large-10"
+				class="featured-text accordion-title small-9 large-10 columns"
 				@click="toggleAccordion"
 			>
 				Have a Kiva Card?
@@ -22,29 +22,33 @@
 			<kv-expandable easing="ease-in-out">
 				<div
 					v-show="open"
-					class="accordion-info row small-12"
+					class="accordion-info row small-12 columns"
 				>
-					<div class="small-3 large-2"></div>
-					<div class="small-9 large-10">
-						<div>
-							<input
-								placeholder="ABCD-1234-EFGH-5678"
-								class="kiva-card-input"
-								v-model="kivaCardCode"
-								@keyup.enter.prevent="updateKivaCard('redemption_code')"
-							>
-							<button class="button secondary"
-								@click.prevent="updateKivaCard('redemption_code')"
-							>
-								Apply
-							</button>
-
-							<!-- This lightbox will be replaced with a Popper tip message. -->
-							<button @click.prevent="triggerDefaultLightbox"
-								class="help-lightbox-trigger"
-							>
-								Need help?
-							</button>
+					<div class="small-9 small-offset-3 large-10 large-offset-2 columns">
+						<div class="row">
+							<div class="small-9 large-5 xlarge-4 columns">
+								<input
+									placeholder="ABCD-1234-EFGH-5678"
+									class="kiva-card-input"
+									v-model="kivaCardCode"
+									@keyup.enter.prevent="updateKivaCard('redemption_code')"
+								>
+							</div>
+							<div class="small-4 large-3 xlarge-2 columns">
+								<button class="button secondary"
+									@click.prevent="updateKivaCard('redemption_code')"
+								>
+									Apply
+								</button>
+							</div>
+							<div class="small-4 columns align-self-middle">
+								<!-- This lightbox will be replaced with a Popper tip message. -->
+								<button @click.prevent="triggerDefaultLightbox"
+									class="help-lightbox-trigger"
+								>
+									Need help?
+								</button>
+							</div>
 							<kv-lightbox
 								:visible="defaultLbVisible"
 								@lightbox-closed="lightboxClosed"
@@ -196,11 +200,6 @@ export default {
 <style lang="scss" scoped>
 @import "settings";
 
-div.columns .kiva-card-entry-wrapper {
-	max-width: rem-calc(800);
-	margin: 0 auto;
-}
-
 .toggle-arrow {
 	transition: transform 300ms ease;
 	display: block;
@@ -215,42 +214,31 @@ div.columns .kiva-card-entry-wrapper {
 
 .accordion-title {
 	font-weight: $global-weight-highlight;
-	padding-left: rem-calc(7);
 	text-align: left;
-
-	@include breakpoint(medium) {
-		padding-left: 0;
-	}
-
-	&:hover {
-		cursor: pointer;
-	}
 }
 
 .flipped {
 	transform: rotate(180deg);
 }
 
-.accordion-info button.secondary {
-	color: $kiva-accent-blue;
-	border: 1px solid $kiva-accent-blue;
-	box-shadow: 0 1px $kiva-accent-blue;
-	visibility: visible;
-	font-size: $medium-text-font-size;
-	margin: rem-calc(15) rem-calc(15) 0 rem-calc(20);
+.accordion-info {
+	margin-top: 1rem;
+	margin-bottom: 1rem;
 
-	@include breakpoint(medium) {
-		padding: rem-calc(6) rem-calc(20);
-		margin-right: rem-calc(15);
-		margin-left: rem-calc(17);
-		width: inherit;
-		font-size: $normal-text-font-size;
-		height: rem-calc(36);
-	}
+	button.secondary {
+		color: $kiva-accent-blue;
+		border: 1px solid $kiva-accent-blue;
+		box-shadow: 0 1px $kiva-accent-blue;
+		visibility: visible;
+		font-size: $medium-text-font-size;
+		margin-bottom: 0;
+		width: 100%;
 
-	@include breakpoint(large) {
-		float: left;
-		margin: rem-calc(15) rem-calc(15) 0 0;
+		@include breakpoint(medium) {
+			padding: rem-calc(6) rem-calc(20);
+			font-size: $normal-text-font-size;
+			height: rem-calc(36);
+		}
 	}
 }
 
@@ -281,38 +269,21 @@ div.columns .kiva-card-entry-wrapper {
 }
 
 .kiva-card-input {
-	width: rem-calc(240);
+	width: 100%;
+	height: rem-calc(50);
 	border: 1px solid $charcoal;
 	color: $charcoal;
 	border-radius: $button-radius;
 	font-weight: 300;
 	text-align: center;
 	display: block;
-	height: rem-calc(50);
 	font-size: $medium-text-font-size;
-	margin-left: rem-calc(20);
-
-	@include breakpoint(medium) {
-		margin: rem-calc(15) rem-calc(15) rem-calc(15) rem-calc(17);
-	}
+	margin-bottom: 1rem;
 
 	@include breakpoint(large) {
-		width: rem-calc(200);
 		font-size: $normal-text-font-size;
-		float: left;
 		height: rem-calc(37);
-	}
-}
-
-.help-lightbox-trigger {
-	margin: 1.2rem 0;
-	position: relative;
-	top: rem-calc(9);
-
-	@include breakpoint(large) {
-		float: left;
-		top: unset;
-		position: unset;
+		margin-bottom: 0;
 	}
 }
 
@@ -320,7 +291,6 @@ div.columns .kiva-card-entry-wrapper {
 	fill: $subtle-gray;
 	width: 1.1rem;
 	height: 1.1rem;
-	cursor: pointer;
 	vertical-align: middle;
 	margin-top: -0.1rem;
 }

--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -1,102 +1,98 @@
 <template>
-	<div>
-		<div
-			class="kiva-card-entry-wrapper row"
-		>
-			<div class="small-3 large-2 columns">
-				<button @click="toggleAccordion">
-					<kv-icon
-						:class="{ flipped: open }"
-						class="toggle-arrow"
-						name="medium-chevron"
-						:from-sprite="true"
-					/>
-				</button>
-			</div>
-			<button
-				class="featured-text accordion-title small-9 large-10 columns"
-				@click="toggleAccordion"
-			>
-				Have a Kiva Card?
+	<div class="kiva-card-entry-wrapper row">
+		<div class="small-3 large-2 columns">
+			<button @click="toggleAccordion">
+				<kv-icon
+					:class="{ flipped: open }"
+					class="toggle-arrow"
+					name="medium-chevron"
+					:from-sprite="true"
+				/>
 			</button>
-			<kv-expandable easing="ease-in-out">
-				<div
-					v-show="open"
-					class="accordion-info row small-12 columns"
-				>
-					<div class="small-9 small-offset-3 large-10 large-offset-2 columns">
-						<div class="row">
-							<div class="small-9 large-5 xlarge-4 columns">
-								<input
-									placeholder="ABCD-1234-EFGH-5678"
-									class="kiva-card-input"
-									v-model="kivaCardCode"
-									@keyup.enter.prevent="updateKivaCard('redemption_code')"
-								>
-							</div>
-							<div class="small-4 large-3 xlarge-2 columns">
-								<button class="button secondary"
-									@click.prevent="updateKivaCard('redemption_code')"
-								>
-									Apply
-								</button>
-							</div>
-							<div class="small-4 columns align-self-middle">
-								<!-- This lightbox will be replaced with a Popper tip message. -->
-								<button @click.prevent="triggerDefaultLightbox"
-									class="help-lightbox-trigger"
-								>
-									Need help?
-								</button>
-							</div>
-							<kv-lightbox
-								:visible="defaultLbVisible"
-								@lightbox-closed="lightboxClosed"
-								title="Where can I find my Kiva Card code?"
+		</div>
+		<button
+			class="featured-text accordion-title small-9 large-10 columns"
+			@click="toggleAccordion"
+		>
+			Have a Kiva Card?
+		</button>
+		<kv-expandable easing="ease-in-out">
+			<div
+				v-show="open"
+				class="accordion-info row small-12 columns"
+			>
+				<div class="small-9 small-offset-3 large-10 large-offset-2 columns">
+					<div class="row">
+						<div class="small-9 large-5 xlarge-4 columns">
+							<input
+								placeholder="ABCD-1234-EFGH-5678"
+								class="kiva-card-input"
+								v-model="kivaCardCode"
+								@keyup.enter.prevent="updateKivaCard('redemption_code')"
 							>
-								<p>
-									Kiva issues three types of Kiva Cards: print-it-yourself cards,
-									email delivery and postal delivery.
-								</p>
-								<p>Print-it-yourself:</p>
-								<img alt="print-kiva-card"
-									class="card-spacing"
-									height="116"
-									src="~@/assets/images/checkout/printcard_codelocation.jpg"
-									width="450"
-								>
-								<p>Email delivery:</p>
-								<img alt="email-kiva-card"
-									class="card-spacing"
-									height="199"
-									src="~@/assets/images/checkout/emailcard_codelocation.jpg"
-									width="450"
-								>
-								<p>Postal delivery:</p>
-								<img alt="postal-kiva-card"
-									class="postal-card"
-									height="158"
-									src="~@/assets/images/checkout/physicalcard_codelocation.jpg"
-									width="430"
-								>
-							</kv-lightbox>
-
-							<ul class="redemption-items">
-								<li v-for="(credit, index) in credits" :key="index">
-									<span class="heading">Kiva Card value: </span>
-									<span class="value">${{ credit.applied }}</span>
-									<button class="remove-wrapper"
-										@click.prevent.stop="removeCredit('redemption_code', credit.id)"
-									>
-										<kv-icon class="remove-x" name="small-x" :from-sprite="true" title="Remove" />
-									</button>
-								</li>
-							</ul>
 						</div>
+						<div class="small-4 large-3 xlarge-2 columns">
+							<button class="button secondary"
+								@click.prevent="updateKivaCard('redemption_code')"
+							>
+								Apply
+							</button>
+						</div>
+						<div class="small-4 columns align-self-middle">
+							<!-- This lightbox will be replaced with a Popper tip message. -->
+							<button @click.prevent="triggerDefaultLightbox"
+								class="help-lightbox-trigger"
+							>
+								Need help?
+							</button>
+						</div>
+						<kv-lightbox
+							:visible="defaultLbVisible"
+							@lightbox-closed="lightboxClosed"
+							title="Where can I find my Kiva Card code?"
+						>
+							<p>
+								Kiva issues three types of Kiva Cards: print-it-yourself cards,
+								email delivery and postal delivery.
+							</p>
+							<p>Print-it-yourself:</p>
+							<img alt="print-kiva-card"
+								class="card-spacing"
+								height="116"
+								src="~@/assets/images/checkout/printcard_codelocation.jpg"
+								width="450"
+							>
+							<p>Email delivery:</p>
+							<img alt="email-kiva-card"
+								class="card-spacing"
+								height="199"
+								src="~@/assets/images/checkout/emailcard_codelocation.jpg"
+								width="450"
+							>
+							<p>Postal delivery:</p>
+							<img alt="postal-kiva-card"
+								class="postal-card"
+								height="158"
+								src="~@/assets/images/checkout/physicalcard_codelocation.jpg"
+								width="430"
+							>
+						</kv-lightbox>
+
+						<ul class="redemption-items">
+							<li v-for="(credit, index) in credits" :key="index">
+								<span class="heading">Kiva Card value: </span>
+								<span class="value">${{ credit.applied }}</span>
+								<button class="remove-wrapper"
+									@click.prevent.stop="removeCredit('redemption_code', credit.id)"
+								>
+									<kv-icon class="remove-x" name="small-x" :from-sprite="true" title="Remove" />
+								</button>
+							</li>
+						</ul>
 					</div>
 				</div>
-			</kv-expandable>
-		</div>
+			</div>
+		</kv-expandable>
 	</div>
 </template>
 

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -214,11 +214,13 @@ export default {
 @import 'settings';
 
 .loan-price-wrapper {
+	display: flex;
+	align-items: flex-start;
 	white-space: nowrap;
-	float: none;
+	justify-content: flex-start;
 
 	@include breakpoint(medium) {
-		float: right;
+		justify-content: flex-end;
 	}
 }
 

--- a/src/components/Checkout/LoanReservation.vue
+++ b/src/components/Checkout/LoanReservation.vue
@@ -1,6 +1,9 @@
 <template>
-	<div class="reservation-info small-text">
-		<span v-if="expiryTime">
+	<div class="reservation-info">
+		<div
+			class="small-text"
+			v-if="expiryTime"
+		>
 			<!-- The loan-message class is on all possible loan-message return types for use in automated tests
 			that QA/David configured -->
 
@@ -10,16 +13,18 @@
 			</div>
 			<!-- Not Reserved -->
 			<div class="loan-message" v-if="loanReservationMsg1">
-				Loan not reserved. <kv-button class="text-link" @click.native="triggerDefaultLightbox">Why?</kv-button>
+				Loan not reserved. <kv-button class="text-link" @click.native="triggerDefaultLightbox">
+					Why?
+				</kv-button>
 			</div>
 			<!-- Time Based Messages -->
 			<div
 				v-if="loanReservationMsg2 || loanReservationMsg3 || loanReservationMsg4"
 				class="loan-message"
 				:class="{red: loanReservationMsg3 || loanReservationMsg4}"
-			>{{ differenceInWords }}
+			>
+				{{ differenceInWords }}
 			</div>
-
 			<!-- TODO: Replace this lightbox with a Popper tip message. -->
 			<kv-lightbox
 				class="loanNotReservedLightbox"
@@ -34,7 +39,7 @@
 					the checkout process.
 				</p>
 			</kv-lightbox>
-		</span>
+		</div>
 	</div>
 </template>
 

--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -1,33 +1,29 @@
 <template>
-	<div class="order-totals small-collapse row">
+	<div class="order-totals row">
 		<div v-if="showKivaCredit" class="kiva-credit columns small-12">
-			<div class="forced-width">
-				<span v-if="showRemoveKivaCredit">
-					Kiva credit: <span class="total-value">({{ kivaCredit }})</span>
-				</span>
-				<span v-if="showApplyKivaCredit">
-					<del>Kiva credit:</del> <span class="total-value"><del>({{ kivaCredit }})</del></span>
-				</span>
-				<button
-					v-if="showRemoveKivaCredit"
-					class="remove-credit"
-					@click="removeCredit('kiva_credit')"
-				>
-					<kv-icon class="remove-credit-icon" name="small-x" :from-sprite="true" title="Remove Credit" />
-				</button>
-				<button
-					v-if="showApplyKivaCredit"
-					class="apply-credit small-text"
-					@click="addCredit('kiva_credit')"
-				>
-					Apply
-				</button>
-			</div>
+			<span v-if="showRemoveKivaCredit">
+				Kiva credit: <span class="total-value">({{ kivaCredit }})</span>
+			</span>
+			<span v-if="showApplyKivaCredit">
+				<del>Kiva credit:</del> <span class="total-value"><del>({{ kivaCredit }})</del></span>
+			</span>
+			<button
+				v-if="showRemoveKivaCredit"
+				class="remove-credit"
+				@click="removeCredit('kiva_credit')"
+			>
+				<kv-icon class="remove-credit-icon" name="small-x" :from-sprite="true" title="Remove Credit" />
+			</button>
+			<button
+				v-if="showApplyKivaCredit"
+				class="apply-credit small-text"
+				@click="addCredit('kiva_credit')"
+			>
+				Apply
+			</button>
 		</div>
 		<div class="order-total columns small-12">
-			<div class="forced-width">
-				<strong>Total: <span class="total-value">{{ orderTotal }}</span></strong>
-			</div>
+			<strong>Total: <span class="total-value">{{ orderTotal }}</span></strong>
 		</div>
 	</div>
 </template>
@@ -119,35 +115,14 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 
 .order-totals {
 	text-align: left;
-	padding-right: 0.625rem;
-	padding-left: rem-calc(21);
 
 	@include breakpoint(medium) {
 		text-align: right;
-	}
-
-	.forced-width {
-		max-width: rem-calc(779);
-		margin: 0 auto;
-
-		@include breakpoint(medium) {
-			margin-right: rem-calc(10);
-		}
-
-		// Needed these custom break points were needed to get the correct spacing
-		// for the kiva credit & order total rows
-		@media screen and (min-width: 760px) and (max-width: 850px) {
-			margin-right: rem-calc(13);
-		}
-
-		@media screen and (min-width: 851px) {
-			margin: 0 auto;
-		}
 	}
 
 	.kiva-credit {

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -49,7 +49,12 @@
 					<div class="kv-lightbox__body"
 						ref="kvLightboxBody"
 					>
-						<slot>Lightbox body</slot>
+						<!-- gives lightbox content foundation grids the correct margins -->
+						<div class="row small-collapse">
+							<div class="small-12 columns">
+								<slot>Lightbox body</slot>
+							</div>
+						</div>
 					</div>
 					<div class="kv-lightbox__controls" v-if="this.$slots.controls">
 						<slot name="controls"></slot>

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -51,7 +51,7 @@
 					>
 						<!-- gives lightbox content foundation grids the correct margins -->
 						<div class="row small-collapse">
-							<div class="small-12 columns">
+							<div class="columns">
 								<slot>Lightbox body</slot>
 							</div>
 						</div>

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -23,26 +23,29 @@
 							</div>
 							<hr>
 						</div>
-						<basket-items-list
-							class="basket-container"
-							:loans="loans"
-							:donations="donations"
-							:kiva-cards="kivaCards"
-							:teams="teams"
-							:loan-reservation-total="parseInt(totals.loanReservationTotal)"
-							@validateprecheckout="validatePreCheckout"
-							@refreshtotals="refreshTotals($event)"
-							@updating-totals="setUpdatingTotals"
-						/>
+						<div class="basket-container">
+							<basket-items-list
+								:loans="loans"
+								:donations="donations"
+								:kiva-cards="kivaCards"
+								:teams="teams"
+								:loan-reservation-total="parseInt(totals.loanReservationTotal)"
+								@validateprecheckout="validatePreCheckout"
+								@refreshtotals="refreshTotals($event)"
+								@updating-totals="setUpdatingTotals"
+							/>
+						</div>
+
 						<hr>
 
-						<kiva-card-redemption
-							class="basket-container"
-							:credits="redemption_credits"
-							:totals="totals"
-							@refreshtotals="refreshTotals"
-							@updating-totals="setUpdatingTotals"
-						/>
+						<div class="basket-container">
+							<kiva-card-redemption
+								:credits="redemption_credits"
+								:totals="totals"
+								@refreshtotals="refreshTotals"
+								@updating-totals="setUpdatingTotals"
+							/>
+						</div>
 
 						<hr>
 

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -24,6 +24,7 @@
 							<hr>
 						</div>
 						<basket-items-list
+							class="basket-container"
 							:loans="loans"
 							:donations="donations"
 							:kiva-cards="kivaCards"
@@ -36,6 +37,7 @@
 						<hr>
 
 						<kiva-card-redemption
+							class="basket-container"
 							:credits="redemption_credits"
 							:totals="totals"
 							@refreshtotals="refreshTotals"
@@ -44,52 +46,61 @@
 
 						<hr>
 
-						<checkout-holiday-promo
-							v-if="holidayModeEnabled"
-							@updating-totals="setUpdatingTotals"
-						/>
+						<div class="basket-container">
+							<div class="row">
+								<div class="small-9 small-offset-3 large-10 large-offset-2 columns">
+									<checkout-holiday-promo
+										v-if="holidayModeEnabled"
+										@updating-totals="setUpdatingTotals"
+									/>
+								</div>
+							</div>
 
-						<order-totals
-							:totals="totals"
-							@refreshtotals="refreshTotals"
-							@updating-totals="setUpdatingTotals"
-						/>
+							<order-totals
+								:totals="totals"
+								@refreshtotals="refreshTotals"
+								@updating-totals="setUpdatingTotals"
+							/>
 
-						<basket-verification />
+							<basket-verification />
 
-						<div class="checkout-actions row" :class="{'small-collapse' : showLoginContinueButton}">
-							<div v-if="isLoggedIn" class="small-12">
-								<form v-if="showKivaCreditButton" action="/checkout" method="GET">
-									<input type="hidden" name="js_loaded" value="false">
-									<kiva-credit-payment
+							<div class="checkout-actions row">
+								<div v-if="isLoggedIn" class="small-12 columns">
+									<form v-if="showKivaCreditButton" action="/checkout" method="GET">
+										<input type="hidden" name="js_loaded" value="false">
+										<kiva-credit-payment
+											@refreshtotals="refreshTotals"
+											@updating-totals="setUpdatingTotals"
+											@complete-transaction="completeTransaction"
+											class=" checkout-button"
+											id="kiva-credit-payment-button"
+										/>
+									</form>
+
+									<checkout-drop-in-payment-wrapper
+										v-else
+										:amount="creditNeeded"
 										@refreshtotals="refreshTotals"
 										@updating-totals="setUpdatingTotals"
 										@complete-transaction="completeTransaction"
-										class=" checkout-button"
-										id="kiva-credit-payment-button"
 									/>
-								</form>
+								</div>
 
-								<checkout-drop-in-payment-wrapper
-									v-else
-									:amount="creditNeeded"
-									@refreshtotals="refreshTotals"
-									@updating-totals="setUpdatingTotals"
-									@complete-transaction="completeTransaction"
-								/>
-							</div>
-
-							<div v-else-if="!isActivelyLoggedIn && showLoginContinueButton" class="small-12">
-								<kv-button
-									class="checkout-button smallest"
-									id="login-to-continue-button"
-									v-kv-track-event="['basket', 'Login to Continue Button']"
-									title="Login to Continue Button"
-									@click.native="loginToContinue"
-									:href="'/ui-login?force=true&doneUrl=/checkout'"
+								<div
+									v-else-if="!isActivelyLoggedIn && showLoginContinueButton"
+									class="small-12 columns"
 								>
-									{{ loginContinueButtonText }}
-								</kv-button>
+									<kv-button
+										class="checkout-button smallest"
+										id="login-to-continue-button"
+										v-kv-track-event="['basket', 'Login to Continue Button']"
+										title="Login to Continue Button"
+										@click.native="loginToContinue"
+										:href="'/ui-login?force=true&doneUrl=/checkout'"
+									>
+										{{ loginContinueButtonText }}
+									</kv-button>
+								</div>
 							</div>
 						</div>
 
@@ -671,6 +682,11 @@ export default {
 	}
 }
 
+.basket-container {
+	max-width: rem-calc(800);
+	margin: 0 auto;
+}
+
 .page-content {
 	padding: 1.625rem 0;
 
@@ -688,9 +704,6 @@ export default {
 		}
 
 		.checkout-actions {
-			max-width: rem-calc(800);
-			margin: 0 auto;
-
 			.checkout-button {
 				width: 100%;
 			}
@@ -700,7 +713,6 @@ export default {
 
 				.checkout-button {
 					width: auto;
-					margin-right: rem-calc(10);
 				}
 			}
 		}

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -909,7 +909,7 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 
 .corporate-campaign-landing {
@@ -943,6 +943,10 @@ export default {
 
 .campaign-checkout {
 	margin-top: 1rem;
+
+	@include breakpoint(large) {
+		min-width: rem-calc(600);
+	}
 }
 
 .campaign-thanks {


### PR DESCRIPTION
Broadly, reworks checkout CSS to use standard Foundation grid with less overrides (mainly by adding .columns class and removing padding/margin css). Aimed to prevent overrides on overrides for the in-context checkout and make working in checkout more predictable. Visually the existing checkout should not have changed (within a few pixels).

* Replace some span > divs
* Fix scoping, removed forced-width class.

* Fix issue where lightbox contents with a foundation grid were indented too much, add a story for that.
* Min-width for the in-context checkout 

