### PR TITLE
Fix: Core-235 altering link and fixing period spacing.

### DIFF
--- a/src/components/BorrowerProfile/LoanDescription.vue
+++ b/src/components/BorrowerProfile/LoanDescription.vue
@@ -41,15 +41,15 @@
 							<span v-if="!showReviewersName">a</span>
 							<!-- eslint-disable max-len -->
 							<a
-								href="/work-with-us/internvolunteers"
+								href="/work-with-us/reviewers"
 								title="Learn more about volunteering at Kiva"
 								v-kv-track-event="['Borrower profile', 'click-Kiva review volunteer', 'Kiva volunteer', this.loanId]"
 							>
-								Kiva volunteer
+								Kiva volunteer<span v-if="!showReviewersName">.</span>
 							</a>
 							<span v-if="showReviewersName">
-								{{ reviewerName }}
-							</span>.
+								{{ reviewerName }}.
+							</span>
 						</span>
 
 						<a


### PR DESCRIPTION
[Core-235](https://kiva.atlassian.net/browse/CORE-235)

From the borrower profile changes that occurred last iteration, it was found the incorrect link was put in place (though it was in the spec). This small change fixes that link and also handles the small space before the period issue that Apyrl brought up in the ticket. 