### PR TITLE
fix: Display error message if getClientToken fails in Braintree checkout

### DIFF
--- a/src/components/Payment/BraintreeDropInInterface.vue
+++ b/src/components/Payment/BraintreeDropInInterface.vue
@@ -108,6 +108,7 @@ export default {
 							scope.setTag('bt_get_client_token_error', errorMessage);
 							Sentry.captureException(errorCode);
 						});
+						this.$showTipMsg('An Error has occured. Please refresh the page and try again.', 'error');
 					} else {
 						this.clientToken = _get(response, 'data.shop.getClientToken');
 						this.initializeDropIn(this.clientToken);


### PR DESCRIPTION
VUE-778