### PR TITLE
GROW-517 fix tracking event label/action/value for ML bandit experiment

### DIFF
--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -527,9 +527,9 @@ export default {
 				this.$kvTrackEvent(
 					'Lending',
 					'EXP-ML-Service-Bandit-LendByCategory',
-					this.mlServiceBanditExpVersion === 'variant-a' ? 'b' : 'a',
-					this.mlServiceBanditExpVersion === 'variant-a' ? mlServiceBandit : null,
-					this.mlServiceBanditExpVersion === 'variant-a' ? mlServiceBandit : null
+					this.mlServiceBanditExpVersion,
+					this.mlServiceBanditExpVersion === 'b' ? mlServiceBandit : null,
+					this.mlServiceBanditExpVersion === 'b' ? mlServiceBandit : null
 				);
 			}
 		},


### PR DESCRIPTION
The snowplow tracking event for this experiment was slightly incorrect (see GROW-517 ticket for full details).
The actual experiment was working properly, as we can see in the ML service data, but the snowplow tracking events were all coming through with the control label "a". This is because the tracking code was expecting "variant-a" to be the name of the version for the variant group, but the experiment setting in settings manager was using "b" for the variant group (and "a" for the control group).