### PR TITLE
Fix memjs options argument usage

### DIFF
--- a/server/util/getGqlFragmentTypes.js
+++ b/server/util/getGqlFragmentTypes.js
@@ -1,4 +1,5 @@
 const fetch = require('./fetch');
+const log = require('./log');
 
 function fetchGqlFragments(url, cache) {
 	return fetch(url, {
@@ -13,22 +14,19 @@ function fetchGqlFragments(url, cache) {
 			// eslint-disable-next-line no-underscore-dangle
 			const fragmentTypes = result.data.__schema.types.filter(t => t.possibleTypes !== null);
 
-			cache.set('ui-gql-fragment-types', JSON.stringify(fragmentTypes), 24 * 60 * 60, (error, success) => {
-				if (error) {
-					console.error(JSON.stringify({
-						meta: {},
-						level: 'error',
-						message: `MemJS Error Setting Cache for ui-gql-fragment-types, Error: ${error}`
-					}));
+			cache.set(
+				'ui-gql-fragment-types',
+				JSON.stringify(fragmentTypes),
+				{ expires: 24 * 60 * 60 },
+				(error, success) => {
+					if (error) {
+						log(`MemJS Error Setting Cache for ui-gql-fragment-types, Error: ${error}`, 'error');
+					}
+					if (success) {
+						log(`MemJS Success Setting Cache for ui-gql-fragment-types, Success: ${success}`);
+					}
 				}
-				if (success) {
-					console.info(JSON.stringify({
-						meta: {},
-						level: 'info',
-						message: `MemJS Success Setting Cache for ui-gql-fragment-types, Success: ${success}`
-					}));
-				}
-			});
+			);
 
 			return fragmentTypes;
 		});
@@ -39,11 +37,7 @@ function getGqlFragmentsFromCache(cache) {
 		cache.get('ui-gql-fragment-types', (error, data) => {
 			let parsedData = [];
 			if (error) {
-				console.error(JSON.stringify({
-					meta: {},
-					level: 'error',
-					message: `MemJS Error Getting ui-gql-fragment-types, Error: ${error}`
-				}));
+				log(`MemJS Error Getting ui-gql-fragment-types, Error: ${error}`, 'error');
 			}
 			if (data) parsedData = JSON.parse(data);
 			resolve(parsedData);

--- a/server/util/initCache.js
+++ b/server/util/initCache.js
@@ -14,13 +14,16 @@ function FakeMemcached(options) {
 
 	// Replace 'set' with a memcached-compatible wrapper
 	const oldSet = lru.set;
-	lru.set = (key, value, age, callback) => {
+	lru.set = (key, value, { expires }, callback) => {
 		try {
-			oldSet.call(lru, key, value, age * 1000);
+			oldSet.call(lru, key, value, (expires ?? 0) * 1000);
 		} catch (error) {
 			if (callback) {
 				callback(error);
 			}
+		}
+		if (callback) {
+			callback(null, true);
 		}
 	};
 

--- a/server/util/memJsUtils.js
+++ b/server/util/memJsUtils.js
@@ -20,8 +20,7 @@ module.exports = {
 				if (error) {
 					log(`MemJS Error Setting Cache for ${key}, Error: ${error}`, 'error');
 					reject();
-				}
-				if (success) {
+				} else {
 					log(`MemJS Success Setting Cache for ${key}, Success: ${success}`);
 					resolve();
 				}

--- a/server/util/vueSsrCache.js
+++ b/server/util/vueSsrCache.js
@@ -1,3 +1,5 @@
+const log = require('./log');
+
 // The Vue ServerSideRenderer requires a cache instance that implements this interface:
 // type RenderCache = {
 //     get: (key: string, cb?: Function) => string | void;
@@ -11,11 +13,7 @@ module.exports = function wrapper(cache) {
 		get(key, cb) {
 			cache.get(key, (error, data) => {
 				if (error) {
-					console.error(JSON.stringify({
-						meta: {},
-						level: 'error',
-						message: `MemJS Error Getting Cache for ${key}, Error: ${error}`
-					}));
+					log(`MemJS Error Getting Cache for ${key}, Error: ${error}`, 'error');
 				}
 				if (!error && data) {
 					const bufferToString = data.toString('utf8');
@@ -28,20 +26,12 @@ module.exports = function wrapper(cache) {
 			});
 		},
 		set(key, value) {
-			cache.set(key, value.html, 1 * 60 * 60, (error, success) => {
+			cache.set(key, value.html, { expires: 0 }, (error, success) => {
 				if (error) {
-					console.error(JSON.stringify({
-						meta: {},
-						level: 'error',
-						message: `MemJS Error Setting Cache for: ${key}, Error: ${error}`
-					}));
+					log(`MemJS Error Setting Cache for: ${key}, Error: ${error}`, 'error');
 				}
 				if (success) {
-					console.info(JSON.stringify({
-						meta: {},
-						level: 'info',
-						message: `MemJS Success Setting Cache for: ${key}, Success: ${success}`
-					}));
+					log(`MemJS Success Setting Cache for: ${key}, Success: ${success}`);
 				}
 			});
 		},


### PR DESCRIPTION
The third argument for `memjs.set()` is [supposed to be an options object](https://github.com/memcachier/memjs#settings-values), with a single option `expires`. Many of the current usages are passing in a number, with the assumption that the number is being used for `expires`. That's not the case. What actually happens is `memjs.set()` will ignore invalid options arguments and use 0 for `expires` (meaning never expire!). Luckily this hasn't caused a problem yet because we use the release hash in our vue component cache keys and the graphql fragment types have never changed!