### PR TITLE
feat: New header frame for cause based landing pages

### DIFF
--- a/src/components/Contentful/HeroWithCarousel.vue
+++ b/src/components/Contentful/HeroWithCarousel.vue
@@ -1,0 +1,74 @@
+<template>
+	<section-with-background :background-content="heroBackground">
+		<template #content>
+			<!-- same wrapper as src/components/BorrowerProfile/ContentContainer.vue -->
+			<kv-page-container>
+				<kv-grid class="tw-grid-cols-12">
+					<div class="tw-col-span-12 md:tw-col-start-2 md:tw-col-span-10 lg:tw-col-span-6">
+						<h1 v-html="heroHeadline">
+						</h1>
+						<h3 v-html="heroSubHeadline" class="tw-pt-2.5 lg:tw-pt-2">
+						</h3>
+					</div>
+					<!-- <div class="tw-col-span-12"> -->
+					<!-- Card carousel goes here -->
+					<!-- </div> -->
+				</kv-grid>
+			</kv-page-container>
+		</template>
+	</section-with-background>
+</template>
+
+<script>
+import SectionWithBackground from '@/components/Contentful/SectionWithBackground';
+import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
+
+/**
+* Hero With Carousel Component
+* This component will display a Hero driven by a Contentful Content
+* Group of type heroWithCarousel. Content will b displayed above a
+* full width carousel. Hero should have cards as Content Items
+* */
+
+export default {
+	components: {
+		// KvCarousel: () => import('@/components/Kv/KvCarousel'),
+		// KvCarouselSlide: () => import('@/components/Kv/KvCarouselSlide'),
+		SectionWithBackground,
+		KvGrid,
+		KvPageContainer,
+	},
+	props: {
+		/**
+		 * Content group content from Contentful
+		* */
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	computed: {
+		heroText() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'genericContentBlock' : false;
+			});
+		},
+		heroHeadline() {
+			return this.heroText?.headline ?? '';
+		},
+		heroSubHeadline() {
+			return this.heroText?.subHeadline ?? '';
+		},
+		heroBackground() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'background' : false;
+			});
+		},
+
+	}
+};
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="kv-tailwind">
+	<div>
 		<!-- MG Selector Desktop -->
 		<!-- eslint-disable max-len -->
 		<section

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -5,11 +5,12 @@
 	>
 		<template v-if="!pageError">
 			<component
-				v-for="({ component, content }) in contentGroups"
+				v-for="({ component, content, wrapperClass }) in contentGroups"
 				:key="content.key"
 				:is="component"
 				:content="content"
 				v-bind="getComponentOptions(content.key)"
+				:class="wrapperClass"
 			/>
 		</template>
 		<template v-else>
@@ -57,7 +58,7 @@ import * as siteThemes from '@/util/siteThemes';
 const WwwPage = () => import('@/components/WwwFrame/WwwPage');
 const WwwPageCorporate = () => import('@/components/WwwFrame/WwwPageCorporate');
 
-// Content Group components
+// Content Group Types
 // TODO: update the campaign components to accept "content" prop
 const CampaignHero = () => import('@/components/CorporateCampaign/CampaignHero');
 const CampaignLogoGroup = () => import('@/components/CorporateCampaign/CampaignLogoGroup');
@@ -67,8 +68,6 @@ const CampaignThanks = () => import('@/components/CorporateCampaign/CampaignThan
 const HomepageBottomCTA = () => import('@/components/Homepage/HomepageBottomCTA');
 const HomepageCorporateSponsors = () => import('@/components/Homepage/HomepageCorporateSponsors');
 // const HomepageGeneralStats = () => import('@/components/Homepage/HomepageGeneralStats');
-const DynamicHero = () => import('@/components/Contentful/DynamicHero');
-
 const HomepageHowItWorks = () => import('@/components/Homepage/HomepageHowItWorks');
 const HomepageLenderQuotes = () => import('@/components/Homepage/HomepageLenderQuotes');
 const HomepageLoanCategories = () => import('@/components/Homepage/HomepageLoanCategories');
@@ -77,6 +76,9 @@ const HomepageStatistics = () => import('@/components/Homepage/HomepageStatistic
 const HomepageTestimonials = () => import('@/components/Homepage/HomepageTestimonials');
 const HomepageVerticalCTA = () => import('@/components/Homepage/HomepageVerticalCTA');
 const HomepageMonthlyGoodInfo = () => import('@/components/Homepage/HomepageMonthlyGoodInfo');
+
+const DynamicHero = () => import('@/components/Contentful/DynamicHero');
+const HeroWithCarousel = () => import('@/components/Contentful/HeroWithCarousel');
 
 const MonthlyGoodSelectorWrapper = () => import('@/components/MonthlyGood/MonthlyGoodSelectorWrapper');
 const MonthlyGoodFrequentlyAskedQuestions = () => import('@/components/MonthlyGood/FrequentlyAskedQuestions');
@@ -111,13 +113,26 @@ const getPageFrameFromType = type => {
 	}
 };
 
+// The components that return kv-tailwind will get wrapped in that class,
+// they have already been migrated to use tailwind CSS. Legacy components
+// should return empty string so they are not wrapped in the kv-tailwind class
+// once all components use tailwind, we can add the 'kv-tailwind' to the
+// :is="pageFrame" component on this page
+const getWrapperClassFromType = type => {
+	switch (type) {
+		case 'heroWithCarousel':
+		case 'monthlyGoodSelector':
+			return 'kv-tailwind';
+		default:
+			return '';
+	}
+};
+
 // Return a component importer function based on content group type from Contentful
 const getComponentFromType = type => {
 	switch (type) {
 		case 'homepageBottomCTA':
 			return HomepageBottomCTA;
-		case 'dynamicHero':
-			return DynamicHero;
 		case 'homepageHowItWorks':
 			return HomepageHowItWorks;
 		case 'homepageLenderQuotes':
@@ -152,6 +167,10 @@ const getComponentFromType = type => {
 			return MonthlyGoodSelectorWrapper;
 		case 'frequentlyAskedQuestions':
 			return KvFrequentlyAskedQuestions;
+		case 'dynamicHero':
+			return DynamicHero;
+		case 'heroWithCarousel':
+			return HeroWithCarousel;
 
 		default:
 			console.error(`Unknown content group type "${type}"`);
@@ -167,6 +186,7 @@ const getContentGroups = pageData => {
 	return groups.map(group => ({
 		component: getComponentFromType(group.type),
 		content: group,
+		wrapperClass: getWrapperClassFromType(group.type),
 	})).filter(group => typeof group.component === 'function');
 };
 


### PR DESCRIPTION
Adds new Content Group of type 'landingPageHero'
Creates frame and headline and subheadline for that content group
Adds tailwind wrapper class to some components from contentful page

Design reference:  https://www.figma.com/file/weQAkMDYoBA5ZnuHf4TPOA/Cause-Based-Landing-Page-Templates?node-id=136%3A331

SUBS-777