### PR TITLE
feat(e2e-testing): add Testing Library for Cypress VUE-788

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -116,6 +116,7 @@
 				"@storybook/addons": "^6.3.2",
 				"@storybook/storybook-deployer": "^2.8.10",
 				"@storybook/vue": "^6.3.2",
+				"@testing-library/cypress": "^8.0.1",
 				"@testing-library/user-event": "^13.2.1",
 				"@testing-library/vue": "^5.8.2",
 				"app-manifest-loader": "^2.4.1",
@@ -7376,6 +7377,103 @@
 			},
 			"peerDependencies": {
 				"tailwindcss": ">=2.0.0"
+			}
+		},
+		"node_modules/@testing-library/cypress": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.1.tgz",
+			"integrity": "sha512-JCGy8u4ia+OQQJxVqKqjqpb0i4kmHQhu5jKFVBp+v/YSICnf52fil2MWIJqO+tH9ZQXtp3aF7uKHsVipWaI0BQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.14.6",
+				"@testing-library/dom": "^8.1.0"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			},
+			"peerDependencies": {
+				"cypress": "^2.1.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@testing-library/cypress/node_modules/@jest/types": {
+			"version": "27.2.5",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
+			"integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^3.0.0",
+				"@types/node": "*",
+				"@types/yargs": "^16.0.0",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/cypress/node_modules/@testing-library/dom": {
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
+			"integrity": "sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^5.0.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.4.4",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@testing-library/cypress/node_modules/@types/yargs": {
+			"version": "16.0.4",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+			"integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+			"dev": true,
+			"dependencies": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"node_modules/@testing-library/cypress/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/cypress/node_modules/aria-query": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+			"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0"
+			}
+		},
+		"node_modules/@testing-library/cypress/node_modules/pretty-format": {
+			"version": "27.3.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
+			"integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": "^27.2.5",
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
 			}
 		},
 		"node_modules/@testing-library/dom": {
@@ -15536,9 +15634,9 @@
 			"dev": true
 		},
 		"node_modules/dom-accessibility-api": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz",
-			"integrity": "sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==",
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
+			"integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
 			"dev": true
 		},
 		"node_modules/dom-converter": {
@@ -47017,6 +47115,80 @@
 				"lodash.uniq": "^4.5.0"
 			}
 		},
+		"@testing-library/cypress": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/cypress/-/cypress-8.0.1.tgz",
+			"integrity": "sha512-JCGy8u4ia+OQQJxVqKqjqpb0i4kmHQhu5jKFVBp+v/YSICnf52fil2MWIJqO+tH9ZQXtp3aF7uKHsVipWaI0BQ==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.14.6",
+				"@testing-library/dom": "^8.1.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "27.2.5",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.5.tgz",
+					"integrity": "sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^3.0.0",
+						"@types/node": "*",
+						"@types/yargs": "^16.0.0",
+						"chalk": "^4.0.0"
+					}
+				},
+				"@testing-library/dom": {
+					"version": "8.10.1",
+					"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.10.1.tgz",
+					"integrity": "sha512-rab7vpf1uGig5efWwsCOn9j4/doy+W3VBoUyzX7C4y77u0wAckwc7R8nyH6e2rw0rRzKJR+gWPiAg8zhiFbxWQ==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/runtime": "^7.12.5",
+						"@types/aria-query": "^4.2.0",
+						"aria-query": "^5.0.0",
+						"chalk": "^4.1.0",
+						"dom-accessibility-api": "^0.5.9",
+						"lz-string": "^1.4.4",
+						"pretty-format": "^27.0.2"
+					}
+				},
+				"@types/yargs": {
+					"version": "16.0.4",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+					"integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"ansi-styles": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+					"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+					"dev": true
+				},
+				"aria-query": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+					"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "27.3.1",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.3.1.tgz",
+					"integrity": "sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^27.2.5",
+						"ansi-regex": "^5.0.1",
+						"ansi-styles": "^5.0.0",
+						"react-is": "^17.0.1"
+					}
+				}
+			}
+		},
 		"@testing-library/dom": {
 			"version": "7.31.2",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
@@ -53828,9 +54000,9 @@
 			"dev": true
 		},
 		"dom-accessibility-api": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz",
-			"integrity": "sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==",
+			"version": "0.5.9",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.9.tgz",
+			"integrity": "sha512-+KPF4o71fl6NrdnqIrJc6m44NA+Rhf1h7In2MRznejSQasWkjqmHOBUlk+pXJ77cVOSYyZeNHFwn/sjotB6+Sw==",
 			"dev": true
 		},
 		"dom-converter": {

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
 		"@storybook/addons": "^6.3.2",
 		"@storybook/storybook-deployer": "^2.8.10",
 		"@storybook/vue": "^6.3.2",
+		"@testing-library/cypress": "^8.0.1",
 		"@testing-library/user-event": "^13.2.1",
 		"@testing-library/vue": "^5.8.2",
 		"app-manifest-loader": "^2.4.1",

--- a/test/e2e/support/commands.js
+++ b/test/e2e/support/commands.js
@@ -4,22 +4,24 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 
-Cypress.Commands.add('lunar', method => {
-	cy.request('POST', `/__lunar/${method}`);
-});
+import '@testing-library/cypress/add-commands';
 
-Cypress.Commands.add('mock', mocks => {
-	const serializedMocks = Object.keys(mocks).reduce(
-		(packet, key) => {
-			let mock = mocks[key];
-			if (typeof mock !== 'function') {
-				// eslint-disable-next-line no-new-func
-				mock = new Function(`return ${JSON.stringify(mocks[key])};`);
-			}
-			return Object.assign(packet, { [key]: mock.toString() });
-		},
-		{}
-	);
-
-	cy.request('POST', '/__lunar/mock', serializedMocks);
-});
+// Cypress.Commands.add('lunar', method => {
+// 	cy.request('POST', `/__lunar/${method}`);
+// });
+//
+// Cypress.Commands.add('mock', mocks => {
+// 	const serializedMocks = Object.keys(mocks).reduce(
+// 		(packet, key) => {
+// 			let mock = mocks[key];
+// 			if (typeof mock !== 'function') {
+// 				// eslint-disable-next-line no-new-func
+// 				mock = new Function(`return ${JSON.stringify(mocks[key])};`);
+// 			}
+// 			return Object.assign(packet, { [key]: mock.toString() });
+// 		},
+// 		{}
+// 	);
+//
+// 	cy.request('POST', '/__lunar/mock', serializedMocks);
+// });

--- a/test/e2e/support/index.js
+++ b/test/e2e/support/index.js
@@ -13,6 +13,6 @@
 // https://on.cypress.io/configuration
 // ***********************************************************
 // import '@cypress/code-coverage/support';
-// import './commands';
+import './commands';
 
 // beforeEach(() => cy.lunar('reset'));


### PR DESCRIPTION
https://testing-library.com/docs/cypress-testing-library/intro

Adding this adds extra commands that are not available by default in Cypress for finding elements. Particularly useful are the commands like findByLabelText and findByPlaceholderText.