### PR TITLE
fix: Fix Mobile MG lightbox CTA button being cut off

### DIFF
--- a/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
@@ -77,7 +77,7 @@
 			</div>
 
 			<template #controls v-if="selectedGroup">
-				<kv-button @click="navigateToMG" class="tw-mt-12">
+				<kv-button @click="navigateToMG">
 					Next
 				</kv-button>
 			</template>


### PR DESCRIPTION
GD-120

This should help, but the real issue is a bug in styleguide, see VUE-700