### PR TITLE
grow-471 removing the (most secure) language

### DIFF
--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -107,7 +107,6 @@
 						<div class="two-step-verification__sub-section">
 							<h3 class="strong">
 								Authentication app
-								<span class="two-step-verification__sub-section--green">(Most secure)</span>
 							</h3>
 							<p>
 								Receive code from an authenticator app on your device,
@@ -368,10 +367,6 @@ export default {
 
 	&__sub-section {
 		margin-top: 2rem;
-
-		&--green {
-			color: $kiva-green;
-		}
 	}
 
 	&--loading {


### PR DESCRIPTION
This additional request came in on top of grow-465. 

Simply removing the green "(Most secure)" text from the /settings/security/mfa page

![Screen Shot 2021-02-03 at 3 59 21 PM](https://user-images.githubusercontent.com/1521381/106824980-d0aafa80-6638-11eb-95b9-55b6689824bf.png)
