### PR TITLE
GROW-563 Add option to redirect to forgotPassword page

### DIFF
--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -79,6 +79,10 @@ module.exports = function authRouter(config = {}) {
 		if (!cookies.kvu) {
 			options.login_hint = 'signUp';
 		}
+		if (req.query.forgot === 'true') {
+			options.prompt = 'login';
+			options.login_hint = 'forgotPassword';
+		}
 		if (req.query.login_hint) {
 			options.login_hint = req.query.login_hint;
 		}


### PR DESCRIPTION
Using `/ui-login?forgot=true` will redirect to the forgot password page, even for logged in users.