### PR TITLE
Carousel tweaks

### DIFF
--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -269,7 +269,6 @@ $card-half-space: rem-calc(14/2);
 	box-shadow: 0 0.65rem $card-margin $card-half-space rgb(153, 153, 153, 0.1);
 	width: $card-width;
 	max-width: calc(100vw - 4rem); // ensure some extra card is shown on mobile
-	flex: 1 0 auto;
 	margin: 1rem 0 2rem 0;
 }
 

--- a/src/components/Homepage/LendByCategory/LoanCategory.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategory.vue
@@ -17,6 +17,7 @@
 				loop: false,
 				align: 'start'
 			}"
+			@interact-carousel="onInteractCarousel"
 		>
 			<kv-carousel-slide
 				v-for="(loan, index) in loans"
@@ -196,6 +197,9 @@ export default {
 					return String(this.name).replace(/\s\[.*\]/g, '');
 			}
 		},
+		onInteractCarousel(interaction) {
+			this.$kvTrackEvent('homepage', 'click-carousel-horizontal-scroll', interaction);
+		}
 	},
 };
 </script>

--- a/src/components/Homepage/LendByCategory/LoanCategory.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategory.vue
@@ -228,7 +228,6 @@ $card-half-space: rem-calc(14/2);
 	box-shadow: 0 0.65rem $card-margin $card-half-space rgb(153, 153, 153, 0.1);
 	width: $card-width;
 	max-width: calc(100vw - 4rem); // ensure some extra card is shown on mobile
-	flex: 1 0 auto;
 	margin: 1rem 0 2rem 0;
 }
 
@@ -256,6 +255,10 @@ $card-half-space: rem-calc(14/2);
 		height: 100%;
 		justify-content: center;
 	}
+}
+
+::v-deep .lend-homepage-loan-card__image-wrapper {
+	padding-bottom: 62.5%;
 }
 
 .spinner {

--- a/src/components/LoanCards/LendHomepageLoanCard.vue
+++ b/src/components/LoanCards/LendHomepageLoanCard.vue
@@ -220,18 +220,20 @@ export default {
 	background: $white;
 	display: flex;
 	flex-direction: column;
-	justify-content: space-between;
-	flex: 1 0 auto;
+	justify-content: flex-start;
+	height: fit-content;
 	border-radius: 0.65rem;
 
 	&__image-wrapper {
 		border-radius: 0.65rem 0.65rem 0 0;
 		overflow: hidden;
 		flex-shrink: 0;
+		height: 0;
+		padding-bottom: 75%;
 
 		::v-deep a.borrower-image-link {
 			position: relative;
-			display: inline-block;
+			display: block;
 			height: 100%;
 
 			.borrower-image {

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -85,8 +85,10 @@
 
 			<hr>
 
-			<campaign-partner :partner-area-content="partnerAreaContent" />
-			<hr>
+			<template v-if="partnerAreaContent">
+				<campaign-partner :partner-area-content="partnerAreaContent" />
+				<hr>
+			</template>
 
 			<campaign-how-kiva-works v-if="!showThanks" />
 


### PR DESCRIPTION
- Give images an aspect ratio so the content doesn't jump. Prevent stretched out cards when one is tall.
- Bring back interaction tracking to homepage carousel
- Don't show extra `<hr>` if we have no partner content