### PR TITLE
fix: story card width bug Safari mobile

### DIFF
--- a/src/components/Contentful/StoryCard.vue
+++ b/src/components/Contentful/StoryCard.vue
@@ -9,7 +9,7 @@
 			v-if="hasBackgroundImage"
 		>
 			<kv-contentful-img
-				class="tw-h-full tw-object-cover"
+				class="tw-h-full tw-w-full tw-object-cover"
 				:width="520"
 				fallback-format="jpg"
 				:contentful-src="backgroundImage.url"


### PR DESCRIPTION
* fixes issue with safari mobile image card width increasing heights for all cards in carousel

GD-141

I don't think this will have any adverse effects, see slack and GD-141 for issue