### PR TITLE
fix: bottom CTA global event on desktop

### DIFF
--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -41,6 +41,7 @@
 				]"
 				:style="{ bottom: mgStickBarOffset + 'px' }"
 				v-show="hasScrolled"
+				v-if="isMobile"
 			>
 				<monthly-good-selector-mobile
 					:pre-selected-category="preSelectedCategory"
@@ -77,7 +78,8 @@ export default {
 			isSticky: false,
 			initialBottomPosition: 0,
 			mgStickBarOffset: 0,
-			hasScrolled: false
+			hasScrolled: false,
+			isMobile: false
 		};
 	},
 	mixins: [
@@ -109,9 +111,15 @@ export default {
 			// Check setting to make sure it is an actual category or return null
 			// Must return null (no preselected category) or a valid category object
 			return this.lendingCategories.find(({ value }) => value === this.preSelectedCategorySetting) ?? null;
-		}
+		},
 	},
 	methods: {
+		// this is required to prevent global events which may trigger
+		// opening the invisible lightbox in the mobile MG selector.
+		// which may have unwanted consequences with the page scroll
+		determineIfMobile() {
+			this.isMobile = document.documentElement.clientWidth < 735;
+		},
 		// Determine if MG desktop selector should be sticky or not
 		onScroll() {
 			if ((document.documentElement.scrollTop + window.innerHeight) <= this.initialBottomPosition) {
@@ -163,6 +171,7 @@ export default {
 		});
 		window.removeEventListener('resize', _throttle(() => {
 			this.initStickyBehavior();
+			this.determineIfMobile();
 		}, 200));
 	},
 	mounted() {
@@ -172,6 +181,7 @@ export default {
 		});
 		window.addEventListener('resize', _throttle(() => {
 			this.initStickyBehavior();
+			this.determineIfMobile();
 		}, 200));
 
 		this.initStickyBehavior();


### PR DESCRIPTION
The global event used on the cause based landing pages is firing an event that is being captured by both the desktop and mobile monthly good selector. 

On the mobile selector, even though the wrapper is hidden on desktop, the lightbox still triggers, causing it to open , which is causing some print overflow classes to be applied to the body which is locking the page scroll 

GD-128