### PR TITLE
fix: fixes FAQs on pages that use ContentfulPage

### DIFF
--- a/src/components/Contentful/FrequentlyAskedQuestions.vue
+++ b/src/components/Contentful/FrequentlyAskedQuestions.vue
@@ -1,0 +1,53 @@
+<template>
+	<section-with-background-classic
+		:background-content="background"
+		:vertical-padding="verticalPadding"
+	>
+		<template #content>
+			<kv-page-container>
+				<kv-frequently-asked-questions
+					:headline="frequentlyAskedQuestionsHeadline"
+					:questions="frequentlyAskedQuestions"
+				/>
+			</kv-page-container>
+		</template>
+	</section-with-background-classic>
+</template>
+
+<script>
+import contentfulStylesMixin from '@/plugins/contentful-ui-setting-styles-mixin';
+import SectionWithBackgroundClassic from '@/components/Contentful/SectionWithBackgroundClassic';
+import KvFrequentlyAskedQuestions from '@/components/Kv/KvFrequentlyAskedQuestions';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
+
+export default {
+	components: {
+		KvFrequentlyAskedQuestions,
+		KvPageContainer,
+		SectionWithBackgroundClassic,
+	},
+	mixins: [contentfulStylesMixin],
+	props: {
+		/**
+		 * Content group content from Contentful
+		* */
+		content: {
+			type: Object,
+			default: () => {},
+		},
+	},
+	computed: {
+		frequentlyAskedQuestionsHeadline() {
+			return this.content?.title ?? null;
+		},
+		frequentlyAskedQuestions() {
+			return this.content?.contents ?? null;
+		},
+		background() {
+			return this.content?.contents?.find(({ contentType }) => {
+				return contentType ? contentType === 'background' : false;
+			});
+		},
+	},
+};
+</script>

--- a/src/components/Kv/KvExpandableQuestion.vue
+++ b/src/components/Kv/KvExpandableQuestion.vue
@@ -82,7 +82,6 @@ export default {
 	},
 	methods: {
 		toggleFaq() {
-			console.log('toggle');
 			if (!this.open) {
 				this.$kvTrackEvent(this.analyticsCategory, 'click-faq-expand', this.title);
 			}

--- a/src/components/Kv/KvFrequentlyAskedQuestions.vue
+++ b/src/components/Kv/KvFrequentlyAskedQuestions.vue
@@ -1,33 +1,24 @@
 <template>
-	<section-with-background-classic
-		:background-content="background"
-		:vertical-padding="verticalPadding"
-	>
-		<template #content>
-			<kv-grid>
-				<div v-if="frequentlyAskedQuestionsHeadline">
-					<h2 class="tw-text-h2">
-						{{ frequentlyAskedQuestionsHeadline }}
-					</h2>
-				</div>
-				<div v-if="frequentlyAskedQuestions" class="tw-divide-y">
-					<kv-expandable-question
-						v-for="(question, index) in frequentlyAskedQuestions"
-						:key="index"
-						:title="question.name"
-						:content="convertFromRichTextToHtml(question.richText)"
-						:id="question.name | changeCase('paramCase')"
-					/>
-				</div>
-			</kv-grid>
-		</template>
-	</section-with-background-classic>
+	<kv-grid>
+		<div v-if="headline">
+			<h2 class="tw-text-h2">
+				{{ headline }}
+			</h2>
+		</div>
+		<div v-if="questions" class="tw-divide-y">
+			<kv-expandable-question
+				v-for="(question, index) in questions"
+				:key="index"
+				:title="question.name"
+				:content="convertFromRichTextToHtml(question.richText)"
+				:id="question.name | changeCase('paramCase')"
+			/>
+		</div>
+	</kv-grid>
 </template>
 
 <script>
-import contentfulStylesMixin from '@/plugins/contentful-ui-setting-styles-mixin';
 import KvExpandableQuestion from '@/components/Kv/KvExpandableQuestion';
-import SectionWithBackgroundClassic from '@/components/Contentful/SectionWithBackgroundClassic';
 import { richTextRenderer } from '@/util/contentful/richTextRenderer';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 
@@ -35,33 +26,21 @@ export default {
 	components: {
 		KvExpandableQuestion,
 		KvGrid,
-		SectionWithBackgroundClassic,
 	},
-	mixins: [contentfulStylesMixin],
 	props: {
 		/**
-		 * Content group content from Contentful
+		 * FAQ Headline
 		* */
-		content: {
-			type: Object,
-			default: () => {},
+		headline: {
+			type: String,
+			default: '',
 		},
-	},
-	data() {
-		return {
-		};
-	},
-	computed: {
-		frequentlyAskedQuestionsHeadline() {
-			return this.content?.title ?? null;
-		},
-		frequentlyAskedQuestions() {
-			return this.content?.contents ?? null;
-		},
-		background() {
-			return this.content?.contents?.find(({ contentType }) => {
-				return contentType ? contentType === 'background' : false;
-			});
+		/**
+		 * Array of questions - output of contentful content field. each questions is a contentful rich text object
+		* */
+		questions: {
+			type: Array,
+			default: () => [],
 		},
 	},
 	methods: {

--- a/src/pages/AutoDeposit/AutoDepositLandingPage.vue
+++ b/src/pages/AutoDeposit/AutoDepositLandingPage.vue
@@ -73,7 +73,8 @@
 		<div class="kv-tailwind row">
 			<kv-frequently-asked-questions
 				class="span-12 column"
-				:content="faqContentGroup"
+				:headline="frequentlyAskedQuestionsHeadline"
+				:questions="frequentlyAskedQuestions"
 			/>
 		</div>
 	</www-page>
@@ -157,6 +158,12 @@ export default {
 			return this.contentGroups?.find(({ type }) => {
 				return type ? type === 'frequentlyAskedQuestions' : false;
 			});
+		},
+		frequentlyAskedQuestionsHeadline() {
+			return this.faqContentGroup?.title ?? null;
+		},
+		frequentlyAskedQuestions() {
+			return this.faqContentGroup?.contents ?? null;
 		},
 		ctaContentGroup() {
 			return this.contentGroups?.find(({ key }) => {

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -80,7 +80,7 @@ const LoansByCategoryCarousel = () => import('@/components/Contentful/LoansByCat
 
 const MonthlyGoodSelectorWrapper = () => import('@/components/MonthlyGood/MonthlyGoodSelectorWrapper');
 
-const KvFrequentlyAskedQuestions = () => import('@/components/Kv/KvFrequentlyAskedQuestions');
+const FrequentlyAskedQuestions = () => import('@/components/Contentful/FrequentlyAskedQuestions');
 
 const TestimonialCards = () => import('@/components/Contentful/TestimonialCards');
 
@@ -169,7 +169,7 @@ const getComponentFromType = type => {
 		case 'monthlyGoodSelector':
 			return MonthlyGoodSelectorWrapper;
 		case 'frequentlyAskedQuestions':
-			return KvFrequentlyAskedQuestions;
+			return FrequentlyAskedQuestions;
 		case 'testimonialCards':
 			return TestimonialCards;
 		case 'cardRow':

--- a/src/pages/Donate/DonateSupportUs.vue
+++ b/src/pages/Donate/DonateSupportUs.vue
@@ -22,7 +22,8 @@
 			<div class="small-12 columns donation-faq-holder">
 				<div class="kv-tailwind">
 					<kv-frequently-asked-questions
-						:content="faqContentGroup"
+						:headline="frequentlyAskedQuestionsHeadline"
+						:questions="frequentlyAskedQuestions"
 					/>
 				</div>
 			</div>
@@ -136,6 +137,12 @@ export default {
 		},
 		faqContentGroup() {
 			return this.page?.contentGroups?.frequentlyAskedQuestions || {};
+		},
+		frequentlyAskedQuestionsHeadline() {
+			return this.faqContentGroup?.title ?? null;
+		},
+		frequentlyAskedQuestions() {
+			return this.faqContentGroup?.contents ?? null;
 		},
 		donationCalloutsCG() {
 			return this.page?.contentGroups?.webDonateSupportUsDonationCallouts || {};

--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -75,7 +75,8 @@
 		<div class="kv-tailwind row">
 			<kv-frequently-asked-questions
 				class="span-12 column"
-				:content="faqContentGroup"
+				:headline="frequentlyAskedQuestionsHeadline"
+				:questions="frequentlyAskedQuestions"
 			/>
 		</div>
 	</www-page>
@@ -227,6 +228,12 @@ export default {
 			return this.contentGroups?.find(({ type }) => {
 				return type ? type === 'frequentlyAskedQuestions' : false;
 			});
+		},
+		frequentlyAskedQuestionsHeadline() {
+			return this.faqContentGroup?.title ?? null;
+		},
+		frequentlyAskedQuestions() {
+			return this.faqContentGroup?.contents ?? null;
 		},
 		heroContentGroup() {
 			return this.contentGroups?.find(({ key }) => {


### PR DESCRIPTION
* Adds a wrapper component that can be used in conjunction with KvFrequentlyAskedQuestions for contentful pages

VUE-790

Fixes FAQ section wrapping for pages that use Contentful page and FAQs (for example lp/climatechange). With this PR, you can either use: 
Contentful/FrequentlyAskedQuestions.vue 
- Will wrap the FAQ section with a page container with a max width and a section background

or KvFrequentlyAskedQuestions
- Will not wrap questions, and you will not be able to apply a sections background (I checked all uses of this in one off pages like /donate/supportus and non of them use the section background anyway)