### PR TITLE
typography: ensure #app fills the full screen height

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,9 @@
 <template>
 	<kv-theme-provider
 		:theme="theme"
-		class="tw-h-full"
+		class="tw-flex tw-flex-col tw-h-full tw-w-full"
 	>
-		<div id="app" class="tw-bg-primary tw-h-full">
+		<div id="app" class="tw-bg-primary tw-flex-grow">
 			<router-view />
 			<vue-progress-bar />
 			<the-tip-message />


### PR DESCRIPTION
The previous 100% height fix could have problems once you scrolled the page down and then turned on dark mode toggle. This appears to fix that and keeps the minimum page height of 100%.