### PR TITLE
grow-662 if all loan shares are reserved, setting the loanProgress ba…

### DIFF
--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -157,5 +157,13 @@ export default {
 			this.use = loan?.use ?? '';
 		},
 	},
+	mounted: {
+		// If all shares are reserved in baskets, set the fundraising meter to 100%
+		checkAllSharesReserved() {
+			if (this.unreservedAmount === '0') {
+				this.fundraisingPercent = 1;
+			}
+		}
+	}
 };
 </script>

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -155,15 +155,12 @@ export default {
 			this.timeLeft = loan?.fundraisingTimeLeft ?? '';
 			this.unreservedAmount = loan?.unreservedAmount ?? '0';
 			this.use = loan?.use ?? '';
-		},
-	},
-	mounted: {
-		// If all shares are reserved in baskets, set the fundraising meter to 100%
-		checkAllSharesReserved() {
+
+			// If all shares are reserved in baskets, set the fundraising meter to 100%
 			if (this.unreservedAmount === '0') {
 				this.fundraisingPercent = 1;
 			}
-		}
-	}
+		},
+	},
 };
 </script>


### PR DESCRIPTION
…r to display 100%

I added a check inside of SummaryCard.vue. If the unreservedAmount of the loan is equal to 0, I'm setting the fundraisingPercent that's passed into LoanProgress to 1 aka 100%, which masks the availability of the basketed loan shares.

