### PR TITLE
refactor: renamed 'web carousel' to 'carousel'

### DIFF
--- a/src/components/Contentful/HeroWithCarousel.vue
+++ b/src/components/Contentful/HeroWithCarousel.vue
@@ -94,7 +94,7 @@ export default {
 		},
 		carousel() {
 			return this.content?.contents?.find(({ contentType }) => {
-				return contentType ? contentType === 'webCarousel' : false;
+				return contentType ? contentType === 'carousel' : false;
 			});
 		},
 		carouselSlides() {

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -181,7 +181,7 @@ export function formatBackground(contentfulContent) {
 }
 
 /**
- * Format Carousel (contentful type id: webCarousel)
+ * Format Carousel (contentful type id: carousel)
  * Takes raw contentful content object and returns an object with targeted keys/values
  *
  * @param {array} contentfulContent data
@@ -369,7 +369,7 @@ export function formatContentType(contentfulContent, contentType) {
 				...formatStoryCard(contentfulContent),
 				contentType
 			};
-		case 'webCarousel':
+		case 'carousel':
 			return {
 				...formatCarousel(contentfulContent),
 				contentType


### PR DESCRIPTION
Now that the Discovery Carousel type has been removed, we can just rename this to Carousel before we use it in more places. This gives mobile the ability to use it as well if they wish