### PR TITLE
Core-102 adding the allSharesReserved state to KivaClassicBasicLoanCard

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -8,6 +8,11 @@
 			v-if="isLoading"
 			class="tw-mb-1 tw-rounded" :style="{width: '100%', height: '15.75rem'}"
 		/>
+
+		<!-- TODO: Once click interaction for this is in place, we need to disable the click
+		if allSharesReserved is true 
+		
+		click="`${allSharesReserved ? 'correct redirect' : ''}`" -->
 		<borrower-image
 			v-if="!isLoading"
 			class="
@@ -60,6 +65,7 @@
 			:money-left="unreservedAmount"
 			:progress-percent="fundraisingPercent"
 			:time-left="timeLeftMessage"
+			:all-shares-reserved="allSharesReserved"
 		/>
 
 		<!-- LoanUse  -->
@@ -105,6 +111,7 @@
 		<kv-button
 			v-if="!isLoading"
 			class="tw-mb-2"
+			:state="`${allSharesReserved ? 'disabled' : ''}`"
 			:to="`/lend/${loan.loanId}`"
 		>
 			Read more
@@ -266,6 +273,12 @@ export default {
 		},
 		timeLeft() {
 			return this.loan?.fundraisingTimeLeft ?? '';
+		},
+		allSharesReserved() {
+			if (parseFloat(this.loan?.unreservedAmount) === 0) {
+				return true;
+			}
+			return false;
 		},
 	},
 	methods: {

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -10,9 +10,9 @@
 		/>
 
 		<!-- TODO: Once click interaction for this is in place, we need to disable the click
-		if allSharesReserved is true 
-		
-		click="`${allSharesReserved ? 'correct redirect' : ''}`" -->
+		if allSharesReserved is true
+		ie.
+		:click="`${allSharesReserved ? 'correct redirect' : ''}`" -->
 		<borrower-image
 			v-if="!isLoading"
 			class="

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -1,10 +1,7 @@
 <template>
 	<figure>
-		<h4 v-if="allSharesReserved">
-			Funding complete
-		</h4>
-		<h4 v-if="!allSharesReserved" class="tw-mb-0.5">
-			{{ moneyLeft | numeral('$0,0[.]00') }} to go{{ timeLeft !== '' ? `. ${timeLeft}` : '' }}
+		<h4 class="tw-mb-0.5">
+			{{ fundingText }}
 		</h4>
 		<kv-progress-bar
 			class="tw-mb-1.5 lg:tw-mb-1"
@@ -15,6 +12,7 @@
 </template>
 
 <script>
+import numeral from 'numeral';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
 
 export default {
@@ -39,5 +37,17 @@ export default {
 			default: false,
 		}
 	},
+	computed: {
+		fundingText() {
+			if (this.allSharesReserved) {
+				return 'Funding complete';
+			}
+			const formattedMoneyLeft = numeral(this.moneyLeft).format('$0,0[.]00');
+			const formattedTimeLeft = `${this.timeLeft !== '' ? `. ${this.timeLeft}` : ''}`;
+
+			const formatttedFundingText = `${formattedMoneyLeft} to go${formattedTimeLeft}`;
+			return 	formatttedFundingText;
+		}
+	}
 };
 </script>

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -1,12 +1,15 @@
 <template>
 	<figure>
-		<h4 class="tw-mb-0.5">
+		<h4 v-if="allSharesReserved">
+			Funding complete
+		</h4>
+		<h4 v-if="!allSharesReserved" class="tw-mb-0.5">
 			{{ moneyLeft | numeral('$0,0[.]00') }} to go{{ timeLeft !== '' ? `. ${timeLeft}` : '' }}
 		</h4>
 		<kv-progress-bar
 			class="tw-mb-1.5 lg:tw-mb-1"
 			aria-label="Percent the loan has funded"
-			:value="progressPercent * 100"
+			:value="`${ allSharesReserved ? 100 : (progressPercent * 100)}`"
 		/>
 	</figure>
 </template>
@@ -31,6 +34,10 @@ export default {
 			type: String,
 			default: '',
 		},
+		allSharesReserved: {
+			type: Boolean,
+			default: false,
+		}
 	},
 };
 </script>


### PR DESCRIPTION
Core-102 All shares reserved state of KivaClassicBasicLoanCard

When all shares are reserved we disable the button click, update the funding text to "Funding complete" and set the fundraising meter to 100%. 

Once we have the click interaction in place for the borrower image, that will also be disabled if allSharesReserved is true. 

Here it is:
<img width="361" alt="Screen Shot 2021-09-23 at 12 55 42 PM" src="https://user-images.githubusercontent.com/1521381/134568793-fa25c2c7-17ef-4b4d-8cfa-05af6df84b8b.png">
 
