### PR TITLE
VUE-574 running promo banner through kvContentfulImg component

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -20,12 +20,14 @@
 							:rotate="36"
 							:show-number="false"
 						/>
-						<img
+						<kv-contentful-img
 							v-if="imageUrl"
 							class="indicator__image"
-							:src="imageUrl"
-							alt=""
-						>
+							:contentful-src="imageUrl"
+							alt="Promotional banner indicator image"
+							fallback-format="gif"
+							:height="94"
+						/>
 						<div
 							class="indicator__goal-status"
 							v-html="goalStatus"
@@ -119,12 +121,14 @@ import smoothReflow from 'vue-smooth-reflow';
 import KvButton from '@/components/Kv/KvButton';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvProgressCircle from '@/components/Kv/KvProgressCircle';
+import KvContentfulImg from '@/components/Kv/KvContentfulImg';
 
 export default {
 	components: {
 		KvButton,
 		KvIcon,
 		KvProgressCircle,
+		KvContentfulImg
 	},
 	mixins: [smoothReflow],
 	props: {

--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -24,7 +24,7 @@
 							v-if="imageUrl"
 							class="indicator__image"
 							:contentful-src="imageUrl"
-							alt="Promotional banner indicator image"
+							alt=""
 							fallback-format="gif"
 							:height="94"
 						/>


### PR DESCRIPTION
[Vue-574](https://kiva.atlassian.net/browse/VUE-574)

Replaced the < img > with < kv-contentful-img > within AppealBannerCircular.vue.

Tested locally and looking good.
 
<img width="854" alt="Screen Shot 2021-04-30 at 2 09 11 PM" src="https://user-images.githubusercontent.com/1521381/116754481-a6f63b00-a9bd-11eb-95ed-dc0813216991.png">
