### PR TITLE
Occasional carousel item width bug

### DIFF
--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -266,6 +266,7 @@ export default {
 	justify-content: center;
 	position: relative;
 
+	// extra specificity to ensure width: auto is respected when bundling css
 	.cards-wrap {
 		display: flex;
 		width: auto;

--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -265,16 +265,16 @@ export default {
 	align-items: center;
 	justify-content: center;
 	position: relative;
+
+	.cards-wrap {
+		display: flex;
+		width: auto;
+	}
 }
 
 $card-width: rem-calc(297);
 $card-margin: rem-calc(14);
 $card-half-space: rem-calc(14/2);
-
-.cards-wrap {
-	display: flex;
-	width: auto;
-}
 
 .cards-loan-card,
 .see-all-card {

--- a/src/components/Homepage/LendByCategory/LoanCategory.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategory.vue
@@ -219,6 +219,7 @@ $card-half-space: rem-calc(14/2);
 	justify-content: center;
 	position: relative;
 
+	// extra specificity to ensure width: auto is respected when bundling css
 	.cards-wrap {
 		display: flex;
 		width: auto;

--- a/src/components/Homepage/LendByCategory/LoanCategory.vue
+++ b/src/components/Homepage/LendByCategory/LoanCategory.vue
@@ -218,11 +218,11 @@ $card-half-space: rem-calc(14/2);
 	align-items: start;
 	justify-content: center;
 	position: relative;
-}
 
-.cards-wrap {
-	display: flex;
-	width: auto;
+	.cards-wrap {
+		display: flex;
+		width: auto;
+	}
 }
 
 .cards-loan-card,


### PR DESCRIPTION
Fix specificity issue depending on what order the CSS bundles are served. Possible it only happen on VMs, but still annoying.
Fixes this:
![image](https://user-images.githubusercontent.com/187937/110397823-6dd9c400-8027-11eb-91ea-7a07312f198d.png)
