### PR TITLE
VUE-643 remove commonjs transform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -17,7 +17,6 @@
 	"plugins": [
 		"@babel/plugin-syntax-dynamic-import",
 		"@babel/plugin-syntax-import-meta",
-		"@babel/plugin-transform-modules-commonjs",
 		[
 			"@babel/plugin-transform-runtime",
 			{

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
   - dependency-name: vue-instantsearch
     versions:
     - ">= 2.7.a"
+  - dependency-name: vue-svg-loader
+    versions:
+    - ">= 0.15.0"    

--- a/package-lock.json
+++ b/package-lock.json
@@ -168,7 +168,7 @@
 				"vue-jest": "^3.0.7",
 				"vue-loader": "^15.9.3",
 				"vue-style-loader": "^4.1.2",
-				"vue-svg-loader": "^0.16.0",
+				"vue-svg-loader": "^0.15.0",
 				"vue-template-compiler": "^2.6.12",
 				"wait-on": "^5.2.0",
 				"webpack": "^4.44.2",
@@ -3183,9 +3183,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-tokens": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.6.1.tgz",
-			"integrity": "sha512-YMiMuw8/WjOjJGnBiUSAYE+tyNNw7gRAbbpPo50eevKWKfEqJKQ4RkAbUJyLBHrJxxP/G5/upDs/hFAmCXyI3g==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.6.2.tgz",
+			"integrity": "sha512-EEhTeS/EkvskJ1ZVMFvyrWhqCdWf6m0fF4MvE8mxERgZaf0nqI9ACIqs3YTFYyErYcUOQyekkhsjcel/ePW0/w==",
 			"dependencies": {
 				"@tailwindcss/typography": "^0.4.0",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"
@@ -32973,9 +32973,9 @@
 			"dev": true
 		},
 		"node_modules/svg-to-vue": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/svg-to-vue/-/svg-to-vue-0.7.0.tgz",
-			"integrity": "sha512-Tg2nMmf3BQorYCAjxbtTkYyWPVSeox5AZUFvfy4MoWK/5tuQlnA/h3LAlTjV3sEvOC5FtUNovRSj3p784l4KOA==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/svg-to-vue/-/svg-to-vue-0.6.0.tgz",
+			"integrity": "sha512-SYGJMBq5EHt/nIJxZ4kA9A6bilaFXtOPFJRoMQ2ml/jFP4N9L7HVFTm+5WCFN3QFnEUXtH6BHzpoOlwP1/5+2A==",
 			"dev": true,
 			"dependencies": {
 				"svgo": "^1.3.2"
@@ -35620,13 +35620,13 @@
 			}
 		},
 		"node_modules/vue-svg-loader": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.16.0.tgz",
-			"integrity": "sha512-2RtFXlTCYWm8YAEO2qAOZ2SuIF2NvLutB5muc3KDYoZq5ZeCHf8ggzSan3ksbbca7CJ/Aw57ZnDF4B7W/AkGtw==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.15.0.tgz",
+			"integrity": "sha512-698GfXu9k2wPxI382Qf7MfrtBXjIjThqmOsksVKHqeTvVO+Ary9q69SVzA6EEJmj5vmF5u1KRVb/I1BDh4fPTQ==",
 			"dev": true,
 			"dependencies": {
 				"loader-utils": "^1.2.3",
-				"svg-to-vue": "^0.7.0"
+				"svg-to-vue": "^0.6.0"
 			},
 			"peerDependencies": {
 				"vue-template-compiler": "^2.0.0"
@@ -64799,9 +64799,9 @@
 			"dev": true
 		},
 		"svg-to-vue": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/svg-to-vue/-/svg-to-vue-0.7.0.tgz",
-			"integrity": "sha512-Tg2nMmf3BQorYCAjxbtTkYyWPVSeox5AZUFvfy4MoWK/5tuQlnA/h3LAlTjV3sEvOC5FtUNovRSj3p784l4KOA==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/svg-to-vue/-/svg-to-vue-0.6.0.tgz",
+			"integrity": "sha512-SYGJMBq5EHt/nIJxZ4kA9A6bilaFXtOPFJRoMQ2ml/jFP4N9L7HVFTm+5WCFN3QFnEUXtH6BHzpoOlwP1/5+2A==",
 			"dev": true,
 			"requires": {
 				"svgo": "^1.3.2"
@@ -66849,13 +66849,13 @@
 			}
 		},
 		"vue-svg-loader": {
-			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.16.0.tgz",
-			"integrity": "sha512-2RtFXlTCYWm8YAEO2qAOZ2SuIF2NvLutB5muc3KDYoZq5ZeCHf8ggzSan3ksbbca7CJ/Aw57ZnDF4B7W/AkGtw==",
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/vue-svg-loader/-/vue-svg-loader-0.15.0.tgz",
+			"integrity": "sha512-698GfXu9k2wPxI382Qf7MfrtBXjIjThqmOsksVKHqeTvVO+Ary9q69SVzA6EEJmj5vmF5u1KRVb/I1BDh4fPTQ==",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.2.3",
-				"svg-to-vue": "^0.7.0"
+				"svg-to-vue": "^0.6.0"
 			},
 			"dependencies": {
 				"json5": {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
 		"vue-jest": "^3.0.7",
 		"vue-loader": "^15.9.3",
 		"vue-style-loader": "^4.1.2",
-		"vue-svg-loader": "^0.16.0",
+		"vue-svg-loader": "^0.15.0",
 		"vue-template-compiler": "^2.6.12",
 		"wait-on": "^5.2.0",
 		"webpack": "^4.44.2",


### PR DESCRIPTION
This seems to drastically improve tree-shaking. I'm not sure if there are improvements across the board or if it's mainly the mdi.js package getting cleaned up. 

Arrived at this direction after reading this article https://webpack.js.org/guides/tree-shaking/#conclusion

With commonjs transform: 891kb
<img width="1681" alt="Screen Shot 2021-07-30 at 12 52 47 PM" src="https://user-images.githubusercontent.com/187937/127709586-23956a59-664c-43bf-9da0-2eb4e3b128aa.png">

Without commonjs transform: 231kb 
<img width="1673" alt="Screen Shot 2021-07-30 at 12 47 55 PM" src="https://user-images.githubusercontent.com/187937/127709581-a1da9676-b9e1-4a05-87dd-a4242304d246.png">

Oddly was having issues with the SVG loader after it was no longer being run through the commonjs transform. Rolling back a version appears to solve that. https://github.com/visualfanatic/vue-svg-loader/issues/121

Since this is kindof a big change I think it'd be good to get some testing in on dev before shipping to prod.