### PR TITLE
VUE-551 Use header & footer themes for the page frame in ContentfulPage

### DIFF
--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -1,5 +1,8 @@
 <template>
-	<component :is="pageFrame">
+	<component :is="pageFrame"
+		:header-theme="headerTheme"
+		:footer-theme="footerTheme"
+	>
 		<template v-if="!pageError">
 			<component
 				v-for="({ component, content }) in contentGroups"
@@ -47,6 +50,7 @@ To use, simply create a route that defines contentfulPage in the meta data, e.g.
 import gql from 'graphql-tag';
 import { preFetchAll } from '@/util/apolloPreFetch';
 import { processPageContent } from '@/util/contentfulUtils';
+import * as siteThemes from '@/util/siteThemes';
 
 // Page frames
 const WwwPage = () => import('@/components/WwwFrame/WwwPage');
@@ -153,6 +157,8 @@ export default {
 	data() {
 		return {
 			contentGroups: [],
+			footerTheme: {},
+			headerTheme: {},
 			pageError: false,
 			pageFrame: WwwPage,
 			title: undefined,
@@ -209,6 +215,8 @@ export default {
 				this.pageError = true;
 			} else {
 				this.title = (pageData?.page?.pageLayout?.pageTitle || pageData?.page?.pageTitle) ?? undefined;
+				this.headerTheme = siteThemes[pageData?.page?.pageLayout?.headerTheme] || {};
+				this.footerTheme = siteThemes[pageData?.page?.pageLayout?.footerTheme] || {};
 				this.pageFrame = getPageFrameFromType(pageData?.page?.pageType);
 				this.contentGroups = getContentGroups(pageData);
 			}

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -311,6 +311,8 @@ export function processPageContent(entryItem) {
 		pageLayout: {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
+			headerTheme: entryItem.fields?.pageLayout?.fields?.headerTheme,
+			footerTheme: entryItem.fields?.pageLayout?.fields?.footerTheme,
 		},
 		settings: entryItem.fields?.settings
 			? formatContentTypes(entryItem.fields?.settings) : []
@@ -363,6 +365,8 @@ export function processPageContentFlat(entryItem) {
 		pageLayout: {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
+			headerTheme: entryItem.fields?.pageLayout?.fields?.headerTheme,
+			footerTheme: entryItem.fields?.pageLayout?.fields?.footerTheme,
 		},
 		settings: entryItem.fields?.settings
 			? formatContentTypes(entryItem.fields?.settings) : []

--- a/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
+++ b/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
@@ -62,6 +62,7 @@
 			},
 			"fields": {
 				"name": "Promo Campaign Test",
+				"headerTheme": "lightHeader",
 				"contentGroups": [{
 					"sys": {
 						"space": {

--- a/test/unit/specs/util/contentfulUtils.spec.js
+++ b/test/unit/specs/util/contentfulUtils.spec.js
@@ -94,7 +94,9 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
+					headerTheme: 'lightHeader',
 					contentGroups: [{}],
+					footerTheme: undefined,
 					pageTitle: 'Test Page Layout Title',
 				},
 				settings: [{}]
@@ -112,6 +114,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
+					headerTheme: 'lightHeader',
 					contentGroups: [{
 						key: 'promo-campaign-test-cg',
 						name: 'Promo Campaign Test Content Groups',
@@ -134,6 +137,7 @@ describe('contentfulUtils.js', () => {
 							images: expect.any(Array)
 						}]
 					}],
+					footerTheme: undefined,
 					pageTitle: 'Test Page Layout Title',
 				},
 				pageTitle: 'Test Page Title',
@@ -170,6 +174,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
+					headerTheme: 'lightHeader',
 					pageTitle: 'Test Page Layout Title',
 				},
 				settings: expect.any(Array),
@@ -189,6 +194,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
+					headerTheme: 'lightHeader',
 					pageTitle: 'Test Page Layout Title',
 				},
 				settings: expect.any(Array),
@@ -243,6 +249,7 @@ describe('contentfulUtils.js', () => {
 				pageType: expect.any(String),
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
+					headerTheme: expect.any(String),
 					pageTitle: expect.any(String)
 				}),
 				settings: expect.any(Array),
@@ -262,6 +269,7 @@ describe('contentfulUtils.js', () => {
 				pageType: expect.any(String),
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
+					headerTheme: expect.any(String),
 					pageTitle: expect.any(String)
 				}),
 				settings: expect.any(Array),
@@ -323,6 +331,8 @@ describe('contentfulUtils.js', () => {
 				pageType: undefined,
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
+					headerTheme: undefined,
+					footerTheme: undefined,
 					pageTitle: undefined
 				}),
 				settings: [],
@@ -342,6 +352,8 @@ describe('contentfulUtils.js', () => {
 				pageType: undefined,
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
+					headerTheme: undefined,
+					footerTheme: undefined,
 					pageTitle: undefined
 				}),
 				settings: [],


### PR DESCRIPTION
The `headerTheme` and `footerTheme` fields on the `PageLayout` content type in Contentful are setup as a dropdown with limited options, similar to the `type` field on `ContentGroup`. The options for each one match up with the names of the exported header and footer themes from `src/util/siteThemes.js`.