### PR TITLE
ML2-359 adding matchRatio to DetailedLoanCard query

### DIFF
--- a/src/graphql/fragments/detailedLoanCard.graphql
+++ b/src/graphql/fragments/detailedLoanCard.graphql
@@ -31,6 +31,7 @@ fragment detailedLoanCard on LoanBasic {
 	}
 	plannedExpirationDate
 	matchingText
+	matchRatio
 	userProperties {
 		favorited
 		lentTo


### PR DESCRIPTION
As I was QAing ML2-359 I noticed this error on the DetailedLoanCard.
Looks good here, but the expanded version (DetailedLoanCard):
![Screen Shot 2021-08-27 at 12 03 23 PM](https://user-images.githubusercontent.com/1521381/131171101-74c29df2-32cc-4a17-98c6-82d439454fa1.png)

 (DetailedLoanCard): Doesn't have matchRatio
 

![Screen Shot 2021-08-27 at 12 03 08 PM](https://user-images.githubusercontent.com/1521381/131171036-c8fc91a0-6709-4f9e-8571-65fa91803e60.png)


After I little digging I discovered that there's an additional .graphql query that needed matchRatio added to it. 