### PR TITLE
Core-129 Only show matching text if loan has a matchingText associate…

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -115,7 +115,7 @@
 		/>
 
 		<loan-matching-text
-			v-if="!isLoading"
+			v-if="!isLoading && loan.matchingText !== ''"
 			class="tw-mb-1.5"
 			:matcher-name="loan.matchingText"
 			:match-ratio="loan.matchRatio"
@@ -241,6 +241,7 @@ const loanQuery = gql`query kcBasicLoanCard($basketId: String, $loanId: Int!) {
 			fundraisingTimeLeft @client
 
 			# for matching-text component
+			isMatchable
 			matchingText
 			matchRatio
 		}


### PR DESCRIPTION
…d to it
[Core-129](https://kiva.atlassian.net/browse/CORE-129)

The loan cards look good in a row! Once I saw them rendered out on the /lp/homepage-classic page though I noticed the matching text was showing for all loans. This change conditionally shows the matching text based on the presences of the matchingText field for the loan. 

