### PR TITLE
Grow 688 fix

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -382,8 +382,6 @@ export default {
 			switch (this.state) {
 				case 'loading':
 					return 'Loading...';
-				case 'lent-to':
-					return 'Lend again';
 				case 'funded':
 					return 'Find another loan like this';
 				case 'refunded':

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -83,7 +83,7 @@
 
 						<!-- Continue to checkout button -->
 						<kv-ui-button
-							v-if="this.state === 'basketed'"
+							v-if="this.state === 'basketed' && this.state !== 'adding'"
 							class="tw-inline-flex tw-flex-1"
 							to="/basket"
 							v-kv-track-event="[
@@ -97,7 +97,7 @@
 
 						<!-- Lend again/lent previously button -->
 						<kv-ui-button
-							v-if="this.lentPreviously"
+							v-if="this.lentPreviously && this.state !== 'basketed' && this.state !== 'adding'"
 							class="tw-inline-flex tw-flex-1"
 							@click="addToBasket"
 							v-kv-track-event="[
@@ -380,6 +380,8 @@ export default {
 			switch (this.state) {
 				case 'loading':
 					return 'Loading...';
+				case 'lent-to':
+					return 'Lend again';
 				case 'funded':
 					return 'Find another loan like this';
 				case 'refunded':

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -69,6 +69,7 @@
 
 						<!-- Lend button -->
 						<kv-ui-button
+							key="lendButton"
 							v-if="lendButtonVisibility"
 							class="tw-inline-flex tw-flex-1"
 							@click="addToBasket"
@@ -83,7 +84,7 @@
 
 						<!-- Continue to checkout button -->
 						<kv-ui-button
-							v-if="this.state === 'basketed' && this.state !== 'adding'"
+							v-if="this.state === 'basketed'"
 							class="tw-inline-flex tw-flex-1"
 							to="/basket"
 							v-kv-track-event="[
@@ -97,7 +98,8 @@
 
 						<!-- Lend again/lent previously button -->
 						<kv-ui-button
-							v-if="this.lentPreviously && this.state !== 'basketed' && this.state !== 'adding'"
+							key="lendAgainButton"
+							v-if="this.state === 'lent-to'"
 							class="tw-inline-flex tw-flex-1"
 							@click="addToBasket"
 							v-kv-track-event="[


### PR DESCRIPTION
While QAing grow-688 I found a couple issues. 

1) The lend again button was showing up when the loan had been basketed. 
<img width="1128" alt="Screen Shot 2021-07-07 at 8 00 29 AM" src="https://user-images.githubusercontent.com/1521381/124800797-4c281500-df13-11eb-973d-1e2e1ae4038e.png">
- Changing the v-if condition on the "lend again" button fixed this issue

2) Tracking was not working correctly for the lend again button, upon click I was getting the tracking info of the Lend button. I added keys to both buttons, which tells vue that the buttons are in fact different and passes through all the data for each button. They are so similar, it seems that vue was only updating some of the fields (not tracking fields) which was causing the issue. 