### PR TITLE
SUBS-663 Added Route for dynamic landing page

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -98,6 +98,13 @@ export default [
 	{ path: '/lend-by-category/:category', component: () => import('@/pages/Lend/LoanChannelCategoryPage') },
 	{ path: '/lend/filter', component: () => import('@/pages/Lend/Filter/LendFilterPage') },
 	{
+		path: '/lp/:dynamicRoute',
+		component: () => import('@/pages/ContentfulPage'),
+		meta: route => ({
+			contentfulPage: `lp/${route.params.dynamicRoute}`,
+		}),
+	},
+	{
 		path: '/monthlygood',
 		component: () => import('@/pages/MonthlyGood/MonthlyGoodLandingPage'),
 		props: route => ({ category: route.query.category })


### PR DESCRIPTION
Added dynamic route for `/lp/support-causes-monthly` 
Added content on contentful, for now just a copy of the `Home` page content. 
I made the page key `lp/support-causes-monthly` which I know doesnt match the format of the keys for the cc landing pages, but thought this would be more descriptive