### PR TITLE
feat: Allow horizontal alignment of grid items

### DIFF
--- a/src/components/Contentful/CenteredRichText.vue
+++ b/src/components/Contentful/CenteredRichText.vue
@@ -5,9 +5,10 @@
 	>
 		<template #content>
 			<kv-page-container>
-				<kv-grid class="tw-mx-auto tw-text-center" :style="customGridStyles">
+				<kv-grid class="tw-mx-auto tw-text-center tw-justify-items-center" :style="customGridStyles">
 					<dynamic-rich-text
 						:html="richContent"
+						:style="maxWidthStyles"
 					/>
 				</kv-grid>
 			</kv-page-container>

--- a/src/components/Contentful/DynamicHeroClassic.vue
+++ b/src/components/Contentful/DynamicHeroClassic.vue
@@ -6,12 +6,15 @@
 		<template #content>
 			<kv-page-container>
 				<kv-grid
-					class="tw-grid-cols-12 tw-gap-2 tw-items-center"
-					:class="{ 'tw-grid-cols-1 tw-mx-auto': singleColumn }"
+					class="tw-grid-cols-12 tw-gap-2 tw-items-center tw-justify-items-center"
 					:style="customGridStyles"
 				>
 					<div
-						class="tw-mx-auto tw-col-span-12 md:tw-col-span-6"
+						class="tw-mx-auto tw-col-span-12"
+						:class="{
+							'md:tw-col-span-6': !singleColumn
+						}"
+						:style="maxWidthStyles"
 					>
 						<!-- eslint-enable max-len -->
 						<template v-if="isHeroCarousel">
@@ -82,8 +85,12 @@
 					</div>
 
 					<div
-						class="tw-col-span-12 md:tw-col-span-6"
-						:class="{ 'tw-order-first': swapOrder }"
+						class="tw-col-span-12"
+						:class="{
+							'tw-order-first': swapOrder,
+							'md:tw-col-span-6': !singleColumn
+						}"
+						:style="maxWidthStyles"
 					>
 						<h1
 							v-if="heroHeadline"

--- a/src/components/Contentful/RichTextItemsCentered.vue
+++ b/src/components/Contentful/RichTextItemsCentered.vue
@@ -7,7 +7,7 @@
 			<kv-page-container>
 				<kv-grid
 					:style="customGridStyles"
-					class="tw-grid-cols-12 tw-text-center"
+					class="tw-grid-cols-12 tw-justify-items-center tw-text-center"
 				>
 					<div
 						v-for="(item, index) in richContentfulContent"
@@ -19,6 +19,7 @@
 							'lg:tw-col-span-4': richContentfulContent.length === 3,
 							'lg:tw-col-span-3': richContentfulContent.length === 4,
 						}"
+						:style="maxWidthStyles"
 					>
 						<div class="tw-pt-2">
 							<dynamic-rich-text :html="parsedRichContent(item)" />

--- a/src/plugins/contentful-ui-setting-styles-mixin.js
+++ b/src/plugins/contentful-ui-setting-styles-mixin.js
@@ -5,22 +5,32 @@ export default {
 		 */
 		customGridStyles() {
 			let customStyles = '';
-			// Check for custom width
-			const maxWidthValue = this.uiSetting?.dataObject?.maxWidthValue ?? null;
-			const maxWidthUnit = this.uiSetting?.dataObject?.maxWidthUnit ?? 'rem';
-			if (maxWidthValue) {
-				customStyles = `max-width: ${maxWidthValue}${maxWidthUnit};`;
-			}
-			// Check for custom text alignment
+			// Custom text alignment
 			const textAlign = this.uiSetting?.dataObject?.textAlign ?? null;
 			if (textAlign) {
 				customStyles = `${customStyles} text-align: ${textAlign};`;
 			}
 			// Vertical alignment of grid items
 			const verticalAlign = this.uiSetting?.dataObject?.verticalAlign ?? null;
-			customStyles = `${customStyles} align-items: ${verticalAlign};`;
+			if (verticalAlign) {
+				customStyles = `${customStyles} align-items: ${verticalAlign};`;
+			}
+
+			// Horizontal alignment of grid items
+			const horizontalAlign = this.uiSetting?.dataObject?.horizontalAlign ?? null;
+			if (horizontalAlign) {
+				customStyles = `${customStyles} justify-items: ${horizontalAlign};`;
+			}
 
 			return customStyles;
+		},
+		maxWidthStyles() {
+			// Custom max-width
+			const maxWidthValue = this.uiSetting?.dataObject?.maxWidthValue ?? null;
+			const maxWidthUnit = this.uiSetting?.dataObject?.maxWidthUnit ?? 'rem';
+			if (maxWidthValue) {
+				return `max-width: ${maxWidthValue}${maxWidthUnit};`;
+			}
 		},
 		/**
 		 * Depends on singleColumn property on Contentful dataObject


### PR DESCRIPTION
This sets the max-width on the children of the grid instead of the grid.

Instead of `tw-mx-auto` on the grid element, it uses `tw-justify-items-...` to horizontally align the grid children and allow overrides from Contentul.