### PR TITLE
VUE-635 use logReadQueryError for app-install-mixin

### DIFF
--- a/src/plugins/app-install-mixin.js
+++ b/src/plugins/app-install-mixin.js
@@ -1,6 +1,7 @@
 import _get from 'lodash/get';
 import appInstallQuery from '@/graphql/query/appInstall.graphql';
 import checkInjections from '@/util/injectionCheck';
+import logReadQueryError from '@/util/logReadQueryError';
 
 const injections = ['apollo', 'cookieStore'];
 
@@ -72,7 +73,7 @@ export default {
 			this.appInstallHasFreeCredits = _get(data, 'shop.basket.hasFreeCredits');
 			this.appInstallLendingRewardOffered = _get(data, 'shop.lendingRewardOffered');
 		} catch (err) {
-			console.error(err);
+			logReadQueryError(err, 'app-install-mixin');
 		}
 	},
 	mounted() {


### PR DESCRIPTION
I determined this to be the source of the multi-line console logging, do to the error happening at the same time as other invariant violation errors, and this being the only place that was using `console.error` with errors caught from `apollo.readQuery`.