### PR TITLE
ML2-359 added matchRatio to graphql query, altered matchingText compo…

### DIFF
--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
@@ -67,6 +67,7 @@
 				/>
 				<matching-text
 					:matching-text="loan.matchingText"
+					:match-ratio="loan.matchRatio"
 					:is-funded="isFunded"
 					:is-selected-by-another="isSelectedByAnother"
 				/>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -59,6 +59,7 @@
 
 				<matching-text
 					:matching-text="loan.matchingText"
+					:match-ratio="loan.matchRatio"
 					:is-funded="isFunded"
 					:is-selected-by-another="isSelectedByAnother"
 				/>

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -103,6 +103,7 @@
 					<div class="columns medium-12 large-4 matching-text-wrap">
 						<matching-text
 							:matching-text="loan.matchingText"
+							:match-ratio="loan.matchRatio"
 							:is-funded="isFunded"
 							:is-selected-by-another="isSelectedByAnother"
 							:wrap="true"

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -77,6 +77,7 @@
 				<div class="matching-text-container" :class="{hide: isFunded || isExpired}">
 					<matching-text
 						:matching-text="loan.matchingText"
+						:match-ratio="loan.matchRatio"
 						:is-funded="isFunded"
 						:is-selected-by-another="isSelectedByAnother"
 						:wrap="true"

--- a/src/components/LoanCards/LendHomepageLoanCard.vue
+++ b/src/components/LoanCards/LendHomepageLoanCard.vue
@@ -97,6 +97,7 @@
 				<div class="lend-homepage-loan-card__matching-text-container" :class="{hide: isFunded || isExpired}">
 					<matching-text
 						:matching-text="loan.matchingText"
+						:match-ratio="loan.matchRatio"
 						:is-funded="isFunded"
 						:is-selected-by-another="isSelectedByAnother"
 						:wrap="true"

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -85,6 +85,7 @@
 					<div v-if="loan.matchingText && !isFunded" class="list-loan-card-matching-text">
 						<matching-text
 							:matching-text="loan.matchingText"
+							:match-ratio="loan.matchRatio"
 							:is-funded="isFunded"
 							:is-selected-by-another="isSelectedByAnother"
 							:is-expired="isExpired"
@@ -138,6 +139,7 @@
 						<div v-if="loan.matchingText && !isFunded" class="list-loan-card-matching-text">
 							<matching-text
 								:matching-text="loan.matchingText"
+								:match-ratio="loan.matchRatio"
 								:is-funded="isFunded"
 								:is-selected-by-another="isSelectedByAnother"
 								:is-expired="isExpired"

--- a/src/components/LoanCards/MatchingText.vue
+++ b/src/components/LoanCards/MatchingText.vue
@@ -7,7 +7,7 @@
 			'wrap': props.wrap,
 		}"
 	>
-		2x matching by {{ props.matchingText }}
+		{{ props.matchRatio + 1 }}x matching by {{ props.matchingText }}
 	</span>
 </template>
 

--- a/src/components/LoansByCategory/FeaturedHeroLoan.vue
+++ b/src/components/LoansByCategory/FeaturedHeroLoan.vue
@@ -71,6 +71,7 @@
 
 								<matching-text
 									:matching-text="loan.matchingText"
+									:match-ratio="loan.matchRatio"
 									:is-funded="isFunded"
 									:is-selected-by-another="isSelectedByAnother"
 								/>

--- a/src/graphql/fragments/loanCardFields.graphql
+++ b/src/graphql/fragments/loanCardFields.graphql
@@ -34,6 +34,7 @@ fragment loanCardFields on LoanBasic {
 	}
 	plannedExpirationDate
 	matchingText
+	matchRatio
 	userProperties {
 		favorited
 		lentTo


### PR DESCRIPTION
…nent to add 1 to matchRatio and display, passed prop through everywhere the <matching-text> component is used.

[ML2-359](https://kiva.atlassian.net/browse/ML2-359)

Updating the ui stack matching language to incorporate the new matchRatio data point. 

After making these changes locally it was hard to track down the loan card of a matching loan when I only had 3 matching loan locally and only 1 of those is fundraising. That being said I'm planning on doing a thorough verification on development once the code gets there.

**Lend By Category**
- Couldn't verify this scenario locally, will be tested in dev.

**Category Pages:** Verified
![Screen Shot 2021-08-23 at 4 43 51 PM](https://user-images.githubusercontent.com/1521381/130529292-13cc8b88-d706-4e7d-91ee-f52996ede3da.png)

**Homepage loan cards**
- Couldn't verify this scenario locally, will be tested in dev.

**Lend Filter Wide Card**
- Couldn't verify this scenario locally, will be tested in dev.

**Verify if needed on LYML card**
- Couldn't verify this scenario locally, will be tested in dev.