### PR TITLE
fix: Fix UI tailwind purging classes

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,10 +3,12 @@ const kvConfig = require('@kiva/kv-components/tailwind.config.js');
 module.exports = {
 	mode: 'jit',
 	presets: [kvConfig],
-	purge: [
-		'./node_modules/@kiva/kv-components/**/*.vue',
-		'./node_modules/@kiva/kv-components/utils/**/*.js',
-		'./server/**/*.html',
-		'./src/**/*.vue',
-	],
+	purge: {
+		content: [
+			'./node_modules/@kiva/kv-components/**/*.vue',
+			'./node_modules/@kiva/kv-components/utils/**/*.js',
+			'./server/**/*.html',
+			'./src/**/*.vue',
+		]
+	}
 };


### PR DESCRIPTION
The configuration for PurgeCSS was not up to date with the version of PurgeCSS that we are using. 

This led to a situation where adding a tailwind class in UI that was *not*  being used in kv-ui-elements would not display because it was purged. 

VUE-647