### PR TITLE
GROW-586 GROW-585

### DIFF
--- a/src/api/localResolvers/my.js
+++ b/src/api/localResolvers/my.js
@@ -1,4 +1,6 @@
-export default ({ kvAuth0 }) => {
+import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql';
+
+export default ({ cookieStore, kvAuth0 }) => {
 	return {
 		resolvers: {
 			My: {
@@ -6,6 +8,27 @@ export default ({ kvAuth0 }) => {
 					return kvAuth0.getLastLogin();
 				}
 			},
+			Query: {
+				hasEverLoggedIn(obj, args, { cache }) {
+					// Return true if the user is currently logged in
+					if (kvAuth0.getKivaId()) {
+						return true;
+					}
+					// Return true if the user has a kvu cookie
+					if (cookieStore.get('kvu')) {
+						return true;
+					}
+
+					try {
+						// Return the previously cached value for this field
+						const cacheData = cache.readQuery({ query: hasEverLoggedInQuery });
+						return !!cacheData?.hasEverLoggedIn;
+					} catch (e) {
+						// Reutrn false if there wasn't a previously cached value
+						return false;
+					}
+				},
+			}
 		},
 	};
 };

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -44,6 +44,7 @@ extend type Query {
 	activeLoan: ActiveLoan
 	autolending: Autolending
 	verificationLightbox: VerificationLightbox
+	hasEverLoggedIn: Boolean
 }
 
 extend type My {

--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -20,6 +20,7 @@
 
 <script>
 import _get from 'lodash/get';
+import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql';
 import { fetchAllExpSettings } from '@/util/experimentPreFetch';
 import appInstallMixin from '@/plugins/app-install-mixin';
 import CookieBanner from '@/components/WwwFrame/CookieBanner';
@@ -63,10 +64,13 @@ export default {
 	},
 	apollo: {
 		preFetch(config, client, args) {
-			return fetchAllExpSettings(config, client, {
-				query: _get(args, 'route.query'),
-				path: _get(args, 'route.path')
-			});
+			return Promise.all([
+				client.query({ query: hasEverLoggedInQuery }),
+				fetchAllExpSettings(config, client, {
+					query: _get(args, 'route.query'),
+					path: _get(args, 'route.path')
+				}),
+			]);
 		}
 	}
 };

--- a/src/components/WwwFrame/WwwPageCorporate.vue
+++ b/src/components/WwwFrame/WwwPageCorporate.vue
@@ -24,6 +24,7 @@
 
 <script>
 import _get from 'lodash/get';
+import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql';
 import { fetchAllExpSettings } from '@/util/experimentPreFetch';
 import CookieBanner from '@/components/WwwFrame/CookieBanner';
 import TheBasketBar from '@/components/WwwFrame/TheBasketBar';
@@ -59,10 +60,13 @@ export default {
 	},
 	apollo: {
 		preFetch(config, client, args) {
-			return fetchAllExpSettings(config, client, {
-				query: _get(args, 'route.query'),
-				path: _get(args, 'route.path')
-			});
+			return Promise.all([
+				client.query({ query: hasEverLoggedInQuery }),
+				fetchAllExpSettings(config, client, {
+					query: _get(args, 'route.query'),
+					path: _get(args, 'route.path')
+				}),
+			]);
 		}
 	}
 };

--- a/src/components/WwwFrame/WwwPageMinimal.vue
+++ b/src/components/WwwFrame/WwwPageMinimal.vue
@@ -17,6 +17,7 @@
 
 <script>
 import _get from 'lodash/get';
+import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql';
 import { fetchAllExpSettings } from '@/util/experimentPreFetch';
 import appInstallMixin from '@/plugins/app-install-mixin';
 import CookieBanner from '@/components/WwwFrame/CookieBanner';
@@ -50,10 +51,13 @@ export default {
 	},
 	apollo: {
 		preFetch(config, client, args) {
-			return fetchAllExpSettings(config, client, {
-				query: _get(args, 'route.query'),
-				path: _get(args, 'route.path')
-			});
+			return Promise.all([
+				client.query({ query: hasEverLoggedInQuery }),
+				fetchAllExpSettings(config, client, {
+					query: _get(args, 'route.query'),
+					path: _get(args, 'route.path')
+				}),
+			]);
 		}
 	}
 };

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -1,6 +1,7 @@
 #import '../../fragments/shopTotals.graphql'
 
 query initializeCheckout($basketId: String) {
+	hasEverLoggedIn @client
 	my {
 		lastLoginTimestamp @client
 		userAccount {

--- a/src/graphql/query/shared/hasEverLoggedIn.graphql
+++ b/src/graphql/query/shared/hasEverLoggedIn.graphql
@@ -1,0 +1,3 @@
+query hasEverLoggedIn {
+	hasEverLoggedIn @client
+}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -105,7 +105,7 @@
 										title="Checkout as guest"
 										@click.native="guestCheckout"
 									>
-										Checkout as guest
+										Continue as guest
 									</kv-button>
 
 									<kv-button

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -262,7 +262,7 @@ export default {
 			isGuestCheckoutExperimentActive: false,
 			guestCheckoutExperimentVersion: null,
 			checkingOutAsGuest: false,
-			hasEverLoggedIn: 'no',
+			hasEverLoggedIn: false,
 		};
 	},
 	apollo: {
@@ -307,7 +307,7 @@ export default {
 			this.myId = _get(data, 'my.userAccount.id');
 			this.teams = _get(data, 'my.lender.teams.values');
 			this.lastActiveLogin = _get(data, 'my.lastLoginTimestamp', 0);
-			this.hasEverLoggedIn = _get(data, 'hasEverLoggedIn');
+			this.hasEverLoggedIn = _get(data, 'hasEverLoggedIn', false);
 			// basket data
 			this.totals = _get(data, 'shop.basket.totals') || {};
 			this.loans = _filter(_get(data, 'shop.basket.items.values'), { __typename: 'LoanReservation' });

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -98,7 +98,7 @@
 										without a 'kvu' cookie which indicates if a user has logged
 										into Kiva on current browser -->
 									<kv-button
-										v-if="showGuestCheckoutButton && guestCheckoutExperimentVersion === 'shown'"
+										v-if="eligibleForGuestCheckout && guestCheckoutExperimentVersion === 'shown'"
 										class="guest-checkout-button checkout-button smallest secondary"
 										id="guest-checkout-button"
 										v-kv-track-event="['basket', 'click-guest-checkout-cta', 'Checkout as guest']"
@@ -262,6 +262,7 @@ export default {
 			isGuestCheckoutExperimentActive: false,
 			guestCheckoutExperimentVersion: null,
 			checkingOutAsGuest: false,
+			hasEverLoggedIn: 'no',
 		};
 	},
 	apollo: {
@@ -306,6 +307,7 @@ export default {
 			this.myId = _get(data, 'my.userAccount.id');
 			this.teams = _get(data, 'my.lender.teams.values');
 			this.lastActiveLogin = _get(data, 'my.lastLoginTimestamp', 0);
+			this.hasEverLoggedIn = _get(data, 'hasEverLoggedIn');
 			// basket data
 			this.totals = _get(data, 'shop.basket.totals') || {};
 			this.loans = _filter(_get(data, 'shop.basket.items.values'), { __typename: 'LoanReservation' });
@@ -376,10 +378,9 @@ export default {
 		this.redirectToLoginExperimentVersion = redirectToLoginExperiment.version;
 
 		// GROW-458 Guest Checkout Experiment
-		// Trigger guest checkout experiment if user doesn't have a
-		// kvu cookie (indicating they have never logged into Kiva on this device)
+		// Trigger guest checkout experiment if user has not logged in before
 		// and guest checkout experiment is active
-		if (!this.cookieStore.get('kvu') && this.isGuestCheckoutExperimentActive) {
+		if (this.eligibleForGuestCheckout) {
 			const guestCheckoutExperiment = this.apollo.readFragment({
 				id: 'Experiment:guest_checkout',
 				fragment: experimentVersionFragment,
@@ -387,7 +388,7 @@ export default {
 			this.guestCheckoutExperimentVersion = guestCheckoutExperiment.version;
 
 			// If a guest checkout experiment version set, trigger tracking
-			if (this.guestCheckoutExperimentVersion) {
+			if (this.guestCheckoutExperimentVersion && this.guestCheckoutExperimentVersion !== 'unassigned') {
 				this.$kvTrackEvent(
 					'Checkout',
 					'EXP-GROW-458-Feb2020',
@@ -457,10 +458,13 @@ export default {
 		showKivaCardForm() {
 			return this.checkingOutAsGuest === false;
 		},
-		showGuestCheckoutButton() {
+		eligibleForGuestCheckout() {
 			// Checking if guest checkout experiment is active
 			// and if Kiva has been logged into on user's current browser
-			if (this.isGuestCheckoutExperimentActive && !this.cookieStore.get('kvu')) {
+			if (this.isGuestCheckoutExperimentActive
+				&& !this.isActivelyLoggedIn
+				&& !this.hasEverLoggedIn
+			) {
 				return true;
 			}
 			return false;

--- a/test/unit/specs/api/localResolvers/my.spec.js
+++ b/test/unit/specs/api/localResolvers/my.spec.js
@@ -1,0 +1,52 @@
+import myResolverFactory from '@/api/localResolvers/my';
+import CookieStore from '@/util/cookieStore';
+import { MockKvAuth0 } from '@/util/KvAuth0';
+import clearDocumentCookies from '../../../setup/clearDocumentCookies';
+
+describe('my.js', () => {
+	describe('Query.hasEverLoggedIn', () => {
+		function testHasEverLoggedIn(expected, {
+			context = {},
+			cookies = {},
+			kvAuth0 = MockKvAuth0,
+		} = {}) {
+			const cookieStore = new CookieStore(cookies);
+			const { resolvers } = myResolverFactory({ cookieStore, kvAuth0 });
+
+			const result = resolvers.Query.hasEverLoggedIn(null, {}, context);
+			expect(result).toBe(expected);
+		}
+
+		afterEach(() => {
+			clearDocumentCookies();
+		});
+
+		it('Returns true if the user is currently logged in', () => {
+			const kvAuth0 = {
+				getKivaId: jest.fn().mockReturnValue('123456')
+			};
+			testHasEverLoggedIn(true, { kvAuth0 });
+			expect(kvAuth0.getKivaId.mock.calls.length).toBe(1);
+		});
+		it('Returns true if the user has a kvu cookie', () => {
+			const cookies = {
+				kvu: '123456',
+			};
+			testHasEverLoggedIn(true, { cookies });
+		});
+		it('Returns true if the cached value for this field is true', () => {
+			const context = {
+				cache: {
+					readQuery: jest.fn().mockReturnValue({
+						hasEverLoggedIn: true,
+					}),
+				},
+			};
+			testHasEverLoggedIn(true, { context });
+			expect(context.cache.readQuery.mock.calls.length).toBe(1);
+		});
+		it('Returns false by default in all other cases', () => {
+			testHasEverLoggedIn(false);
+		});
+	});
+});


### PR DESCRIPTION
This adds a new local resolver field to handle the kvu cookie being server-only. It works by using the kvu cookie to set a "hasEverLoggedIn" field in the apollo cache on the server, and then forces the browser to use the cached value for that field.

That new field is used to fix the issue in GROW-586 that was sending experiment events for users that were ineligible for guest checkout.

This also includes the requested change in GROW-585, "Checkout as guest" -> "Continue as guest".