### PR TITLE
VUE-695 Set cache headers for live loan images to prevent caching

### DIFF
--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -78,6 +78,10 @@ async function serveImg(type, cache, req, res) {
 		}
 
 		res.contentType('image/jpeg');
+		res.set('Cache-Control', [
+			'no-store, no-cache, must-revalidate, max-age=0',
+			'post-check=0, pre-check=0'
+		]);
 		res.send(loanImg);
 	} catch (err) {
 		log(`Error serving image, ${err}`, 'error');


### PR DESCRIPTION
Cache headers for dynamic images: https://stackoverflow.com/questions/21802820/dynamic-images-for-email-such-as-countdown-clocks-in-light-of-gmail-image-cachi/40569195