### PR TITLE
Check for HUSKY=0 param before running husky install from the prepare…

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -8,7 +8,7 @@ RUN mkdir /ui
 COPY ./ /ui/
 WORKDIR /ui
 
-RUN npm ci
+RUN HUSKY=0 npm ci
 RUN npm run build
 
 # run stage
@@ -35,7 +35,7 @@ COPY --from=build-stage /ui/package.json .
 COPY --from=build-stage /ui/package-lock.json .
 
 # Install PROD dependencies only
-RUN npm install --production --ignore-scripts
+RUN HUSKY=0 NODE_ENV=production npm ci
 
 # Expose API port to the outside
 EXPOSE 8888

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"storybook": "start-storybook -p 6006",
 		"build-storybook": "build-storybook",
 		"deploy-storybook": "storybook-to-ghpages",
-		"prepare": "is-ci || husky install"
+		"prepare": "[ $HUSKY -eq 0 ] || husky install"
 	},
 	"dependencies": {
 		"@babel/eslint-parser": "^7.12.1",


### PR DESCRIPTION
… script. Set local HUSKY var in build and deploy. This allows us to remove the --ignore-scripts flag which is required to boostrap node-canvas. Switched to setting NODE_ENV=production for npm ci when preparing prod dependencies for the docker container.