### PR TITLE
fix: fix rendering of empty paragraph tags in RTF

### DIFF
--- a/test/unit/fixtures/RichTextField.json
+++ b/test/unit/fixtures/RichTextField.json
@@ -1,0 +1,54 @@
+{
+    "nodeType": "document",
+    "data": {},
+    "content": [
+		{
+            "nodeType": "heading-1",
+            "content": [
+                {
+                    "nodeType": "text",
+                    "value": "Headline",
+                    "marks": [],
+                    "data": {}
+                }
+            ],
+            "data": {}
+        },
+		{
+            "nodeType": "paragraph",
+            "content": [
+                {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                }
+            ],
+            "data": {}
+        },
+        {
+            "nodeType": "heading-2",
+            "content": [
+                {
+                    "nodeType": "text",
+                    "value": "Fund people to improve their lives and build a greener future.",
+                    "marks": [],
+                    "data": {}
+                }
+            ],
+            "data": {}
+        },
+        {
+            "nodeType": "paragraph",
+            "content": [
+                {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                }
+            ],
+            "data": {}
+        }
+    ]
+}

--- a/test/unit/specs/util/richTextRenderer.spec.js
+++ b/test/unit/specs/util/richTextRenderer.spec.js
@@ -1,0 +1,54 @@
+import {
+	removeTrailingParagraphTag,
+} from '@/util/contentful/richTextRenderer';
+
+import RichTextField from '../../fixtures/RichTextField.json';
+
+describe('richTextRenderer.js', () => {
+	describe('removeTrailingParagraphTag', () => {
+		it('returns a rich text object without the empty trailing paragraph tag', () => {
+			expect(removeTrailingParagraphTag(RichTextField)).toStrictEqual({
+				nodeType: 'document',
+				data: {},
+				content: [
+					{
+						nodeType: 'heading-1',
+						content: [
+							{
+								nodeType: 'text',
+								value: 'Headline',
+								marks: [],
+								data: {}
+							}
+						],
+						data: {}
+					},
+					{
+						nodeType: 'paragraph',
+						content: [
+							{
+								nodeType: 'text',
+								value: '',
+								marks: [],
+								data: {}
+							}
+						],
+						data: {}
+					},
+					{
+						nodeType: 'heading-2',
+						content: [
+							{
+								nodeType: 'text',
+								value: 'Fund people to improve their lives and build a greener future.',
+								marks: [],
+								data: {}
+							}
+						],
+						data: {}
+					},
+				]
+			});
+		});
+	});
+});


### PR DESCRIPTION
* Sometimes contentful will add annoying empty paragraph tags in the rendered content from RTF's. This filters those out, but keeps empty paragraphs in the middle of the content

VUE-791
