### PR TITLE
Core-107 click interactions and tracking events for KivaClassicBasicL…

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -136,7 +136,7 @@
 			:to="`/lend/${loanId}`"
 			v-kv-track-event="['Lending', 'click-Read-more', 'Read more', loanId]"
 		>
-			Read more
+			Learn more
 			<kv-material-icon
 				class="tw-align-middle"
 				:icon="mdiChevronRight"

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -9,7 +9,7 @@
 			class="tw-mb-1 tw-rounded" :style="{width: '100%', height: '15.75rem'}"
 		/>
 
-		<!-- If allSharesReserved, disable link by make it a span -->
+		<!-- If allSharesReserved, disable link by making it a span -->
 		<router-link
 			:is="allSharesReserved ? 'span' : 'router-link'"
 			:to="`${!allSharesReserved ? `/lend/${loanId}` : diable}`"

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -15,11 +15,10 @@
 			<!-- If allSharesReserved, disable link by making it a span -->
 			<router-link
 				:is="allSharesReserved ? 'span' : 'router-link'"
-				:to="`${!allSharesReserved ? `/lend/${loanId}` : diable}`"
-				v-kv-track-event="['KivaClassicBasicLoanCard', 'click-borrower-image', loanId]"
+				:to="`/lend/${loanId}`"
+				v-kv-track-event="['Lending', 'click-Read more', 'Photo', loanId]"
 			>
 				<borrower-image
-					v-if="!isLoading"
 					class="
 					tw-relative
 					tw-w-full
@@ -41,7 +40,7 @@
 				/>
 				<div v-if="countryName">
 					<summary-tag
-						class="tw-absolute tw-bottom-2 tw-left-1"
+						class="tw-absolute tw-bottom-2 tw-left-1 tw-text-primary"
 						:city="city"
 						:state="state"
 						:country-name="countryName"
@@ -135,7 +134,7 @@
 			class="tw-mb-2"
 			:state="`${allSharesReserved ? 'disabled' : ''}`"
 			:to="`/lend/${loanId}`"
-			v-kv-track-event="['KivaClassicBasicLoanCard', 'click-Read-more-CTA-button', loanId]"
+			v-kv-track-event="['Lending', 'click-Read-more', 'Read more', loanId]"
 		>
 			Read more
 			<kv-material-icon

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -9,30 +9,32 @@
 			class="tw-mb-1 tw-rounded" :style="{width: '100%', height: '15.75rem'}"
 		/>
 
-		<!-- TODO: Once click interaction for this is in place, we need to disable the click
-		if allSharesReserved is true
-		ie.
-		:click="`${allSharesReserved ? 'correct redirect' : ''}`" -->
-		<borrower-image
-			v-if="!isLoading"
-			class="
+		<!-- Is there a way to display the click completely if allSharesAreReserved? -->
+		<router-link
+			:to="`${!allSharesReserved ? `/lend/${loanId}` : ''}`"
+			v-kv-track-event="['KivaClassicBasicLoanCard', 'click-borrower-image', loanId]"
+		>
+			<borrower-image
+				v-if="!isLoading"
+				class="
 				tw-w-full
 				tw-bg-black
 				tw-rounded
 			"
-			:alt="'photo of ' + borrowerName"
-			:aspect-ratio="3 / 4"
-			:default-image="{ width: 336 }"
-			:hash="imageHash"
-			:images="[
-				{ width: 336, viewSize: 1024 },
-				{ width: 336, viewSize: 768 },
-				{ width: 416, viewSize: 480 },
-				{ width: 374, viewSize: 414 },
-				{ width: 335, viewSize: 375 },
-				{ width: 280 },
-			]"
-		/>
+				:alt="'photo of ' + borrowerName"
+				:aspect-ratio="3 / 4"
+				:default-image="{ width: 336 }"
+				:hash="imageHash"
+				:images="[
+					{ width: 336, viewSize: 1024 },
+					{ width: 336, viewSize: 768 },
+					{ width: 416, viewSize: 480 },
+					{ width: 374, viewSize: 414 },
+					{ width: 335, viewSize: 375 },
+					{ width: 280 },
+				]"
+			/>
+		</router-link>
 
 		<!-- Borrower name-->
 		<kv-loading-placeholder
@@ -112,7 +114,8 @@
 			v-if="!isLoading"
 			class="tw-mb-2"
 			:state="`${allSharesReserved ? 'disabled' : ''}`"
-			:to="`/lend/${loan.loanId}`"
+			:to="`/lend/${loanId}`"
+			v-kv-track-event="['KivaClassicBasicLoanCard', 'click-Read-more-CTA', loanId]"
 		>
 			Read more
 			<kv-material-icon

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -136,7 +136,7 @@
 			:to="`/lend/${loanId}`"
 			v-kv-track-event="['Lending', 'click-Read-more', 'Read more', loanId]"
 		>
-			Learn more
+			View loan
 			<kv-material-icon
 				class="tw-align-middle"
 				:icon="mdiChevronRight"

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -9,18 +9,19 @@
 			class="tw-mb-1 tw-rounded" :style="{width: '100%', height: '15.75rem'}"
 		/>
 
-		<!-- Is there a way to display the click completely if allSharesAreReserved? -->
+		<!-- If allSharesReserved, disable link by make it a span -->
 		<router-link
-			:to="`${!allSharesReserved ? `/lend/${loanId}` : ''}`"
+			:is="allSharesReserved ? 'span' : 'router-link'"
+			:to="`${!allSharesReserved ? `/lend/${loanId}` : diable}`"
 			v-kv-track-event="['KivaClassicBasicLoanCard', 'click-borrower-image', loanId]"
 		>
 			<borrower-image
 				v-if="!isLoading"
 				class="
-				tw-w-full
-				tw-bg-black
-				tw-rounded
-			"
+					tw-w-full
+					tw-bg-black
+					tw-rounded
+				"
 				:alt="'photo of ' + borrowerName"
 				:aspect-ratio="3 / 4"
 				:default-image="{ width: 336 }"
@@ -115,7 +116,7 @@
 			class="tw-mb-2"
 			:state="`${allSharesReserved ? 'disabled' : ''}`"
 			:to="`/lend/${loanId}`"
-			v-kv-track-event="['KivaClassicBasicLoanCard', 'click-Read-more-CTA', loanId]"
+			v-kv-track-event="['KivaClassicBasicLoanCard', 'click-Read-more-CTA-button', loanId]"
 		>
 			Read more
 			<kv-material-icon


### PR DESCRIPTION
…oanCard

[Core-107](https://kiva.atlassian.net/browse/CORE-107)

- Click interaction added to borrower image by wrapping it in a router-link. 
      - There's a conditional in place that if allSharesReserved is true, we disable the < router-link > by converting it to a span tag.
- Tracking info added for borrower image click and "Read more" cta button click added based on spec in ticket. 

