### PR TITLE
VUE-559 Stop blue links from vibrating against the red error state background

### DIFF
--- a/src/components/Kv/KvTipMessage.vue
+++ b/src/components/Kv/KvTipMessage.vue
@@ -162,6 +162,11 @@ export default {
 	&.message-text-error {
 		background-color: $kiva-accent-red;
 
+		a {
+			color: #fff;
+			text-decoration: underline;
+		}
+
 		.icon.icon-error {
 			fill: $white;
 		}


### PR DESCRIPTION
Changes from
<img width="1102" alt="Screen Shot 2021-04-19 at 2 48 33 PM" src="https://user-images.githubusercontent.com/187937/115309553-4fd0aa80-a121-11eb-83ef-b3bcafc59312.png">
 
 to
<img width="1166" alt="Screen Shot 2021-04-19 at 2 48 18 PM" src="https://user-images.githubusercontent.com/187937/115309572-54955e80-a121-11eb-815c-4249d1b0e5ac.png">
