### PR TITLE
build: Allow Tailwind @apply syntax within Vue <style lang="postcss"> tags

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -95,6 +95,26 @@ module.exports = {
 				]
 			},
 			{
+				// Allow Tailwind @apply in Vue using <style type="postcss">
+				test: /\.(postcss)$/,
+				use: [
+					'vue-style-loader',
+					{ loader: 'css-loader' },
+					{
+						loader: 'postcss-loader',
+						options: {
+							postcssOptions: {
+								plugins: [
+									require('cssnano'),
+									require('tailwindcss'),
+									require('autoprefixer'),
+								]
+							}
+						}
+					},
+				]
+			},
+			{
 				// Extract tailwind styles since they are global
 				test: /\.css$/,
 				include: [resolve('src/assets/scss/tailwind')],


### PR DESCRIPTION
Allows writing CSS in .Vue filles like:
```
<template>
  <div class="my-special-snowflake">
    I'm special
  </div>
</template>
...
<style lang="postcss" scoped>
.my-special-snowflake {
	@apply tw-bg-primary-inverse md:tw-bg-secondary md:tw-w-[1234px];
}
</style>
```

The CSS this outputs is 
```
<style type="text/css">
.my-special-snowflake {
  --tw-bg-opacity:1;
  background-color:rgba(var(--bg-primary-inverse), var(--tw-bg-opacity));
}

@media (min-width:45.875rem) {
  .my-special-snowflake {
    --tw-bg-opacity:1;
    background-color:rgba(var(--bg-secondary),var(--tw-bg-opacity));
    width:1234px
  }
}
</style>
```

https://tailwindcss.com/docs/extracting-components#extracting-component-classes-with-apply

The majority of the time, I'd recommend against using this technique. Using the utility classes and breaking your re-usable element into it's own Vue component gives us more advantages (like re-using the bundled tailwind .css file the user has already downloaded.

However, I ran into an issue in a typography task where making a reusable Vue component didn't really make sense, but regular CSS classes did.

This gives us the ability to utilize the design system that Tailwind gives us (colors, breakpoints, spacing, etc), while still writing regular CSS classes. I think this might be a good way to handle unusual one-off widths and other values, especially when you need breakpoints too.

The CSS generated like this does not get added to the main Tailwind CSS file. It goes into a `<style>` tag loaded only on that page.