### PR TITLE
Fix z-index for sticky state of MG selector

### DIFF
--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -171,6 +171,8 @@ footer.www-footer {
 		transition: bottom 0.4s;
 		// probably doable with tw, will revisit later
 		box-shadow: 0 -5px 80px rgba(0, 0, 0, 0.1);
+		// Temporary scss override to ensure layering over header in mobile
+		z-index: 1000;
 	}
 }
 </style>


### PR DESCRIPTION
This restores prior styles to prevent the header from showing above the mobile full-screen lightbox and obscuring the headline. No issues on desktop.