### PR TITLE
GROW-434 Contentful Homepage loan categories component

### DIFF
--- a/src/components/Homepage/HomepageLoanCategories.vue
+++ b/src/components/Homepage/HomepageLoanCategories.vue
@@ -1,0 +1,52 @@
+<template>
+	<section class="homepage-loan-categories">
+		<div class="row column">
+			<h2 class="homepage-loan-categories__header text-center">
+				{{ sectionHeadline }}
+			</h2>
+			<loan-categories-section />
+		</div>
+	</section>
+</template>
+
+<script>
+import LoanCategoriesSection from '@/components/Homepage/LendByCategory/LoanCategoriesSection';
+
+export default {
+	components: {
+		LoanCategoriesSection,
+	},
+	props: {
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	computed: {
+		sectionText() {
+			return this.content?.contents?.find(({ key }) => key.indexOf('homepage-loan-categories-text') > -1);
+		},
+		sectionHeadline() {
+			return this.sectionText?.headline ?? 'Support causes you care about.';
+		},
+	},
+};
+</script>
+
+<style lang="scss">
+@import 'settings';
+
+.homepage-loan-categories {
+	.row {
+		max-width: 69.15rem;
+	}
+
+	&__header {
+		font-weight: bold;
+
+		@include breakpoint(large) {
+			@include large-text();
+		}
+	}
+}
+</style>

--- a/src/components/Homepage/LendByCategory/LoanCategoriesSection.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategoriesSection.vue
@@ -138,6 +138,7 @@ export default {
 				case 52:
 					return 'women';
 				case 96:
+				case 106:
 					return 'COVID-19';
 				case 93:
 					return 'shelter';
@@ -146,12 +147,16 @@ export default {
 				case 87:
 					return 'agriculture';
 				case 102:
+				case 104:
 					return 'technology';
 				case 4:
+				case 88:
 					return 'education';
 				case 25:
+				case 105:
 					return 'health';
 				case 32:
+				case 107:
 					return 'refugees';
 				default:
 					// remove any text contained within square brackets, including the brackets

--- a/src/pages/Homepage/iwd/IWD2021Homepage.vue
+++ b/src/pages/Homepage/iwd/IWD2021Homepage.vue
@@ -1,7 +1,7 @@
 <template>
 	<div class="iwd-2021-homepage">
 		<homepage-hero class="section" :content="heroContentGroup" />
-		<!-- loan categories component -->
+		<homepage-loan-categories class="section" :content="loansContentGroup" />
 		<!-- how it works component -->
 		<!-- mind the gap component -->
 		<!-- iwd kiva stats component -->
@@ -13,10 +13,12 @@
 
 <script>
 import HomepageHero from '@/components/Homepage/HomepageHero';
+import HomepageLoanCategories from '@/components/Homepage/HomepageLoanCategories';
 
 export default {
 	components: {
 		HomepageHero,
+		HomepageLoanCategories,
 	},
 	props: {
 		content: {
@@ -34,6 +36,9 @@ export default {
 	computed: {
 		heroContentGroup() {
 			return this.content?.page?.contentGroups?.homepageHero ?? null;
+		},
+		loansContentGroup() {
+			return this.content?.page?.contentGroups?.homepageLoanCategories ?? null;
 		},
 	},
 };
@@ -59,7 +64,7 @@ export default {
 		padding: 2rem 0;
 
 		@include breakpoint(large) {
-			padding: 2rem 0;
+			padding: 4rem 0;
 		}
 	}
 }


### PR DESCRIPTION
Some complex pre-fetching would be needed to have the category ids defined in Contentful instead of Settings Manager, so I skipped doing that for now to focus on the other parts of the page.