### PR TITLE
Created loan count display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.4.1",
 				"@graphql-tools/load": "^6.2.4",
 				"@graphql-tools/url-loader": "^6.3.0",
-				"@kiva/kv-components": "^0.10.4",
+				"@kiva/kv-components": "^0.10.5",
 				"@mdi/js": "^5.9.55",
 				"@sentry/browser": "^5.21.1",
 				"@sentry/integrations": "^5.27.1",
@@ -41183,9 +41183,9 @@
 			}
 		},
 		"@kiva/kv-tokens": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.6.1.tgz",
-			"integrity": "sha512-YMiMuw8/WjOjJGnBiUSAYE+tyNNw7gRAbbpPo50eevKWKfEqJKQ4RkAbUJyLBHrJxxP/G5/upDs/hFAmCXyI3g==",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-0.6.2.tgz",
+			"integrity": "sha512-EEhTeS/EkvskJ1ZVMFvyrWhqCdWf6m0fF4MvE8mxERgZaf0nqI9ACIqs3YTFYyErYcUOQyekkhsjcel/ePW0/w==",
 			"requires": {
 				"@tailwindcss/typography": "^0.4.0",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -24,14 +24,14 @@
 							<p>Filters</p>
 						</div>
 						<div class="md:tw-hidden">
-							<p> {{totalCount}} Loans </p>
+							<p> {{ totalCount }} Loans </p>
 						</div>
 						<div class="tw-col-span-2">
 							<div class="tw-bg-gray-300 tw-h-4 tw-mb-2 md:tw-mb-3 lg:tw-mb-3.5">
 								Search Loans
 							</div>
 							<div class="tw-hidden md:tw-block tw-h-4 tw-mb-2 md:tw-mb-3 lg:tw-mb-3.5">
-								<p> {{totalCount}} Loans </p>
+								<p> {{ totalCount }} Loans </p>
 							</div>
 							<kv-grid class="tw-grid-rows-4">
 								<div class="tw-bg-gray-300 tw-h-4">

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -23,12 +23,16 @@
 						<div class="tw-bg-gray-300 tw-text-left md:tw-text-center">
 							<p>Filters</p>
 						</div>
-
+						<div class="md:tw-hidden">
+							<p> {{totalCount}} Loans </p>
+						</div>
 						<div class="tw-col-span-2">
-							<div class="tw-bg-gray-300 tw-h-4">
+							<div class="tw-bg-gray-300 tw-h-4 tw-mb-2 md:tw-mb-3 lg:tw-mb-3.5">
 								Search Loans
 							</div>
-							<p>Loan Count</p>
+							<div class="tw-hidden md:tw-block tw-h-4 tw-mb-2 md:tw-mb-3 lg:tw-mb-3.5">
+								<p> {{totalCount}} Loans </p>
+							</div>
 							<kv-grid class="tw-grid-rows-4">
 								<div class="tw-bg-gray-300 tw-h-4">
 									Loan Card 1


### PR DESCRIPTION
I have imported the data for the loan count and displayed it onto the website.

https://kiva.atlassian.net/browse/PSD-279?atlOrigin=eyJpIjoiMzVhNmFiMWQzNzRlNGQ1NGJjNzRjZjgwMzYzZjBkNGQiLCJwIjoiaiJ9

The way that you could test this is by loading up the site and noticing that the loan count has appeared. From there you can minimize your screen so that you can see the responsiveness of the loan count. It will then move from being under the search box to next to the filter tap at the top left. 