### PR TITLE
VUE-634 add caching for github action build dependencies

### DIFF
--- a/.github/workflows/lighthouse-dev.yml
+++ b/.github/workflows/lighthouse-dev.yml
@@ -21,9 +21,22 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 15.x
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            ~/.cache
+            ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: npm install, build
         run: |
-          npm install
+          npm ci --prefer-offline
           npm run build
       - name: run Lighthouse CI
         run: |

--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -18,9 +18,22 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 15.x
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            ~/.cache
+            ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: npm install, build
         run: |
-          npm install
+          npm ci --prefer-offline
           npm run build
       - name: run Lighthouse CI
         run: |

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -21,10 +21,23 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: '15.x'
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-dependencies
+      with:
+        path: |
+          ~/.cache
+          ~/.npm
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
     - name: Update NPM to v7
       run: npm install -g npm@latest
     - name: Install dependencies
-      run: npm ci
+      run: npm ci --prefer-offline
     - name: Run Lint
       run: npm run lint
     - name: Run Unit Tests

--- a/.github/workflows/storybook-to-gh-pages.yml
+++ b/.github/workflows/storybook-to-gh-pages.yml
@@ -21,8 +21,21 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '15.x'
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-dependencies
+        with:
+          path: |
+            ~/.cache
+            ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - run: npm install -g npm@latest
-      - run: npm install
+      - run: npm ci --prefer-offline
       - run: npm run deploy-storybook -- --ci --script=build-storybook
         env:
           GH_TOKEN: Kiva:${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Following these guides ([github](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action), [cypress](https://docs.cypress.io/guides/continuous-integration/introduction#Caching), [stack overflow](https://stackoverflow.com/questions/55230628/is-there-a-way-to-speedup-npm-ci-using-cache)), this will make it so that the npm cache and the cypress binary cache are preserved between builds, allowing subsequent PRs to install much faster.

It's possible to preserve multiple caches, based on a key name. This uses key names based on the hash of package-lock, so anytime package-lock changes a new cache is created. The restore-keys tell github which caches to use as a fallback in case there isn't an exact match for the key (as would be the case when package-lock changes). This allows most dependencies to be installed from cache, while new/changed dependencies will be fetched from npm.