### PR TITLE
Prevent thrash with setting useMatcherAccountIds after adding to bask…

### DIFF
--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -803,7 +803,7 @@ export default {
 				this.updateBasketState();
 			});
 		},
-		async setInitialFilters() {
+		setInitialFilters() {
 			// initialize filter object
 			let filters = LoanSearchFilters();
 


### PR DESCRIPTION
…et by converting initialFilters into a standard data object instead of a computed property.