### PR TITLE
Add background color (powered by hex code selected in Contentful) to …

### DIFF
--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -6,7 +6,10 @@
 			:theme="headerTheme"
 		/>
 		<slot name="secondary"></slot>
-		<main :class="mainClasses">
+		<main
+			:class="mainClasses"
+			:style="backgroundColor ? `background-color: ${backgroundColor};` : ''"
+		>
 			<slot name="tertiary"></slot>
 			<slot></slot>
 		</main>
@@ -47,6 +50,10 @@ export default {
 		appInstallMixin
 	],
 	props: {
+		backgroundColor: {
+			type: String,
+			default: null
+		},
 		grayBackground: {
 			type: Boolean,
 			default: false,

--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -6,10 +6,7 @@
 			:theme="headerTheme"
 		/>
 		<slot name="secondary"></slot>
-		<main
-			:class="mainClasses"
-			:style="backgroundColor ? `background-color: ${backgroundColor};` : ''"
-		>
+		<main :class="mainClasses">
 			<slot name="tertiary"></slot>
 			<slot></slot>
 		</main>
@@ -50,10 +47,6 @@ export default {
 		appInstallMixin
 	],
 	props: {
-		backgroundColor: {
-			type: String,
-			default: null
-		},
 		grayBackground: {
 			type: Boolean,
 			default: false,
@@ -127,5 +120,19 @@ export default {
 			background: $kiva-bg-lightgray;
 		}
 	}
+}
+</style>
+
+<style lang="scss" scoped>
+.tw-bg-primary {
+	background-color: rgb(var(--bg-primary));
+}
+
+.tw-bg-secondary {
+	background-color: rgb(var(--bg-secondary));
+}
+
+.tw-bg-tertiary {
+	background-color: rgb(var(--bg-tertiary));
 }
 </style>

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -2,7 +2,7 @@
 	<component :is="pageFrame"
 		:header-theme="headerTheme"
 		:footer-theme="footerTheme"
-		:background-color="pageBackgroundColor"
+		:main-class="pageBackgroundColor"
 	>
 		<template v-if="!pageError">
 			<component
@@ -294,7 +294,7 @@ export default {
 				this.pageError = true;
 			} else {
 				this.title = (pageData?.page?.pageLayout?.pageTitle || pageData?.page?.pageTitle) ?? undefined;
-				this.pageBackgroundColor = pageData?.page?.pageLayout?.pageBackgroundColor ?? undefined;
+				this.pageBackgroundColor = pageData?.page?.pageLayout?.pageBackgroundColor ?? '';
 				this.headerTheme = siteThemes[pageData?.page?.pageLayout?.headerTheme] || {};
 				this.footerTheme = siteThemes[pageData?.page?.pageLayout?.footerTheme] || {};
 				this.pageFrame = getPageFrameFromType(pageData?.page?.pageType);

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -2,6 +2,7 @@
 	<component :is="pageFrame"
 		:header-theme="headerTheme"
 		:footer-theme="footerTheme"
+		:background-color="pageBackgroundColor"
 	>
 		<template v-if="!pageError">
 			<component
@@ -230,6 +231,7 @@ export default {
 	inject: ['apollo', 'cookieStore'],
 	data() {
 		return {
+			pageBackgroundColor: '',
 			contentGroups: [],
 			footerTheme: {},
 			headerTheme: {},
@@ -292,6 +294,7 @@ export default {
 				this.pageError = true;
 			} else {
 				this.title = (pageData?.page?.pageLayout?.pageTitle || pageData?.page?.pageTitle) ?? undefined;
+				this.pageBackgroundColor = pageData?.page?.pageLayout?.pageBackgroundColor ?? undefined;
 				this.headerTheme = siteThemes[pageData?.page?.pageLayout?.headerTheme] || {};
 				this.footerTheme = siteThemes[pageData?.page?.pageLayout?.footerTheme] || {};
 				this.pageFrame = getPageFrameFromType(pageData?.page?.pageType);

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -418,6 +418,7 @@ export function processPageContent(entryItem) {
 		pageLayout: {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
+			pageBackgroundColor: entryItem.fields?.pageLayout?.fields?.pageBackgroundColor,
 			headerTheme: entryItem.fields?.pageLayout?.fields?.headerTheme,
 			footerTheme: entryItem.fields?.pageLayout?.fields?.footerTheme,
 		},

--- a/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
+++ b/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
@@ -62,6 +62,7 @@
 			},
 			"fields": {
 				"name": "Promo Campaign Test",
+				"pageBackgroundColor": "",
 				"headerTheme": "lightHeader",
 				"contentGroups": [{
 					"sys": {

--- a/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
+++ b/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
@@ -62,7 +62,6 @@
 			},
 			"fields": {
 				"name": "Promo Campaign Test",
-				"pageBackgroundColor": "",
 				"headerTheme": "lightHeader",
 				"contentGroups": [{
 					"sys": {

--- a/test/unit/specs/util/contentfulUtils.spec.js
+++ b/test/unit/specs/util/contentfulUtils.spec.js
@@ -118,7 +118,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
-					pageBackgroundColor: '',
+					pageBackgroundColor: undefined,
 					headerTheme: 'lightHeader',
 					contentGroups: [{}],
 					footerTheme: undefined,
@@ -139,7 +139,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
-					pageBackgroundColor: '',
+					pageBackgroundColor: undefined,
 					headerTheme: 'lightHeader',
 					contentGroups: [{
 						key: 'promo-campaign-test-cg',

--- a/test/unit/specs/util/contentfulUtils.spec.js
+++ b/test/unit/specs/util/contentfulUtils.spec.js
@@ -118,6 +118,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
+					pageBackgroundColor: '',
 					headerTheme: 'lightHeader',
 					contentGroups: [{}],
 					footerTheme: undefined,
@@ -138,6 +139,7 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
+					pageBackgroundColor: '',
 					headerTheme: 'lightHeader',
 					contentGroups: [{
 						key: 'promo-campaign-test-cg',


### PR DESCRIPTION
…WwwPage via ContentfulPage.

The Page Layout content model in Contentful now has a color picker coupled with validation! You can select only 3 hex codes at this time to pass that validation: #ffffff, #f5f5f5, #e0e0e0.

We originally were going to have a dropdown of acceptable tailwind classes but due to the need of a wrapping kv-tailwind class we couldn't do that just yet.