### PR TITLE
SUBS-738 MG Selector Pre Selected Cause

### DIFF
--- a/.storybook/stories/MonthlyGoodSelector.stories.js
+++ b/.storybook/stories/MonthlyGoodSelector.stories.js
@@ -1,0 +1,87 @@
+import MonthlyGoodSelectorDesktop from '@/components/MonthlyGood/MonthlyGoodSelectorDesktop';
+import MonthlyGoodSelectorMobile from '@/components/MonthlyGood/MonthlyGoodSelectorMobile';
+import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
+
+const lendingCategories = loanGroupCategoriesMixin.data().lendingCategories;
+
+export default {
+	title: 'components/MonthlyGoodSelector',
+	args: {
+		preSelectedCategory: null,
+	},
+	argTypes: {
+		preSelectedCategory: {
+			control: {
+				type: 'select',
+				options: {
+					'none': null,
+					'default': lendingCategories.find(({value}) => value ==='default' ),
+					'women': lendingCategories.find(({value}) => value ==='women' ),
+					'agriculture': lendingCategories.find(({value}) => value ==='agriculture' ),
+					'refugees': lendingCategories.find(({value}) => value ==='refugees' ),
+					'education': lendingCategories.find(({value}) => value ==='education' ),
+					'eco_friendly':lendingCategories.find(({value}) => value ==='eco_friendly' ),
+					'us_borrowers': lendingCategories.find(({value}) => value ==='us_borrowers' ),
+					'disaster_relief_covid': lendingCategories.find(({value}) => value ==='disaster_relief_covid' ),
+				},
+			}
+		},
+	}
+};
+
+export const Desktop = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		MonthlyGoodSelectorDesktop,
+	},
+	template: `
+		<div style="margin-top: 25rem;">
+			<monthly-good-selector-desktop/>
+		</div>
+	`,
+});
+
+export const DesktopWithPreSelected = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		MonthlyGoodSelectorDesktop,
+	},
+	template: `
+		<div style="margin-top: 25rem;">
+			<!-- Key prop is not needed, just a hack for storybook to update component when prop changes -->
+			<monthly-good-selector-desktop :pre-selected-category="preSelectedCategory" :key="preSelectedCategory?.value ?? null" />
+		</div>
+	`,
+});
+DesktopWithPreSelected.args = {
+	preSelectedCategory: lendingCategories.find(({value}) => value ==='refugees' )
+};
+
+export const Mobile = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		MonthlyGoodSelectorMobile,
+	},
+	template: `
+		<div>
+			<monthly-good-selector-mobile/>
+		</div>
+	`,
+});
+
+export const MobileWithPreSelected = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	components: {
+		MonthlyGoodSelectorMobile,
+	},
+	template: `
+		<div>
+			<!-- Key prop is not needed, just a hack for storybook to update component when prop changes -->
+			<monthly-good-selector-mobile :pre-selected-category="preSelectedCategory" :key="preSelectedCategory?.value ?? null" />
+		</div>
+	`,
+});
+MobileWithPreSelected.args = {
+	preSelectedCategory: lendingCategories.find(({value}) => value ==='climate' )
+};
+

--- a/src/components/MonthlyGood/MonthlyGoodSelectorDesktop.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorDesktop.vue
@@ -109,6 +109,15 @@ import clickOutside from '@/plugins/click-outside';
 const mgSelectorImgRequire = require.context('@/assets/images/mg-selector-icons/', true);
 
 export default {
+	props: {
+		/**
+		 * The category value to preSelect. Or null for no selection
+		* */
+		preSelectedCategory: {
+			type: Object,
+			default: null,
+		},
+	},
 	components: {
 		KvButton,
 	},
@@ -129,7 +138,7 @@ export default {
 	},
 	data() {
 		return {
-			selectedGroup: null,
+			selectedGroup: this.preSelectedCategory,
 			mgAmount: null,
 			isCauseOpen: false,
 			isAmountOpen: false,
@@ -163,11 +172,11 @@ export default {
 	},
 	mounted() {
 		document.addEventListener('keyup', this.onKeyUp);
-		this.$root.$on('openMonthlyGoodSelector', this.showCausesRootEvent);
+		this.$root.$on('openMonthlyGoodSelector', this.onCtaClick);
 	},
 	beforeDestroy() {
 		document.removeEventListener('keyup', this.onKeyUp);
-		this.$root.$off('openMonthlyGoodSelector', this.showCausesRootEvent);
+		this.$root.$off('openMonthlyGoodSelector', this.onCtaClick);
 	},
 	methods: {
 		onKeyUp(e) {
@@ -188,14 +197,22 @@ export default {
 				}
 			});
 		},
-		showCausesRootEvent() {
+		onCtaClick() {
 			/**
 			 * Move focus to button from whatever triggered this event
 			 * And open causes.
 			 */
 			document.getElementsByClassName('monthly-selector__button')[0].focus();
-			this.isCauseOpen = true;
-			this.isAmountOpen = false;
+
+			// if preSelectedCategory is present, open amounts.
+			if (this.preSelectedCategory) {
+				this.isCauseOpen = false;
+				this.isAmountOpen = true;
+			} else {
+				// if no preSelectedCategory is present, open causes.
+				this.isCauseOpen = true;
+				this.isAmountOpen = false;
+			}
 		},
 		toggleCauses() {
 			this.isCauseOpen = !this.isCauseOpen;
@@ -252,7 +269,8 @@ export default {
 			}
 			return numeral(this.mgAmount).format('$0,0.00');
 		},
-	}
+	},
+
 };
 
 </script>

--- a/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
@@ -90,6 +90,15 @@ import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
 const mgSelectorImgRequire = require.context('@/assets/images/mg-selector-icons/', true);
 
 export default {
+	props: {
+		/**
+		 * The category value to preSelect. Or null for no selection
+		* */
+		preSelectedCategory: {
+			type: Object,
+			default: null,
+		},
+	},
 	components: {
 		KvButton,
 		KvIcon,
@@ -111,7 +120,7 @@ export default {
 	},
 	data() {
 		return {
-			selectedGroup: null,
+			selectedGroup: this.preSelectedCategory,
 			mgAmount: null,
 			mgAmountOptions: [
 				{
@@ -145,13 +154,20 @@ export default {
 		};
 	},
 	mounted() {
-		this.$root.$on('openMonthlyGoodSelector', this.showCausesRootEvent);
+		this.$root.$on('openMonthlyGoodSelector', this.onCtaClick);
 	},
 	beforeDestroy() {
-		this.$root.$off('openMonthlyGoodSelector', this.showCausesRootEvent);
+		this.$root.$off('openMonthlyGoodSelector', this.onCtaClick);
 	},
 	methods: {
 		showLightbox() {
+			// if preSelectedCategory is present, open amounts.
+			if (this.preSelectedCategory) {
+				this.lightboxStep = 'amount';
+			} else {
+				// if no preSelectedCategory is present, open causes.
+				this.lightboxStep = 'cause';
+			}
 			this.lightboxVisible = true;
 		},
 		hideLightbox() {
@@ -175,13 +191,12 @@ export default {
 				}
 			});
 		},
-		showCausesRootEvent() {
+		onCtaClick() {
 			/**
 			 * Move focus to button from whatever triggered this event
 			 * And open causes.
 			 */
 			document.getElementsByClassName('monthly-selector-mobile__button')[0].focus();
-			this.lightboxStep = 'cause';
 			this.showLightbox();
 		},
 		selectCause(option) {

--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -6,7 +6,7 @@
 			:class="{ 'sticky': isSticky}"
 			:style="{bottom: mgStickBarOffset + 'px'}"
 		>
-			<monthly-good-selector />
+			<monthly-good-selector-desktop :pre-selected-category="preSelectedCategory" />
 		</section>
 
 		<!-- MG Selector Mobile -->
@@ -14,7 +14,7 @@
 			class="monthly-good-selector section show-for-small-only"
 			v-if="isMobile"
 		>
-			<monthly-good-selector-mobile />
+			<monthly-good-selector-mobile :pre-selected-category="preSelectedCategory" />
 		</section>
 	</div>
 </template>
@@ -22,12 +22,22 @@
 <script>
 import _throttle from 'lodash/throttle';
 
-import MonthlyGoodSelector from '@/components/MonthlyGood/MonthlyGoodSelector';
+import MonthlyGoodSelectorDesktop from '@/components/MonthlyGood/MonthlyGoodSelectorDesktop';
 import MonthlyGoodSelectorMobile from '@/components/MonthlyGood/MonthlyGoodSelectorMobile';
+import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
 
 export default {
+	props: {
+		/**
+		 * Content group content from Contentful
+		* */
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
 	components: {
-		MonthlyGoodSelector,
+		MonthlyGoodSelectorDesktop,
 		MonthlyGoodSelectorMobile,
 	},
 	data() {
@@ -38,10 +48,25 @@ export default {
 			isMobile: false
 		};
 	},
+	mixins: [
+		loanGroupCategoriesMixin,
+	],
 	computed: {
 		throttledScroll() {
 			// prevent onScroll from being called more than once every 100ms
 			return _throttle(this.onScroll, 100);
+		},
+		mgSelectorSetting() {
+			return this.content?.contents?.find(({ key }) => key.indexOf('monthly-good-selector-setting') > -1);
+		},
+		preSelectedCategorySetting() {
+			return this.mgSelectorSetting?.dataObject?.preSelectedCategory ?? null;
+		},
+		preSelectedCategory() {
+			// Validated Category Setting
+			// Check setting to make sure it is an actual category or return null
+			// Must return null (no preselected category) or a valid category object
+			return this.lendingCategories.find(({ value }) => value === this.preSelectedCategorySetting) ?? null;
 		}
 	},
 	methods: {


### PR DESCRIPTION
* Allows MG Selector to read contentful setting and preselect a cause in both mobile and desktop
* Renamed MG Selector desktop component

Works off UI Setting on contentful, which contains a data object and looks like:

```
{
    "preSelectedCategory": "refugees"
}
```

Example: 
https://app.contentful.com/spaces/j0p9a6ql0rn7/environments/development/entries/34Cn8yRZCnqRjwv580UZyu?previousEntries=6Q14Zf7ttG0iBKLdQ4KAjD,3z8Yn1Inpy8iCZPY72pAS5