### PR TITLE
PSD-280: add data call with Graphql flss query to filter-alpha page

### DIFF
--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -4,7 +4,7 @@ query flssLoanData(
   $filterObject: [FundraisingLoanSearchFilterInput!]
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
-  $limit: Int = 50
+  $limit: Int = 0
   $offset: Int = 0
 ) {
   fundraisingLoans(filters: $filterObject,

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -4,7 +4,7 @@ query flssLoanData(
   $filterObject: [FundraisingLoanSearchFilterInput!]
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
-  $limit: Int = 0
+  $limit: Int = 20
   $offset: Int = 0
 ) {
   fundraisingLoans(filters: $filterObject,

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -4,7 +4,7 @@ query flssLoanData(
   $filterObject: [FundraisingLoanSearchFilterInput!] = { countryIsoCode: {any: ["US"]}}
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
-  $limit: Int = 20
+  $limit: Int = 50
   $offset: Int = 0
 ) {
   fundraisingLoans(filters: $filterObject,

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -1,7 +1,7 @@
 #import '../fragments/loanCardFields.graphql'
 
 query flssLoanData(
-  $filterObject: [FundraisingLoanSearchFilterInput!] = { countryIsoCode: {any: ["US"]}}
+  $filterObject: [FundraisingLoanSearchFilterInput!]
   $imgDefaultSize: String = "w480h360"
   $imgRetinaSize: String = "w960h720"
   $limit: Int = 50

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -18,18 +18,55 @@
 
 <script>
 import { lightHeader } from '@/util/siteThemes';
-
 import WwwPage from '@/components/WwwFrame/WwwPage';
+import flssLoanQuery from '@/graphql/query/flssLoansQuery.graphql';
 
 export default {
+	inject: ['apollo'],
 	components: {
 		WwwPage,
+	},
+	mounted() {
+		this.fetchLoans();
 	},
 	data() {
 		return {
 			headerTheme: lightHeader,
 			loanId: Number(this.$route.params.id || 0),
+			loanQueryFilters: () => {},
+			totalCount: 0,
+			loans: [],
+			zeroLoans: false,
 		};
+	},
+	methods: {
+		fetchLoans() {
+			this.apollo
+				.query({
+					query: flssLoanQuery,
+					variables: {
+						filterObject: this.loanQueryFilters,
+					},
+					fetchPolicy: 'network-only',
+				})
+				.then(({ data }) => {
+					const newLoans = data.fundraisingLoans?.values ?? [];
+					this.loans = newLoans;
+					// leaving console.log for sanity check
+					// flss query is defaulted to US loans currently to keep loans count
+					// manageable
+					console.log(newLoans);
+
+					const totalCount = data.fundraisingLoans.totalCount ?? 0;
+					this.totalCount = totalCount;
+					// leaving console.log for sanity check
+					console.log(totalCount);
+
+					if (this.totalCount === 0) {
+						this.zeroLoans = true;
+					}
+				});
+		},
 	},
 };
 </script>

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -48,6 +48,7 @@ export default {
 					query: flssLoanQuery,
 					variables: {
 						filterObject: this.loanQueryFilters,
+						limit: 20
 					},
 					fetchPolicy: 'network-only',
 				})

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -33,7 +33,7 @@ export default {
 		return {
 			headerTheme: lightHeader,
 			loanId: Number(this.$route.params.id || 0),
-			loanQueryFilters: () => {},
+			loanQueryFilters: { countryIsoCode: { any: ['US'] } },
 			totalCount: 0,
 			loans: [],
 			zeroLoans: false,

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -33,6 +33,8 @@ export default {
 		return {
 			headerTheme: lightHeader,
 			loanId: Number(this.$route.params.id || 0),
+			// flss query is defaulted to US loans currently to keep loans count
+			// manageable for now
 			loanQueryFilters: { countryIsoCode: { any: ['US'] } },
 			totalCount: 0,
 			loans: [],
@@ -53,8 +55,6 @@ export default {
 					const newLoans = data.fundraisingLoans?.values ?? [];
 					this.loans = newLoans;
 					// leaving console.log for sanity check
-					// flss query is defaulted to US loans currently to keep loans count
-					// manageable
 					console.log(newLoans);
 
 					const totalCount = data.fundraisingLoans.totalCount ?? 0;


### PR DESCRIPTION
Jira ticket:
https://kiva.atlassian.net/browse/PSD-280

What does it do:
adds flss query to filter-alpha page to provide access to live loans and data for component presentation. 

How to test:
download the branch and run the dev server
when the `filter-alpha` page renders open the developer tools console and look for `console.log` outputs for loans from the US and the totalCount number of available loans. 