### PR TITLE
fixing tracking event, changing from function that was removed to string

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -112,7 +112,7 @@
 									<kv-button
 										class="checkout-button smallest"
 										id="login-to-continue-button"
-										v-kv-track-event="['basket', 'click-sign-in-cta', loginContinueButtonText]"
+										v-kv-track-event="['basket', 'click-sign-in-cta', 'Continue']"
 										title="Login to Continue Button"
 										@click.native="loginToContinue"
 										:href="'/ui-login?force=true&doneUrl=/checkout'"


### PR DESCRIPTION
The loginContinueButtonText() function was previous remove and text was set to a string of 'Continue', this is a cleanup from those changes. 