### PR TITLE
feat: contentful button wrapper component

### DIFF
--- a/src/components/Contentful/ButtonWrapper.vue
+++ b/src/components/Contentful/ButtonWrapper.vue
@@ -1,0 +1,65 @@
+<template>
+	<kv-button
+		v-if="buttonText"
+		:href="buttonTo"
+		:variant="buttonStyle"
+		@click="buttonClick(buttonCustomEvent, $event)"
+		v-kv-track-event="buttonAnalytics"
+	>
+		{{ buttonText }}
+	</kv-button>
+</template>
+
+<script>
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+
+/**
+* Contentful Button Wrapper
+* Takes a contentful button content type parses button attributes and renders a button
+* */
+export default {
+	components: {
+		KvButton
+	},
+	props: {
+		/**
+		 * Contentful Button content object
+		* */
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	computed: {
+		buttonAnalytics() {
+			const contentfulAnaltyicsEvent = this.content?.analyticsClickEvent ?? null;
+			return contentfulAnaltyicsEvent;
+		},
+		buttonCustomEvent() {
+			return this.content?.webClickEventName ?? null;
+		},
+		buttonStyle() {
+			return this.content?.style ?? 'primary';
+		},
+		buttonText() {
+			return this.content?.label ?? null;
+		},
+		buttonTo() {
+			if (this.buttonCustomEvent) {
+				return undefined;
+			}
+			return this.content?.webLink ?? '';
+		},
+	},
+	methods: {
+		buttonClick(customEventName, event) {
+			if (customEventName) {
+				// Current behavior is to replace a button navigation if a custom event name is passed
+				event.stopPropagation();
+				// Emit root level event that any component can listen for
+				this.$root.$emit(customEventName);
+			}
+		},
+	}
+};
+</script>

--- a/src/components/Contentful/DynamicHeroClassic.vue
+++ b/src/components/Contentful/DynamicHeroClassic.vue
@@ -34,26 +34,15 @@
 							</kv-carousel>
 						</template>
 						<template v-if="isHeroImage">
-							<template v-if="buttonTo">
-								<router-link
-									:to="buttonTo"
-									v-kv-track-event="[
-										'Hero',
-										'click-hero-loancards',
-										heroMedia[0].description,
-									]"
-								>
-									<kv-contentful-img
-										v-if="heroMedia[0].url"
-										class="tw-block tw-mx-auto tw-mt-0 tw-mb-4 md:tw-mb-0"
-										:contentful-src="heroMedia[0].url"
-										:width="500"
-										fallback-format="jpg"
-										:alt="heroMedia[0].description"
-									/>
-								</router-link>
-							</template>
-							<template v-else>
+							<component
+								:is="buttonTo ? 'router-link' : 'span'"
+								:to="buttonTo"
+								v-kv-track-event="[
+									'Hero',
+									'click-hero-loancards',
+									heroMedia[0].description,
+								]"
+							>
 								<kv-contentful-img
 									v-if="heroMedia[0].url"
 									class="tw-block tw-mx-auto tw-mt-0 tw-mb-4 md:tw-mb-0"
@@ -62,30 +51,18 @@
 									fallback-format="jpg"
 									:alt="heroMedia[0].description"
 								/>
-							</template>
+							</component>
 						</template>
 						<template v-if="isResponsiveHeroImage && responsiveHeroImages.length">
-							<template v-if="buttonTo">
-								<router-link
-									:to="buttonTo"
-									v-kv-track-event="[
-										'Hero',
-										'click-hero-loancards',
-										responsiveHeroDescription,
-									]"
-								>
-									<kv-contentful-img
-										class="tw-block tw-mx-auto tw-mt-0 tw-mb-4 md:tw-mb-0"
-										:contentful-src="responsiveHeroImages[0].url"
-										:width="responsiveHeroImages[0].width"
-										:height="responsiveHeroImages[0].height"
-										fallback-format="jpg"
-										:alt="responsiveHeroDescription"
-										:source-sizes="responsiveHeroImages"
-									/>
-								</router-link>
-							</template>
-							<template v-else>
+							<component
+								:is="buttonTo ? 'router-link' : 'span'"
+								:to="buttonTo"
+								v-kv-track-event="[
+									'Hero',
+									'click-hero-loancards',
+									responsiveHeroDescription,
+								]"
+							>
 								<kv-contentful-img
 									class="tw-block tw-mx-auto tw-mt-0 tw-mb-4 md:tw-mb-0"
 									:contentful-src="responsiveHeroImages[0].url"
@@ -95,7 +72,7 @@
 									:alt="responsiveHeroDescription"
 									:source-sizes="responsiveHeroImages"
 								/>
-							</template>
+							</component>
 						</template>
 						<template v-if="isHeroVideo">
 							<video
@@ -130,16 +107,9 @@
 						<div v-if="heroBody" class="tw-prose tw-mb-2 md:tw-mb-3">
 							<dynamic-rich-text :html="heroBody" />
 						</div>
-						<kv-button
-							v-if="buttonText"
-							class="tw-w-full md:tw-w-auto"
-							:to="buttonTo"
-							:variant="buttonStyle"
-							@click.native="buttonClick"
-							v-kv-track-event="buttonAnalytics"
-						>
-							{{ buttonText }}
-						</kv-button>
+						<button-wrapper
+							:content="buttonContent"
+						/>
 					</div>
 				</kv-grid>
 			</kv-page-container>
@@ -152,7 +122,7 @@ import contentfulStylesMixin from '@/plugins/contentful-ui-setting-styles-mixin'
 import SectionWithBackgroundClassic from '@/components/Contentful/SectionWithBackgroundClassic';
 import { richTextRenderer } from '@/util/contentful/richTextRenderer';
 import DynamicRichText from '@/components/Contentful/DynamicRichText';
-import KvButton from '~/@kiva/kv-components/vue/KvButton';
+import ButtonWrapper from '@/components/Contentful/ButtonWrapper';
 import KvContentfulImg from '~/@kiva/kv-components/vue/KvContentfulImg';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
@@ -166,7 +136,7 @@ import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 
 export default {
 	components: {
-		KvButton,
+		ButtonWrapper,
 		KvCarousel: () => import('@/components/Kv/KvCarousel'),
 		KvCarouselSlide: () => import('@/components/Kv/KvCarouselSlide'),
 		DynamicRichText,
@@ -191,26 +161,12 @@ export default {
 				return contentType ? contentType === 'background' : false;
 			});
 		},
-		buttonAnalytics() {
-			const defaults = ['Hero', 'click-hero-cta', this.buttonText];
-			const contentfulAnaltyicsEvent = this.buttonContent?.analyticsClickEvent ?? null;
-			return contentfulAnaltyicsEvent || defaults;
-		},
 		buttonContent() {
 			return this.content?.contents?.find(({ contentType }) => {
 				return contentType ? contentType === 'button' : false;
 			});
 		},
-		buttonStyle() {
-			return this.buttonContent?.style ?? 'primary';
-		},
-		buttonText() {
-			return this.buttonContent?.label ?? null;
-		},
 		buttonTo() {
-			if (this.$attrs?.customEventName) {
-				return '';
-			}
 			return this.buttonContent?.webLink ?? '';
 		},
 		genericContentBlock() {
@@ -304,16 +260,5 @@ export default {
 			return imageSet?.description ?? '';
 		},
 	},
-	methods: {
-		buttonClick(event) {
-			const customEventName = this.$attrs?.customEventName ?? null;
-			if (customEventName) {
-				// Current behavior is to replace a button navigation if a custom event name is passed
-				event.stopPropagation();
-				// Emit root level event that any component can listen for
-				this.$root.$emit(customEventName);
-			}
-		},
-	}
 };
 </script>

--- a/src/components/Contentful/DynamicHeroClassic.vue
+++ b/src/components/Contentful/DynamicHeroClassic.vue
@@ -37,11 +37,11 @@
 							<component
 								:is="buttonTo ? 'router-link' : 'span'"
 								:to="buttonTo"
-								v-kv-track-event="[
+								v-kv-track-event="buttonTo ? [
 									'Hero',
 									'click-hero-loancards',
 									heroMedia[0].description,
-								]"
+								] : null"
 							>
 								<kv-contentful-img
 									v-if="heroMedia[0].url"
@@ -57,11 +57,11 @@
 							<component
 								:is="buttonTo ? 'router-link' : 'span'"
 								:to="buttonTo"
-								v-kv-track-event="[
+								v-kv-track-event="buttonTo ? [
 									'Hero',
 									'click-hero-loancards',
 									responsiveHeroDescription,
-								]"
+								] : null"
 							>
 								<kv-contentful-img
 									class="tw-block tw-mx-auto tw-mt-0 tw-mb-4 md:tw-mb-0"
@@ -108,6 +108,7 @@
 							<dynamic-rich-text :html="heroBody" />
 						</div>
 						<button-wrapper
+							class="tw-w-full md:tw-w-auto"
 							:content="buttonContent"
 						/>
 					</div>

--- a/src/components/Contentful/DynamicRichText.vue
+++ b/src/components/Contentful/DynamicRichText.vue
@@ -16,19 +16,10 @@ export default {
 				template: `<div class="tw-prose tw-whitespace-pre-wrap">${this.html}</div>`,
 				components: {
 					KvContentfulImg: () => import('~/@kiva/kv-components/vue/KvContentfulImg'),
-					KvButton: () => import('~/@kiva/kv-components/vue/KvButton')
+					ButtonWrapper: () => import('@/components/Contentful/ButtonWrapper')
 				},
-				props: [
-					/* define props as needed */
-				],
-				methods: {
-					buttonClick(customEventName, event) {
-						// Current behavior is to replace a button navigation if a custom event name is passed
-						event.stopPropagation();
-						// Emit root level event that any component can listen for
-						this.$root.$emit(customEventName);
-					},
-				}
+				props: {
+				},
 			};
 		},
 	},
@@ -38,8 +29,7 @@ export default {
 			[
 				createElement(this.dynamicComponent, {
 					props: {
-						/* pass prop values as needed */
-					}
+					},
 				})
 			]
 		);

--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -340,7 +340,7 @@ export default Vue => {
 	Vue.directive('kv-track-event', {
 		bind: (el, binding) => {
 			// TODO: add arg for once, submit + change events
-			if (typeof el === 'object') {
+			if (typeof el === 'object' && binding.value) {
 				el.addEventListener('click', () => {
 					try {
 						kvActions.parseEventProperties(binding.value);

--- a/src/util/contentful/richTextRenderer.js
+++ b/src/util/contentful/richTextRenderer.js
@@ -58,31 +58,11 @@ export function richTextRenderer(content) {
 		const isButton = contentfulEntryNode?.data?.target?.sys?.contentType?.sys?.id === 'button';
 		if (isRichTextContent) {
 			const richTextHTML = richTextRenderer(contentfulEntryNode?.data?.target?.fields?.richText);
-			return `
-				<div class="tw-prose tw-whitespace-pre-wrap">${richTextHTML}</div>
-			`;
+			return `<div>${richTextHTML}</div>`;
 		}
 		if (isButton) {
-			const analyticsClickEvent = contentfulEntryNode?.data?.target?.fields?.analyticsClickEvent;
-			const webClickEventName = contentfulEntryNode?.data?.target?.fields?.webClickEventName;
-
-			const analyticsDirective = () => {
-				return analyticsClickEvent ? `v-kv-track-event="['${analyticsClickEvent.join("','")}']"` : '';
-			};
-
-			const clickFunctionality = () => {
-				if (webClickEventName) {
-					return `@click="buttonClick('${webClickEventName}', $event)"`;
-				}
-				return `href="${contentfulEntryNode?.data?.target?.fields?.webLink ?? '#'}"`;
-			};
-			return `
-				<kv-button
-					variant="${contentfulEntryNode?.data?.target?.fields?.style ?? 'primary'}"
-					${analyticsDirective()}
-					${clickFunctionality()}
-				>${contentfulEntryNode?.data?.target?.fields?.label ?? ''}</kv-button>
-			`;
+			const buttonObject = JSON.stringify(contentfulEntryNode?.data?.target?.fields).replace(/"/g, '\'');
+			return `<button-wrapper class="tw-whitespace-normal" :content="${buttonObject}"/>`;
 		}
 		return '';
 	};
@@ -97,7 +77,10 @@ export function richTextRenderer(content) {
 			},
 			[BLOCKS.EMBEDDED_ASSET]: node => {
 				return assetRenderer(node?.data?.target?.fields);
-			}
+			},
+			[BLOCKS.DOCUMENT]: (node, next) => {
+				return `<div class="tw-prose tw-whitespace-pre-wrap">${next(node.content)}</div>`;
+			},
 		}
 	};
 	return documentToHtmlString(content, options);

--- a/tailwind.purge.safelist.txt
+++ b/tailwind.purge.safelist.txt
@@ -60,3 +60,7 @@ tw-text-subhead
 tw-text-base
 tw-text-small
 tw-text-link
+
+# Whitespace Classes
+tw-whitespace-normal
+tw-whitespace-pre-wrap


### PR DESCRIPTION
* Refactor button handling in DynamicHeroClassic
* Add new component
* Enable buttons to be rendered from contentful, inside of both RTF's and as items in content with support for global event handlers (like openMonthlyGoodSelector)

Sample page that uses buttons inside RTF's - /design
Sample using buttons as content items /lp/homepage-classic

VUE-713