### PR TITLE
feat: Cause based landing page improvements

### DIFF
--- a/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<kv-button
-			class="tw-mx-auto tw-w-full"
+			class="tw-mx-auto"
 			@click="showLightbox"
 			v-kv-track-event="[
 				'homepage',
@@ -10,12 +10,16 @@
 			]"
 			id="mobileMonthlyGoodSelectorButton"
 		>
-			Get started
+			<span class="tw-flex tw-items-center tw-text-h3">
+				Get started
+				<kv-material-icon class="tw-w-3.5 tw-h-3.5" :icon="mdiChevronRight" />
+			</span>
 		</kv-button>
 		<kv-lightbox
 			:visible="lightboxVisible"
 			title="Monthly Subscription"
 			@lightbox-closed="hideLightbox"
+			class="tw-text-left"
 		>
 			<div class="tw-pb-3" v-html="monthlySubscriptionCopy"></div>
 			<div v-if="selectedGroup">
@@ -56,7 +60,7 @@
 					{{ option.marketingName }}
 				</button>
 			</div>
-			<div class="tw-mt-2" v-if="lightboxStep === 'amount'">
+			<div class="tw-mt-2 tw-mb-4" v-if="lightboxStep === 'amount'">
 				<label class="tw-text-h4 tw-py-1" for="mgAmountDropdown">
 					Choose your amount
 				</label>
@@ -89,9 +93,12 @@
 import numeral from 'numeral';
 import { validationMixin } from 'vuelidate';
 import { required } from 'vuelidate/lib/validators';
+import { mdiChevronRight } from '@mdi/js';
+
 import loanGroupCategoriesMixin from '@/plugins/loan-group-categories';
 import { documentToHtmlString } from '~/@contentful/rich-text-html-renderer';
 
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 import KvUiSelect from '~/@kiva/kv-components/vue/KvSelect';
@@ -118,6 +125,7 @@ export default {
 	components: {
 		KvButton,
 		KvLightbox,
+		KvMaterialIcon,
 		KvUiSelect,
 	},
 	mixins: [
@@ -168,6 +176,7 @@ export default {
 			],
 			lightboxVisible: false,
 			lightboxStep: 'amount',
+			mdiChevronRight,
 		};
 	},
 	mounted() {

--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -1,25 +1,53 @@
 <template>
 	<div>
 		<!-- MG Selector Desktop -->
-		<!-- eslint-disable max-len -->
 		<section
-			class="monthly-good-selector md:tw-visible tw-invisible tw-bg-brand-50 tw-px-3 tw-py-0 tw-rounded-t"
-			:class="{ 'sticky': isSticky, 'tw-fixed tw-bottom-0 tw-w-full tw-z-sticky': isSticky, 'tw-relative': !isSticky }"
-			:style="{bottom: mgStickBarOffset + 'px'}"
+			:class="[
+				'monthly-good-selector',
+				'tw-invisible md:tw-visible',
+				'tw-bg-brand-50',
+				'tw-px-3 tw-py-0',
+				'tw-rounded-t',
+				{
+					'sticky': isSticky,
+					'tw-fixed tw-bottom-0 tw-w-full tw-z-sticky': isSticky,
+					'tw-relative': !isSticky
+				}
+			]"
+			:style="{ bottom: mgStickBarOffset + 'px' }"
 		>
 			<monthly-good-selector-desktop :pre-selected-category="preSelectedCategory" />
 		</section>
 
-		<!-- MG Selector Mobile show-for-small-only  -->
-		<section
-			class="monthly-good-selector tw-visible md:tw-invisible tw-bg-brand-50 tw-px-3 tw-py-2"
-			:class="{ 'sticky': isSticky, 'tw-fixed tw-bottom-0 tw-w-full tw-z-sticky': isSticky, 'tw-relative': !isSticky }"
-			:style="{bottom: mgStickBarOffset + 'px'}"
-			v-if="isMobile"
+		<!-- MG Selector Mobile show-for-small-only, show only after scrolling initially  -->
+		<transition
+			enter-active-class="tw-transition-all tw-duration-1000 tw-delay-300 tw-ease-in-out"
+			enter-class="tw-translate-y-full tw-opacity-0"
+			enter-to-class="tw-translate-y-0 tw-opacity-100"
 		>
-			<monthly-good-selector-mobile :pre-selected-category="preSelectedCategory" :rich-text-content="mgMobileRichText" />
-		</section>
-		<!-- eslint-enable max-len -->
+			<section
+				:class="[
+					'monthly-good-selector',
+					'tw-visible md:tw-invisible',
+					'tw-bg-primary',
+					'tw-border-t tw-border-b tw-border-tertiary',
+					'tw-px-3 tw-pt-2.5 tw-pb-3',
+					'tw-text-center',
+					{
+						'sticky': isSticky,
+						'tw-fixed tw-bottom-0 tw-w-full tw-z-sticky': isSticky,
+						'tw-relative': !isSticky
+					}
+				]"
+				:style="{ bottom: mgStickBarOffset + 'px' }"
+				v-show="hasScrolled"
+			>
+				<monthly-good-selector-mobile
+					:pre-selected-category="preSelectedCategory"
+					:rich-text-content="mgMobileRichText"
+				/>
+			</section>
+		</transition>
 	</div>
 </template>
 
@@ -49,7 +77,7 @@ export default {
 			isSticky: false,
 			initialBottomPosition: 0,
 			mgStickBarOffset: 0,
-			isMobile: false
+			hasScrolled: false
 		};
 	},
 	mixins: [
@@ -103,7 +131,7 @@ export default {
 			const heightOfMgSelector = this.$el.getElementsByClassName('monthly-good-selector')[0].offsetHeight;
 			const scrollPositionOfPage = window.scrollY;
 
-			// override for always stickey behavior
+			// override for always sticky behavior
 			if (this.alwaysSticky) {
 				this.initialBottomPosition = 0;
 			} else {
@@ -126,27 +154,27 @@ export default {
 			}
 			// set offset
 			this.mgStickBarOffset = offsetHeight;
-		},
-		determineIfMobile() {
-			this.isMobile = document.documentElement.clientWidth < 735;
 		}
 	},
 	beforeDestroy() {
 		window.removeEventListener('scroll', this.throttledScroll);
+		window.removeEventListener('scroll', () => {
+			this.hasScrolled = true;
+		});
 		window.removeEventListener('resize', _throttle(() => {
 			this.initStickyBehavior();
-			this.determineIfMobile();
 		}, 200));
 	},
 	mounted() {
 		window.addEventListener('scroll', this.throttledScroll);
+		window.addEventListener('scroll', () => {
+			this.hasScrolled = true;
+		});
 		window.addEventListener('resize', _throttle(() => {
 			this.initStickyBehavior();
-			this.determineIfMobile();
 		}, 200));
 
 		this.initStickyBehavior();
-		this.determineIfMobile();
 	},
 };
 </script>
@@ -174,8 +202,6 @@ footer.www-footer {
 
 .monthly-good-selector {
 	&.sticky {
-		// non-standard "bottom" property requires additional tailwinds config to support
-		transition: bottom 0.4s;
 		// probably doable with tw, will revisit later
 		box-shadow: 0 -5px 80px rgba(0, 0, 0, 0.1);
 		// Temporary scss override to ensure layering over header in mobile


### PR DESCRIPTION
GD-121
![Screen Shot 2021-09-22 at 11 31 55 AM](https://user-images.githubusercontent.com/4371888/134401378-642899e5-0774-4213-8575-97727cbfd62c.png)


Some light refactoring, mostly prettier syntax in the template and removing isMobile check since class based showing/hiding the selector is working. 

Changes from GD-121 ticket (only for the mobile selector, desktop selector to remain  unchanged):
* Make button text not scale down from mobile
* Make selector animate in 
* Add icon on button
* Add border top and bottom 
* Make button not full width
* Change background color