### PR TITLE
VUE-317 Deprecated Slot Syntax Migration

### DIFF
--- a/.storybook/stories/KvCarousel.stories.js
+++ b/.storybook/stories/KvCarousel.stories.js
@@ -7,7 +7,7 @@ import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
 import causeList from '../mock-data/cause-selector-data-mock';
 
 const defaultCarouselSlides = `
-	<template slot="default">
+	<template #default>
 		<kv-carousel-slide style="background-color: green;">
 			<img src="https://via.placeholder.com/300x220/e8f0f6/000000" style="width: 100%;">
 		</kv-carousel-slide>

--- a/.storybook/stories/KvLightbox.stories.js
+++ b/.storybook/stories/KvLightbox.stories.js
@@ -94,7 +94,7 @@ export const SmallContent = (args, { argTypes }) => ({
 				:no-padding-sides="noPaddingSides"
 			>
 				<p>Small amount of content</p>
-				<template slot="controls">
+				<template #controls>
 					<kv-button>Button 1</kv-button>
 					<kv-button>Button 2</kv-button>
 				</template>
@@ -118,7 +118,7 @@ export const WithControls = (args, { argTypes }) => ({
 				:no-padding-sides="noPaddingSides"
 			>
 				${loremIpsum}
-				<template slot="controls">
+				<template #controls>
 					<kv-button>Button 1</kv-button>
 					<kv-button>Button 2</kv-button>
 				</template>
@@ -160,7 +160,7 @@ export const WithFoundationGrid = (args, { argTypes }) => ({
 					</div>
 				</div>
 				${loremIpsum}
-				<template slot="controls">
+				<template #controls>
 					<kv-button>Button 1</kv-button>
 					<kv-button>Button 2</kv-button>
 				</template>

--- a/.storybook/stories/KvTooltip.stories.js
+++ b/.storybook/stories/KvTooltip.stories.js
@@ -14,7 +14,7 @@ export const Default = () => ({
 		<div>
 			<button id="my-cool-btn">Hover of Focus Me!</button>
 			<kv-tooltip controller="my-cool-btn">
-				<template slot="title">
+				<template #title>
 					What is an Experimental Field Partner?
 				</template>
 				If a Field Partner is labeled as Experimental, this means that Kiva has

--- a/src/components/Checkout/DonateRepaymentsToggle.vue
+++ b/src/components/Checkout/DonateRepaymentsToggle.vue
@@ -11,7 +11,7 @@
 			<span id="donate-repayments-tooltip">Donate loan repayments instead?</span>
 		</kv-checkbox>
 		<kv-tooltip controller="donate-repayments-tooltip">
-			<template slot="title">
+			<template #title>
 				Thanks for your support!
 			</template>
 			When you check this box, repayments go back to Kiva in the form of donations,

--- a/src/components/CorporateCampaign/CampaignJoinTeamForm.vue
+++ b/src/components/CorporateCampaign/CampaignJoinTeamForm.vue
@@ -38,8 +38,8 @@
 					</div>
 				</div>
 
-				<template slot="controls">
-					<div slot="controls" class="text-center">
+				<template #controls>
+					<div class="text-center">
 						<div v-if="showForm">
 							<kv-button class="smaller" @click.native.prevent="handleJoinTeam">
 								Join Now

--- a/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
+++ b/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
@@ -174,7 +174,7 @@
 				</kv-accordion-item>
 			</div>
 
-			<template slot="controls">
+			<template #controls>
 				<kv-button
 					class="button smallest"
 					@click.native.prevent="applyFilters"

--- a/src/components/Settings/SubscriptionsSettingsCards.vue
+++ b/src/components/Settings/SubscriptionsSettingsCards.vue
@@ -39,7 +39,7 @@
 			<template>
 				&nbsp;
 			</template>
-			<template slot="controls">
+			<template #controls>
 				<kv-button
 					value="Yes"
 					id="cancel-subscription-yes"

--- a/src/components/Subscriptions/SubscriptionsOneTime.vue
+++ b/src/components/Subscriptions/SubscriptionsOneTime.vue
@@ -116,7 +116,7 @@
 							</div>
 						</div>
 					</form>
-					<template slot="controls">
+					<template #controls>
 						<kv-button
 							data-test="one-time-save-button"
 							class="smaller button"

--- a/src/components/WwwFrame/LendMenu/LendListMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendListMenu.vue
@@ -4,7 +4,7 @@
 			Explore Categories
 		</router-link>
 		<expandable-list-item id="lend-menu-category-panel" ref="categories">
-			<template slot="title">
+			<template #title>
 				<span>Categories</span>
 				<kv-icon class="chevron-icon" name="small-chevron-mobile" :from-sprite="true" />
 			</template>
@@ -23,7 +23,7 @@
 			</ul>
 		</expandable-list-item>
 		<expandable-list-item id="lend-menu-region-panel" ref="regions">
-			<template slot="title">
+			<template #title>
 				<span>Regions</span>
 				<kv-icon class="chevron-icon" name="small-chevron-mobile" :from-sprite="true" />
 			</template>
@@ -37,7 +37,7 @@
 					:id="`lend-menu-${region.name}-panel` | changeCase('paramCase')"
 					ref="regionCountries"
 				>
-					<template slot="title">
+					<template #title>
 						<span v-kv-track-event="['TopNav','click-Lend-Region', region.name]">
 							{{ region.name }}
 						</span>
@@ -51,7 +51,7 @@
 			All loans
 		</router-link>
 		<expandable-list-item id="lend-menu-my-kiva-panel" ref="myKiva" v-if="userId">
-			<template slot="title">
+			<template #title>
 				<span>My Kiva</span>
 				<kv-icon class="chevron-icon" name="small-chevron-mobile" :from-sprite="true" />
 			</template>
@@ -67,7 +67,7 @@
 					<span v-else>Starred loans</span>
 				</li>
 				<expandable-list-item id="lend-menu-saved-searches-panel" ref="searches" v-if="hasSearches">
-					<template slot="title">
+					<template #title>
 						<span>Saved searches</span>
 						<kv-icon class="chevron-icon" name="small-chevron-mobile" :from-sprite="true" />
 					</template>

--- a/src/pages/AlgoliaPOC.vue
+++ b/src/pages/AlgoliaPOC.vue
@@ -108,7 +108,7 @@
 											class="loan-card-group"
 											:results-per-page="15"
 										>
-											<template slot="default" slot-scope="{ items }">
+											<template #default="{ items }">
 												<algolia-adapter
 													v-for="(item, itemIndex) in items" :key="item.id"
 													:loan="item"

--- a/src/pages/Autolending/AutolendingPage.vue
+++ b/src/pages/Autolending/AutolendingPage.vue
@@ -1,6 +1,9 @@
 <template>
 	<www-page class="autolending" :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
+
 		<div class="title-area">
 			<div class="row column">
 				<h1>Auto-lending settings</h1>

--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -54,7 +54,7 @@
 							OFF
 						</kv-radio>
 					</div>
-					<template slot="controls">
+					<template #controls>
 						<kv-button
 							data-test="status-save-button"
 							class="smaller button"

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -68,7 +68,7 @@
 							</kv-radio>
 						</div>
 					</div>
-					<template slot="controls">
+					<template #controls>
 						<kv-button
 							data-test="when-save-button"
 							class="smaller button"

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -103,7 +103,7 @@
 							</div>
 						</transition>
 					</div>
-					<template slot="controls">
+					<template #controls>
 						<div class="row">
 							<div class="columns shrink">
 								<save-button @autolendingSaved="settingsSaved" />

--- a/src/pages/Build/BuildPage.vue
+++ b/src/pages/Build/BuildPage.vue
@@ -1,6 +1,9 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
+
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<h1>Developer Home</h1>

--- a/src/pages/Build/CodeOfConductPage.vue
+++ b/src/pages/Build/CodeOfConductPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<h1>Code Of Conduct</h1>

--- a/src/pages/Build/DataPage.vue
+++ b/src/pages/Build/DataPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<h1>Data Snapshots</h1>

--- a/src/pages/Build/DocsPage.vue
+++ b/src/pages/Build/DocsPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<h1>Developer Docs</h1>

--- a/src/pages/Build/GettingStartedPage.vue
+++ b/src/pages/Build/GettingStartedPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<h1>Getting Started</h1>

--- a/src/pages/Build/Research.vue
+++ b/src/pages/Build/Research.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<div>

--- a/src/pages/Build/TermsOfService.vue
+++ b/src/pages/Build/TermsOfService.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page>
-		<developer-secondary-menu slot="secondary" />
+		<template #secondary>
+			<developer-secondary-menu />
+		</template>
 		<div class="row page-content">
 			<div class="small-12 columns">
 				<h1>Terms Of Service</h1>

--- a/src/pages/Legal/Legal.vue
+++ b/src/pages/Legal/Legal.vue
@@ -1,10 +1,12 @@
 <template>
 	<www-page>
-		<custom-secondary-menu
-			slot="secondary"
-			class="hide-for-large"
-			:menu-items="menuItems"
-		/>
+		<template #secondary>
+			<custom-secondary-menu
+
+				class="hide-for-large"
+				:menu-items="menuItems"
+			/>
+		</template>
 		<div class="row page-content">
 			<tertiary-menu class="show-for-large large-2 tertiary-menu-terms">
 				<ul>

--- a/src/pages/Lend/Filter/LendFilterPage.vue
+++ b/src/pages/Lend/Filter/LendFilterPage.vue
@@ -60,7 +60,7 @@
 								:class="{'filter-menu-open': filterMenuOpen}"
 								:results-per-page="15"
 							>
-								<template slot="default" slot-scope="{ items }">
+								<template #default="{ items }">
 									<algolia-adapter
 										v-for="(item, itemIndex) in items" :key="item.id"
 										:loan="item"

--- a/src/pages/Lend/admin/CategorySet.vue
+++ b/src/pages/Lend/admin/CategorySet.vue
@@ -20,9 +20,11 @@
 			</select>
 			<kv-icon class="icon icon-x" name="x" @click.native="removeCategory(category)" :from-sprite="true" />
 		</li>
-		<kv-button slot="footer" class="add-button setting" @click.native="addCategory">
-			+ Add category
-		</kv-button>
+		<template #footer>
+			<kv-button class="add-button setting" @click.native="addCategory">
+				+ Add category
+			</kv-button>
+		</template>
 	</draggable>
 </template>
 

--- a/src/pages/LendingStats/LendingStatsPage.vue
+++ b/src/pages/LendingStats/LendingStatsPage.vue
@@ -1,8 +1,10 @@
 <template>
 	<www-page>
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
 		<div class="row page-content">
-			<the-portfolio-tertiary-menu slot="tertiary" class="show-for-large" />
+			<the-portfolio-tertiary-menu class="show-for-large" />
 			<div class="small-12 large-9 columns">
 				<h1>Lending stats</h1>
 				<p>

--- a/src/pages/Search/SentenceSearch.vue
+++ b/src/pages/Search/SentenceSearch.vue
@@ -36,14 +36,13 @@
 									aria-expanded="false"
 								>
 									<template
-										slot="defaultOption"
+										#defaultOption
 										class="featured-text"
 									>
 										women and men
 									</template>
 									<template
-										slot="item"
-										slot-scope="{ item }"
+										#item="{ item }"
 										class="featured-text"
 									>
 										{{ item.label }}
@@ -61,14 +60,13 @@
 										aria-expanded="false"
 									>
 										<template
-											slot="defaultOption"
+											#defaultOption
 											class="featured-text"
 										>
 											any region
 										</template>
 										<template
-											slot="item"
-											slot-scope="{ item }"
+											#item="{ item }"
 											class="featured-text"
 										>
 											{{ item.label }}
@@ -114,7 +112,7 @@
 									class="loan-card-group row small-up-1 large-up-2 xxlarge-up-3"
 									:results-per-page="15"
 								>
-									<template slot="default" slot-scope="{ items }">
+									<template #default="{ items }">
 										<algolia-adapter
 											v-for="(item, itemIndex) in items" :key="item.id"
 											:loan="item"

--- a/src/pages/Settings/EmailSettings.vue
+++ b/src/pages/Settings/EmailSettings.vue
@@ -1,6 +1,9 @@
 <template>
 	<www-page class="email-settings" :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
+
 		<div class="email-settings__title-area">
 			<div class="row column">
 				<h1>Email Settings</h1>

--- a/src/pages/Settings/PaymentSettings.vue
+++ b/src/pages/Settings/PaymentSettings.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page class="payments" :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
 		<div class="title-area">
 			<div class="row column">
 				<h1>
@@ -109,7 +111,7 @@
 			<p>
 				This will remove this card from your payment settings forever.
 			</p>
-			<template slot="controls">
+			<template #controls>
 				<kv-button
 					class="smallest secondary"
 					@click.prevent.native="showRemoveLightbox = false"
@@ -144,7 +146,7 @@
 					here
 				</router-link>
 			</p>
-			<template slot="controls">
+			<template #controls>
 				<kv-button
 					id="active-card-no"
 					class="smallest secondary"

--- a/src/pages/Settings/SecuritySettings.vue
+++ b/src/pages/Settings/SecuritySettings.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page class="security-login-page" :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
 		<div class="security-login-page__title-area">
 			<div class="row column">
 				<h1>

--- a/src/pages/Settings/SettingsPage.vue
+++ b/src/pages/Settings/SettingsPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
 		<div class="title-area">
 			<div class="row column">
 				<h1>Settings</h1>

--- a/src/pages/Settings/SubscriptionsSettings.vue
+++ b/src/pages/Settings/SubscriptionsSettings.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page class="subscriptions" :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
 		<div class="title-area">
 			<div class="row column">
 				<h1>Subscription settings</h1>

--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -1,6 +1,8 @@
 <template>
 	<www-page class="two-step-verification" :gray-background="true">
-		<the-my-kiva-secondary-menu slot="secondary" />
+		<template #secondary>
+			<the-my-kiva-secondary-menu />
+		</template>
 		<div class="two-step-verification__title-area">
 			<div class="row column">
 				<h1>


### PR DESCRIPTION
* Finished migrating all instances of deprecated slot syntax to new 2.6+ slot syntax

____

Finishes migration of old slot syntax. Three types of changes in all these files: 

Simple slot syntax change: 
```
-                               <template slot="controls">
+                               <template #controls>
```

In cases where a custom element is inserted in a slot, the custom element must be wrapped in a template tag:
```
-               <the-my-kiva-secondary-menu slot="secondary" />
+               <template #secondary>
+                       <the-my-kiva-secondary-menu />
+               </template>
```


For slots with scope, the replacement looks like
```
-                                                                                       <template slot="default" slot-scope="{ items }">
+                                                                                       <template #default="{ items }">
```