### PR TITLE
feat: sort lending teams by overallLoandAmount on borrowerProfile page

### DIFF
--- a/src/components/BorrowerProfile/LendersAndTeams.vue
+++ b/src/components/BorrowerProfile/LendersAndTeams.vue
@@ -142,11 +142,11 @@ import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvTextLink from '~/@kiva/kv-components/vue/KvTextLink';
 import SupporterDetails from './SupporterDetails';
 
-const teamsQuery = gql`query teamsQuery($loanId: Int!, $limit: Int, $offset: Int) {
+const teamsQuery = gql`query teamsQuery($loanId: Int!, $limit: Int, $offset: Int, $sortBy: String) {
 	lend {
 		loan(id: $loanId) {
 			id
-			teams(limit: $limit, offset: $offset) {
+			teams(limit: $limit, offset: $offset, sortBy: $sortBy ) {
 				totalCount
 				values {
 					id
@@ -239,6 +239,7 @@ export default {
 			observer: null,
 			itemQueryLimit: 20,
 			itemQueryOffset: 0,
+			sortBy: 'overallLoanedAmount',
 			totalItemCount: 0,
 			supporterOfLoan: false,
 			userId: '',
@@ -328,7 +329,8 @@ export default {
 				variables: {
 					loanId: this.loanId,
 					limit: this.itemQueryLimit,
-					offset: this.itemQueryOffset
+					offset: this.itemQueryOffset,
+					sortBy: this.sortBy,
 				}
 			}).then(({ data }) => {
 				this.totalItemCount = data?.lend?.loan?.[this.displayType]?.totalCount ?? 0;


### PR DESCRIPTION
**Sort contributing Lending Teams by the most number of contributing team members, descending**
[Core-78](https://kiva.atlassian.net/browse/CORE-78)

Now that Torgie's implemented sorting behavior for teams, I'm implementing that sorting behavior by "overallLoanedAmount".

Currently I'm getting this console error: 
Uncaught (in promise) TypeError: Invalid attempt to spread non-iterable instance.
In order to be iterable, non-array objects must have a [Symbol.iterator]() method.
