### PR TITLE
ci: let __mocks__ folder be included in docker images for unit testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 node_modules
-__mocks__
 .storybook
 .vscode
 .editorconfig


### PR DESCRIPTION
This allows unit tests to be run when building docker images.