### PR TITLE
feat: Adds custom event fields to buttons in RTF's

### DIFF
--- a/src/components/Contentful/DynamicRichText.vue
+++ b/src/components/Contentful/DynamicRichText.vue
@@ -20,9 +20,17 @@ export default {
 				},
 				props: [
 					/* define props as needed */
-				]
+				],
+				methods: {
+					buttonClick(customEventName, event) {
+						// Current behavior is to replace a button navigation if a custom event name is passed
+						event.stopPropagation();
+						// Emit root level event that any component can listen for
+						this.$root.$emit(customEventName);
+					},
+				}
 			};
-		}
+		},
 	},
 	render(createElement) {
 		return createElement(

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -209,6 +209,8 @@ const customMGEventsAndConfig = {
 	customEventName: 'openMonthlyGoodSelector'
 };
 
+// TODO deprecate this when DynamicHero.vue and HomepageBottomCTA.vue
+// are no longer in use
 const componentOptions = {
 	// Selected MG Landing page component keys to recieve custom attrubutes
 	'homepage-hero-monthly-good': customMGEventsAndConfig,

--- a/src/util/contentful/richTextRenderer.js
+++ b/src/util/contentful/richTextRenderer.js
@@ -64,15 +64,23 @@ export function richTextRenderer(content) {
 		}
 		if (isButton) {
 			const analyticsClickEvent = contentfulEntryNode?.data?.target?.fields?.analyticsClickEvent;
+			const webClickEventName = contentfulEntryNode?.data?.target?.fields?.webClickEventName;
 
 			const analyticsDirective = () => {
-				return analyticsClickEvent ? `v-kv-track-event="['${analyticsClickEvent.join("','")}']"` : null;
+				return analyticsClickEvent ? `v-kv-track-event="['${analyticsClickEvent.join("','")}']"` : '';
+			};
+
+			const clickFunctionality = () => {
+				if (webClickEventName) {
+					return `@click="buttonClick('${webClickEventName}', $event)"`;
+				}
+				return `href="${contentfulEntryNode?.data?.target?.fields?.webLink ?? '#'}"`;
 			};
 			return `
 				<kv-button
 					variant="${contentfulEntryNode?.data?.target?.fields?.style ?? 'primary'}"
-					href="${contentfulEntryNode?.data?.target?.fields?.webLink ?? '#'}"
 					${analyticsDirective()}
+					${clickFunctionality()}
 				>${contentfulEntryNode?.data?.target?.fields?.label ?? ''}</kv-button>
 			`;
 		}


### PR DESCRIPTION
* Adds a field on contentful Button types. 'webClickEventName'
* For the Rich Text Renderer, if this field is present, render the button with an onclick which passes this value up to dynamic rich text component
* In dynamic rich text component, emit a global event of the same name
* TLDR: This allows a button inside of a rich text field in contentful to open up the monthly good interactive selector.

GD-116