### PR TITLE
VUE-712 Prevent infinite loop in event tracking queue

### DIFF
--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -193,8 +193,14 @@ export default Vue => {
 				const item = queue.remove();
 				const method = item.eventType;
 				const { eventData } = item;
-				if (typeof kvActions[method] === 'function') {
-					kvActions[method](eventData, true);
+				if (inBrowser && typeof kvActions[method] === 'function') {
+					// Wrapping the event call in a setTimeout ensures that this while loop
+					// completes before the event functions are called. This is needed because
+					// the event functions can add more events to this queue, and we only want
+					// to process this queue once.
+					window.setTimeout(() => {
+						kvActions[method](eventData, true);
+					});
 				}
 			}
 		},


### PR DESCRIPTION
I encountered this bug this weekend on my home pc. Homepage would load but then lock up (frozen animations, no interactions working). Some digging with the javascript debugger revealed that this loop would never end if snowplow was not loaded. What happened is that each time a snowplow event would be removed, the track event function would be called, and because snowplow wasn't loaded the event would be added back to the queue, which caused the while loop to never stop because the queue was never empty. This fix makes it so that the track event functions aren't called until the loop has already finished, so even if events are added back to the queue the loop doesn't continue.

I'd like to try to get this into today's release.