### PR TITLE
Add TheHeader styles to each pages css file.

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -73,7 +73,8 @@ module.exports = {
 			},
 			{
 				// Inject styles from the /pages/ directory as <style> tags
-				test: /\/pages\/.+\.scss$/,
+				// Also injects TheHeader styles to each page css file
+				test: /(\/pages\/.+\.scss|\/TheHeader\.scss)/,
 				use: [
 					{ loader: 'thread-loader' },
 					{ loader: 'vue-style-loader' },


### PR DESCRIPTION
This is a "blunt" solution to the fouc when our pages server render. It adds the header css to every page's generated `.css` file so keep an eye on the file size and Lighthouse reports.