### PR TITLE
VUE-326 Refactor donate from macro site page

### DIFF
--- a/src/pages/Donate/DonateFromMacro.vue
+++ b/src/pages/Donate/DonateFromMacro.vue
@@ -5,7 +5,7 @@
 		:footer-theme="footerTheme"
 	>
 		<donate-from-macro-hero
-			:data="donateFromMacroContent"
+			:data="heroContentGroup"
 		/>
 
 		<div class="FAQ-wrapper section">
@@ -35,17 +35,14 @@
 </template>
 
 <script>
-import _get from 'lodash/get';
 import gql from 'graphql-tag';
 
 import { lightHeader, lightFooter } from '@/util/siteThemes';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import DonateFromMacroHero from '@/pages/Donate/DonateFromMacroHero';
-import { processContent } from '@/util/contentfulUtils';
+import { processPageContent } from '@/util/contentfulUtils';
 import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
 import { documentToHtmlString } from '~/@contentful/rich-text-html-renderer';
-
-const billionImpactImagesRequire = require.context('@/assets/images/10-years-billion-impact', true);
 
 const pageQuery = gql`query donateContent {
 	contentful {
@@ -66,14 +63,7 @@ export default {
 		return {
 			headerTheme: lightHeader,
 			footerTheme: lightFooter,
-			donationFAQs: null,
-			impactHeadline: '',
-			impactBody: '',
-			donateFromMacroContent: () => {},
-			impactImageSet: [
-				['small', billionImpactImagesRequire('./10-years-billion-impact_ghost.jpg')],
-				['small retina', billionImpactImagesRequire('./10-years-billion-impact_2x_ghost.jpg')],
-			]
+			pageData: {},
 		};
 	},
 	inject: ['apollo'],
@@ -85,28 +75,52 @@ export default {
 			});
 		},
 		result({ data }) {
-			const contentfulPageData = _get(data, 'contentful.entries.items');
-			if (!contentfulPageData) {
-				return false;
-			}
-			// Processing data from contentful
-			// eslint-disable-next-line
-			this.donateFromMacroContent = processContent(contentfulPageData);
-			// pulling the FAQs off the data for use in faqCopy computed function
-			// eslint-disable-next-line
-			this.donationFAQs = _get(this.donateFromMacroContent, 'page.pageLayout.fields.contentGroups[1].fields.content.fields.bodyCopy');
-			// eslint-disable-next-line max-len
-			this.allDonationImpactText = _get(this.donateFromMacroContent, 'page.pageLayout.fields.contentGroups[2].fields.content.fields');
-			this.impactHeadline = _get(this.allDonationImpactText, 'headline');
-			this.impactBody = _get(this.allDonationImpactText, 'bodyCopy');
+			const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
+			this.pageData = pageEntry ? processPageContent(pageEntry) : null;
 		},
 	},
 	computed: {
+		impactImageSet() {
+			const smallImage = this.impactContentGroup?.media?.[0]?.file?.url ?? null;
+			const smallImageRetina = this.impactContentGroup?.media?.[1]?.file?.url ?? null;
+
+			return [
+				['small', smallImage],
+				['small retina', smallImageRetina],
+			];
+		},
+		pageLayout() {
+			return this.pageData?.page?.pageLayout;
+		},
+		heroContentGroup() {
+			// eslint-disable-next-line max-len
+			return this.pageLayout?.contentGroups?.find(contentGroup => contentGroup.key === 'donation-hero');
+		},
+		impactContentGroup() {
+			// eslint-disable-next-line max-len
+			return this.pageLayout?.contentGroups?.find(contentGroup => contentGroup.key === 'donation-impact');
+		},
+		faqContentGroup() {
+			// eslint-disable-next-line max-len
+			return this.pageLayout?.contentGroups?.find(contentGroup => contentGroup.key === 'donation-faqs');
+		},
+		donationFAQs() {
+			return this.faqContentGroup?.contents?.find(contentBlock => contentBlock.key === 'donate-page-faqs');
+		},
+		allDonationImpactText() {
+			// eslint-disable-next-line max-len
+			return this.impactContentGroup?.contents?.find(contentBlock => contentBlock.key === 'donation-impact-content');
+		},
 		faqCopy() {
-			return documentToHtmlString(this.donationFAQs);
+			const bodyCopy = this.donationFAQs?.bodyCopy;
+			return documentToHtmlString(bodyCopy);
+		},
+		impactHeadline() {
+			return this.allDonationImpactText?.headline;
 		},
 		impactBodyCopy() {
-			return documentToHtmlString(this.impactBody);
+			const bodyCopy = this.allDonationImpactText?.bodyCopy;
+			return documentToHtmlString(bodyCopy);
 		},
 	}
 };

--- a/src/pages/Donate/DonateFromMacroHero.vue
+++ b/src/pages/Donate/DonateFromMacroHero.vue
@@ -3,7 +3,7 @@
 		<template v-slot:images>
 			<kv-responsive-image
 				class="donation-hero-picture show-for-large"
-				:images="heroImages"
+				:images="heroResponsiveImageSet"
 				alt=""
 			/>
 		</template>
@@ -27,13 +27,12 @@
 	</kv-hero>
 </template>
 <script>
-import _get from 'lodash/get';
 import KvHero from '@/components/Kv/KvHero';
 import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
+import { createArrayOfResponsiveImageSet } from '@/util/contentfulUtils';
 import { documentToHtmlString } from '~/@contentful/rich-text-html-renderer';
-import DonateForm from './DonateForm';
 
-const heroImagesRequire = require.context('@/assets/images/donate-macro-hero', true);
+import DonateForm from './DonateForm';
 
 export default {
 	props: {
@@ -52,55 +51,35 @@ export default {
 	},
 	data() {
 		return {
-			// TODO: These need to be hooked up to the files in contentful still
-			// https://app.contentful.com/spaces/j0p9a6ql0rn7/environments/development/entries/6pXrrPQucbeNLqf47tW3wh
-			heroImages: [
-				['small', heroImagesRequire('./donate-1-sm-standard.jpg')],
-				['small retina', heroImagesRequire('./donate-1-sm-retina.jpg')],
-				['medium', heroImagesRequire('./donate-2-med-standard.jpg')],
-				['medium retina', heroImagesRequire('./donate-2-med-retina.jpg')],
-				['large', heroImagesRequire('./donate-3-lg-standard.jpg')],
-				['large retina', heroImagesRequire('./donate-3-lg-retina.jpg')],
-				['xxlarge', heroImagesRequire('./donate-4-xxl-standard.jpg')],
-				['xxlarge retina', heroImagesRequire('./donate-4-xxl-retina.jpg')],
-				['xga', heroImagesRequire('./donate-5-xga-standard.jpg')],
-				['xga retina', heroImagesRequire('./donate-5-xga-retina.jpg')],
-				['wxga', heroImagesRequire('./donate-6-wxga-standard.jpg')],
-				['wga retina', heroImagesRequire('./donate-6-wxga-retina.jpg')],
-			],
 		};
 	},
 	computed: {
+		heroResponsiveImageSet() {
+			const imageSet = this.data?.contents?.find(contentItem => contentItem.name === 'donation-page-images');
+			return createArrayOfResponsiveImageSet(imageSet);
+		},
 		donationHeroContent() {
-			return _get(this.data, 'page.pageLayout.fields.contentGroups[0].fields.contents[1].fields');
+			return this.data?.contents?.find(contentItem => contentItem.key === 'donation-form-copy');
 		},
 		headlineCopy() {
-			return _get(this.donationHeroContent, 'headline');
+			return this.donationHeroContent?.headline;
 		},
 		subheadCopy() {
-			return _get(this.donationHeroContent, 'subHeadline');
+			return this.donationHeroContent?.subHeadline;
 		},
 		buttonCopy() {
-			return _get(this.donationHeroContent, 'primaryCtaText');
-		},
-		// Will be used once images are coming through from contentful
-		zeroImages() {
-			// eslint-disable-next-line
-			const donationImages = _get(this.data, 'page.pageLayout.fields.contentGroups[0].fields.contents[0].fields.images');
-			return donationImages;
+			return this.donationHeroContent?.primaryCtaText;
 		},
 		donationValues() {
 			// defining the donation dollar amount to pass down for button values
-			// eslint-disable-next-line
-			const donationAmounts = _get(this.data, 'page.pageLayout.fields.contentGroups[0].fields.contents[2].fields.dataObject.amounts');
+			const donationSetting = this.data?.contents?.find(contentItem => contentItem.key === 'donationAmounts');
+			const donationAmounts = donationSetting?.dataObject?.amounts;
 			return donationAmounts;
 		},
 		formDisclaimer() {
 			// extracting form disclaimer from contentful to pass into form
-			const formDisclaimerContent = _get(
-				this.data,
-				'page.pageLayout.fields.contentGroups[0].fields.contents[3].fields.richText'
-			);
+			// eslint-disable-next-line max-len
+			const formDisclaimerContent = this.data?.contents?.find(contentItem => contentItem.key === 'macro-donate-button-disclaimer');
 			return documentToHtmlString(formDisclaimerContent);
 		},
 	}


### PR DESCRIPTION
* Get images from contentful (VUE-326)
* Add contentful util helper which converts contentful responsive image into kv-responsive-image array
* Remove _get from page
* Remove usage of 'content' from contentful use, contents instead.

This is both the work for VUE-326 and VUE-463 (partial). And necessary so we can remove the content group 'content' field

TODO: 
There are corresponding changes in contentful, I've already made them in the dev environment, related to the support-kiva page nested content. 

Once this gets to prod, we can delete the 'support-kiva' page from prod, and copy the updated one from dev. 
