### PR TITLE
fix: sets index of loanCarousel to 0 when new category is clicked, al…

### DIFF
--- a/src/components/LoanCollections/KivaClassicLoanCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicLoanCarousel.vue
@@ -15,6 +15,7 @@
 			:embla-options="{
 				loop: false,
 			}"
+			ref="categoryCarousel"
 			:multiple-slides-visible="true"
 			slides-to-scroll="visible"
 			:slide-max-width="singleSlideWidth"
@@ -173,6 +174,13 @@ export default {
 				this.name = channel?.name || '';
 				this.url = channel?.url || '';
 				this.id = channel?.id || '';
+				if (this.$refs && this.$refs.categoryCarousel) {
+					// Scroll the first slide when swtiching categories
+					this.$refs.categoryCarousel.goToSlide(0);
+					// Reinitailize the category, to ensure proper number of indexes
+					// are displayed on the frontend
+					this.$refs.categoryCarousel.reInit();
+				}
 			},
 			immediate: true,
 		},


### PR DESCRIPTION
…so re-initializes to ensure proper number of indexes is displayed below category arrow

- [Core-136](https://kiva.atlassian.net/browse/CORE-136)
     - When user chooses new category, loan cards are staying on previously scrolled to index.
     - FIXED by setting the index to 0 by calling goToIndex() in KvCarousel
- [Core-137](https://kiva.atlassian.net/browse/CORE-137)
     - On production, if one category has 4 carousel clicks of loans then 4 will show for all categories even if that category only has 2 "carousel clicks. 
     - Results in this error: 
     - <img width="1084" alt="Screen Shot 2021-10-04 at 2 13 32 PM" src="https://user-images.githubusercontent.com/1521381/135918200-b03277e5-003c-4971-8a8a-f5ba54ca9340.png">
     - FIXED by calling the reInit() function
 