### PR TITLE
Revert "VUE-506: Forward query parameters along with live-loan URL redirects"

### DIFF
--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -141,15 +141,7 @@ async function redirectToUrl(type, cache, req, res) {
 		try {
 			const loanData = await fetchRecommendedLoans(type, id, cache);
 			const offsetLoanId = loanData[offset - 1].id;
-
-			let redirect = `/lend/${offsetLoanId}`;
-			// If the original request had query params on it, forward those along
-			const requestUrl = new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
-			const queryParams = new URLSearchParams(requestUrl.search);
-			if (queryParams) {
-				redirect += `?${queryParams}`;
-			}
-			res.redirect(302, redirect);
+			res.redirect(302, `/lend/${offsetLoanId}`);
 		} catch (err) {
 			log(`Error redirecting to url, ${err}`, 'error');
 			res.redirect(302, '/lend-by-category/');


### PR DESCRIPTION
Reverts kiva/ui#2942

Rolling this back as it appears to break live loan images and redirects on dev. 
