### PR TITLE
fix: styling changes for cause landing pages and rich text support fo…

### DIFF
--- a/src/components/Contentful/DynamicHeroClassic.vue
+++ b/src/components/Contentful/DynamicHeroClassic.vue
@@ -11,7 +11,7 @@
 					:style="customGridStyles"
 				>
 					<div
-						class="tw-mx-auto tw-col-span-12 md:tw-col-span-6 xl:tw-col-span-5"
+						class="tw-mx-auto tw-col-span-12 md:tw-col-span-6"
 					>
 						<!-- eslint-enable max-len -->
 						<template v-if="isHeroCarousel">
@@ -82,7 +82,7 @@
 					</div>
 
 					<div
-						class="tw-col-span-12 md:tw-col-span-6 xl:tw-col-span-7"
+						class="tw-col-span-12 md:tw-col-span-6"
 						:class="{ 'tw-order-first': swapOrder }"
 					>
 						<h1

--- a/src/components/Contentful/DynamicRichText.vue
+++ b/src/components/Contentful/DynamicRichText.vue
@@ -13,7 +13,7 @@ export default {
 	computed: {
 		dynamicComponent() {
 			return {
-				template: `<div class="tw-prose">${this.html}</div>`,
+				template: `<div class="tw-prose tw-whitespace-pre-wrap">${this.html}</div>`,
 				components: {
 					KvContentfulImg: () => import('~/@kiva/kv-components/vue/KvContentfulImg'),
 					KvButton: () => import('~/@kiva/kv-components/vue/KvButton')

--- a/src/components/Contentful/HeroWithCarousel.vue
+++ b/src/components/Contentful/HeroWithCarousel.vue
@@ -112,7 +112,7 @@ export default {
 				return 'tw-text-center';
 			}
 			// default class string for left aligned text
-			return 'md:tw-col-start-2 md:tw-col-span-10 lg:tw-col-span-6';
+			return '';
 		},
 		singleSlideWidth() {
 			// tw-grid width is 1072px == 67 rem

--- a/src/util/contentful/richTextRenderer.js
+++ b/src/util/contentful/richTextRenderer.js
@@ -57,8 +57,9 @@ export function richTextRenderer(content) {
 		const isRichTextContent = contentfulEntryNode?.data?.target?.sys?.contentType?.sys?.id === 'richTextContent';
 		const isButton = contentfulEntryNode?.data?.target?.sys?.contentType?.sys?.id === 'button';
 		if (isRichTextContent) {
+			const richTextHTML = richTextRenderer(contentfulEntryNode?.data?.target?.fields?.richText);
 			return `
-				<div class="tw-prose">${richTextRenderer(contentfulEntryNode?.data?.target?.fields?.richText)}</div>
+				<div class="tw-prose tw-whitespace-pre-wrap">${richTextHTML}</div>
 			`;
 		}
 		if (isButton) {


### PR DESCRIPTION
…r soft breaks

GD-113

This will need to be included in the next release. 

* Makes the heroWithCarousel component and the dynamicHeroClassic be 50%/50% column on xl screens
* Adds support to the rich text renderer for soft breaks (shift+enter) on the contentful rich text editor. See: https://github.com/kiva/ui/pull/2386

