### PR TITLE
Use while loop to empty tracking event queue

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -157,7 +157,6 @@ router.onReady(() => {
 		app.$Progress.finish();
 		// fire pageview
 		app.$fireAsyncPageView(to, from);
-		app.$kvFireQueuedEvents();
 	});
 
 	router.onError(() => app.$Progress.fail());

--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -189,16 +189,12 @@ export default Vue => {
 		fireQueuedEvents() {
 			kvActions.checkLibs();
 
-			if (!queue.isEmpty()) {
-				// eslint-disable-next-line no-plusplus
-				for (let i = 0; i <= queue.items.length; i++) {
-					if (queue.isEmpty()) return false;
-					const item = queue.remove();
-					const method = item.eventType;
-					const { eventData } = item;
-					if (typeof kvActions[method] === 'function') {
-						kvActions[method](eventData, true);
-					}
+			while (!queue.isEmpty()) {
+				const item = queue.remove();
+				const method = item.eventType;
+				const { eventData } = item;
+				if (typeof kvActions[method] === 'function') {
+					kvActions[method](eventData, true);
 				}
 			}
 		},


### PR DESCRIPTION
The condition in the for loop checked `queue.items.length` every time the loop ran, however that length was constantly getting smaller as items are removed. So when you start with 3 items in the queue, you eventually end up with `i == 2` and `queue.items.length == 1`, so the loop is skipped and the last event in the queue does not get sent. Using a while loop that only checks if the queue is empty will ensure that all items in the queue get processed.