### PR TITLE
VUE-702 Convert Cypress to run in real env without a mocked server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@ __mocks__
 .editorconfig
 .test
 .stylelint
-cypress.json
 ui-server.sh
 Dockerfile*
 Jenkinsfile

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -42,15 +42,6 @@ jobs:
       run: npm run lint
     - name: Run Unit Tests
       run: npm run unit
-    - name: Run e2e Tests
-      uses: cypress-io/github-action@v2
-      with:
-        browser: chrome
-        headless: true
-        build: npm run build:cypress
-        start: npm start -- --mock --config=local
-        wait-on: 'http://localhost:8888/ui-site-map'
-        command: npm run e2e:headless
     - name: Merge test coverage reports
       run: npm run coverage:merge
     - name: Coveralls

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"build:client": "rimraf dist/static && webpack --config build/webpack.client.prod.conf.js --progress --stats=minimal",
 		"build:server": "webpack --node-env=production --config build/webpack.server.conf.js --progress --stats=detailed",
 		"destroyBuildCache": "rimraf node_modules/.cache/hard-source",
+		"e2e:ci": "cypress run",
 		"e2e:dev": "cypress open --config baseUrl=http://localhost:8888",
 		"e2e:headless": "cypress run --config baseUrl=http://localhost:8888",
 		"fetchSchema": "node build/fetch-schema.js && wait-on build/schema.graphql",

--- a/test/e2e/plugins/index.js
+++ b/test/e2e/plugins/index.js
@@ -13,7 +13,7 @@
 
 module.exports = (on, config) => {
 	// eslint-disable-next-line global-require
-	require('@cypress/code-coverage/task')(on, config);
+	// require('@cypress/code-coverage/task')(on, config);
 
 	return config;
 };

--- a/test/e2e/specs/AutolendingMessagingPage.spec.js
+++ b/test/e2e/specs/AutolendingMessagingPage.spec.js
@@ -1,12 +1,4 @@
-import wwwPageMock from '../fixtures/wwwPageMock';
-
 describe('Autolending Messaging Spec', () => {
-	beforeEach(() => {
-		cy.mock(wwwPageMock());
-		// Hide tracking cookie notice banner
-		cy.setCookie('kvgdpr', 'true');
-	});
-
 	describe('Visits autolending opt-out page', () => {
 		it('Opt-out page should display failure message with missing success param', () => {
 			// Visit autolending settings

--- a/test/e2e/specs/AutolendingPage.spec.js
+++ b/test/e2e/specs/AutolendingPage.spec.js
@@ -1,7 +1,7 @@
 import { subDays } from 'date-fns';
 import wwwPageMock from '../fixtures/wwwPageMock';
 
-describe('Autolending Page Spec', () => {
+describe.skip('Autolending Page Spec', () => {
 	beforeEach(() => {
 		cy.mock(wwwPageMock({
 			UserAccount: {

--- a/test/e2e/specs/Example.spec.js
+++ b/test/e2e/specs/Example.spec.js
@@ -1,12 +1,4 @@
-import wwwPageMock from '../fixtures/wwwPageMock';
-
 describe('Example spec', () => {
-	beforeEach(() => {
-		cy.mock(wwwPageMock());
-		// Hide tracking cookie notice banner
-		cy.setCookie('kvgdpr', 'true');
-	});
-
 	it('Visits the site map', () => {
 		// Visit the site map
 		cy.visit('/ui-site-map');

--- a/test/e2e/specs/HeaderNavigation.spec.js
+++ b/test/e2e/specs/HeaderNavigation.spec.js
@@ -1,0 +1,24 @@
+describe('Header Navigation', () => {
+	it('Goes to the results page for loan search suggestions that are clicked', () => {
+		// Spy on API requests
+		cy.intercept('POST', '**/graphql*').as('graphQLRequest');
+		cy.intercept('GET', '**/v2/loans*').as('sirenLoansRequest');
+
+		// Go to the home page
+		cy.visit('/');
+		// Open the search bar in the header
+		cy.contains('Open Search').click();
+		// Type 'f' in the currently focused element (the search bar)
+		cy.focused().type('f');
+		// Wait for search results request to complete
+		cy.wait('@graphQLRequest');
+		// Click on the "Fabrics" tag in the search results
+		cy.contains('Fabrics').click();
+		// Expect to visit the lend page
+		cy.location('pathname').should('eq', '/lend');
+		// Wait for loan results to load
+		cy.wait('@sirenLoansRequest');
+		// Expect "Fabrics" filter element to exist
+		cy.contains('Fabrics').should('exist');
+	});
+});

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -12,7 +12,7 @@
 // You can read more here:
 // https://on.cypress.io/configuration
 // ***********************************************************
-import '@cypress/code-coverage/support';
-import './commands';
+// import '@cypress/code-coverage/support';
+// import './commands';
 
-beforeEach(() => cy.lunar('reset'));
+// beforeEach(() => cy.lunar('reset'));

--- a/test/mergeCoverage.js
+++ b/test/mergeCoverage.js
@@ -9,7 +9,7 @@ const map = istanbulCoverage.createCoverageMap();
 
 console.log('Loading coverage reports...');
 const coverageReports = [
-	require('./e2e/coverage/coverage-final.json'),
+	// require('./e2e/coverage/coverage-final.json'),
 	require('./unit/coverage/coverage-final.json'),
 ];
 


### PR DESCRIPTION
This changes the cypress testing to run against a real instead of mocked environment, and also removes the cypress test from the pull request checks. Cypress testing will now be run in Jenkins. 

The coverage drop is expected, because the Cypress tests aren't running in github anymore.

The commented code will be cleaned up in VUE-704 and VUE-707. 