### PR TITLE
feat: change eco friendly label in UI

### DIFF
--- a/src/plugins/loan-group-categories.js
+++ b/src/plugins/loan-group-categories.js
@@ -40,8 +40,8 @@ export default {
 				},
 				{
 					value: 'eco_friendly',
-					label: 'Support eco-friendly loans',
-					shortName: 'eco-friendly loans',
+					label: 'Support climate change loans',
+					shortName: 'climate change loans',
 					marketingName: 'Climate',
 					marketingOrder: 6
 				},


### PR DESCRIPTION
* Changes the 'eco friendly' label to 'climate' in the UI without touching the MG value or loan channel

GD-112

I think this is what we want. The url for the category will still be `/monthlygood?category=eco_friendly` but the drop downs and interactive selector will all display `climate` this is because the query param maps directly to the value we send to the API