### PR TITLE
feat: Render contentful preview API results when preview query param …

### DIFF
--- a/src/graphql/query/contentful.graphql
+++ b/src/graphql/query/contentful.graphql
@@ -1,6 +1,0 @@
-query contentful($contentType: String!, $contentKey: String) {
-	contentful {
-		entries(contentType: $contentType, contentKey: $contentKey)
-	}
-}
-

--- a/src/graphql/query/contentfulEntries.graphql
+++ b/src/graphql/query/contentfulEntries.graphql
@@ -1,0 +1,8 @@
+# The preview parameter should come from a route query param and
+# should not be passed in manually. It is handled by: src/util/apolloPreFetch.js on the server side and
+# src/plugins/apollo-plugin.js on the client
+query contentfulEntries($contentType: String!, $contentKey: String, $preview: Boolean) {
+	contentful {
+		entries(contentType: $contentType, contentKey: $contentKey, preview: $preview)
+	}
+}

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -49,11 +49,11 @@ To use, simply create a route that defines contentfulPage in the meta data, e.g.
 },
 */
 
-import gql from 'graphql-tag';
 import { preFetchAll } from '@/util/apolloPreFetch';
 import { processPageContent } from '@/util/contentfulUtils';
 import logFormatter from '@/util/logFormatter';
 import * as siteThemes from '@/util/siteThemes';
+import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 
 // Page frames
 const WwwPage = () => import('@/components/WwwFrame/WwwPage');
@@ -88,13 +88,6 @@ const MonthlyGoodSelectorWrapper = () => import('@/components/MonthlyGood/Monthl
 const KvFrequentlyAskedQuestions = () => import('@/components/Kv/KvFrequentlyAskedQuestions');
 
 const TestimonialCards = () => import('@/components/Contentful/TestimonialCards');
-
-// Query for getting contentful page data
-const pageQuery = gql`query contentfulPage($key: String) {
-	contentful {
-		entries(contentType: "page", contentKey: $key)
-	}
-}`;
 
 // Get the Contentful Page data from the data of an Apollo query result
 const getPageData = data => {
@@ -236,23 +229,27 @@ export default {
 		};
 	},
 	apollo: {
-		query: pageQuery,
+		query: contentfulEntries,
 		preFetchVariables({ route }) {
 			return {
-				key: route?.meta?.contentfulPage(route),
+				contentType: 'page',
+				contentKey: route?.meta?.contentfulPage(route),
 			};
 		},
 		variables() {
 			return {
-				key: this.$route?.meta?.contentfulPage(this.$route),
+				contentType: 'page',
+				contentKey: this.$route?.meta?.contentfulPage(this.$route),
 			};
 		},
 		preFetch(config, client, args) {
 			return client.query({
-				query: pageQuery,
+				query: contentfulEntries,
 				variables: {
-					key: args?.route?.meta?.contentfulPage(args?.route),
-				},
+					contentType: 'page',
+					contentKey: args?.route?.meta?.contentfulPage(args?.route),
+					preview: args?.route?.query?.preview === 'true'
+				}
 			}).then(({ data }) => {
 				// Get Contentful page data
 				const pageData = getPageData(data);

--- a/src/pages/Homepage/DefaultHomepage.vue
+++ b/src/pages/Homepage/DefaultHomepage.vue
@@ -30,7 +30,7 @@ import gql from 'graphql-tag';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 
-import contentful from '@/graphql/query/contentful.graphql';
+import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 import { settingEnabled } from '@/util/settingsUtils';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import WhyKiva from '@/components/Homepage/WhyKiva';
@@ -93,7 +93,7 @@ export default {
 	},
 	created() {
 		this.apollo.query({
-			query: contentful,
+			query: contentfulEntries,
 			variables: {
 				contentType: 'uiSetting',
 				contentKey: 'ui-homepage-promo',

--- a/src/pages/Possibility/12DaysOfLending.vue
+++ b/src/pages/Possibility/12DaysOfLending.vue
@@ -37,7 +37,7 @@
 
 <script>
 import _get from 'lodash/get';
-import contentful from '@/graphql/query/contentful.graphql';
+import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 import KvHero from '@/components/Kv/KvHero';
 import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
 import KivaContentBlock from '@/pages/Possibility/KivaContentBlock';
@@ -75,7 +75,7 @@ export default {
 	inject: ['apollo'],
 	created() {
 		this.apollo.query({
-			query: contentful,
+			query: contentfulEntries,
 			variables: {
 				contentType: 'uiSetting',
 				contentKey: 'ui-global-promo',

--- a/src/util/contentful/isContentfulQuery.js
+++ b/src/util/contentful/isContentfulQuery.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * Returns true if contentful query
+ *
+ * @param {object} GraphQL Query AST Object
+ * @returns {Boolean} Is this a GQL query which looks like:
+ * {
+ * 	contentful {}
+ * }
+ */
+export function isContentfulQuery(queryAST) {
+	try {
+		const { operation } = queryAST.definitions[0];
+		const name = queryAST.definitions[0].selectionSet.selections[0].name.value;
+
+		return operation === 'query' && name === 'contentful';
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
…is active for ContentfulPage component

VUE-671

We can add a custom URL per content type for the preview functionality in contentful, this PR only deals with the contentful page content type, allowing users to hit the preview button on contentful and preview a page -- contentful is currently set to go to `/{entry.fields.key}?preview=true`

I tried several approaches to this. My goal was to try to make it as invisible and removed from the rest of the code as possible, and to also have the capabilities to expand this in the future to other content types besides pages. 

Approaches: 
_1 - Have separate routes and components - for example `/preview/entryId` then, render that accordingly._
This was a considerable amount of work, as all the logic in contentfulPage would have to be duplicated. 

_2 - Use a custom link in apollo client to read the query and add the `preview: true` variable if the preview query param is present._
I really like this approach, as it would completely abstract the preview functionality from the vue templates and would be handled entirely by apolloClient. I could not get this to work because I couldn't get the apolloLink to know about the query param. I suppose we could possible get the query param, put that in a cookie, and then have apolloLink access that?

_3 - Current approach._
Modifies the query in all the appropriate places based on the query param. I dislike that if preFetch is a function that returns a promise, theres no easy way to modify the variables in that query (like in ContentfulPage) so we have to add the conditional variable there: `preview: args?.route?.query?.preview === 'true'`

I also don't like having to include code to deal with preview in both apolloPreFetch and apollo-plugin. 

The upside is that this code does work for both `preFetch: true` and `preFetch function` apollo configs.

Future Improvements: 
Add separate routes for previewing other content group types. These would be preview only routes for example `/preview/content-group/{key}` that would let you preview that content in isolation of the rest of the page

