### PR TITLE
grow-490 spacing adjustments post review meeting

### DIFF
--- a/src/components/Homepage/HomepageBottomCTA.vue
+++ b/src/components/Homepage/HomepageBottomCTA.vue
@@ -6,7 +6,7 @@
 				class="bottom-cta__headline"
 			></p>
 			<kv-button
-				class="rounded smallest impact-text bottom-cta__button"
+				class="rounded smaller impact-text bottom-cta__button"
 				:to="buttonLink"
 				v-kv-track-event="[
 					'homepage',

--- a/src/components/Homepage/HomepageBottomCTA.vue
+++ b/src/components/Homepage/HomepageBottomCTA.vue
@@ -57,13 +57,13 @@ export default {
 .bottom-cta {
 	&__headline {
 		font-size: rem-calc(44);
-		font-weight: 600;
+		font-weight: 300;
 		margin-bottom: rem-calc(30);
 		line-height: 1.3;
 	}
 
 	&__button {
-		margin-bottom: rem-calc(30);
+		margin-bottom: 1rem;
 	}
 }
 

--- a/src/components/Homepage/HomepageCorporateSponsors.vue
+++ b/src/components/Homepage/HomepageCorporateSponsors.vue
@@ -67,7 +67,7 @@ export default {
 .sponsors {
 	&__section-img {
 		width: rem-calc(220);
-		margin: 2.5rem;
+		margin: 0 2.5rem 2.5rem 2.5rem;
 
 		@include breakpoint(large) {
 			width: rem-calc(320);

--- a/src/components/Homepage/HomepageCorporateSponsors.vue
+++ b/src/components/Homepage/HomepageCorporateSponsors.vue
@@ -82,7 +82,7 @@ export default {
 
 		@include breakpoint(large) {
 			font-size: rem-calc(36);
-			margin-bottom: rem-calc(50);
+			margin-bottom: 1rem;
 		}
 	}
 

--- a/src/components/Homepage/HomepageTestimonials.vue
+++ b/src/components/Homepage/HomepageTestimonials.vue
@@ -131,10 +131,16 @@ export default {
 
 .testimonials {
 	&__header {
-		margin-bottom: rem-calc(70);
+		margin-bottom: rem-calc(64);
 	}
 
 	&__supporter-card {
+		margin-bottom: rem-calc(40);
+
+		@include breakpoint(large) {
+			margin-bottom: 0;
+		}
+
 		&--img-wrapper {
 			position: relative;
 		}
@@ -173,6 +179,7 @@ export default {
 
 		&--quote {
 			line-height: 1.5;
+			margin-bottom: 0;
 		}
 
 		&--page-flourish {

--- a/src/pages/Homepage/iwd/IWD2021Homepage.vue
+++ b/src/pages/Homepage/iwd/IWD2021Homepage.vue
@@ -96,10 +96,6 @@ export default {
 	.section {
 		position: relative;
 		padding: 2rem 0;
-
-		@include breakpoint(large) {
-			padding: 4rem 0;
-		}
 	}
 }
 </style>


### PR DESCRIPTION
General spacing adjustments across the page.
- Dropped the margin between sections from 4rem to 2 rem (consistent with current homepage)
- Made minor spacing adjustments for consistency in some headings of sections.
- Made adjustments to bottomCTA section based on current homepage: 

**Desktop:**
![Screen Shot 2021-02-24 at 1 55 17 PM](https://user-images.githubusercontent.com/1521381/109070912-f5c6e200-76a7-11eb-808f-1f0c418c181f.png)


**Mobile**
![Screen Shot 2021-02-24 at 1 54 50 PM](https://user-images.githubusercontent.com/1521381/109070843-de87f480-76a7-11eb-8b9e-31523f64f9cc.png)


**Spacing adjusted below loan cards above How it works section:**
![Screen Shot 2021-02-24 at 1 56 00 PM](https://user-images.githubusercontent.com/1521381/109070968-09724880-76a8-11eb-9dcf-81fe9a9ab635.png)

**Space adjusted below the testimonials section:**
![Screen Shot 2021-02-24 at 1 58 39 PM](https://user-images.githubusercontent.com/1521381/109071300-68d05880-76a8-11eb-99b0-3ea07eecdea4.png)

