### PR TITLE
grow-601 closed button hover state fixed

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -292,6 +292,7 @@ export default {
 		&:hover,
 		&:focus {
 			background-color: $kiva-bg-darkgray;
+			color: $white;
 			fill: $dark-charcoal;
 		}
 	}


### PR DESCRIPTION
Error: 
Closed appeal banner, button in hover state: 
<img width="985" alt="Screen Shot 2021-05-06 at 2 48 06 PM" src="https://user-images.githubusercontent.com/1521381/117369795-4ada5d80-ae7a-11eb-9293-fe2d15d20b7f.png">

Fixed: 
<img width="773" alt="Screen Shot 2021-05-06 at 2 48 45 PM" src="https://user-images.githubusercontent.com/1521381/117369811-52016b80-ae7a-11eb-8fd1-bef1ae80894a.png">
