### PR TITLE
Core 239

### DIFF
--- a/src/api/localResolvers/loan.js
+++ b/src/api/localResolvers/loan.js
@@ -107,14 +107,11 @@ function fundraisingTimeLeft(loan) {
 	}
 
 	const now = parseISO(new Date().toISOString());
-
 	const diffInDays = differenceInDays(plannedExpirationDate, now);
-	console.log('plannedEXP', plannedExpirationDate);
-	console.log('NOW', parseISO(new Date().toISOString()));
-	console.log('diffInDays', diffInDays);
 
-	// use differenceInDays to see if the plannedExpirationDate is greater than 28 day from now
-	if (diffInDays > -28) {
+	// If the fundraising time left is greater than 28 days,
+	// we set the display units to days
+	if (diffInDays > 28) {
 		return formatDistanceToNowStrict(plannedExpirationDate, { unit: 'day' });
 	}
 	return formatDistanceToNowStrict(plannedExpirationDate);

--- a/src/api/localResolvers/loan.js
+++ b/src/api/localResolvers/loan.js
@@ -109,7 +109,8 @@ function fundraisingTimeLeft(loan) {
 	const now = parseISO(new Date().toISOString());
 	const diffInDays = differenceInDays(plannedExpirationDate, now);
 
-	// If the fundraising time left is greater than 28 days,
+	// Return the distance between the expiration time and now in words.
+	// If the time left is greater than 28 days,
 	// we set the display units to days
 	if (diffInDays > 28) {
 		return formatDistanceToNowStrict(plannedExpirationDate, { unit: 'day' });

--- a/src/api/localResolvers/loan.js
+++ b/src/api/localResolvers/loan.js
@@ -106,8 +106,7 @@ function fundraisingTimeLeft(loan) {
 		return '';
 	}
 
-	const now = parseISO(new Date().toISOString());
-	const diffInDays = differenceInDays(plannedExpirationDate, now);
+	const diffInDays = differenceInDays(plannedExpirationDate, new Date());
 
 	// Return the distance between the expiration time and now in words.
 	// If the time left is greater than 28 days,

--- a/src/api/localResolvers/loan.js
+++ b/src/api/localResolvers/loan.js
@@ -2,6 +2,7 @@ import {
 	isValid as isValidDate,
 	formatDistanceToNowStrict,
 	parseISO,
+	differenceInDays,
 } from 'date-fns';
 import numeral from 'numeral';
 import logFormatter from '@/util/logFormatter';
@@ -105,7 +106,17 @@ function fundraisingTimeLeft(loan) {
 		return '';
 	}
 
-	// Return the distance between the expiration time and now in words.
+	const now = parseISO(new Date().toISOString());
+
+	const diffInDays = differenceInDays(plannedExpirationDate, now);
+	console.log('plannedEXP', plannedExpirationDate);
+	console.log('NOW', parseISO(new Date().toISOString()));
+	console.log('diffInDays', diffInDays);
+
+	// use differenceInDays to see if the plannedExpirationDate is greater than 28 day from now
+	if (diffInDays > -28) {
+		return formatDistanceToNowStrict(plannedExpirationDate, { unit: 'day' });
+	}
 	return formatDistanceToNowStrict(plannedExpirationDate);
 }
 

--- a/test/unit/specs/api/localResolvers/loan.spec.js
+++ b/test/unit/specs/api/localResolvers/loan.spec.js
@@ -168,6 +168,7 @@ describe('loan.js', () => {
 			const tenMinutes = add(now, { minutes: 10 });
 			const twoHours = add(now, { hours: 2 });
 			const fiveDays = add(now, { days: 5 });
+			const fourtyDays = add(now, { days: 40 });
 
 			testFundraisingTimeLeft({
 				loan: { plannedExpirationDate: formatISO(tenMinutes) },
@@ -180,6 +181,12 @@ describe('loan.js', () => {
 			testFundraisingTimeLeft({
 				loan: { plannedExpirationDate: formatISO(fiveDays) },
 				expected: '5 days',
+			});
+			testFundraisingTimeLeft({
+				loan: {
+					plannedExpirationDate: formatISO(fourtyDays)
+				},
+				expected: '40 days',
 			});
 		});
 


### PR DESCRIPTION
[Core-239](https://kiva.atlassian.net/browse/CORE-239)

Updated the time remaining display on borrower profile. Added an additional check to see if the differenceInDays is larger than 28, if it is we pass through the unit we want returned, which is days. 

I've verified this between the old and new borrower profiles for a few loans and the display of time remaining is the same. 
A loan I used on my VM: https://dev-vm-01.kiva.org/lend-beta/2260639

**Old Borrower profile:** 
<img width="1321" alt="Screen Shot 2021-10-29 at 11 55 02 AM" src="https://user-images.githubusercontent.com/1521381/139480772-c3d2aefd-1eb9-4c14-bb7b-2e4073df698b.png">

**New Borrower profile:**
<img width="1283" alt="Screen Shot 2021-10-29 at 11 54 14 AM" src="https://user-images.githubusercontent.com/1521381/139480692-18f05de0-fcc2-4430-89f9-7a42da05338a.png">

**Borrower profile with less than 28 days remains unchanged**
<img width="1321" alt="Screen Shot 2021-10-29 at 11 55 41 AM" src="https://user-images.githubusercontent.com/1521381/139480864-3548680a-cd3d-4522-84f6-23b6b1cde371.png">


I've also added a test to cover a 40 days case. 
