### PR TITLE
feat: Render contentful preview API results when preview query param …

### DIFF
--- a/src/api/ContentfulPreviewLink.js
+++ b/src/api/ContentfulPreviewLink.js
@@ -1,0 +1,18 @@
+import { ApolloLink } from 'apollo-link';
+
+export default ({ cookieStore }) => {
+	return new ApolloLink((operation, forward) => {
+		// Only do this on contentful queries
+		if (operation.operationName.includes('contentful')) {
+			// Fetch contentfulPreview value from cookie
+			const isPreview = cookieStore.get('contentfulPreview');
+			// Add the preview variable to the current query
+			if (!operation?.variables?.preview && isPreview === 'true') {
+				// eslint-disable-next-line no-param-reassign
+				operation.variables.preview = true;
+			}
+		}
+
+		return forward(operation);
+	});
+};

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -8,6 +8,7 @@ import {
 } from 'apollo-cache-inmemory';
 import Auth0LinkCreator from './Auth0Link';
 import BasketLinkCreator from './BasketLink';
+import ContentfulPreviewLink from './ContentfulPreviewLink';
 import ExperimentIdLink from './ExperimentIdLink';
 import HttpLinkCreator from './HttpLink';
 import NetworkErrorLink from './NetworkErrorLink';
@@ -49,6 +50,7 @@ export default function createApolloClient({
 			ExperimentIdLink({ cookieStore }),
 			Auth0LinkCreator({ cookieStore, kvAuth0 }),
 			BasketLinkCreator({ cookieStore }),
+			ContentfulPreviewLink({ cookieStore }),
 			HttpLinkCreator({ uri }),
 		]),
 		cache,

--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -12,6 +12,7 @@ import showTipMessage from '@/graphql/mutation/tipMessage/showTipMessage.graphql
 
 import { preFetchAll } from '@/util/apolloPreFetch';
 import { authenticationGuard } from '@/util/authenticationGuard';
+import { contentfulPreviewCookie } from '@/util/contentfulPreviewCookie';
 
 import createApp from '@/main';
 import '@/assets/iconLoader';
@@ -129,6 +130,7 @@ router.onReady(() => {
 		const prevMatched = router.getMatchedComponents(from);
 		const activated = _dropWhile(matched, (c, i) => prevMatched[i] === c);
 
+		contentfulPreviewCookie({ route: to, cookieStore });
 		authenticationGuard({ route: to, apolloClient, kvAuth0 })
 			.then(() => {
 			// Pre-fetch graphql queries from activated components

--- a/src/graphql/query/contentful.graphql
+++ b/src/graphql/query/contentful.graphql
@@ -1,6 +1,0 @@
-query contentful($contentType: String!, $contentKey: String) {
-	contentful {
-		entries(contentType: $contentType, contentKey: $contentKey)
-	}
-}
-

--- a/src/graphql/query/contentfulEntries.graphql
+++ b/src/graphql/query/contentfulEntries.graphql
@@ -1,0 +1,7 @@
+# The preview parameter should come from a route query param and
+# should not be passed in manually. It is handled by src/api/ContentfulPreviewLink.js
+query contentfulEntries($contentType: String!, $contentKey: String, $preview: Boolean) {
+	contentful {
+		entries(contentType: $contentType, contentKey: $contentKey, preview: $preview)
+	}
+}

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -49,11 +49,11 @@ To use, simply create a route that defines contentfulPage in the meta data, e.g.
 },
 */
 
-import gql from 'graphql-tag';
 import { preFetchAll } from '@/util/apolloPreFetch';
 import { processPageContent } from '@/util/contentfulUtils';
 import logFormatter from '@/util/logFormatter';
 import * as siteThemes from '@/util/siteThemes';
+import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 
 // Page frames
 const WwwPage = () => import('@/components/WwwFrame/WwwPage');
@@ -88,13 +88,6 @@ const MonthlyGoodSelectorWrapper = () => import('@/components/MonthlyGood/Monthl
 const KvFrequentlyAskedQuestions = () => import('@/components/Kv/KvFrequentlyAskedQuestions');
 
 const TestimonialCards = () => import('@/components/Contentful/TestimonialCards');
-
-// Query for getting contentful page data
-const pageQuery = gql`query contentfulPage($key: String) {
-	contentful {
-		entries(contentType: "page", contentKey: $key)
-	}
-}`;
 
 // Get the Contentful Page data from the data of an Apollo query result
 const getPageData = data => {
@@ -236,23 +229,26 @@ export default {
 		};
 	},
 	apollo: {
-		query: pageQuery,
+		query: contentfulEntries,
 		preFetchVariables({ route }) {
 			return {
-				key: route?.meta?.contentfulPage(route),
+				contentType: 'page',
+				contentKey: route?.meta?.contentfulPage(route),
 			};
 		},
 		variables() {
 			return {
-				key: this.$route?.meta?.contentfulPage(this.$route),
+				contentType: 'page',
+				contentKey: this.$route?.meta?.contentfulPage(this.$route),
 			};
 		},
 		preFetch(config, client, args) {
 			return client.query({
-				query: pageQuery,
+				query: contentfulEntries,
 				variables: {
-					key: args?.route?.meta?.contentfulPage(args?.route),
-				},
+					contentType: 'page',
+					contentKey: args?.route?.meta?.contentfulPage(args?.route),
+				}
 			}).then(({ data }) => {
 				// Get Contentful page data
 				const pageData = getPageData(data);

--- a/src/pages/Homepage/DefaultHomepage.vue
+++ b/src/pages/Homepage/DefaultHomepage.vue
@@ -30,7 +30,7 @@ import gql from 'graphql-tag';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 
-import contentful from '@/graphql/query/contentful.graphql';
+import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 import { settingEnabled } from '@/util/settingsUtils';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import WhyKiva from '@/components/Homepage/WhyKiva';
@@ -93,7 +93,7 @@ export default {
 	},
 	created() {
 		this.apollo.query({
-			query: contentful,
+			query: contentfulEntries,
 			variables: {
 				contentType: 'uiSetting',
 				contentKey: 'ui-homepage-promo',

--- a/src/pages/Possibility/12DaysOfLending.vue
+++ b/src/pages/Possibility/12DaysOfLending.vue
@@ -37,7 +37,7 @@
 
 <script>
 import _get from 'lodash/get';
-import contentful from '@/graphql/query/contentful.graphql';
+import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 import KvHero from '@/components/Kv/KvHero';
 import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
 import KivaContentBlock from '@/pages/Possibility/KivaContentBlock';
@@ -75,7 +75,7 @@ export default {
 	inject: ['apollo'],
 	created() {
 		this.apollo.query({
-			query: contentful,
+			query: contentfulEntries,
 			variables: {
 				contentType: 'uiSetting',
 				contentKey: 'ui-global-promo',

--- a/src/plugins/apollo-plugin.js
+++ b/src/plugins/apollo-plugin.js
@@ -1,6 +1,6 @@
-import _get from 'lodash/get';
 import checkInjections from '@/util/injectionCheck';
 import logReadQueryError from '@/util/logReadQueryError';
+import { isContentfulQuery } from '@/util/contentful/isContentfulQuery';
 
 const injections = ['apollo', 'cookieStore'];
 
@@ -22,6 +22,8 @@ export default Vue => {
 
 				if (query) {
 					const basketId = this.cookieStore.get('kvbskt');
+					const isContentfulPreview = this.cookieStore.get('contentfulPreview');
+
 					// if the query was prefetched, read the data from the cache
 					if (preFetch) {
 						try {
@@ -33,12 +35,15 @@ export default Vue => {
 										cookieStore: this.cookieStore,
 										route: this.$route,
 									}),
+									/* Adds `preview: true` variable if the query is a contentful query
+									and the preview cookie value exists */
+									...(isContentfulQuery(query) && isContentfulPreview && { preview: true })
 								}
 							});
 							result.call(this, { data });
 						} catch (e) {
 							// if there's an error, skip reading from the cache and just wait for the watch query
-							logReadQueryError(e, `ApolloMixin ${_get(query, 'definitions[0].name.value')}`);
+							logReadQueryError(e, `ApolloMixin ${query?.definitions?.[0]?.name?.value}`);
 						}
 					}
 
@@ -48,7 +53,8 @@ export default Vue => {
 							query,
 							variables: {
 								basketId,
-								...variables.call(this)
+								...variables.call(this),
+								...(isContentfulQuery(query) && isContentfulPreview && { preview: true })
 							}
 						});
 
@@ -57,6 +63,7 @@ export default Vue => {
 						this.$watch(variables, vars => observer.setVariables({
 							basketId,
 							...vars,
+							...(isContentfulQuery(query) && isContentfulPreview && { preview: true })
 						}), { deep: true });
 
 						// Subscribe to the observer to see each result

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -9,6 +9,8 @@ import createApp from '@/main';
 import headScript from '@/head/script';
 import noscriptTemplate from '@/head/noscript.html';
 import { authenticationGuard } from '@/util/authenticationGuard';
+import { contentfulPreviewCookie } from '@/util/contentfulPreviewCookie';
+
 import logFormatter from '@/util/logFormatter';
 
 const isDev = process.env.NODE_ENV !== 'production';
@@ -101,6 +103,7 @@ export default context => {
 				// TODO: Check for + redirect to kiva php app external route
 				return reject({ code: 404 });
 			}
+			contentfulPreviewCookie({ route: router.currentRoute, cookieStore });
 			// Use route meta property to determine if route needs authentication
 			// authenticationGuard will reject promise with a redirect to login if
 			// required authentication query fails

--- a/src/util/contentful/isContentfulQuery.js
+++ b/src/util/contentful/isContentfulQuery.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/prefer-default-export */
+/**
+ * Returns true if contentful query
+ *
+ * @param {object} GraphQL Query AST Object
+ * @returns {Boolean} Is this a GQL query which looks like:
+ * {
+ * 	contentful {}
+ * }
+ */
+export function isContentfulQuery(queryAST) {
+	try {
+		const { operation } = queryAST.definitions[0];
+		const name = queryAST.definitions[0].selectionSet.selections[0].name.value;
+
+		return operation === 'query' && name === 'contentful';
+	} catch {
+		return false;
+	}
+}

--- a/src/util/contentfulPreviewCookie.js
+++ b/src/util/contentfulPreviewCookie.js
@@ -1,0 +1,12 @@
+// Contentful Preview Functionality
+// Create or delete cookie value if preview query parameter exists on route
+// This cookie value is read by apollo in src/api/ContentfulPreviewLink.js
+// eslint-disable-next-line import/prefer-default-export
+export function contentfulPreviewCookie({ route, cookieStore }) {
+	const isPreview = route?.query?.preview;
+	if (isPreview && isPreview === 'true') {
+		cookieStore.set('contentfulPreview', 'true');
+	} else {
+		cookieStore.remove('contentfulPreview');
+	}
+}


### PR DESCRIPTION
…is active for ContentfulPage component

* Uses cookies to create an apollo link that automatically adds the preview variable to the apollo query when necessary
VUE-671

Uses a cookie as discussed in https://github.com/kiva/ui/pull/3214 this allows the components, for example: `src/pages/ContentfulPage.vue` to be totally agnostic to the preview query param on the route