### PR TITLE
refactor: auto deposit landing page

### DIFF
--- a/src/pages/AutoDeposit/AutoDepositLandingPage.vue
+++ b/src/pages/AutoDeposit/AutoDepositLandingPage.vue
@@ -79,9 +79,8 @@
 </template>
 
 <script>
-import _get from 'lodash/get';
 import gql from 'graphql-tag';
-import { processPageContentFlat } from '@/util/contentfulUtils';
+import { processPageContent } from '@/util/contentfulUtils';
 
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import KvFrequentlyAskedQuestions from '@/components/Kv/KvFrequentlyAskedQuestions';
@@ -137,33 +136,49 @@ export default {
 		result({ data }) {
 			// Extract page content from contentful
 			const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
-			this.pageData = pageEntry ? processPageContentFlat(pageEntry) : null;
+			this.pageData = pageEntry ? processPageContent(pageEntry) : null;
 
-			this.isMonthlyGoodSubscriber = _get(data, 'my.autoDeposit.isSubscriber', false);
-			this.hasAutoDeposits = !!_get(data, 'my.autoDeposit') && !this.isMonthlyGoodSubscriber;
-			const legacySubs = _get(data, 'my.subscriptions.values', []);
+			this.isMonthlyGoodSubscriber = data?.my?.autoDeposit?.isSubscriber ?? false;
+			this.hasAutoDeposits = data?.my?.autoDeposit ?? false;
+
+			const legacySubs = data?.my?.subscriptions?.values ?? [];
 			this.hasLegacySubscription = legacySubs.length > 0;
 		},
 	},
 	computed: {
+		contentGroups() {
+			return this.pageData?.page?.pageLayout?.contentGroups ?? [];
+		},
 		canDisplayForm() {
 			return !this.isMonthlyGoodSubscriber && !this.hasAutoDeposits && !this.hasLegacySubscription;
 		},
+		faqContentGroup() {
+			return this.contentGroups?.find(({ type }) => {
+				return type ? type === 'frequentlyAskedQuestions' : false;
+			});
+		},
+		ctaContentGroup() {
+			return this.contentGroups?.find(({ key }) => {
+				return key ? key === 'auto-deposit-cta' : false;
+			});
+		},
 		headerAreaHeadline() {
-			return this.pageData?.page?.contentGroups?.autoDepositCta?.contents?.[0]?.headline;
+			return this.ctaContentGroup?.contents?.[0]?.headline;
 		},
 		headerAreaBodyCopy() {
-			const rawRichText = this.pageData?.page?.contentGroups?.autoDepositCta?.contents?.[0]?.bodyCopy;
+			const rawRichText = this.ctaContentGroup?.contents?.[0]?.bodyCopy;
 			return documentToHtmlString(rawRichText);
 		},
-		faqContentGroup() {
-			return this.pageData?.page?.contentGroups?.autoDepositFaqs ?? {};
+		whatToExpectContentGroup() {
+			return this.contentGroups?.find(({ key }) => {
+				return key ? key === 'auto-deposit-what-to-expect' : false;
+			});
 		},
 		whatToExpectHeadline() {
-			return this.pageData?.page?.contentGroups?.autoDepositWhatToExpect?.name;
+			return this.whatToExpectContentGroup?.title;
 		},
 		whatToExpect() {
-			return this.pageData?.page?.contentGroups?.autoDepositWhatToExpect?.contents;
+			return this.whatToExpectContentGroup?.contents;
 		}
 	},
 	methods: {


### PR DESCRIPTION
* Refactor _get on page
* Refactor content group naming and access content groups with processPageContent

This was the only page that had ContentGroups that were camelCased. This PR just standardizes some of the naming and accessing of the content groups on the page, as well as use processPageContent and remove lodash/_get