### PR TITLE
ML2-204 Render a span instead anchor if disabling links.

### DIFF
--- a/src/components/Checkout/CheckoutItemImg.vue
+++ b/src/components/Checkout/CheckoutItemImg.vue
@@ -1,12 +1,12 @@
 <template>
 	<router-link
+		:is="disableLink ? 'span' : 'router-link'"
 		:to="`/lend/${loanId}`"
 		v-kv-track-event="['basket', 'click-Read more', 'Photo', loanId, loanId]"
 	>
 		<img class="loan-img"
 			:src="imageUrl"
 			:alt="'photo of ' + name"
-			@click="handleImageClick"
 		>
 	</router-link>
 </template>
@@ -30,13 +30,6 @@ export default {
 			type: String,
 			default: ''
 		}
-	},
-	methods: {
-		handleImageClick(event) {
-			if (this.disableLink) {
-				event.preventDefault();
-			}
-		},
 	}
 };
 </script>


### PR DESCRIPTION
Prevents keyboard focus. Couldn't find any CSS references to this so I think it's fairly safe.