### PR TITLE
Make the promoOnly query variable dynamic so it's not universally app…

### DIFF
--- a/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
+++ b/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
@@ -192,32 +192,6 @@ export default {
 			const selectedLoan = this.loans.find(loan => loan.id === payload.loanId);
 			this.$emit('show-loan-details', selectedLoan);
 		},
-		activateLoanWatchQuery() {
-			this.loadingLoans = true;
-			const observer = this.apollo.watchQuery({
-				query: basicLoanQuery,
-				variables: this.loanQueryVars,
-				fetchPolicy: 'network-only'
-			});
-			this.$watch(() => this.loanQueryVars, vars => {
-				observer.setVariables(vars);
-				this.loadingLoans = true;
-				this.zeroLoans = false;
-			}, { deep: true });
-			// Subscribe to the observer to see each result
-			observer.subscribe({
-				next: ({ data }) => {
-					this.loans = data.lend?.loans?.values ?? [];
-					this.totalCount = data.lend?.loans?.totalCount ?? 0;
-					this.$emit('update-total-count', this.totalCount);
-					this.checkIfPageIsOutOfRange(this.loans.length, this.pageQuery.page);
-					this.loadingLoans = false;
-					if (!this.totalCount) {
-						this.zeroLoans = true;
-					}
-				}
-			});
-		},
 		fetchLoans() {
 			this.loadingLoans = true;
 			this.zeroLoans = false;

--- a/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
+++ b/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
@@ -51,8 +51,6 @@ import _invokeMap from 'lodash/invokeMap';
 import _mapValues from 'lodash/mapValues';
 import _merge from 'lodash/merge';
 import basicLoanQuery from '@/graphql/query/basicLoanData.graphql';
-import cookieStore from '@/util/cookieStore';
-// import KvButton from '@/components/Kv/KvButton';
 import KvLoadingOverlay from '@/components/Kv/KvLoadingOverlay';
 import KvPagination from '@/components/Kv/KvPagination';
 import LoanCardController from '@/components/LoanCards/LoanCardController';
@@ -120,6 +118,10 @@ export default {
 			type: Array,
 			default: () => [],
 		},
+		promoOnly: {
+			type: Object,
+			default: null
+		},
 		sortBy: {
 			type: String,
 			default: 'popularity'
@@ -154,7 +156,7 @@ export default {
 				loans: () => [],
 				offset: this.offset,
 				filters: this.loanQueryFilters,
-				promoOnly: { basketId: cookieStore.get('kvbskt') },
+				promoOnly: this.promoOnly,
 				sortBy: this.sortBy,
 			};
 		},
@@ -170,8 +172,10 @@ export default {
 		},
 		isVisible(next) {
 			if (next) {
-				this.loadingLoans = false;
-				this.activateLoanWatchQuery();
+				this.fetchLoans();
+				this.$watch(() => this.loanQueryVars, () => {
+					this.fetchLoans();
+				}, { deep: true });
 			}
 		},
 	},
@@ -211,6 +215,27 @@ export default {
 					if (!this.totalCount) {
 						this.zeroLoans = true;
 					}
+				}
+			});
+		},
+		fetchLoans() {
+			this.loadingLoans = true;
+			this.zeroLoans = false;
+
+			this.apollo.query({
+				query: basicLoanQuery,
+				variables: this.loanQueryVars,
+				// fetchPolicy: 'network-only'
+			}).then(({ data }) => {
+				this.loans = data.lend?.loans?.values ?? [];
+				this.totalCount = data.lend?.loans?.totalCount ?? 0;
+
+				this.$emit('update-total-count', this.totalCount);
+				this.checkIfPageIsOutOfRange(this.loans.length, this.pageQuery.page);
+
+				this.loadingLoans = false;
+				if (!this.totalCount) {
+					this.zeroLoans = true;
 				}
 			});
 		},

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -534,6 +534,7 @@ $row-arrow-width: 2.5rem;
 		width: rem-calc(100);
 		height: rem-calc(100);
 		pointer-events: none;
+		z-index: 1;
 
 		.close-button {
 			border: none;

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -109,6 +109,7 @@
 			/>
 
 			<kv-lightbox
+				class="loan-details-lightbox"
 				:visible="loanDetailsVisible"
 				:no-padding-top="true"
 				:no-padding-bottom="true"
@@ -1132,6 +1133,15 @@ export default {
 
 		@include breakpoint(large) {
 			height: rem-calc(28);
+		}
+	}
+}
+
+.loan-details-lightbox {
+	::v-deep .kv-lightbox__header {
+		button.kv-lightbox__close-btn {
+			background: $white;
+			border-radius: 1.25rem;
 		}
 	}
 }

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -54,6 +54,7 @@
 							:is-logged-in="!isVisitor"
 							:is-visible="showLoanRows"
 							:key="'one-category'"
+							:promo-only="promoOnlyQuery"
 							:row-number="1"
 							:show-loans="showLoans"
 							:sort-by="sortBy"
@@ -662,6 +663,12 @@ export default {
 		},
 		promoFundId() {
 			return this.promoData?.promoFund?.id ?? null;
+		},
+		promoOnlyQuery() {
+			if (this.promoApplied) {
+				return { basketId: cookieStore.get('kvbskt') };
+			}
+			return null;
 		},
 		teamId() {
 			return this.promoData?.promoGroup?.teamId ?? null;


### PR DESCRIPTION
…lied which breaks visits with no promo applied. Update loan query to remove watch query which fixes the same results hangup on the loading state and ensure we can react when the promise completes. watchQuery .subscribe will never call it's next function if the cache results do not change.