### PR TITLE
ML2-222 Don't send the raw contentful image

### DIFF
--- a/src/components/CorporateCampaign/CampaignLogoGroup.vue
+++ b/src/components/CorporateCampaign/CampaignLogoGroup.vue
@@ -2,12 +2,24 @@
 	<div class="campaign-logo-group">
 		<kiva-logo class="campaign-logo-group__kiva" />
 		<span v-if="corporateLogoUrl" class="campaign-logo-group__separator" aria-hidden="true">+</span>
-		<img
-			v-if="corporateLogoUrl"
+		<picture
 			class="campaign-logo-group__corporate"
-			:src="corporateLogoUrl"
-			alt=""
+			v-if="corporateLogoUrl"
 		>
+			<source
+				type="image/webp"
+				:srcset="`
+					${corporateLogoUrl}?h=56&fm=webp 2x,
+					${corporateLogoUrl}?h=23&fm=webp 1x`"
+			>
+			<img
+				:srcset="`
+					${corporateLogoUrl}?h=56&fm=png 2x,
+					${corporateLogoUrl}?h=23&fm=png 1x`"
+				:src="`${corporateLogoUrl}?h=23&fm=png`"
+				alt=""
+			>
+		</picture>
 	</div>
 </template>
 

--- a/src/components/CorporateCampaign/CampaignPartner.vue
+++ b/src/components/CorporateCampaign/CampaignPartner.vue
@@ -2,12 +2,24 @@
 	<section class="campaign-partner section">
 		<div class="row align-center">
 			<div class="small-12 medium-10 large-6 columns">
-				<img
+				<picture
 					v-if="partnerImage.url"
 					class="campaign-partner__img"
-					:src="partnerImage.url"
-					:alt="partnerImage.title"
 				>
+					<source
+						type="image/webp"
+						:srcset="`
+							${partnerImage.url}?w=1000&fm=webp 2x,
+							${partnerImage.url}?w=500&fm=webp 1x`"
+					>
+					<img
+						:srcset="`
+							${partnerImage.url}?w=1000&fm=jpg 2x,
+							${partnerImage.url}?w=500&fm=jpg 1x`"
+						:src="`${partnerImage.url}?w=500&fm=jpg`"
+						:alt="partnerImage.title"
+					>
+				</picture>
 			</div>
 			<div class="small-10 large-6 columns">
 				<h2

--- a/src/components/CorporateCampaign/CampaignPartnerThanks.vue
+++ b/src/components/CorporateCampaign/CampaignPartnerThanks.vue
@@ -1,11 +1,23 @@
 <template>
 	<div class="campaign-partner-thanks">
-		<img
+		<picture
 			v-if="partnerImage.url"
 			class="campaign-partner-thanks__img"
-			:src="partnerImage.url"
-			alt=""
 		>
+			<source
+				type="image/webp"
+				:srcset="`
+					${partnerImage.url}?w=1000&fm=webp 2x,
+					${partnerImage.url}?w=500&fm=webp 1x`"
+			>
+			<img
+				:srcset="`
+					${partnerImage.url}?w=1000&fm=jpg 2x,
+					${partnerImage.url}?w=500&fm=jpg 1x`"
+				:src="`${partnerImage.url}?w=500&fm=jpg`"
+				:alt="partnerImage.title"
+			>
+		</picture>
 		<h2
 			v-if="headline"
 			class="campaign-partner-thanks__header"


### PR DESCRIPTION
The images uploaded for Visa's campaign were pretty giant for what they were.
Contentful lets you add query params to dynamically set the height/width/format/quality. Saves a lot of bytes.

Original
![image](https://user-images.githubusercontent.com/187937/106670952-92dba280-6562-11eb-8b06-97e776ffae6f.png)

Using picture
![image](https://user-images.githubusercontent.com/187937/106670972-98d18380-6562-11eb-9286-4d55b853e591.png)
