### PR TITLE
fix: Fix for carousel on cause based landing pages

### DIFF
--- a/src/components/Contentful/HeroWithCarousel.vue
+++ b/src/components/Contentful/HeroWithCarousel.vue
@@ -14,7 +14,7 @@
 							:embla-options="{ loop: false }"
 							:multiple-slides-visible="true"
 							slides-to-scroll="visible"
-							class="tw-w-full"
+							class="tw-w-full tw-overflow-visible md:tw-overflow-hidden"
 							:slide-max-width="singleSlideWidth"
 						>
 							<template v-for="(slide, index) in carouselSlides" #[`slide${index}`]>


### PR DESCRIPTION
Makes the carousel not be affected by page padding on mobile.

Before: 
![Screen Shot 2021-09-15 at 3 44 57 PM](https://user-images.githubusercontent.com/4371888/133519593-374c1a6c-cbc0-40ea-88eb-cb57081ba496.png)

After:
![Screen Shot 2021-09-15 at 3 47 18 PM](https://user-images.githubusercontent.com/4371888/133519775-cc8e6876-15c2-417a-ae77-b9c5d0fe5c70.png)
