### PR TITLE
grow-601, added specific color value for hover state of appeal-banner…

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -272,6 +272,7 @@ export default {
 
 			&:hover,
 			&:focus {
+				color: $white;
 				background: darken($kiva-green, 10%);
 			}
 		}
@@ -292,7 +293,6 @@ export default {
 		&:hover,
 		&:focus {
 			background-color: $kiva-bg-darkgray;
-			color: $white;
 			fill: $dark-charcoal;
 		}
 	}


### PR DESCRIPTION
…__btn--toggle-open, forcing the style once compiled to dev

The last fix didn't work once compiled to dev. This commit removes the last one and adds a more specific color definition where it's needed. 

Fixed state: 
![Screen Shot 2021-05-07 at 12 10 22 PM](https://user-images.githubusercontent.com/1521381/117497365-4753de80-af2d-11eb-9962-cd876cc59b6c.png)
