### PR TITLE
grow-766 dividing the repaymentRate by 100 in order to pass the corre…

### DIFF
--- a/src/components/BorrowerProfile/TrusteeDetails.vue
+++ b/src/components/BorrowerProfile/TrusteeDetails.vue
@@ -104,7 +104,7 @@ export default {
 			return numeral(this.totalLoansValue).format('$0,0[.]00');
 		},
 		repaymentRateFormatted() {
-			return numeral(this.repaymentRate).format('0%');
+			return numeral(this.repaymentRate/100).format('0%');
 		},
 	},
 };

--- a/src/components/BorrowerProfile/TrusteeDetails.vue
+++ b/src/components/BorrowerProfile/TrusteeDetails.vue
@@ -104,7 +104,7 @@ export default {
 			return numeral(this.totalLoansValue).format('$0,0[.]00');
 		},
 		repaymentRateFormatted() {
-			return numeral(this.repaymentRate/100).format('0%');
+			return numeral(this.repaymentRate / 100).format('0%');
 		},
 	},
 };


### PR DESCRIPTION
…ctly formatted value to numeral for further formatting.

[Grow-766](https://kiva.atlassian.net/browse/GROW-766)

The repayment rate was being passed into numeral looking like this: 81.50
After numeral percentage formatting of '0%', the returned value looked like this: 8150%.

Dividing the repayment rate by 100 gave me .8150, which after numeral formatting correctly returns me 82%. 


**Broken:** 
<img width="794" alt="Screen Shot 2021-08-05 at 8 13 13 AM" src="https://user-images.githubusercontent.com/1521381/128396996-fac5f6c3-0b8b-4b08-92d5-21819c54a589.png">


**Fixed** THIS SCREEN SHOT IS FROM A DIFFERENT BORROWER PROFILE THAN THE ONE ABOVE.
<img width="670" alt="Screen Shot 2021-08-05 at 11 42 45 AM" src="https://user-images.githubusercontent.com/1521381/128397049-f16f2d13-1908-4a5c-a890-4061a9113cac.png">
