### PR TITLE
More about loan prose

### DIFF
--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -14,9 +14,7 @@
 				<div v-html="moreInfoAboutLoan">
 				</div>
 
-				<div
-					v-if="loanAlertText"
-				>
+				<div v-if="loanAlertText">
 					<h3>
 						About {{ partnerName }}:
 					</h3>
@@ -26,9 +24,7 @@
 					>
 					</p>
 				</div>
-				<div
-					v-if="dualStatementNote"
-				>
+				<div v-if="dualStatementNote">
 					<h3>
 						Important Note About This Loan
 					</h3>
@@ -37,9 +33,7 @@
 				</div>
 			</div>
 		</div>
-		<div
-			v-if="!partnerName && !loading"
-		>
+		<div v-if="!partnerName && !loading">
 			<div class="tw-prose tw-mb-2">
 				<h3>
 					Business description


### PR DESCRIPTION
@emuvente In the last code review you brought up and issue with tw-prose in the "More about this loan" section of the borrower profile. This fixes that spacing issue up. Also made a couple changes to some lines to bring things up to one line where applicable 🧹 

The diff makes it look more complicated, but essentially I just added a div with a tw-prose class inside the < section > element, which allowed me to apply tw-prose to each item in the component except < borrower-business-details >, where it's not needed for the correct display of text. 