### PR TITLE
grow-470 hiding the monthly good selector portion of the monthlygoodh…

### DIFF
--- a/src/pages/Homepage/MonthlyGoodHomepage.vue
+++ b/src/pages/Homepage/MonthlyGoodHomepage.vue
@@ -58,7 +58,10 @@
 			</div>
 		</section>
 
-		<section class="monthly-good-info section">
+		<section
+			v-if="showMonthlyGoodSection"
+			class="monthly-good-info section"
+		>
 			<div class="row align-center">
 				<div class="small-10 large-12 columns">
 					<h1 class="monthly-good-info__header" v-html="infoHeadline">
@@ -91,6 +94,7 @@
 
 		<!-- MG Selector Desktop -->
 		<section
+			v-if="showMonthlyGoodSection"
 			class="monthly-good-selector show-for-medium"
 			:class="{ 'sticky': isSticky}"
 			:style="{bottom: mgStickBarOffset + 'px'}"
@@ -99,7 +103,10 @@
 		</section>
 
 		<!-- MG Selector Mobile -->
-		<section class="monthly-good-selector section hide-for-large">
+		<section
+			v-if="showMonthlyGoodSection"
+			class="monthly-good-selector section hide-for-large"
+		>
 			<div class="row align-center hide-for-large">
 				<div class="small-10 columns">
 					<kv-button
@@ -363,6 +370,7 @@ export default {
 			isSticky: false,
 			initialBottomPosition: 0,
 			mgStickBarOffset: 0,
+			showMonthlyGoodSection: false,
 		};
 	},
 	computed: {

--- a/src/pages/Homepage/MonthlyGoodHomepage.vue
+++ b/src/pages/Homepage/MonthlyGoodHomepage.vue
@@ -59,7 +59,7 @@
 		</section>
 
 		<section
-			v-if="showMonthlyGoodSection"
+			v-if="showMonthlyGoodSelectorSection"
 			class="monthly-good-info section"
 		>
 			<div class="row align-center">
@@ -94,7 +94,7 @@
 
 		<!-- MG Selector Desktop -->
 		<section
-			v-if="showMonthlyGoodSection"
+			v-if="showMonthlyGoodSelectorSection"
 			class="monthly-good-selector show-for-medium"
 			:class="{ 'sticky': isSticky}"
 			:style="{bottom: mgStickBarOffset + 'px'}"
@@ -104,7 +104,7 @@
 
 		<!-- MG Selector Mobile -->
 		<section
-			v-if="showMonthlyGoodSection"
+			v-if="showMonthlyGoodSelectorSection"
 			class="monthly-good-selector section hide-for-large"
 		>
 			<div class="row align-center hide-for-large">
@@ -370,7 +370,7 @@ export default {
 			isSticky: false,
 			initialBottomPosition: 0,
 			mgStickBarOffset: 0,
-			showMonthlyGoodSection: false,
+			showMonthlyGoodSelectorSection: false,
 		};
 	},
 	computed: {


### PR DESCRIPTION
…omepage

R2.2 of GROW-470 requests that the "monthly good selector sections" of the monthlygoodhomepage be removed.
- I've added a data point and conditionally hid it for now. 

(In the near future)
We have an experiment that will test showing/hiding this MG selector module (grow-427). Once that ticket is sorted out, the data point, can been hooked up to the experiment setting.



