### PR TITLE
VUE-610 Bring tailwind prefix into UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.4.1",
 				"@graphql-tools/load": "^6.2.4",
 				"@graphql-tools/url-loader": "^6.3.0",
-				"@kiva/kv-components": "^0.4.0",
+				"@kiva/kv-components": "^0.4.1",
 				"@sentry/browser": "^5.21.1",
 				"@sentry/integrations": "^5.27.1",
 				"algoliasearch": "^3.34.0",
@@ -3070,19 +3070,19 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.4.0.tgz",
-			"integrity": "sha512-4QXo9grCF49ATtJ9fdLbMlit2mA7P5FmGni3KrsPj/Tv4md0MFfla9j/ZvRq/LturRHikELu2LFzsgqiHaplew==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.4.1.tgz",
+			"integrity": "sha512-v1frhnogSWNjHBZDxPEcZPx0jJEQ9TNyS6bEifCHZA96lxKf1cfnXq8qaovkp7zaMVSKplxNyaGvkWHfAk4pGw==",
 			"dependencies": {
-				"@kiva/kv-tokens": "^0.2.1",
+				"@kiva/kv-tokens": "^0.2.2",
 				"@mdi/js": "^5.9.55",
 				"vue": "^2.6.12"
 			}
 		},
 		"node_modules/@kiva/kv-tokens": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.2.1.tgz",
-			"integrity": "sha512-HheXNZDJyshJJulWxNBxfutMZCyWhf6w+Qj/HIik49bdnN9PVZfqC+8B2+Hoiq8mp7p9SnzSKMEuYzWgxU/1Ww==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.2.2.tgz",
+			"integrity": "sha512-NDUNl0IxYsnAnmF7BGBxWfRgNzJ+8bfh/I44YoH2aFgnatfSsxpxI7c1cqHYHhrl02CgVrFeeaeMh2KxYMIVXg==",
 			"dependencies": {
 				"@tailwindcss/typography": "^0.4.0",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"
@@ -40273,19 +40273,19 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.4.0.tgz",
-			"integrity": "sha512-4QXo9grCF49ATtJ9fdLbMlit2mA7P5FmGni3KrsPj/Tv4md0MFfla9j/ZvRq/LturRHikELu2LFzsgqiHaplew==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.4.1.tgz",
+			"integrity": "sha512-v1frhnogSWNjHBZDxPEcZPx0jJEQ9TNyS6bEifCHZA96lxKf1cfnXq8qaovkp7zaMVSKplxNyaGvkWHfAk4pGw==",
 			"requires": {
-				"@kiva/kv-tokens": "^0.2.1",
+				"@kiva/kv-tokens": "^0.2.2",
 				"@mdi/js": "^5.9.55",
 				"vue": "^2.6.12"
 			}
 		},
 		"@kiva/kv-tokens": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.2.1.tgz",
-			"integrity": "sha512-HheXNZDJyshJJulWxNBxfutMZCyWhf6w+Qj/HIik49bdnN9PVZfqC+8B2+Hoiq8mp7p9SnzSKMEuYzWgxU/1Ww==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.2.2.tgz",
+			"integrity": "sha512-NDUNl0IxYsnAnmF7BGBxWfRgNzJ+8bfh/I44YoH2aFgnatfSsxpxI7c1cqHYHhrl02CgVrFeeaeMh2KxYMIVXg==",
 			"requires": {
 				"@tailwindcss/typography": "^0.4.0",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@godaddy/terminus": "^4.4.1",
 		"@graphql-tools/load": "^6.2.4",
 		"@graphql-tools/url-loader": "^6.3.0",
-		"@kiva/kv-components": "^0.4.0",
+		"@kiva/kv-components": "^0.4.1",
 		"@sentry/browser": "^5.21.1",
 		"@sentry/integrations": "^5.27.1",
 		"algoliasearch": "^3.34.0",

--- a/src/components/BorrowerProfile/BorrowerAvatar.vue
+++ b/src/components/BorrowerProfile/BorrowerAvatar.vue
@@ -1,5 +1,5 @@
 <template>
-	<picture class="rounded-full overflow-hidden bg-black">
+	<picture class="tw-rounded-full tw-overflow-hidden tw-bg-black">
 		<source
 			v-for="({ media, urls }, index) in sources"
 			:key="index"

--- a/src/components/BorrowerProfile/BorrowerName.vue
+++ b/src/components/BorrowerProfile/BorrowerName.vue
@@ -1,5 +1,5 @@
 <template>
-	<h1 class="text-h2">
+	<h1 class="tw-text-h2">
 		{{ name }}
 	</h1>
 </template>

--- a/src/components/BorrowerProfile/LoanUse.vue
+++ b/src/components/BorrowerProfile/LoanUse.vue
@@ -1,5 +1,5 @@
 <template>
-	<p class="text-h2">
+	<p class="tw-text-h2">
 		{{ loanUseFiltered }}
 	</p>
 </template>

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -1,17 +1,21 @@
 <template>
-	<section class="flex flex-wrap bg-gray-100 p-2.5 md:bg-white md:p-3 md:rounded lg:p-4">
+	<section class="tw-flex tw-flex-wrap tw-bg-gray-100 tw-p-2.5 md:tw-bg-white md:tw-p-3 md:tw-rounded lg:tw-p-4">
 		<borrower-avatar
-			class="flex-none w-8 h-8 mr-1.5 mb-1.5 md:w-9 md:h-9 md:mr-3 md:mb-3 lg:w-10 lg:h-10 lg:mr-4 lg:mb-4"
+			class="
+				tw-flex-none tw-w-8 tw-h-8 tw-mr-1.5 tw-mb-1.5
+				md:tw-w-9 md:tw-h-9 md:tw-mr-3 md:tw-mb-3
+				lg:tw-w-10 lg:tw-h-10 lg:tw-mr-4 lg:tw-mb-4
+			"
 			:alt="`Small, circular photograph of ${name}`"
 			:fallback="fallbackImage"
 			:sources="images"
 		/>
-		<div class="flex-auto">
+		<div class="tw-flex-auto">
 			<borrower-name :name="name" />
 			<!-- fundraising progress placeholder  -->
 		</div>
 		<loan-use
-			class="flex-none w-full"
+			class="tw-flex-none tw-w-full"
 			:borrower-count="borrowerCount"
 			:loan-amount="loanAmount"
 			:name="name"

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -1,12 +1,12 @@
 <template>
 	<www-page id="borrower-profile">
-		<div class="container">
-			<div class="grid grid-cols-12 gap-x-2">
-				<div class="col-span-12 md:col-start-2 md:col-span-10 lg:col-span-7">
+		<div class="tw-container">
+			<div class="tw-grid tw-grid-cols-12 tw-gap-x-2">
+				<div class="tw-col-span-12 md:tw-col-start-2 md:tw-col-span-10 lg:tw-col-span-7">
 					<summary-card />
 					<!-- Borrower details -->
 				</div>
-				<div class="col-span-12 md:col-start-6 md:col-span-6 lg:col-span-5">
+				<div class="tw-col-span-12 md:tw-col-start-6 md:tw-col-span-6 lg:tw-col-span-5">
 					<!-- Powered by lenders info -->
 				</div>
 			</div>


### PR DESCRIPTION
This brings in the latest Tailwind config via the @kiva/kv-components package, which alters our Tailwind classes to put a 'tw' prefix on all of them.

The purpose is to prevent class name collisions between Tailwind classes and Foundation or any other class names used on the site.
https://tailwindcss.com/docs/configuration#prefix


After this is merged, writing Tailwind classes on UI will require a 'tw' prefix. e.g., `class="flex align-center mb-2"` would become `class="tw-flex tw-align-center tw-mb-2"`