### PR TITLE
ML2-359 fixing NaN return on the /lend/filter page

### DIFF
--- a/src/components/LoanCards/AlgoliaLoanCardAdapter.vue
+++ b/src/components/LoanCards/AlgoliaLoanCardAdapter.vue
@@ -61,6 +61,7 @@ export default {
 			latestUserProperties: null,
 			latestStatus: null,
 			latestMatchingText: null,
+			matchRatio: 1,
 		};
 	},
 	computed: {
@@ -88,6 +89,7 @@ export default {
 				},
 				use: _get(this.loan, 'use'),
 				matchingText: this.latestMatchingText || _get(this.loan, 'matchingText'),
+				matchRatio: this.matchRatio || _get(this.loan, 'matchRatio'),
 				name: _get(this.loan, 'name'),
 				partnerName: _get(this.loan, 'partner.name'),
 				plannedExpirationDate: exprirationDate.toISOString(),
@@ -128,8 +130,9 @@ export default {
 						favorited: _get(data, 'lend.loans.values[0].userProperties.favorited'),
 						lentTo: _get(data, 'lend.loans.values[0].userProperties.lentTo'),
 					};
-					// patch in latest matchingText
+					// patch in latest matchingText & matchRatio
 					this.latestMatchingText = _get(data, 'lend.loans.values[0].matchingText');
+					this.matchRatio = _get(data, 'lend.loans.values[0].matchRatio');
 					// patch in latest status
 					this.latestStatus = _get(data, 'lend.loans.values[0].status');
 				}

--- a/src/graphql/query/algoliaLoanStatus.graphql
+++ b/src/graphql/query/algoliaLoanStatus.graphql
@@ -9,6 +9,7 @@ query algoliaLoanStatus(
 				id
 				status
 				matchingText
+				matchRatio
 				minNoteSize
 				loanFundraisingInfo {
 					fundedAmount


### PR DESCRIPTION
I found another case of matchRatio not making it through to the loan card when QAing ML2-359. This code pipes matchRatio into place and results in the correct display of the matching text. 

![Screen Shot 2021-08-27 at 2 26 29 PM](https://user-images.githubusercontent.com/1521381/131184810-06c74ab8-7188-40db-8915-4f109d801d67.png)
