### PR TITLE
Core 111

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -130,7 +130,7 @@
 		/>
 
 		<kv-button
-			v-if="!isLoading"
+			v-if="!isLoading && !allSharesReserved"
 			class="tw-mb-2"
 			:state="`${allSharesReserved ? 'disabled' : ''}`"
 			:to="`/lend/${loanId}`"
@@ -142,6 +142,21 @@
 				:icon="mdiChevronRight"
 			/>
 		</kv-button>
+
+		<!-- If allSharesReserved show message and hide cta button -->
+		<div
+			v-if="allSharesReserved"
+			class="
+				tw-rounded
+				tw-bg-brand-100
+				tw-text-center
+				tw-w-full
+				tw-py-1 tw-px-1.5
+				tw-mb-2 tw-mt-2
+			"
+		>
+			Another lender has selected this loan. Please choose a different borrower to support.
+		</div>
 	</div>
 </template>
 

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -6,7 +6,7 @@
 		<kv-progress-bar
 			class="tw-mb-1.5 lg:tw-mb-1"
 			aria-label="Percent the loan has funded"
-			:value="`${ allSharesReserved ? 100 : (progressPercent * 100)}`"
+			:value="progressPercent * 100"
 		/>
 	</figure>
 </template>
@@ -39,9 +39,6 @@ export default {
 	},
 	computed: {
 		fundingText() {
-			if (this.allSharesReserved) {
-				return 'Funding complete';
-			}
 			const formattedMoneyLeft = numeral(this.moneyLeft).format('$0,0[.]00');
 			const formattedTimeLeft = `${this.timeLeft !== '' ? `. ${this.timeLeft}` : ''}`;
 


### PR DESCRIPTION
[Core-111](https://kiva.atlassian.net/browse/CORE-111)

Updating the allSharesReserved state of the KivaClassicBasicLoanCard. 

- Removed previous implementation around changing the fundraising text to "Fully funded" and artificially setting the loan-progress-bar to 100%
- Added a new div in KivaClassicBasicLoanCard.vue with and allSharesReserved v-if condition, which contains the allSharesReserved messaging and looks like this. 
<img width="361" alt="Screen Shot 2021-09-24 at 3 38 03 PM" src="https://user-images.githubusercontent.com/1521381/134742894-ad5149ab-6461-421d-b7fa-7fcff4088aa2.png">

