### PR TITLE
fix: minor webpack dev issues

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -279,8 +279,8 @@ module.exports = {
 			exclude: /vue-loader.*type=style/
 		}),
 		new MiniCssExtractPlugin({
-			filename: assetsPath('css/[name].[contenthash].css'),
-			chunkFilename: assetsPath('css/[name].[contenthash].css'),
+			filename: isProd ? assetsPath('css/[name].[contenthash].css') : assetsPath('css/[name].css'),
+			chunkFilename: isProd ? assetsPath('css/[name].[contenthash].css') : assetsPath('css/[name].css'),
 		}),
 		new VueLoaderPlugin(),
 		new webpack.DefinePlugin({

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -126,7 +126,7 @@ chokidar.watch(path.resolve(__dirname, 'index.template.html')).on('change', () =
 });
 
 // update when the client manifest changes
-clientCompiler.plugin('done', rawStats => {
+clientCompiler.hooks.done.tap('done', rawStats => {
 	// abort if there were errors
 	const stats = rawStats.toJson();
 	if (stats.errors.length) return;


### PR DESCRIPTION
While doing research and testing on: https://github.com/kiva/ui/pull/3223 I came across these 2 minor webpack improvements. 

Improving ExtractCSS which should not use hashes for dev - https://webpack.js.org/plugins/mini-css-extract-plugin/#advanced-configuration-example
Refactoring deprecated compiler hook - reference: https://webpack.js.org/api/compiler-hooks/