### PR TITLE
core-108 setting faceZoom value on images, gets the correct sizes ret…

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -32,11 +32,11 @@
 					:default-image="{ width: 336 }"
 					:hash="imageHash"
 					:images="[
-						{ width: 336, faceZoom: 0.7, viewSize: 1024 },
-						{ width: 336, faceZoom: 0.7, viewSize: 768 },
-						{ width: 416, faceZoom: 0.7, viewSize: 480 },
-						{ width: 374, faceZoom: 0.7, viewSize: 414 },
-						{ width: 335, faceZoom: 0.7, viewSize: 375 },
+						{ width: 336, faceZoom: 1, viewSize: 1024 },
+						{ width: 336, faceZoom: 1, viewSize: 768 },
+						{ width: 416, faceZoom: 1, viewSize: 480 },
+						{ width: 374, faceZoom: 1, viewSize: 414 },
+						{ width: 335, faceZoom: 1, viewSize: 375 },
 						{ width: 280 },
 					]"
 				/>

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -25,17 +25,18 @@
 					tw-w-full
 					tw-bg-black
 					tw-rounded
+					tw-object-contain
 				"
 					:alt="'photo of ' + borrowerName"
 					:aspect-ratio="3 / 4"
 					:default-image="{ width: 336 }"
 					:hash="imageHash"
 					:images="[
-						{ width: 336, viewSize: 1024 },
-						{ width: 336, viewSize: 768 },
-						{ width: 416, viewSize: 480 },
-						{ width: 374, viewSize: 414 },
-						{ width: 335, viewSize: 375 },
+						{ width: 336, faceZoom: 0.7, viewSize: 1024 },
+						{ width: 336, faceZoom: 0.7, viewSize: 768 },
+						{ width: 416, faceZoom: 0.7, viewSize: 480 },
+						{ width: 374, faceZoom: 0.7, viewSize: 414 },
+						{ width: 335, faceZoom: 0.7, viewSize: 375 },
 						{ width: 280 },
 					]"
 				/>


### PR DESCRIPTION
…urned

[Core-108](https://kiva.atlassian.net/browse/CORE-108) 

**Before changes:** 
<img width="1127" alt="Screen Shot 2021-09-28 at 3 38 09 PM" src="https://user-images.githubusercontent.com/1521381/135169495-fa6924cc-86fb-4b55-a49d-51ddd189a12e.png">

**After changes:**
![Screen Shot 2021-09-28 at 3 39 13 PM](https://user-images.githubusercontent.com/1521381/135169512-aedb9186-6805-4a08-ade3-18d88ec0135c.png)

I was able to get the correctly sized images returned only when I had an optional 'faceZoom' value set on the images that were being requested. @emuvente Do you have any insight as to why we wouldn't be getting the correctly sized images with the code that was previously in place? Additionally, now with the faceZoom value, a few of the returned images are zooming in on the borrower's torso. In this example, they are both wearing a lot of patterned fabric, perhaps those are being mis-identified as faces in these cases? Is there a way to correct that? 

Example: 
![Screen Shot 2021-09-28 at 3 39 55 PM](https://user-images.githubusercontent.com/1521381/135169948-a4c730f6-4f90-4524-92a0-8511b5d16a88.png)

