### PR TITLE
general flss loans query

### DIFF
--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -4,11 +4,11 @@ query flssLoanData(
   $filterObject: [FundraisingLoanSearchFilterInput!] = { countryIsoCode: {any: ["US"]}}
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
-  $limit: Int
-  $offest: Int
+  $limit: Int = 20
+  $offset: Int = 0
 ) {
   fundraisingLoans(filters: $filterObject,
-  							limit:  $limit,
+  							limit: $limit,
   							pageNumber: $offset) {
     totalCount
     values {

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -1,11 +1,15 @@
 #import '../fragments/loanCardFields.graphql'
 
 query flssLoanData(
-  $filterObject: [FundraisingLoanSearchFilterInput!]
+  $filterObject: [FundraisingLoanSearchFilterInput!] = { countryIsoCode: {any: ["US"]}}
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
+  $limit: Int = 50
+  $pageNumber: Int
 ) {
-  fundraisingLoans(filters: $filterObject) {
+  fundraisingLoans(filters: $filterObject,
+  							limit:  $limit,
+  							pageNumber: $pageNumber) {
     totalCount
     values {
       id

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -4,12 +4,12 @@ query flssLoanData(
   $filterObject: [FundraisingLoanSearchFilterInput!] = { countryIsoCode: {any: ["US"]}}
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
-  $limit: Int = 50
-  $pageNumber: Int
+  $limit: Int
+  $offest: Int
 ) {
   fundraisingLoans(filters: $filterObject,
   							limit:  $limit,
-  							pageNumber: $pageNumber) {
+  							pageNumber: $offset) {
     totalCount
     values {
       id

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -1,0 +1,21 @@
+#import '../fragments/loanCardFields.graphql'
+
+query flssLoanData(
+  $filterObject: [FundraisingLoanSearchFilterInput!]
+  $imgDefaultSize: String = "w480h360"
+  $imgRetinaSize: String = "w960h720"
+) {
+  fundraisingLoans(filters: $filterObject) {
+    totalCount
+    values {
+      id
+      ...loanCardFields
+      image {
+        id
+        default: url(customSize: $imgDefaultSize)
+        retina: url(customSize: $imgRetinaSize)
+        hash
+      }
+    }
+  }
+}


### PR DESCRIPTION
Jira Ticket:
https://kiva.atlassian.net/browse/PSD-265

What does this do:
creates graphql loan query to flss service with filtering ability. the query should return all information necessary to populate a loan card. 


how to test:
The full expanded version of the query with a country default of ["US"] should return loans from the flss endpoint:
`https://marketplace-api.k1.kiva.org/graphql`

```graphql
fragment loanCardFields on LoanBasic {
	id
	status
	name
	borrowerCount
	geocode {
		# city added for DetailedLoanCard Query Cache
		city
		# state is used for US loans on LoanChannelCategoryPage
		state
		country {
			isoCode
			name
			region
		}
	}
	use
	activity {
		id
		name
	}
	sector {
		id
		name
	}
	whySpecial
	lenderRepaymentTerm
	loanAmount
	minNoteSize
	loanFundraisingInfo {
		fundedAmount
		reservedAmount
		isExpiringSoon
	}
	plannedExpirationDate
	matchingText
	userProperties {
		favorited
		lentTo
	}
	# lenders added for DetailedLoanCard Query Cache
	lenders(limit: 0) {
		totalCount
	}
	... on LoanPartner {
		partnerName
	}
	...on LoanDirect {
		trusteeName
	}
}

query flssLoanData(
  $filterObject: [FundraisingLoanSearchFilterInput!] = { countryIsoCode: {any: ["US"]}}
  $imgDefaultSize: String = "w480h360"
  $imgRetinaSize: String = "w960h720"
) {
  fundraisingLoans(filters: $filterObject) {
    totalCount
    values {
      id
      ...loanCardFields
      image {
        id
        default: url(customSize: $imgDefaultSize)
        retina: url(customSize: $imgRetinaSize)
        hash
      }
    }
  }
}
```