### PR TITLE
vue-605 fixing menu overlap issue when few loans are returned on /len…

### DIFF
--- a/src/pages/Lend/Filter/FilterComponents/LendFilterMenu.vue
+++ b/src/pages/Lend/Filter/FilterComponents/LendFilterMenu.vue
@@ -205,7 +205,8 @@ export default {
 
 	#lend-filter-wrapper {
 		position: relative;
-		height: 2rem;
+		height: auto;
+		min-height: 2rem;
 
 		#algolia-pagination-stats {
 			display: block;


### PR DESCRIPTION
…d/filter

[Vue-605](https://kiva.atlassian.net/browse/VUE-605)

Just added a little css to fix up this menu overlap issue. Set height:auto, which made room for the menu on the page. Then set a min-height:2rem.

**Issue:** 
![Screen Shot 2021-06-02 at 12 49 38 PM](https://user-images.githubusercontent.com/1521381/120543276-01116400-c3a1-11eb-8cac-cf9b019d338a.png)


**Fixed:** 
![Screen Shot 2021-06-02 at 12 50 09 PM](https://user-images.githubusercontent.com/1521381/120543342-11c1da00-c3a1-11eb-868e-bbd21bd34bf0.png)
