### PR TITLE
VUE-715 flss form control fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@godaddy/terminus": "^4.4.1",
 				"@graphql-tools/load": "^6.2.4",
 				"@graphql-tools/url-loader": "^6.3.0",
-				"@kiva/kv-components": "^0.21.1",
+				"@kiva/kv-components": "^0.21.4",
 				"@kiva/kv-tokens": "^0.12.0",
 				"@mdi/js": "^5.9.55",
 				"@sentry/browser": "^5.21.1",
@@ -3814,9 +3814,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.21.1.tgz",
-			"integrity": "sha512-f63pAEaknJCko8E6VtATKFGqiFkYBLs8ufYyRC0mJZu3Xc1EvV5EX7/b5rSbHMuRH1EWdpMNoDwXXSB5QXWHMQ==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.21.4.tgz",
+			"integrity": "sha512-ZYxut/OAJEGk/mzDh1YzM2OFUbw1Vmu33Ovw02r9J0kklIuy+scdLbQMF0jnk/FCWEUW/DTrX139D7QqEEnSFw==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^0.12.0",
 				"@mdi/js": "^5.9.55",
@@ -43925,9 +43925,9 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.21.1.tgz",
-			"integrity": "sha512-f63pAEaknJCko8E6VtATKFGqiFkYBLs8ufYyRC0mJZu3Xc1EvV5EX7/b5rSbHMuRH1EWdpMNoDwXXSB5QXWHMQ==",
+			"version": "0.21.4",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-0.21.4.tgz",
+			"integrity": "sha512-ZYxut/OAJEGk/mzDh1YzM2OFUbw1Vmu33Ovw02r9J0kklIuy+scdLbQMF0jnk/FCWEUW/DTrX139D7QqEEnSFw==",
 			"requires": {
 				"@kiva/kv-tokens": "^0.12.0",
 				"@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@godaddy/terminus": "^4.4.1",
 		"@graphql-tools/load": "^6.2.4",
 		"@graphql-tools/url-loader": "^6.3.0",
-		"@kiva/kv-components": "^0.21.1",
+		"@kiva/kv-components": "^0.21.4",
 		"@kiva/kv-tokens": "^0.12.0",
 		"@mdi/js": "^5.9.55",
 		"@sentry/browser": "^5.21.1",

--- a/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
+++ b/src/pages/Lend/FilterAlpha/LendFilterAlpha.vue
@@ -74,7 +74,7 @@
 									name="sectorBox.name"
 									v-model="sector"
 									:key="sectorBox.id"
-									:checked="false"
+									:value="sectorBox.name"
 								>
 									{{ sectorBox.name }}
 								</kv-checkbox>


### PR DESCRIPTION
Fixes a binding and pulls in latest KvComponents to support arrays in checkboxes + label/input id fix.


KvComponents changelog:
0.21.4 (2021-09-30)
KvCheckbox, KvRadio, KvSwitch: Avoid SSR problems when setting the UUID (ff55726)

0.21.3 (2021-09-30)
KvCheckbox: Background color now reliably changes when checkbox is clicked (fc509b2)

0.21.2 (2021-09-30)
KvCheckbox: Allow checkboxes to use an array in v-model (39b2e92)

0.21.1 (2021-09-28)
KvButton: prevent underline on focus when button is an anchor tag (10199ba)
KvCarousel: Use themable class names. Change to low-opacity instead of text-color for disabled state. (6aa9f0d)