### PR TITLE
fix: fix monthly good selector styling tailwind class wrapper

### DIFF
--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<div class="kv-tailwind">
 		<!-- MG Selector Desktop -->
 		<!-- eslint-disable max-len -->
 		<section


### PR DESCRIPTION
Fix for sticky selector in `/lp/support-refugees`

I tried adding the `kv-tailwind` class to the page wrapper in: `src/pages/ContentfulPage.vue` but that broke a lot of the other components, so this is an easier fix just for the landing page. 

SUBS-788