### PR TITLE
SUBS-499 Friendly BT Errors

### DIFF
--- a/src/components/AutoDeposit/AutoDepositDropInPaymentWrapper.vue
+++ b/src/components/AutoDeposit/AutoDepositDropInPaymentWrapper.vue
@@ -32,9 +32,13 @@
 <script>
 import numeral from 'numeral';
 import * as Sentry from '@sentry/browser';
+
+import braintreeDropInError from '@/plugins/braintree-dropin-error-mixin';
+
 import braintreeCreateAutoDepositSubscription from '@/graphql/mutation/braintreeCreateAutoDepositSubscription.graphql';
 import braintreeUpdateSubscriptionPaymentMethod from
 	'@/graphql/mutation/braintreeUpdateSubscriptionPaymentMethod.graphql';
+
 import KvButton from '@/components/Kv/KvButton';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
@@ -48,6 +52,7 @@ export default {
 		KvLoadingSpinner
 	},
 	inject: ['apollo'],
+	mixins: [braintreeDropInError],
 	props: {
 		amount: {
 			type: Number,
@@ -120,20 +125,7 @@ export default {
 					}).then(kivaBraintreeResponse => {
 					// Check for errors in transaction
 						if (kivaBraintreeResponse.errors) {
-							const errorCode = kivaBraintreeResponse.errors?.[0]?.code;
-							const errorMessage = kivaBraintreeResponse.errors?.[0]?.message;
-							const standardErrorCode = `(Braintree error: ${errorCode})`;
-							// eslint-disable-next-line max-len
-							const standardError = `There was an error processing your payment. Please try again. ${standardErrorCode}`;
-
-							// Payment method failed, unselect attempted payment method
-							this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
-							// Potential error message: 'Transaction failed. Please select a different payment method.';
-
-							this.$showTipMsg(standardError, 'error');
-
-							// Fire specific exception to Snowplow
-							this.$kvTrackEvent(this.action, 'DropIn Payment Error', `${errorCode}: ${errorMessage}`);
+							this.processBraintreeDropInError(this.action, kivaBraintreeResponse);
 
 							// exit
 							return kivaBraintreeResponse;
@@ -172,20 +164,7 @@ export default {
 				}).then(kivaBraintreeResponse => {
 					// Check for errors in transaction
 					if (kivaBraintreeResponse.errors) {
-						const errorCode = kivaBraintreeResponse.errors?.[0]?.code;
-						const errorMessage = kivaBraintreeResponse.errors?.[0]?.message;
-						const standardErrorCode = `(Braintree error: ${errorCode})`;
-						const standardError = `There was an error processing your payment.
-						Please try again. ${standardErrorCode}`;
-
-						// Payment method failed, unselect attempted payment method
-						this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
-						// Potential error message: 'Transaction failed. Please select a different payment method.';
-
-						this.$showTipMsg(standardError, 'error');
-
-						// Fire specific exception to Snowplow
-						this.$kvTrackEvent(this.action, 'DropIn Payment Error', `${errorCode}: ${errorMessage}`);
+						this.processBraintreeDropInError(this.action, kivaBraintreeResponse);
 
 						// exit
 						return kivaBraintreeResponse;

--- a/src/components/AutoDeposit/AutoDepositDropInPaymentWrapper.vue
+++ b/src/components/AutoDeposit/AutoDepositDropInPaymentWrapper.vue
@@ -126,7 +126,8 @@ export default {
 					// Check for errors in transaction
 						if (kivaBraintreeResponse.errors) {
 							this.processBraintreeDropInError(this.action, kivaBraintreeResponse);
-
+							// Payment method failed, unselect attempted payment method
+							this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
 							// exit
 							return kivaBraintreeResponse;
 						}
@@ -165,7 +166,8 @@ export default {
 					// Check for errors in transaction
 					if (kivaBraintreeResponse.errors) {
 						this.processBraintreeDropInError(this.action, kivaBraintreeResponse);
-
+						// Payment method failed, unselect attempted payment method
+						this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
 						// exit
 						return kivaBraintreeResponse;
 					}

--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -287,7 +287,8 @@ export default {
 					if (kivaBraintreeResponse.errors) {
 						this.$emit('updating-totals', false);
 						this.processBraintreeDropInError('basket', kivaBraintreeResponse);
-
+						// Payment method failed, unselect attempted payment method
+						this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
 						// exit
 						return kivaBraintreeResponse;
 					}

--- a/src/components/MonthlyGood/MonthlyGoodDropInPaymentWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodDropInPaymentWrapper.vue
@@ -136,7 +136,8 @@ export default {
 						// Check for errors in transaction
 						if (kivaBraintreeResponse.errors) {
 							this.processBraintreeDropInError(this.action, kivaBraintreeResponse);
-
+							// Payment method failed, unselect attempted payment method
+							this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
 							// exit
 							return kivaBraintreeResponse;
 						}
@@ -177,7 +178,8 @@ export default {
 					// Check for errors in transaction
 					if (kivaBraintreeResponse.errors) {
 						this.processBraintreeDropInError(this.action, kivaBraintreeResponse);
-
+						// Payment method failed, unselect attempted payment method
+						this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
 						// exit
 						return kivaBraintreeResponse;
 					}

--- a/src/plugins/braintree-dropin-error-mixin.js
+++ b/src/plugins/braintree-dropin-error-mixin.js
@@ -7,8 +7,6 @@ export default {
 			// eslint-disable-next-line max-len
 			const standardError = `There was an error processing your payment. Please try again. ${standardErrorCode}`;
 
-			// Payment method failed, unselect attempted payment method
-			this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
 			// Potential error message: 'Transaction failed. Please select a different payment method.';
 			this.$showTipMsg(standardError, 'error');
 

--- a/src/plugins/braintree-dropin-error-mixin.js
+++ b/src/plugins/braintree-dropin-error-mixin.js
@@ -1,0 +1,19 @@
+export default {
+	methods: {
+		processBraintreeDropInError(trackCategory, kivaBraintreeResponse) {
+			const errorCode = kivaBraintreeResponse.errors?.[0]?.extensions?.code;
+			const errorMessage = kivaBraintreeResponse.errors?.[0]?.message;
+			const standardErrorCode = `(Braintree error: ${errorCode})`;
+			// eslint-disable-next-line max-len
+			const standardError = `There was an error processing your payment. Please try again. ${standardErrorCode}`;
+
+			// Payment method failed, unselect attempted payment method
+			this.$refs.braintreeDropInInterface.btDropinInstance.clearSelectedPaymentMethod();
+			// Potential error message: 'Transaction failed. Please select a different payment method.';
+			this.$showTipMsg(standardError, 'error');
+
+			// Fire specific exception to Snowplow
+			this.$kvTrackEvent(trackCategory, 'DropIn Payment Error', `${errorCode}: ${errorMessage}`);
+		},
+	},
+};


### PR DESCRIPTION
* Extracted BT DropIn Wrapper error processing to a plugin
* The UI has to use extensions.code instead of errors.code to display friendly errors

The API returns a response that looks like:
```
{
  "errors": [
    {
      "message": "Some error",
      "locations": [
        {
          "line": 3,
          "column": 5
        }
      ],
      "path": [
        "shop",
        "doNoncePaymentDepositAndCheckout"
      ],
      "code": "braintree.transactionRequestRejected",
      "extensions": {
        "code": "braintree.transactionRequestRejected"
      }
    }
  ],
  "data": {
    "shop": {
      "doNoncePaymentDepositAndCheckout": null
    }
  }
}
```
This can be replicated in the GQL playground, but on the UI side, `errors[0].code` is always undefined. I'm not sure where that is happening. Maybe `src/util/apolloPreFetch.js` But these queries aren't in preFetch so I'm not sure. 

`errors[0].extensions.code` contains the same error as `errors[0].code` that we want to log and display, so modified mutation error handling to use that, also moved the error handling into a plugin since all these components use the exact same error handling

Looker showing the BT error code always undefined: https://kiva.looker.com/sql/hnkrkc4dnmgvst

While working on this, I noticed that there are a couple of other mutation handlers that are looking for `errors[0].code`, are these working correctly? -- For example: `validateGuestBasketAndCheckout`