### PR TITLE
adding ? incase headline is not defined

### DIFF
--- a/src/components/Homepage/HomepageStatistics.vue
+++ b/src/components/Homepage/HomepageStatistics.vue
@@ -85,7 +85,7 @@ export default {
 			return this.content?.contents?.find(({ key }) => key.indexOf('homepage-statistics-headline-text') > -1);
 		},
 		statsHeadline() {
-			return this.statsText.headline ?? '';
+			return this.statsText?.headline ?? '';
 		},
 		statsBlockText() {
 			// eslint-disable-next-line max-len


### PR DESCRIPTION
Adding the ? to the statsHeadline incase it's undefined. 

`statsHeadline() {
	return this.statsText?.headline ?? '';
},`

This small change got left behind on my VM yesterday, I noticed it on my VM this morning.