### PR TITLE
core-110 added new optional kv-text-link to LoanUse.vue that directs …

### DIFF
--- a/src/components/BorrowerProfile/LoanUse.vue
+++ b/src/components/BorrowerProfile/LoanUse.vue
@@ -3,7 +3,6 @@
 		{{ loanUseFiltered }}
 		<kv-text-link
 			v-if="loanId"
-			class="tw-inline"
 			:to="`/lend/${loanId}`"
 			v-kv-track-event="['Lending', 'click-Read more', 'Learn more', loanId]"
 		>
@@ -63,7 +62,6 @@ export default {
 			// eslint-disable-next-line max-len
 			return loanUseFilter(this.use, this.name, this.status, this.loanAmount, this.borrowerCount, this.loanUseMaxLength);
 		},
-
 	}
 };
 

--- a/src/components/BorrowerProfile/LoanUse.vue
+++ b/src/components/BorrowerProfile/LoanUse.vue
@@ -1,10 +1,20 @@
 <template>
 	<p>
 		{{ loanUseFiltered }}
+		<kv-text-link
+			v-if="loanId"
+			class="tw-inline"
+			:to="`/lend/${loanId}`"
+			v-kv-track-event="['Lending', 'click-Read more', 'Learn more', loanId]"
+		>
+			Learn more
+		</kv-text-link>
 	</p>
 </template>
 
 <script>
+import KvTextLink from '~/@kiva/kv-components/vue/KvTextLink';
+
 const loanUseFilter = require('../../plugins/loan-use-filter');
 
 export default {
@@ -14,6 +24,9 @@ export default {
 				{ property: 'og:description', vmid: 'og:description', content: this.loanUseFiltered },
 			]
 		};
+	},
+	components: {
+		KvTextLink,
 	},
 	props: {
 		loanAmount: {
@@ -39,6 +52,10 @@ export default {
 		loanUseMaxLength: {
 			type: Number,
 			default: 0,
+		},
+		loanId: {
+			type: String,
+			default: '',
 		}
 	},
 	computed: {
@@ -46,6 +63,7 @@ export default {
 			// eslint-disable-next-line max-len
 			return loanUseFilter(this.use, this.name, this.status, this.loanAmount, this.borrowerCount, this.loanUseMaxLength);
 		},
+
 	}
 };
 

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -99,7 +99,7 @@
 			v-if="!isLoading"
 			class="tw-mb-2.5"
 			loan-use-max-length="52"
-			:loan-id="loanId"
+			:loan-id="`${allSharesReserved ? '' : loanId}`"
 			:use="loan.use"
 			:name="borrowerName"
 			:status="loan.status"

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -99,6 +99,7 @@
 			v-if="!isLoading"
 			class="tw-mb-2.5"
 			loan-use-max-length="52"
+			:loan-id="loanId"
 			:use="loan.use"
 			:name="borrowerName"
 			:status="loan.status"


### PR DESCRIPTION
…to borrower profile if a loanId is passed into <loan-use>

I added a new optional kv-text-link to LoanUse.vue that directs to the borrower profile if a loanId is passed into the < loan-use > component. Also added the condition that if allSharesReserved is true, pass through a blank string for the loanId, which hides the link to the loan as stated in core-111

Looks like this: 
<img width="365" alt="Screen Shot 2021-09-24 at 3 10 57 PM" src="https://user-images.githubusercontent.com/1521381/134740122-335da225-08df-4764-93d0-e85cc8875a36.png">

