### PR TITLE
core-100 Adding CTA button to KivaClassicBasicLoanCard

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,8 @@ import { addParameters } from '@storybook/vue';
 import { MINIMAL_VIEWPORTS} from '@storybook/addon-viewport';
 import Vue from 'vue';
 import Meta from 'vue-meta';
+import KvThemeProvider from '~/@kiva/kv-components/vue/KvThemeProvider';
+import { defaultTheme } from '@kiva/kv-tokens/configs/kivaColors';
 
 //load all the svg icon sprites
 import '@/assets/iconLoader';
@@ -86,4 +88,11 @@ addParameters({
     },
   },
 });
+
+// Wrap all stories with the kv-theme-provider component
+export const decorators = [(story) => ({
+	components: { story, KvThemeProvider },
+	template: '<kv-theme-provider :theme="theme"><story /></kv-theme-provider>',
+	data() { return { theme: defaultTheme } }
+})];
 

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -37,7 +37,7 @@
 
 		<borrower-name
 			v-if="!isLoading"
-			class="md:tw-mb-1.5 lg:tw-mb-2 tw-text-h3"
+			class="tw-mb-1 tw-text-h3"
 			:name="borrowerName"
 		/>
 
@@ -56,6 +56,7 @@
 		<!-- Contains amount to go and fundraising bar -->
 		<loan-progress-group
 			v-if="!ifLoading"
+			class="tw-mb-2.5"
 			:money-left="unreservedAmount"
 			:progress-percent="fundraisingPercent"
 			:time-left="timeLeftMessage"
@@ -69,6 +70,7 @@
 
 		<loan-use
 			v-if="!isLoading"
+			class="tw-mb-2.5"
 			loan-use-max-length="52"
 			:use="loan.use"
 			:name="borrowerName"
@@ -85,7 +87,7 @@
 
 		<loan-matching-text
 			v-if="!isLoading"
-			class="tw-mb-1"
+			class="tw-mb-1.5"
 			:matcher-name="loan.matchingText"
 			:match-ratio="loan.matchRatio"
 			:status="loan.status"
@@ -94,11 +96,23 @@
 			:loan-amount="loan.loanAmount"
 		/>
 
-		<!-- Button -->
+		<!-- CTA Button -->
 		<kv-loading-placeholder
 			v-if="isLoading"
 			class="tw-rounded" :style="{width: '9rem', height: '3rem'}"
 		/>
+
+		<kv-button
+			v-if="!isLoading"
+			class="tw-mb-2"
+			:to="`/lend/${loan.loanId}`"
+		>
+			Read more
+			<kv-material-icon
+				class="tw-align-middle"
+				:icon="mdiChevronRight"
+			/>
+		</kv-button>
 	</div>
 </template>
 
@@ -114,6 +128,9 @@ import KvLoadingPlaceholder from '@/components/Kv/KvLoadingPlaceholder';
 import KvLoadingParagraph from '@/components/Kv/KvLoadingParagraph';
 import LoanProgressGroup from '@/components/LoanCards/LoanProgressGroup';
 import LoanMatchingText from '@/components/LoanCards/LoanMatchingText';
+import { mdiChevronRight } from '@mdi/js';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
 const loanQuery = gql`query kcBasicLoanCard($basketId: String, $loanId: Int!) {
 	shop (basketId: $basketId) {
@@ -197,6 +214,8 @@ export default {
 		LoanUse,
 		LoanProgressGroup,
 		LoanMatchingText,
+		KvButton,
+		KvMaterialIcon,
 	},
 	data() {
 		return {
@@ -204,6 +223,7 @@ export default {
 			basketItems: null,
 			isLoading: false,
 			queryObserver: null,
+			mdiChevronRight,
 		};
 	},
 	computed: {

--- a/src/components/LoanCards/LoanMatchingText.vue
+++ b/src/components/LoanCards/LoanMatchingText.vue
@@ -15,7 +15,7 @@
 		>
 			🎉
 		</span>
-		<h4 class="tw-inline-block ">
+		<h4 class="tw-inline-block">
 			{{ constructedMatchingText }}
 		</h4>
 	</span>


### PR DESCRIPTION
[Core-100](https://kiva.atlassian.net/browse/CORE-100)

Adding CTA button to KivaClassicBasicLoanCard. 

New loan card with all the pieces assembled.

**THE ISSUE DESCRIBED BELOW IS NO LONGER OCCURRING, FIXED STATE SHOWN BELOW IN COMMENTS**

_**One note, I'm not sure why `<kv-button>` is rendering with the secondary style in my local storybook. According to the [docs](https://608b4cf87f686c00213841b1-vwqtxldhix.chromatic.com/?path=/docs/kvbutton--variant-secondary), primary is the default button variant, but even when I define the variant="primary" it still renders as the secondary style.

`<kv-button
			v-if="!isLoading"
			class="tw-mb-2"
			:to="`/lend/${loan.loanId}`"
		>
			Read more
			<kv-material-icon
				class="tw-align-middle"
				:icon="mdiChevronRight"
			/>
		</kv-button>`

This is my import line, including the KvButton component.
`import KvButton from '~/@kiva/kv-components/vue/KvButton';`


<img width="961" alt="Screen Shot 2021-09-22 at 5 13 13 PM" src="https://user-images.githubusercontent.com/1521381/134433966-92066934-b7e7-481f-a74e-e3e559dba822.png">_