### PR TITLE
Implement Contentful driven loan chanel selector and carousel.

### DIFF
--- a/src/components/Contentful/LoansByCategoryCarousel.vue
+++ b/src/components/Contentful/LoansByCategoryCarousel.vue
@@ -1,0 +1,78 @@
+<template>
+	<section-with-background-classic
+		:background-content="background"
+		:vertical-padding="verticalPadding"
+	>
+		<template #content>
+			<kv-page-container>
+				<div>
+					<kiva-classic-multi-category-carousel
+						:contentful-loan-channels="contentfulLoanChannels"
+						:loan-display-settings="loanDisplaySettings"
+					/>
+				</div>
+			</kv-page-container>
+		</template>
+	</section-with-background-classic>
+</template>
+
+<script>
+import contentfulStylesMixin from '@/plugins/contentful-ui-setting-styles-mixin';
+import KivaClassicMultiCategoryCarousel from '@/components/LoanCollections/KivaClassicMultiCategoryCarousel';
+import SectionWithBackgroundClassic from '@/components/Contentful/SectionWithBackgroundClassic';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
+
+export default {
+	components: {
+		KivaClassicMultiCategoryCarousel,
+		KvPageContainer,
+		SectionWithBackgroundClassic,
+	},
+	mixins: [contentfulStylesMixin],
+	props: {
+		/**
+		 * Content group content from Contentful
+		* */
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	data() {
+		return {
+
+		};
+	},
+	computed: {
+		/**
+		 * Extract Background content from Contentful
+		* */
+		background() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'background' : false;
+			});
+		},
+		/**
+		 * Extract Loan Channel settings from Contentful Ui Setting dataObject
+		* */
+		contentfulLoanChannels() {
+			const uiSetting = this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'uiSetting' : false;
+			});
+			return uiSetting?.dataObject?.loanChannels ?? [];
+		},
+		/**
+		 * Extract Loan Display settings from Contentful Ui Setting dataObject
+		* */
+		loanDisplaySettings() {
+			const uiSetting = this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'uiSetting' : false;
+			});
+			return {
+				loanLimit: uiSetting?.dataObject?.loanLimit ?? 1,
+				showViewMoreCard: uiSetting?.dataObject?.showViewMoreCard ?? false
+			};
+		}
+	}
+};
+</script>

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="kv-tailwind tw-w-[336px]"
+		class="kv-tailwind tw-min-w-[230px] tw-max-w-[374px]"
 		:id="`${loanId}-loan-card`"
 	>
 		<!-- Borrower image w/ location <summary-tag> -->
@@ -81,7 +81,7 @@
 
 		<!-- Contains amount to go and fundraising bar -->
 		<loan-progress-group
-			v-if="!ifLoading"
+			v-if="!isLoading"
 			class="tw-mb-2.5"
 			:money-left="unreservedAmount"
 			:progress-percent="fundraisingPercent"
@@ -98,7 +98,7 @@
 		<loan-use
 			v-if="!isLoading"
 			class="tw-mb-2.5"
-			loan-use-max-length="52"
+			:loan-use-max-length="52"
 			:use="loan.use"
 			:name="borrowerName"
 			:status="loan.status"

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -6,7 +6,7 @@
 		<kv-progress-bar
 			class="tw-mb-1.5 lg:tw-mb-1"
 			aria-label="Percent the loan has funded"
-			:value="`${ allSharesReserved ? 100 : (progressPercent * 100)}`"
+			:value="allSharesReserved ? 100 : (progressPercent * 100)"
 		/>
 	</figure>
 </template>

--- a/src/components/LoanCollections/KivaClassicLoanCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicLoanCarousel.vue
@@ -1,0 +1,215 @@
+<template>
+	<div class="tw-pt-4">
+		<transition name="kvfade">
+			<div
+				v-if="isLoading"
+				class="spinner"
+			>
+				<kv-loading-spinner />
+			</div>
+		</transition>
+
+		<kv-carousel
+			v-if="augmentedLoanIds.length > 0 && isVisible"
+			class="tw-w-full tw-overflow-visible md:tw-overflow-hidden"
+			:autoplay="false"
+			:embla-options="{
+				loop: false,
+				align: 'start'
+			}"
+			indicator-style="none"
+			:multiple-slides-visible="true"
+			slides-to-scroll="visible"
+			:slide-max-width="singleSlideWidth"
+			@interact-carousel="onInteractCarousel"
+		>
+			<template v-for="(loanId, index) in augmentedLoanIds" #[`slide${index}`]>
+				<!-- Show View more Card -->
+				<router-link
+					v-if="loanId === 3"
+					:key="`view-more-card-${loanId}`"
+					class="tw-flex tw-items-center tw-h-full tw-w-full hover:tw-bg-brand-50 tw-rounded"
+					:to="cleanUrl"
+					v-kv-track-event="[
+						'Homepage',
+						'click-carousel-view-all-category-loans',
+						`${viewAllLoansCategoryTitle}`]"
+				>
+					<div class="tw-w-full tw-text-center">
+						<h3>{{ viewAllLoansCategoryTitle }}</h3>
+					</div>
+				</router-link>
+
+				<!-- show loan card -->
+				<!-- TODO Re-implement card position analytics -->
+				<kiva-classic-basic-loan-card
+					v-else
+					:item-index="index"
+					:key="`loan-${loanId}`"
+					:loan-id="loanId"
+				/>
+			</template>
+		</kv-carousel>
+	</div>
+</template>
+
+<script>
+import KivaClassicBasicLoanCard from '@/components/LoanCards/KivaClassicBasicLoanCard';
+import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+import KvCarousel from '~/@kiva/kv-components/vue/KvCarousel';
+
+export default {
+	components: {
+		KvCarousel,
+		KvLoadingSpinner,
+		KivaClassicBasicLoanCard,
+	},
+	props: {
+		isLoggedIn: {
+			type: Boolean,
+			default: false
+		},
+		itemsInBasket: {
+			type: Array,
+			default: () => [],
+		},
+		isVisible: {
+			type: Boolean,
+			default: false
+		},
+		loanIds: {
+			type: Array,
+			default: () => [],
+		},
+		rowNumber: {
+			type: Number,
+			default: null
+		},
+		selectedChannel: {
+			type: Object,
+			default: () => {},
+		},
+		showViewMoreCard: {
+			type: Boolean,
+			default: false
+		},
+	},
+	data() {
+		return {
+			name: '',
+			id: 0,
+			url: '',
+		};
+	},
+	computed: {
+		isLoading() {
+			return this.augmentedLoanIds.length === 0 && this.isVisible;
+		},
+		augmentedLoanIds() {
+			const clonedLoanIds = [...this.loanIds];
+			// const promoCardId = 1;
+			// const loadMoreCardId = 2;
+			const viewMoreCardId = 3;
+			// TODO: splice if promoCard if active on row
+			// if (this.showPromoCard) {
+			// 	clonedLoanIds.splice(1, 0, promoCardId);
+			// }
+			// TODO: append loadMoreCard if active
+			// if (this.showLoadMoreCard) {
+			// 	clonedLoanIds.push(loadMoreCardId);
+			// 	return clonedLoanIds;
+			// }
+			// append viewMoreCard if active
+			if (this.showViewMoreCard) {
+				clonedLoanIds.push(viewMoreCardId);
+				return clonedLoanIds;
+			}
+			return clonedLoanIds;
+		},
+		cleanUrl() {
+			// Convert LoanChannel Url to use first path segment /lend-by-category instead of /lend
+			// grab last segment of url
+			const lastPathIndex = this.url.lastIndexOf('/');
+			const urlSegment = this.url.slice(lastPathIndex);
+			// ensure string type
+			let cleanUrl = String(urlSegment);
+
+			// empty url value for certain urls and if no url is passed in
+			if (
+				this.url.includes('loans-with-research-backed-impact') === true
+				|| this.url.includes('recently-viewed-loans') === true
+				|| this.url === '') {
+				cleanUrl = '';
+			}
+
+			// retain countries not lent to location in /lend
+			if (this.url.includes('new-countries-for-you')) {
+				return '/lend/countries-not-lent';
+			}
+
+			// special handling for CASH-794 Favorite Country row
+			if (this.url.includes('favorite-countries-link')) {
+				return this.url.replace('favorite-countries-link', '');
+			}
+
+			// otherwise transform to use /lend-by-category as root path
+			return `/lend-by-category${cleanUrl}`;
+		},
+		viewAllLoansCategoryTitle() {
+			return `View all ${this.cleanCategoryName(this.id)}`;
+		},
+		singleSlideWidth() {
+			const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
+			// handle tiny screens
+			if (viewportWidth < 414) {
+				return `${viewportWidth - 80}px`;
+			}
+			if (viewportWidth >= 414 && viewportWidth < 768) return '278px';
+			if (viewportWidth >= 768 && viewportWidth < 1024) return '336px';
+			return '336px';
+		},
+	},
+	watch: {
+		selectedChannel: {
+			handler(channel) {
+				this.name = channel?.name || '';
+				this.url = channel?.url || '';
+				this.id = channel?.id || '';
+			},
+			immediate: true,
+		},
+	},
+	methods: {
+		// TODO: consider deprecating in favor of Contentful controlled value similar to shortName
+		cleanCategoryName(categoryId) {
+			switch (categoryId) {
+				case 52:
+					return 'loans to women';
+				case 96:
+					return 'COVID-19 loans';
+				case 93:
+					return 'shelter loans';
+				case 89:
+					return 'arts loans';
+				case 87:
+					return 'agriculture loans';
+				case 102:
+					return 'technology loans';
+				case 4:
+					return 'education loans';
+				case 25:
+					return 'health loans';
+				case 32:
+					return 'loans to refugees and IDPs';
+				default:
+					// remove any text contained within square brackets, including the brackets
+					return String(this.name).replace(/\s\[.*\]/g, '');
+			}
+		},
+		// TODO: Review all tracking cateogries
+		onInteractCarousel(interaction) {
+			this.$kvTrackEvent('homepage', 'click-carousel-horizontal-scroll', interaction);
+		},
+	},
+};
+</script>

--- a/src/components/LoanCollections/KivaClassicLoanCategorySelector.vue
+++ b/src/components/LoanCollections/KivaClassicLoanCategorySelector.vue
@@ -1,0 +1,43 @@
+<template>
+	<div
+		class="tw-flex tw-justify-center tw-max-w-[700px] tw-flex-wrap tw-mx-auto"
+	>
+		<kv-button
+			class="tw-mx-1 tw-mb-3"
+			v-for="category in loanChannels" :key="category.id"
+			:variant="selectedChannel === category.id ? 'link' : 'ghost'"
+			@click="handleCategoryClick(category.id)"
+		>
+			{{ category.shortName }}
+		</kv-button>
+	</div>
+</template>
+
+<script>
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+
+export default {
+	components: {
+		KvButton,
+	},
+	props: {
+		/**
+		 * Array of loan channel data in an object
+		* */
+		loanChannels: {
+			type: Array,
+			default: () => [],
+		},
+		selectedChannel: {
+			type: Number,
+			default: 0
+		}
+	},
+	methods: {
+		handleCategoryClick(categoryId) {
+			this.$emit('handle-category-click', { categoryId });
+			return false;
+		}
+	}
+};
+</script>

--- a/src/components/LoanCollections/KivaClassicMultiCategoryCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicMultiCategoryCarousel.vue
@@ -1,0 +1,123 @@
+<template>
+	<div>
+		<kiva-classic-loan-category-selector
+			v-if="combinedLoanChannelData.length > 1"
+			:loan-channels="combinedLoanChannelData"
+			:selected-channel="selectedChannel.id"
+			@handle-category-click="handleCategoryClick"
+		/>
+		<kiva-classic-loan-carousel
+			:is-visible="showCarousel"
+			:loan-ids="selectedChannelLoanIds"
+			:selected-channel="selectedChannel"
+			:show-view-more-card="showViewMoreCard"
+		/>
+	</div>
+</template>
+
+<script>
+import gql from 'graphql-tag';
+import KivaClassicLoanCarousel from '@/components/LoanCollections/KivaClassicLoanCarousel';
+import KivaClassicLoanCategorySelector from '@/components/LoanCollections/KivaClassicLoanCategorySelector';
+
+export default {
+	inject: ['apollo', 'cookieStore'],
+	components: {
+		KivaClassicLoanCarousel,
+		KivaClassicLoanCategorySelector,
+	},
+	props: {
+		/**
+		 * Array of loan channel data in an object
+		 * ex. [{ id: 52, shortName: 'some short name' }]
+		* */
+		contentfulLoanChannels: {
+			type: Array,
+			default: () => [],
+		},
+		/**
+		 * Additional display settings
+		 * Possible Options:
+		 * loanLimit: integer that controls how many loans will be loaded for ALL channels
+		* */
+		loanDisplaySettings: {
+			type: Object,
+			default: () => {}
+		}
+	},
+	data() {
+		return {
+			loanChannelData: [],
+			selectedChannel: {},
+			showCarousel: false
+		};
+	},
+	computed: {
+		combinedLoanChannelData() {
+			return this.contentfulLoanChannels.map(channel => {
+				const matchedLoanChannel = this.loanChannelData.find(lc => lc.id === channel.id);
+				return { ...matchedLoanChannel, ...channel };
+			});
+		},
+		loanChannelIds() {
+			return this.contentfulLoanChannels.map(channelSetting => {
+				return channelSetting.id;
+			});
+		},
+		loanQueryLimit() {
+			return this.loanDisplaySettings?.loanLimit ?? 1;
+		},
+		selectedChannelLoanIds() {
+			const selectedChannel = this.combinedLoanChannelData.find(channel => {
+				return this.selectedChannel?.id === channel.id;
+			});
+			return selectedChannel?.loans?.values?.map(loan => loan.id) ?? [];
+		},
+		showViewMoreCard() {
+			return this.loanDisplaySettings?.showViewMoreCard ?? false;
+		}
+	},
+	mounted() {
+		this.fetchLoanChannel();
+	},
+	methods: {
+		handleCategoryClick(payload) {
+			this.selectedChannel = this.combinedLoanChannelData.find(
+				loanChannel => loanChannel.id === payload.categoryId
+			);
+		},
+		fetchLoanChannel() {
+			this.apollo.query({
+				query: gql`query selectedLoanCategory($loanChannelIds: [Int]!, $loanLimit: Int) {
+					lend {
+						loanChannelsById(ids: $loanChannelIds){
+							id
+							name
+							url
+							# description
+							loans(limit: $loanLimit) {
+								values {
+									id
+								}
+							}
+						}
+					}
+				}`,
+				variables: {
+					loanChannelIds: this.loanChannelIds,
+					loanLimit: this.loanQueryLimit
+				},
+			}).then(result => {
+				// Set All Active Loan Channels Data
+				const loanChannels = result?.data?.lend?.loanChannelsById ?? [];
+				this.loanChannelData = loanChannels;
+				// Activate the first channel available
+				const initialChannel = this.combinedLoanChannelData[0];
+				this.selectedChannel = initialChannel;
+				// Make the carousel visible
+				this.showCarousel = true;
+			});
+		},
+	}
+};
+</script>

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -84,6 +84,7 @@ const CenteredRichText = () => import('@/components/Contentful/CenteredRichText'
 const DynamicHero = () => import('@/components/Contentful/DynamicHero');
 const DynamicHeroClassic = () => import('@/components/Contentful/DynamicHeroClassic');
 const HeroWithCarousel = () => import('@/components/Contentful/HeroWithCarousel');
+const LoansByCategoryCarousel = () => import('@/components/Contentful/LoansByCategoryCarousel');
 
 const MonthlyGoodSelectorWrapper = () => import('@/components/MonthlyGood/MonthlyGoodSelectorWrapper');
 
@@ -126,6 +127,7 @@ const getWrapperClassFromType = type => {
 		case 'centeredRichText':
 		case 'dynamicHeroClassic':
 		case 'heroWithCarousel':
+		case 'loansByCategoryCarousel':
 		case 'monthlyGoodSelector':
 		case 'testimonialCards':
 		case 'richTextItemsCentered':
@@ -182,6 +184,8 @@ const getComponentFromType = type => {
 			return DynamicHeroClassic;
 		case 'heroWithCarousel':
 			return HeroWithCarousel;
+		case 'loansByCategoryCarousel':
+			return LoansByCategoryCarousel;
 		case 'richTextItemsCentered':
 			return RichTextItemsCentered;
 		default:


### PR DESCRIPTION
A variable set of loan channel ids and shortName fields are set in contentful. These are then used to generate the selector if there are more than 1 present in the array. The first loan channel is automatically loaded into a loan carousel.

Sample with existing Homepage Categories
![image](https://user-images.githubusercontent.com/1862756/134750981-f7fcd0b1-401b-489c-8964-dcda8d0e51a2.png)
