### PR TITLE
grow-481 shortened copy, title swaps on last step of MFA flow

### DIFF
--- a/src/components/Settings/PhoneAuthentication.vue
+++ b/src/components/Settings/PhoneAuthentication.vue
@@ -201,11 +201,14 @@ export default {
 		lightboxTitle() {
 			if (this.step === 1) {
 				if (this.enrollmentType === 'SMS') {
-					return 'We just sent you a text message';
+					return 'We sent you a text message';
 				}
 				if (this.enrollmentType === 'voice') {
 					return 'You’ll receive a call shortly';
 				}
+			}
+			if (this.step === 4) {
+				return 'Complete setup';
 			}
 			return 'Phone number';
 		}

--- a/src/pages/Settings/FirstMFASetup.vue
+++ b/src/pages/Settings/FirstMFASetup.vue
@@ -1,8 +1,5 @@
 <template>
 	<div class="first-mfa-setup">
-		<h2 class="first-mfa-setup__heading">
-			Complete setup
-		</h2>
 		<p class="first-mfa-setup__description">
 			To complete your setup, you will need to enter a 2-step verification code on the login page.
 		</p>


### PR DESCRIPTION
[GROW-481](https://kiva.atlassian.net/browse/GROW-481)

Requirements of ticket: 
R1 - Left align the title during the phone/SMS flows (it’s currently offset to the right approx 17px)
*** Unable to reproduce this issue.**

R2 - Make the window width the same size for the “We just sent you a text message” prompt
*** I shortened this text by removing "just" text now reads -> "We sent you a text message"**

R3 - On the last phone setup page, replace “Phone number” title with “Complete setup”, remove the current “Complete setup.”
*** added an additional step check in the lightboxTitle() function and removed the now duplicated title from FirstMFASetup.vue

