### PR TITLE
grow-709 adding aria-lable to <kv-progress-bar> within LoanProgress.vue

### DIFF
--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -2,6 +2,7 @@
 	<figure>
 		<kv-progress-bar
 			class="tw-mb-1.5 lg:tw-mb-1"
+			aria-label="Percent the loan has funded"
 			:value="progressPercent * 100"
 		/>
 		<figcaption class="tw-flex">


### PR DESCRIPTION
I added aria-label="Percent the loan has funded" to the <kv-progress-bar> include within LoanProgress.vue which stops this error/warning from being thrown. 

<img width="1471" alt="Screen Shot 2021-06-28 at 2 37 57 PM" src="https://user-images.githubusercontent.com/1521381/123700974-71839780-d81e-11eb-85be-8a6eb12e1c04.png">
