### PR TITLE
Vue 530

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -412,7 +412,7 @@ export default {
 			this.$kvTrackEvent('basket', 'click-open nudge');
 			this.nudgeLightboxVisible = true;
 			this.$nextTick(() => {
-				this.$refs.nudgeLightbox.openNudgeLightbox();
+				this.$refs.nudgeLightbox.expandNudgeLightbox();
 			});
 		},
 		donationNudgeDescription() {

--- a/src/components/Checkout/DonationNudge/donationNudgeLightboxMixin.js
+++ b/src/components/Checkout/DonationNudge/donationNudgeLightboxMixin.js
@@ -48,7 +48,8 @@ export default {
 			this.$kvTrackEvent('basket', 'Update Nudge Donation', `Update Success${clickSource}`, amount * 100);
 			this.closeNudgeLightbox();
 		},
-		openNudgeLightbox() {
+		expandNudgeLightbox() {
+			console.log('expandNudgeLightbox triggered');
 			this.$refs.nudgeBoxes.openNudgeLightbox();
 		},
 	},

--- a/src/components/Checkout/DonationNudge/donationNudgeLightboxMixin.js
+++ b/src/components/Checkout/DonationNudge/donationNudgeLightboxMixin.js
@@ -49,7 +49,6 @@ export default {
 			this.closeNudgeLightbox();
 		},
 		expandNudgeLightbox() {
-			console.log('expandNudgeLightbox triggered');
 			this.$refs.nudgeBoxes.openNudgeLightbox();
 		},
 	},


### PR DESCRIPTION
[VUE-530](https://kiva.atlassian.net/browse/VUE-530) 

We've had some [sentry errors related to the donationNudgeLightbox](https://sentry.io/organizations/kiva/issues/2165976202/?project=1201288&query=is%3Aunresolved&statsPeriod=14d). 

We think this is due to the duplicate names of the openNudgeLightbox within the donationNudgeLightboxMixin.js file. 

Old code: 
**openNudgeLightbox**() {
	this.$refs.nudgeBoxes.**openNudgeLightbox**();
},


I've updated the function name to expandNudgeLightbox and also updated DonationItem.vue where we're calling the mixin's function.