### PR TITLE
grow-601 appeal closed button state fixed by removing smallest class,…

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -99,7 +99,7 @@
 				</div>
 				<div class="shrink columns">
 					<kv-button
-						class="appeal-banner__btn appeal-banner__btn--toggle-open smallest rounded"
+						class="appeal-banner__btn appeal-banner__btn--toggle-open rounded"
 						@click.native="onClickToggleBanner"
 						v-kv-track-event="[
 							'promo',
@@ -262,6 +262,7 @@ export default {
 
 		&:hover,
 		&:focus {
+			color: $kiva-green;
 			background: $kiva-bg-darkgray;
 		}
 


### PR DESCRIPTION
… fixing hover state of button when appeal is open

[Grow-601](https://kiva.atlassian.net/browse/GROW-601)

Found two more css errors in dev. 

1) open appeal button hover state. Text should remain kiva-green, it’s white in dev.
<img width="715" alt="Screen Shot 2021-05-06 at 12 58 50 PM" src="https://user-images.githubusercontent.com/1521381/117359107-cf71af80-ae6b-11eb-9c16-c35210263dc6.png">

2) Closed appeal - button had smallest class which was causing additional styles applied (ie the box-shadow here) 
<img width="982" alt="Screen Shot 2021-05-06 at 12 58 36 PM" src="https://user-images.githubusercontent.com/1521381/117359123-d39dcd00-ae6b-11eb-926f-20e235506093.png">

