### PR TITLE
VUE-649 re-encode cookies included in request to start session

### DIFF
--- a/server/util/getSessionCookies.js
+++ b/server/util/getSessionCookies.js
@@ -3,7 +3,7 @@ const fetch = require('./fetch');
 
 const getCookieString = cookies => {
 	return Object.keys(cookies)
-		.map(key => `${key}=${cookies[key]}`)
+		.map(key => `${encodeURIComponent(key)}=${encodeURIComponent(cookies[key])}`)
 		.join(';');
 };
 


### PR DESCRIPTION
The request cookies are decoded by default when [they are first read](https://github.com/kiva/ui/blob/master/server/vue-middleware.js#L60):
```
const cookies = cookie.parse(req.headers.cookie || '');
```
Doing that is useful because those cookies are directly used by the app. However, when sending those cookies to the monolith when starting a new session, we haven't been encoding them again, leading to request failures when there are non-ASCII characters in the cookie values.

This PR encodes the cookies before including them in the monolith request.
