### PR TITLE
feat: Get Inspired section renderer for contentful content type Carou…

### DIFF
--- a/src/components/Contentful/CarouselWithHeader.vue
+++ b/src/components/Contentful/CarouselWithHeader.vue
@@ -1,0 +1,86 @@
+<template>
+	<section-with-background-classic
+		:background-content="background"
+		:vertical-padding="verticalPadding"
+	>
+		<template #content>
+			<kv-page-container>
+				<kv-grid>
+					<dynamic-rich-text class="tw-prose tw-text-center" :html="headerRichText" />
+					<kv-carousel
+						:embla-options="{ loop: false }"
+						:multiple-slides-visible="true"
+						slides-to-scroll="visible"
+						class="tw-w-full"
+						slide-max-width="21rem"
+					>
+						<template v-for="(slide, index) in carouselSlides" #[`slide${index}`]>
+							<dynamic-rich-text :html="getRichText(slide.richText)" :key="index" />
+						</template>
+					</kv-carousel>
+				</kv-grid>
+			</kv-page-container>
+		</template>
+	</section-with-background-classic>
+</template>
+
+<script>
+import SectionWithBackgroundClassic from '@/components/Contentful/SectionWithBackgroundClassic';
+import { richTextRenderer } from '@/util/contentful/richTextRenderer';
+import DynamicRichText from '@/components/Contentful/DynamicRichText';
+import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
+import KvCarousel from '~/@kiva/kv-components/vue/KvCarousel';
+
+export default {
+	components: {
+		DynamicRichText,
+		KvCarousel,
+		KvGrid,
+		KvPageContainer,
+		SectionWithBackgroundClassic,
+	},
+	props: {
+		/**
+		 * Content group content from Contentful
+		* */
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	methods: {
+		getRichText(richText) {
+			return richText ? richTextRenderer(richText) : '';
+		}
+	},
+	computed: {
+		background() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'background' : false;
+			});
+		},
+		carousel() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'webCarousel' : false;
+			});
+		},
+		carouselSlides() {
+			return this.carousel?.slides ?? [];
+		},
+		headerRichText() {
+			const richContent = this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'richTextContent' : false;
+			});
+			const richText = richContent?.richText ?? '';
+			return richText ? richTextRenderer(richText) : '';
+		},
+		verticalPadding() {
+			const uiSetting = this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'uiSetting' : false;
+			});
+			return uiSetting?.dataObject?.verticalPadding ?? {};
+		},
+	}
+};
+</script>

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -88,6 +88,7 @@ const MonthlyGoodFrequentlyAskedQuestions = () => import('@/components/MonthlyGo
 const KvFrequentlyAskedQuestions = () => import('@/components/Kv/KvFrequentlyAskedQuestions');
 
 const TestimonialCards = () => import('@/components/Contentful/TestimonialCards');
+const CarouselWithHeader = () => import('@/components/Contentful/CarouselWithHeader');
 
 // Query for getting contentful page data
 const pageQuery = gql`query contentfulPage($key: String) {
@@ -129,6 +130,7 @@ const getWrapperClassFromType = type => {
 		case 'heroWithCarousel':
 		case 'monthlyGoodSelector':
 		case 'testimonialCards':
+		case 'carouselWithHeader':
 			return 'kv-tailwind';
 		default:
 			return '';
@@ -184,7 +186,8 @@ const getComponentFromType = type => {
 			return DynamicHeroClassic;
 		case 'heroWithCarousel':
 			return HeroWithCarousel;
-
+		case 'carouselWithHeader':
+			return CarouselWithHeader;
 		default:
 			console.error(`Unknown content group type "${type}"`);
 			return null;

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -181,6 +181,21 @@ export function formatBackground(contentfulContent) {
 }
 
 /**
+ * Format Carousel (contentful type id: webCarousel)
+ * Takes raw contentful content object and returns an object with targeted keys/values
+ *
+ * @param {array} contentfulContent data
+ * @returns {object}
+ */
+export function formatCarousel(contentfulContent) {
+	return {
+		key: contentfulContent.fields?.key,
+		// eslint-disable-next-line no-use-before-define
+		slides: formatContentTypes(contentfulContent.fields?.slides),
+	};
+}
+
+/**
  * Format StoryCard (contentful type id: storyCard)
  * Takes raw contentful content object and returns an object with targeted keys/values
  *
@@ -350,6 +365,11 @@ export function formatContentType(contentfulContent, contentType) {
 		case 'storyCard':
 			return {
 				...formatStoryCard(contentfulContent),
+				contentType
+			};
+		case 'webCarousel':
+			return {
+				...formatCarousel(contentfulContent),
 				contentType
 			};
 		default:


### PR DESCRIPTION
…sel with header

- Renders the get inspired section, made up of a rich text field plus a carousel field. 
- Test url: https://dev-vm-01.kiva.org/lp/eddie-test-landing

GD-44
GD-45

![Screen Shot 2021-08-25 at 12 18 01 PM](https://user-images.githubusercontent.com/4371888/130853764-83051612-5288-4980-a60c-5bbc2bec00a0.png)
