### PR TITLE
Grow 478 updates

### DIFF
--- a/src/components/Homepage/HomepageStatistics.vue
+++ b/src/components/Homepage/HomepageStatistics.vue
@@ -21,7 +21,7 @@
 			<div
 				v-for="(statBlock, index) in statsBlockText"
 				:key="statBlock.key"
-				class="small-12 medium-4 columns"
+				class="small-12 medium-4 columns stat-block__block"
 			>
 				<kv-contentful-img
 					v-if="statBlock.image.url"
@@ -169,9 +169,16 @@ export default {
 		font-size: 4rem;
 		font-weight: 600;
 		line-height: rem-calc(73.6);
+		text-align: center;
+
+		@include breakpoint(large) {
+			text-align: left;
+		}
 	}
 
 	&__video-wrapper {
+		margin-top: 2.5rem;
+
 		&--video {
 			width: 100%;
 			border-radius: rem-calc(10);
@@ -181,6 +188,10 @@ export default {
 	.stat-block {
 		margin-top: rem-calc(40);
 
+		&__block {
+			margin-bottom: 1rem;
+		}
+
 		&__icon {
 			margin-bottom: rem-calc(20);
 		}
@@ -189,7 +200,6 @@ export default {
 			font-size: rem-calc(21);
 
 			&::v-deep i {
-				color: $kiva-green;
 				font-weight: bold;
 				font-style: normal;
 			}

--- a/src/components/Homepage/HomepageStatistics.vue
+++ b/src/components/Homepage/HomepageStatistics.vue
@@ -17,15 +17,15 @@
 				></video>
 			</span>
 		</div>
-		<div class="row stat-block">
+		<div class="row stats-wrap">
 			<div
 				v-for="(statBlock, index) in statsBlockText"
 				:key="statBlock.key"
-				class="small-12 medium-4 columns stat-block__block"
+				class="small-12 medium-4 columns stats-wrap__block"
 			>
 				<kv-contentful-img
 					v-if="statBlock.image.url"
-					:class="'stat-block__icon stat-block__icon-' + index"
+					:class="'stats-wrap__block--icon stats-wrap__block--icon-' + index"
 					:contentful-src="statBlock.image.url"
 					:alt="statBlock.image.description"
 					fallback-format="png"
@@ -33,7 +33,7 @@
 					:height="64"
 				/>
 				<p
-					class="stat-block__stat green-emphasis"
+					class="stats-wrap__block--stat green-emphasis"
 					v-html="formattedTextStrings[index]"
 				>
 				</p>
@@ -189,24 +189,24 @@ export default {
 		}
 	}
 
-	.stat-block {
+	.stats-wrap {
 		margin-top: rem-calc(40);
 
 		&__block {
 			margin-bottom: 1rem;
 			text-align: center;
-		}
 
-		&__icon {
-			margin-bottom: rem-calc(20);
-		}
+			&--icon {
+				margin-bottom: rem-calc(20);
+			}
 
-		&__stat {
-			font-size: rem-calc(21);
+			&--stat {
+				font-size: rem-calc(21);
 
-			&::v-deep i {
-				font-weight: bold;
-				font-style: normal;
+				&::v-deep i {
+					font-weight: bold;
+					font-style: normal;
+				}
 			}
 		}
 	}

--- a/src/components/Homepage/HomepageStatistics.vue
+++ b/src/components/Homepage/HomepageStatistics.vue
@@ -1,5 +1,5 @@
 <template>
-	<section class="statistics section">
+	<section class="statistics">
 		<div class="row">
 			<h2
 				v-html="statsHeadline"
@@ -29,8 +29,8 @@
 					:contentful-src="statBlock.image.url"
 					:alt="statBlock.image.description"
 					fallback-format="png"
-					:width="48"
-					:height="48"
+					:width="65"
+					:height="64"
 				/>
 				<p
 					class="stat-block__stat green-emphasis"
@@ -179,6 +179,10 @@ export default {
 	&__video-wrapper {
 		margin-top: 2.5rem;
 
+		@include breakpoint(large) {
+			margin-top: 0;
+		}
+
 		&--video {
 			width: 100%;
 			border-radius: rem-calc(10);
@@ -190,6 +194,7 @@ export default {
 
 		&__block {
 			margin-bottom: 1rem;
+			text-align: center;
 		}
 
 		&__icon {

--- a/src/pages/Homepage/LendByCategoryHomepage.vue
+++ b/src/pages/Homepage/LendByCategoryHomepage.vue
@@ -175,7 +175,7 @@
 				</p>
 			</div>
 
-			<homepage-statistics class="section"
+			<homepage-statistics
 				v-if="statisticsContentfulContentGroup"
 				:content="statisticsContentfulContentGroup"
 			/>


### PR DESCRIPTION
Grow-478: https://kiva.atlassian.net/browse/GROW-478

We've refreshed the look the homepage statistics section. 
**Mobile:** 
<img width="225" alt="Screen Shot 2021-04-08 at 12 59 40 PM" src="https://user-images.githubusercontent.com/1521381/114089006-80cff600-986a-11eb-9c5a-5ed8144d0137.png">

**Tablet:** 
<img width="769" alt="Screen Shot 2021-04-08 at 1 00 14 PM" src="https://user-images.githubusercontent.com/1521381/114089065-90e7d580-986a-11eb-8ae4-9ac5762756e1.png">

**Desktop:**
<img width="1131" alt="Screen Shot 2021-04-08 at 12 59 59 PM" src="https://user-images.githubusercontent.com/1521381/114089082-96452000-986a-11eb-8216-9d64c07e3d70.png">