### PR TITLE
build: package-lock updates that we removed from borrower profile frame build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33512,6 +33512,7 @@
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
 			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
@@ -33531,6 +33532,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-convert": "^1.9.0"
 			},
@@ -33543,6 +33545,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -33557,6 +33560,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"color-name": "1.1.3"
 			}
@@ -33565,13 +33569,15 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/ts-loader/node_modules/enhanced-resolve": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
 			"integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.1.2",
 				"memory-fs": "^0.5.0",
@@ -33586,6 +33592,7 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -33595,6 +33602,7 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
 			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
 			},
@@ -33607,6 +33615,7 @@
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
 			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
@@ -33621,6 +33630,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -33630,6 +33640,7 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
 			},
@@ -33642,6 +33653,7 @@
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -41543,7 +41555,6 @@
 			"integrity": "sha512-MvTmxrOSo+zZ5MaMx9LVWM8DlvVHeryCJKPJx8BYCEN38r8mIK7uCFYok8oMPmACrVe0MfXOdJCm1HKkBKjsMg==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.12.1",
 				"@babel/generator": "^7.12.1",
 				"@babel/parser": "^7.12.3",
 				"@babel/plugin-transform-react-jsx": "^7.12.1",
@@ -42547,7 +42558,6 @@
 				"react-dom": "16.13.1",
 				"regenerator-runtime": "^0.13.7",
 				"ts-dedent": "^2.0.0",
-				"ts-loader": "^6.2.2",
 				"vue-docgen-api": "^4.33.1",
 				"vue-docgen-loader": "^1.5.0",
 				"webpack": "^4.44.2"
@@ -65453,6 +65463,7 @@
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.2.tgz",
 			"integrity": "sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"chalk": "^2.3.0",
 				"enhanced-resolve": "^4.0.0",
@@ -65466,6 +65477,7 @@
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -65475,6 +65487,7 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -65486,6 +65499,7 @@
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -65494,13 +65508,15 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"enhanced-resolve": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.5.0.tgz",
 					"integrity": "sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"graceful-fs": "^4.1.2",
 						"memory-fs": "^0.5.0",
@@ -65511,13 +65527,15 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
 					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"minimist": "^1.2.0"
 					}
@@ -65527,6 +65545,7 @@
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
 					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"big.js": "^5.2.2",
 						"emojis-list": "^3.0.0",
@@ -65537,13 +65556,15 @@
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -65552,7 +65573,8 @@
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
 					"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				}
 			}
 		},


### PR DESCRIPTION
These are the package-lock.json updates that I removed from [this PR.](https://github.com/kiva/ui/pull/2953)

These updates were a result of running npm install in the /kiva/ui repo. 