### PR TITLE
GROW-401 Reset MFA if there is an inactive recovery code on page load

### DIFF
--- a/src/components/Settings/AppAuthentication.vue
+++ b/src/components/Settings/AppAuthentication.vue
@@ -156,6 +156,9 @@ export default {
 	mounted() {
 		this.startEnrollment();
 	},
+	beforeDestroy() {
+		this.lightboxVisible = false;
+	},
 	methods: {
 		afterScan() {
 			this.step = 1;

--- a/src/components/Settings/PhoneAuthentication.vue
+++ b/src/components/Settings/PhoneAuthentication.vue
@@ -210,6 +210,9 @@ export default {
 			return 'Phone number';
 		}
 	},
+	beforeDestroy() {
+		this.lightboxVisible = false;
+	},
 	methods: {
 		getMFAToken() {
 			return new Promise((resolve, reject) => {


### PR DESCRIPTION
If a user cancels their App Authentication setup (by closing the lightbox or closing the page) we can end up in a situation where a recovery code was generated but it was not shown to the user. We can identify those situations by the user having a recovery code method that is not active (there is only ever 1 recovery code method, and it only becomes active once the user confirms their first MFA enrollment). We can fix this situation by reseting the user's MFA so that they get a new recovery code on their next setup.