### PR TITLE
core-5 fixing up cols on medium and large screens

### DIFF
--- a/src/components/Contentful/RichTextItemsCentered.vue
+++ b/src/components/Contentful/RichTextItemsCentered.vue
@@ -12,7 +12,13 @@
 					<div
 						v-for="(item, index) in richContentfulContent"
 						:key="index"
-						:class="`tw-col-span-12 lg:tw-col-span-${12/richContentfulContent.length}`"
+						:class="{
+							'tw-col-span-12': true,
+							'md:tw-col-span-6': richContentfulContent.length >= 2,
+							'lg:tw-col-span-6': richContentfulContent.length === 2,
+							'lg:tw-col-span-4': richContentfulContent.length === 3,
+							'lg:tw-col-span-3': richContentfulContent.length === 4,
+						}"
 					>
 						<div class="tw-pt-2">
 							<dynamic-rich-text :html="parsedRichContent(item)" />


### PR DESCRIPTION
The column break was not working properly on dev. 

:class="`tw-col-span-12 lg:tw-col-span-${12/richContentfulContent.length}`"

This was because I was breaking the tailwinds class into pieces, which wasn't allowing the function to run before rendering, preventing tailwinds from working correctly, even though the right classes were rendered on the front end. 

The fix passes through full tailwind class names based on the calculation... which works. 
https://tailwindcss.com/docs/just-in-time-mode#arbitrary-value-support

* I spoke to Nathan and he did want to go with the 2 column view for medium view ports. 

**Small:**
<img width="322" alt="Screen Shot 2021-09-22 at 12 26 04 PM" src="https://user-images.githubusercontent.com/1521381/134400606-af98d077-74f9-443d-a9b5-29bce5d75c18.png">

**Medium:** 
<img width="823" alt="Screen Shot 2021-09-22 at 12 25 54 PM" src="https://user-images.githubusercontent.com/1521381/134400621-70a580c2-ca1e-424a-9a6e-452bd9f5326a.png">

**Large:**
<img width="1367" alt="Screen Shot 2021-09-22 at 12 25 44 PM" src="https://user-images.githubusercontent.com/1521381/134400637-fd7fadb3-0bb9-474f-bf45-d1ebe704c785.png">

