### PR TITLE
VUE-479 Removes Federation Apollo Client

### DIFF
--- a/.storybook/mixins/apollo-story-mixin.js
+++ b/.storybook/mixins/apollo-story-mixin.js
@@ -5,25 +5,6 @@ export default ({
 	loading = false,
 } = {}) => ({
 	provide: {
-		federation: {
-			mutate() {
-				return loading ? new Promise(() => {}) : Promise.resolve(mutationResult);
-			},
-			readQuery() {
-				return queryResult.data;
-			},
-			watchQuery() {
-				return {
-					subscribe() {}
-				}
-			},
-			query() {
-				return loading ? new Promise(() => {}) : Promise.resolve(queryResult);
-			},
-			readFragment() {
-				return fragmentResult
-			}
-		},
 		apollo: {
 			mutate() {
 				return loading ? new Promise(() => {}) : Promise.resolve(mutationResult);

--- a/.storybook/stories/MGCovid19Response.stories.js
+++ b/.storybook/stories/MGCovid19Response.stories.js
@@ -7,6 +7,7 @@ Vue.use(kivaPlugins)
 import StoryRouter from 'storybook-vue-router';
 import MGCovid19 from '@/pages/LandingPages/MGCovid19/MGCovid19.vue';
 import apolloStoryMixin from '../mixins/apollo-story-mixin';
+import kvAuth0StoryMixin from '../mixins/kv-auth0-story-mixin';
 
 export default {
 	title: 'Pages/MGCovid19Response',
@@ -18,15 +19,7 @@ export const Default = () => ({
 	components: {
 		MGCovid19,
 	},
-	mixins: [apolloStoryMixin()],
-	provide: {
-		federation: {
-			query() {
-				return Promise.resolve({});
-			}
-		},
-		kvAuth0: {}
-	},
+	mixins: [apolloStoryMixin(), kvAuth0StoryMixin],
 	template: `
 		<m-g-covid-19 style="margin: -2rem" />
 	`,

--- a/config/dev-vm.js
+++ b/config/dev-vm.js
@@ -53,9 +53,6 @@ module.exports = merge(base, {
 			serverCallbackUri: 'https://dev-vm-01.kiva.org/process-ssr-auth',
 			domain: 'login.dev.kiva.org',
 		},
-		federationService: {
-			uri: 'https://marketplace-api.dk1.kiva.org/graphql'
-		},
 		paypal: {
 			url: 'www.sandbox.paypal.com',
 			environment: 'sandbox'

--- a/config/local.js
+++ b/config/local.js
@@ -9,9 +9,6 @@ module.exports = merge(base, {
 		auth0: {
 			enable: false,
 		},
-		federationService: {
-			uri: 'https://marketplace-api.k1.kiva.org/graphql',
-		},
 	},
 	server: {
 		graphqlUri: 'https://marketplace-api.k1.kiva.org/graphql',

--- a/config/local.vm.js
+++ b/config/local.vm.js
@@ -8,9 +8,6 @@ module.exports = merge(base, {
 		auth0: {
 			enable: false,
 		},
-		federationService: {
-			uri: 'https://marketplace-api.k1.kiva.org/graphql',
-		},
 	},
 	server: {
 		sessionUri: '',

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -17,33 +17,27 @@ import initState from './localState';
 export default function createApolloClient({
 	appConfig,
 	cookieStore,
-	existingCache,
 	kvAuth0,
 	types = [],
 	uri,
 }) {
-	let cache;
-	if (!existingCache) {
-		cache = new InMemoryCache({
-			fragmentMatcher: new IntrospectionFragmentMatcher({
-				introspectionQueryResultData: {
-					__schema: { types }
-				}
-			}),
-			// Return a custom cache id for types that don't have an id field
-			dataIdFromObject: object => {
-				if (object.__typename === 'Setting' && object.key) return `Setting:${object.key}`;
-				return defaultDataIdFromObject(object);
-			},
-			// Use a simpler underlying cache for server renders
-			resultCaching: typeof window !== 'undefined',
-			// Block modifying cache results outside of normal operations
-			// see https://github.com/apollographql/apollo-client/pull/4543
-			freezeResults: true,
-		});
-	} else {
-		cache = existingCache;
-	}
+	const cache = new InMemoryCache({
+		fragmentMatcher: new IntrospectionFragmentMatcher({
+			introspectionQueryResultData: {
+				__schema: { types }
+			}
+		}),
+		// Return a custom cache id for types that don't have an id field
+		dataIdFromObject: object => {
+			if (object.__typename === 'Setting' && object.key) return `Setting:${object.key}`;
+			return defaultDataIdFromObject(object);
+		},
+		// Use a simpler underlying cache for server renders
+		resultCaching: typeof window !== 'undefined',
+		// Block modifying cache results outside of normal operations
+		// see https://github.com/apollographql/apollo-client/pull/4543
+		freezeResults: true,
+	});
 
 	// initialize local state resolvers
 	const { resolvers, defaults } = initState({ appConfig, cookieStore, kvAuth0 });
@@ -75,11 +69,9 @@ export default function createApolloClient({
 		assumeImmutableResults: true,
 	});
 
-	if (!existingCache) {
-		// set default local state
-		cache.writeData({ data: defaults });
-		client.onResetStore(() => cache.writeData({ data: defaults }));
-	}
+	// set default local state
+	cache.writeData({ data: defaults });
+	client.onResetStore(() => cache.writeData({ data: defaults }));
 
 	return client;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -52,17 +52,6 @@ export default function createApp({
 		kvAuth0,
 	});
 
-	const federationApolloURI = appConfig.federationService ? appConfig.federationService.uri : apollo.uri;
-
-	const apolloFederationClient = createApolloClient({
-		appConfig,
-		cookieStore,
-		existingCache: apolloClient.cache,
-		kvAuth0,
-		types: apollo.types,
-		uri: federationApolloURI,
-	});
-
 	const router = createRouter();
 	// Checking that sentry is enabled & is not server side
 	if (appConfig.enableSentry && typeof window !== 'undefined') {
@@ -83,7 +72,6 @@ export default function createApp({
 			apollo: apolloClient,
 			cookieStore,
 			device,
-			federation: apolloFederationClient,
 			kvAuth0,
 			locale,
 		}

--- a/src/pages/Autolending/AutolendingSettingsPage.vue
+++ b/src/pages/Autolending/AutolendingSettingsPage.vue
@@ -35,7 +35,7 @@ const pageQuery = gql`query autolendProfileEnabled {
 }`;
 
 export default {
-	inject: ['apollo', 'cookieStore', 'federation'],
+	inject: ['apollo', 'cookieStore'],
 	components: {
 		AutolendingWho,
 		AutolendingStatus,

--- a/src/pages/Homepage/DefaultHomepage.vue
+++ b/src/pages/Homepage/DefaultHomepage.vue
@@ -69,7 +69,7 @@ export default {
 			promoContent: {}
 		};
 	},
-	inject: ['apollo', 'cookieStore', 'federation'],
+	inject: ['apollo', 'cookieStore'],
 	apollo: {
 		query: pageQuery,
 		preFetch(config, client) {
@@ -92,7 +92,7 @@ export default {
 		},
 	},
 	created() {
-		this.federation.query({
+		this.apollo.query({
 			query: contentful,
 			variables: {
 				contentType: 'uiSetting',

--- a/src/pages/Possibility/12DaysOfLending.vue
+++ b/src/pages/Possibility/12DaysOfLending.vue
@@ -72,9 +72,9 @@ export default {
 			],
 		};
 	},
-	inject: ['apollo', 'federation'],
+	inject: ['apollo'],
 	created() {
-		this.federation.query({
+		this.apollo.query({
 			query: contentful,
 			variables: {
 				contentType: 'uiSetting',


### PR DESCRIPTION
* Removes secondary apollo client

This was the second apolloClient that I created to be able to run contentful queries from the federation service and queries to the vm. This is no longer needed with our new docker setup. 