### PR TITLE
Ensure loan grid page is reset if out of range. Further guards around…

### DIFF
--- a/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
+++ b/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
@@ -168,14 +168,21 @@ export default {
 			}
 		},
 		isVisible(next) {
-			if (next) {
+			if (next && this.showLoans) {
+				this.fetchLoans();
+			}
+		},
+		showLoans(next) {
+			if (next && this.isVisible) {
 				this.fetchLoans();
 			}
 		},
 		loanQueryVars: {
 			handler(next, prev) {
 				this.loanQueryVarsStack.push(prev);
-				this.fetchLoans();
+				if (this.showLoans && this.isVisible) {
+					this.fetchLoans();
+				}
 			},
 			deep: true,
 		}
@@ -230,14 +237,13 @@ export default {
 			// if it is, changes page to the last page and displays a tip message
 			const loansOutOfRange = loansArrayLength === 0 && pageQueryParam;
 			if (loansOutOfRange) {
-				// eslint-disable-next-line max-len
-				this.$showTipMsg(`There are currently ${this.lastLoanPage} pages of results. We’ve loaded the last page for you.`);
 				this.pageChange(this.lastLoanPage);
 			}
 		},
 		pageChange(number) {
 			const offset = loansPerPage * (number - 1);
 			this.offset = offset;
+			this.pageQuery = { page: number };
 			this.pushChangesToUrl();
 		},
 		updateFromParams(query) {

--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -184,19 +184,22 @@ export default {
 			this.$refs.campaignLoanCarousel.goToSlide(0);
 		},
 		isVisible(next) {
-			if (next) {
+			if (next && this.showLoans) {
 				this.loadingLoans = false;
+				this.fetchLoans();
 			}
 		},
 		showLoans(next) {
-			if (next) {
+			if (next && this.isVisible) {
 				this.fetchLoans();
 			}
 		},
 		loanQueryVars: {
 			handler(next, prev) {
 				this.loanQueryVarsStack.push(prev);
-				this.fetchLoans();
+				if (this.showLoans && this.isVisible) {
+					this.fetchLoans();
+				}
 			},
 			deep: true,
 		}
@@ -225,8 +228,11 @@ export default {
 				// Handle appending new loans to carousel
 				const newLoanIds = newLoans.length ? newLoans.map(loan => loan.id) : [];
 				const existingLoanIds = this.loans.length ? this.loans.map(loan => loan.id) : [];
+
+				// Filter out any loans already in the stack
+				const newLoansFiltered = newLoans.filter(loan => !existingLoanIds.includes(loan.id));
 				if (newLoanIds.toString() !== existingLoanIds.toString()) {
-					this.loans = this.loans.concat(newLoans);
+					this.loans = [...this.loans, ...newLoansFiltered];
 				}
 
 				if (this.isVisible) {


### PR DESCRIPTION
… when either view will execute it's fetchLoans query. Filter existing loans out of new loans result before adding to the carousel in row view.