### PR TITLE
adding fill color to fight place of svg

### DIFF
--- a/src/assets/inline-svgs/logos/yelp-logo.svg
+++ b/src/assets/inline-svgs/logos/yelp-logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 25.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 21.2 29.1" style="enable-background:new 0 0 21.2 29.1;" xml:space="preserve">
+	 viewBox="0 0 21.2 29.1" style="enable-background:new 0 0 21.2 29.1;" xml:space="preserve" fill="#277056">
 <style type="text/css">
 	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#277056;}
 </style>


### PR DESCRIPTION
Yelp logo had a color issue too once rendered. Locally it looked good, only once it got up on dev was it an issue. I added the fill to the actual <svg tag>, that seemed to fix things up. 

![Screen Shot 2021-08-04 at 3 49 20 PM](https://user-images.githubusercontent.com/1521381/128259701-b0b147b2-902c-4103-8c9b-dae72d8ce0f4.png)