### PR TITLE
grow-440 guest checkout button in place

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -747,16 +747,6 @@ export default {
 			}
 
 			.guest-checkout-button {
-				color: $kiva-accent-blue;
-				border: 1px solid $kiva-accent-blue;
-				box-shadow: 0 2px $kiva-accent-blue;
-
-				&:hover {
-					color: $kiva-accent-darkblue;
-					border: 1px solid $kiva-accent-darkblue;
-					box-shadow: 0 2px $kiva-accent-darkblue;
-				}
-
 				@include breakpoint(medium) {
 					margin-right: 1rem;
 				}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -93,6 +93,20 @@
 									v-else-if="!isActivelyLoggedIn && showLoginContinueButton"
 									class="small-12 columns"
 								>
+									<!-- Guest checkout button shown to user's with a 'kvu' cookie
+										which indicates if a user has logged into Kiva on current browser -->
+									<kv-button
+										v-if="showGuestCheckoutButton"
+										class="guest-checkout-button checkout-button smallest secondary"
+										id="guest-checkout-button"
+										v-kv-track-event="['basket', 'Guest Checkout Button']"
+										title="Checkout as guest"
+										@click.native="guestCheckout"
+									>
+										<!-- :href="'/ui-login?force=true&doneUrl=/checkout'" -->
+										Checkout as guest
+									</kv-button>
+
 									<kv-button
 										class="checkout-button smallest"
 										id="login-to-continue-button"
@@ -445,6 +459,13 @@ export default {
 		showKivaCreditButton() {
 			return parseFloat(this.creditNeeded) === 0;
 		},
+		showGuestCheckoutButton() {
+			// Checking if Kiva has been logged into on user's current browser
+			if (!cookieStore.get('kvu')) {
+				return true;
+			}
+			return false;
+		},
 		showLoginContinueButton() {
 			if (!this.myId || !this.isActivelyLoggedIn) {
 				return true;
@@ -482,6 +503,9 @@ export default {
 			}
 
 			// Doing nothing here allows the normal link handling to happen, which will send the user to /ui-login
+		},
+		guestCheckout() {
+			console.log('Guest checkout method triggered.');
 		},
 		doPopupLogin() {
 			if (this.kvAuth0.enabled) {
@@ -720,6 +744,22 @@ export default {
 
 				.checkout-button {
 					width: auto;
+				}
+			}
+
+			.guest-checkout-button {
+				color: $kiva-accent-blue;
+				border: 1px solid $kiva-accent-blue;
+				box-shadow: 0 2px $kiva-accent-blue;
+
+				&:hover {
+					color: $kiva-accent-darkblue;
+					border: 1px solid $kiva-accent-darkblue;
+					box-shadow: 0 2px $kiva-accent-darkblue;
+				}
+
+				@include breakpoint(medium) {
+					margin-right: 1rem;
 				}
 			}
 		}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -103,7 +103,6 @@
 										title="Checkout as guest"
 										@click.native="guestCheckout"
 									>
-										<!-- :href="'/ui-login?force=true&doneUrl=/checkout'" -->
 										Checkout as guest
 									</kv-button>
 


### PR DESCRIPTION
Guest checkout button shown on /checkout page if user's browser doesn't contain a 'kvu' cookie? 
ticket: https://kiva.atlassian.net/browse/GROW-440.

Desktop: 
<img width="981" alt="Screen Shot 2021-02-16 at 2 01 45 PM" src="https://user-images.githubusercontent.com/1521381/108127094-917ca080-705f-11eb-8df2-6ec8df60461a.png">

Mobile: 
<img width="279" alt="Screen Shot 2021-02-16 at 2 01 39 PM" src="https://user-images.githubusercontent.com/1521381/108127078-8cb7ec80-705f-11eb-8097-c65fd182a87c.png">
