### PR TITLE
 Core-48 Centered partner logos fed from contentful.

### DIFF
--- a/src/components/Contentful/MediaItemsCentered.vue
+++ b/src/components/Contentful/MediaItemsCentered.vue
@@ -1,0 +1,76 @@
+<template>
+	<section-with-background-classic
+		:background-content="sectionBackground"
+		:vertical-padding="verticalPadding"
+	>
+		<template #content>
+			<kv-page-container>
+				<kv-grid
+					:style="customGridStyles"
+					class="tw-grid-cols-12 lg:tw-grid-cols-10 lg:tw-gap-y-4
+						tw-justify-items-center tw-text-center tw-rounded tw-bg-white
+						tw-py-5 lg:tw-px-[177px]"
+				>
+					<span
+						v-for="(item, index) in contentfulMediaItems"
+						:key="index"
+						class="tw-flex tw-justify-items-center tw-items-center tw-mb-2"
+						:class="[itemClasses, {
+							'md:tw-col-span-12': index === 9
+						}]"
+					>
+						<kv-contentful-img
+							:contentful-src="item.file.url"
+							:alt="item.file.description"
+							:width="item.file.details.image.width"
+							:height="item.file.details.image.height"
+							:style="maxWidthStyles"
+						/>
+					</span>
+				</kv-grid>
+			</kv-page-container>
+		</template>
+	</section-with-background-classic>
+</template>
+
+<script>
+import SectionWithBackgroundClassic from '@/components/Contentful/SectionWithBackgroundClassic';
+import contentfulStylesMixin from '@/plugins/contentful-ui-setting-styles-mixin';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
+import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
+import KvContentfulImg from '~/@kiva/kv-components/vue/KvContentfulImg';
+
+export default {
+	components: {
+		KvGrid,
+		KvPageContainer,
+		SectionWithBackgroundClassic,
+		KvContentfulImg,
+	},
+	mixins: [contentfulStylesMixin],
+	props: {
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	computed: {
+		sectionBackground() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'background' : false;
+			});
+		},
+		contentfulMediaItems() {
+			const mediaItemsContentfulData = this.content?.media ?? [];
+			console.log('length', mediaItemsContentfulData.length);
+			return mediaItemsContentfulData;
+		},
+		itemClasses() {
+			return ['tw-col-span-6', {
+				'md:tw-col-span-4': this.contentfulMediaItems.length >= 6,
+				'lg:tw-col-span-2': this.contentfulMediaItems.length >= 6,
+			}];
+		}
+	}
+};
+</script>

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -97,6 +97,8 @@ const TestimonialCards = () => import('@/components/Contentful/TestimonialCards'
 
 const RichTextItemsCentered = () => import('@/components/Contentful/RichTextItemsCentered');
 
+const MediaItemsCentered = () => import('@/components/Contentful/MediaItemsCentered');
+
 // Get the Contentful Page data from the data of an Apollo query result
 const getPageData = data => {
 	const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
@@ -135,6 +137,7 @@ const getWrapperClassFromType = type => {
 		case 'monthlyGoodSelector':
 		case 'testimonialCards':
 		case 'richTextItemsCentered':
+		case 'mediaItemsCentered':
 		case 'frequentlyAskedQuestions':
 			return 'kv-tailwind';
 		default:
@@ -194,6 +197,8 @@ const getComponentFromType = type => {
 			return LoansByCategoryCarousel;
 		case 'richTextItemsCentered':
 			return RichTextItemsCentered;
+		case 'mediaItemsCentered':
+			return MediaItemsCentered;
 		default:
 			logFormatter(`ContenfulPage: Unknown content group type "${type}"`, 'error');
 			return null;


### PR DESCRIPTION
[Core-48](https://kiva.atlassian.net/browse/CORE-48)

Partner logos section

**Mobile:** 
![Screen Shot 2021-09-30 at 7 31 28 PM](https://user-images.githubusercontent.com/1521381/135552122-7322355d-7412-4df0-8208-94a5233e2118.png)


**Tablet:** 
![Screen Shot 2021-09-30 at 7 31 09 PM](https://user-images.githubusercontent.com/1521381/135552145-3ccabd1e-3771-4067-8d1c-e69d5b3f425c.png)

**Desktop:**
![Screen Shot 2021-09-30 at 7 31 47 PM](https://user-images.githubusercontent.com/1521381/135552197-bb6d4416-6951-4fb8-b681-7e3ef2dc8ba6.png)

