### PR TITLE
grow-521 removing the loginButtonExperimentShown and setting button t…

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -116,7 +116,7 @@
 										@click.native="loginToContinue"
 										:href="'/ui-login?force=true&doneUrl=/checkout'"
 									>
-										{{ loginContinueButtonText }}
+										Continue
 									</kv-button>
 								</div>
 							</div>
@@ -433,24 +433,9 @@ export default {
 			return false;
 		},
 		checkoutSteps() {
-			if (this.loginButtonExperimentShown) {
-				return [
-					'Basket',
-					'Payment',
-					'Thank You!'
-				];
-			}
-			return [
-				'Basket',
-				'Account',
-				'Payment',
-				'Thank You!'
-			];
+			return ['Basket', 'Account', 'Payment', 'Thank You!'];
 		},
 		currentStep() {
-			if (this.loginButtonExperimentShown) {
-				return this.isLoggedIn ? 1 : 0;
-			}
 			return this.isLoggedIn ? 2 : 0;
 		},
 		creditNeeded() {
@@ -473,9 +458,6 @@ export default {
 			}
 			return false;
 		},
-		loginContinueButtonText() {
-			return this.loginButtonExperimentShown ? 'Continue' : 'Login to Continue';
-		},
 		emptyBasket() {
 			if (this.loans.length === 0 && this.kivaCards.length === 0
 				&& (!this.donations.length
@@ -484,9 +466,6 @@ export default {
 			}
 			return false;
 		},
-		loginButtonExperimentShown() {
-			return this.loginButtonExperimentVersion === 'b';
-		}
 	},
 	methods: {
 		loginToContinue(event) {
@@ -515,17 +494,6 @@ export default {
 				const authorizeOptions = {};
 				if (!this.isActivelyLoggedIn) {
 					authorizeOptions.prompt = 'login';
-				}
-
-				if (this.loginButtonExperimentShown) {
-					// Pass custom JSON configuration to Auth0 login page
-					const kvConfig = JSON.stringify({ socialExp: true });
-					// Choose register as initial screen if no user has logged in on this browser before
-					if (!this.cookieStore.get('kvu')) {
-						authorizeOptions.login_hint = `signUp|${kvConfig}`;
-					} else {
-						authorizeOptions.login_hint = `login|${kvConfig}`;
-					}
 				}
 
 				this.kvAuth0.popupLogin(authorizeOptions).then(result => {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -433,10 +433,10 @@ export default {
 			return false;
 		},
 		checkoutSteps() {
-			return ['Basket', 'Account', 'Payment', 'Thank You!'];
+			return ['Basket', 'Payment', 'Thank You!'];
 		},
 		currentStep() {
-			return this.isLoggedIn ? 2 : 0;
+			return this.isLoggedIn ? 1 : 0;
 		},
 		creditNeeded() {
 			return this.totals.creditAmountNeeded || '0.00';


### PR DESCRIPTION
…ext to Continue

These changes cover the requested R1 changes for [grow-521](https://kiva.atlassian.net/browse/GROW-521)

The request was to change the button text from "login to continue" to "continue" to be more inclusive of the guest checkout scenario. 

- The button text was being controlled by the loginButtonExperimentShown setting. I spoke to Brandon who said that experiment was no longer being used, so I removed it and hardcoded the "continue" text for the button.

-  I think I cleaned up all the loose ends removing the exp, let me know if you see something I missed. 


🙏 Thanks for the review. 