### PR TITLE
VUE-478 Remove Old Setting

### DIFF
--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -12,10 +12,7 @@
 					<div class="overlay-column columns medium-12 large-8">
 						<p class="mg-headline" v-html="pageCopy.headline">
 						</p>
-						<p class="mg-subhead" v-if="!isContentfulActive">
-							{{ pageCopy.subhead }}
-						</p>
-						<div class="mg-subhead" v-if="isContentfulActive" v-html="heroBody">
+						<div class="mg-subhead" v-html="heroBody">
 						</div>
 						<landing-form
 							:amount.sync="monthlyGoodAmount"
@@ -77,7 +74,6 @@ import experimentVersionFragment from '@/graphql/fragments/experimentVersion.gra
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 
 import { processPageContentFlat } from '@/util/contentfulUtils';
-import { settingEnabled } from '@/util/settingsUtils';
 
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import KvHero from '@/components/Kv/KvHero';
@@ -153,7 +149,6 @@ export default {
 				['wxga retina', heroImagesRequire('./monthlygood-banner-xxl-retina.jpg')],
 			],
 			pageData: {},
-			isContentfulActive: false
 		};
 	},
 	inject: ['apollo'],
@@ -188,16 +183,6 @@ export default {
 			// Check for contentful content
 			const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
 			this.pageData = pageEntry ? processPageContentFlat(pageEntry) : null;
-
-			// returns the contentful content of the uiSetting key ui-homepage-monthly-good
-			// which controls when the contentful page layout should be active
-			const uiMonthlyGoodLandingSetting = this.pageData?.page?.settings?.find(item => item.key === 'ui-homepage-monthly-good') ?? null; // eslint-disable-line max-len
-			this.isContentfulActive = settingEnabled(
-				uiMonthlyGoodLandingSetting,
-				'active',
-				'startDate',
-				'endDate'
-			);
 		},
 	},
 	computed: {
@@ -215,7 +200,6 @@ export default {
 		pageCopy() {
 			return {
 				headline: 'It\'s easy to do good.',
-				subhead: 'Support borrowers worldwide with monthly contributions as little as $5.',
 				button: 'Start Monthly Good'
 			};
 		}

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -149,7 +149,6 @@ export default {
 			],
 			thanksPageVersion: 'a',
 			isMonthlyGoodSubscriber: false,
-			isContentfulActive: false,
 			pageData: {},
 		};
 	},
@@ -204,17 +203,7 @@ export default {
 			// Check for contentful content
 			const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
 			this.pageData = pageEntry ? processPageContent(pageEntry) : null;
-
-			// returns the contentful content of the uiSetting key ui-homepage-monthly-good
-			// which controls when the contentful page layout should be active
-			const uiMonthlyGoodLandingSetting = this.pageData?.page?.settings?.find(item => item.key === 'ui-homepage-monthly-good') ?? null; // eslint-disable-line max-len
-			this.isContentfulActive = settingEnabled(
-				uiMonthlyGoodLandingSetting,
-				'active',
-				'startDate',
-				'endDate'
-			);
-		}
+		},
 	},
 	computed: {
 		borrowerSupport() {
@@ -232,33 +221,15 @@ export default {
 			// eslint-disable-next-line max-len
 			return this.ctaContentGroup?.contents?.find(contentItem => contentItem.key === 'thanks-mg-cta');
 		},
-		contentfulHeadline() {
+		ctaHeadline() {
 			return this.ctaContentBlock?.headline;
 		},
-		contentfulSubHeadline() {
+		ctaBodyCopy() {
 			return this.ctaContentBlock?.subHeadline;
 		},
-		contentfulPrimaryCtaText() {
+		ctaButtonText() {
 			return this.ctaContentBlock?.primaryCtaText;
 		},
-		ctaHeadline() {
-			if (this.isContentfulActive) {
-				return this.contentfulHeadline;
-			}
-			return null;
-		},
-		ctaBodyCopy() {
-			if (this.isContentfulActive) {
-				return this.contentfulSubHeadline;
-			}
-			return null;
-		},
-		ctaButtonText() {
-			if (this.isContentfulActive) {
-				return this.contentfulPrimaryCtaText;
-			}
-			return null;
-		}
 	},
 	mounted() {
 		confetti({


### PR DESCRIPTION
* Removes 'ui-homepage-monthly-good' setting which was used to activate contentful content on the MG landing page and thanks page.

This setting was essentially a hack - I used it to turn contentful on for these pages on a certain date. These sections (mg landing/ thanks page mg cta) should always be driven by contentful moving forward, so the setting is no longer necessary. Once this code is out, this setting will need to be removed on contentful from these page layouts as well. 

Note - The 'ui-homepage-monthly-good' setting is still active and used on the homepage to toggle the "monthly good" homepage.