### PR TITLE
GROW-519 show braintree drop-in for guest checkout

### DIFF
--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -6,6 +6,8 @@
 				:amount="amount"
 				flow="checkout"
 				:payment-types="paymentTypes"
+				:preselect-vaulted-payment-method="!isGuestCheckout"
+				:auth="isGuestCheckout ? 'token-key' : 'client-token'"
 				@transactions-enabled="enableCheckoutButton = $event"
 			/>
 			<div v-if="isGuestCheckout" id="guest-checkout">

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -83,6 +83,7 @@
 									<checkout-drop-in-payment-wrapper
 										v-else
 										:amount="creditNeeded"
+										:is-guest-checkout="checkingOutAsGuest"
 										@refreshtotals="refreshTotals"
 										@updating-totals="setUpdatingTotals"
 										@complete-transaction="completeTransaction"
@@ -261,6 +262,7 @@ export default {
 			redirectToLoginExperimentVersion: null,
 			isGuestCheckoutExperimentActive: false,
 			guestCheckoutExperimentVersion: null,
+			checkingOutAsGuest: false,
 		};
 	},
 	apollo: {
@@ -420,6 +422,9 @@ export default {
 	},
 	computed: {
 		isLoggedIn() {
+			if (this.checkingOutAsGuest) {
+				return true;
+			}
 			if (this.myId !== null && this.myId !== undefined && this.isActivelyLoggedIn) {
 				return true;
 			}
@@ -457,6 +462,9 @@ export default {
 			return this.totals.creditAmountNeeded || '0.00';
 		},
 		showKivaCreditButton() {
+			if (this.checkingOutAsGuest) {
+				return false;
+			}
 			return parseFloat(this.creditNeeded) === 0;
 		},
 		showGuestCheckoutButton() {
@@ -506,7 +514,7 @@ export default {
 			// Doing nothing here allows the normal link handling to happen, which will send the user to /ui-login
 		},
 		guestCheckout() {
-			console.log('Guest checkout method triggered.');
+			this.checkingOutAsGuest = true;
 		},
 		doPopupLogin() {
 			if (this.kvAuth0.enabled) {


### PR DESCRIPTION
This will show the braintree drop-in and guest checkout fields when a non-logged in user selects "Checkout as guest". This does not remember that the user selected that option, so if they refresh the page before completing the checkout they will need to select "Checkout as guest" again. We can change that behavior in another ticket if needed.