### PR TITLE
Ensure theme wrapper expands cards and remove min-heights which preve…

### DIFF
--- a/src/components/Contentful/StoryCard.vue
+++ b/src/components/Contentful/StoryCard.vue
@@ -1,5 +1,5 @@
 <template>
-	<kv-theme-provider :theme="theme">
+	<kv-theme-provider :theme="theme" class="tw-h-full">
 		<div
 			class="
 				overflow-hidden
@@ -133,13 +133,6 @@ export default {
 	.story-card,
 	.story-card__imageCard {
 		border-radius: 2.5rem;
-		min-height: 550px;
-		@include breakpoint(medium) {
-			min-height: 600px;
-		}
-		@include breakpoint(large) {
-			min-height: 720px;
-		}
 	}
 
 	.story-card__imageCard {


### PR DESCRIPTION
…nt content based relational sizing.

This ensures cards all have the same height alongside one another which was broken on the MG cause pages and the cause pages.