### PR TITLE
build: enable commitlint for project commits VUE-757

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx --no-install commitlint --edit $1

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	extends: [
+		'@commitlint/config-conventional',
+	],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,8 @@
 				"@babel/plugin-transform-modules-commonjs": "^7.10.1",
 				"@babel/plugin-transform-runtime": "^7.11.5",
 				"@babel/preset-env": "^7.10.1",
+				"@commitlint/cli": "^14.1.0",
+				"@commitlint/config-conventional": "^14.1.0",
 				"@storybook/addon-a11y": "^6.3.2",
 				"@storybook/addon-essentials": "^6.3.2",
 				"@storybook/addon-knobs": "^6.2.9",
@@ -2040,6 +2042,393 @@
 			},
 			"engines": {
 				"node": ">=0.1.95"
+			}
+		},
+		"node_modules/@commitlint/cli": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-14.1.0.tgz",
+			"integrity": "sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/format": "^14.1.0",
+				"@commitlint/lint": "^14.1.0",
+				"@commitlint/load": "^14.1.0",
+				"@commitlint/read": "^14.0.0",
+				"@commitlint/types": "^14.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "5.0.0",
+				"resolve-global": "1.0.0",
+				"yargs": "^17.0.0"
+			},
+			"bin": {
+				"commitlint": "cli.js"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/cli/node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"dev": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/@commitlint/cli/node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@commitlint/cli/node_modules/yargs": {
+			"version": "17.2.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+			"integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@commitlint/config-conventional": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz",
+			"integrity": "sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==",
+			"dev": true,
+			"dependencies": {
+				"conventional-changelog-conventionalcommits": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/ensure": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-14.1.0.tgz",
+			"integrity": "sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/types": "^14.0.0",
+				"lodash": "^4.17.19"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/execute-rule": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz",
+			"integrity": "sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==",
+			"dev": true,
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/format": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-14.1.0.tgz",
+			"integrity": "sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/types": "^14.0.0",
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/is-ignored": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz",
+			"integrity": "sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/types": "^14.0.0",
+				"semver": "7.3.5"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/lint": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-14.1.0.tgz",
+			"integrity": "sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/is-ignored": "^14.0.0",
+				"@commitlint/parse": "^14.0.0",
+				"@commitlint/rules": "^14.1.0",
+				"@commitlint/types": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/load": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-14.1.0.tgz",
+			"integrity": "sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/execute-rule": "^14.0.0",
+				"@commitlint/resolve-extends": "^14.1.0",
+				"@commitlint/types": "^14.0.0",
+				"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "^7.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"typescript": "^4.4.3"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/load/node_modules/cosmiconfig": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+			"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+			"dev": true,
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@commitlint/message": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-14.0.0.tgz",
+			"integrity": "sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/parse": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-14.0.0.tgz",
+			"integrity": "sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/types": "^14.0.0",
+				"conventional-changelog-angular": "^5.0.11",
+				"conventional-commits-parser": "^3.2.2"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/read": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-14.0.0.tgz",
+			"integrity": "sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/top-level": "^14.0.0",
+				"@commitlint/types": "^14.0.0",
+				"fs-extra": "^10.0.0",
+				"git-raw-commits": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/read/node_modules/fs-extra": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+			"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@commitlint/read/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/@commitlint/resolve-extends": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz",
+			"integrity": "sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"resolve-global": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/rules": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-14.1.0.tgz",
+			"integrity": "sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==",
+			"dev": true,
+			"dependencies": {
+				"@commitlint/ensure": "^14.1.0",
+				"@commitlint/message": "^14.0.0",
+				"@commitlint/to-lines": "^14.0.0",
+				"@commitlint/types": "^14.0.0",
+				"execa": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/rules/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@commitlint/rules/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@commitlint/rules/node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/@commitlint/to-lines": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-14.0.0.tgz",
+			"integrity": "sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==",
+			"dev": true,
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/top-level": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-14.0.0.tgz",
+			"integrity": "sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
+			}
+		},
+		"node_modules/@commitlint/top-level/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@commitlint/top-level/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@commitlint/top-level/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@commitlint/types": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-14.0.0.tgz",
+			"integrity": "sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=v12"
 			}
 		},
 		"node_modules/@contentful/rich-text-html-renderer": {
@@ -9472,6 +9861,12 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
+		"node_modules/array-ify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"dev": true
+		},
 		"node_modules/array-includes": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -12410,6 +12805,16 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
+		"node_modules/compare-func": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+			"dev": true,
+			"dependencies": {
+				"array-ify": "^1.0.0",
+				"dot-prop": "^5.1.0"
+			}
+		},
 		"node_modules/component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -12646,6 +13051,208 @@
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/conventional-changelog-angular": {
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+			"integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+			"dev": true,
+			"dependencies": {
+				"compare-func": "^2.0.0",
+				"q": "^1.5.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-changelog-conventionalcommits": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
+			"integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+			"dev": true,
+			"dependencies": {
+				"compare-func": "^2.0.0",
+				"lodash": "^4.17.15",
+				"q": "^1.5.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-commits-parser": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.3.tgz",
+			"integrity": "sha512-YyRDR7On9H07ICFpRm/igcdjIqebXbvf4Cff+Pf0BrBys1i1EOzx9iFXNlAbdrLAR8jf7bkUYkDAr8pEy0q4Pw==",
+			"dev": true,
+			"dependencies": {
+				"is-text-path": "^1.0.1",
+				"JSONStream": "^1.0.4",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
+			},
+			"bin": {
+				"conventional-commits-parser": "cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/hosted-git-info": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+			"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/meow": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+			"integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimist": "^1.2.0",
+				"camelcase-keys": "^6.2.2",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.0",
+				"read-pkg-up": "^7.0.1",
+				"redent": "^3.0.0",
+				"trim-newlines": "^3.0.0",
+				"type-fest": "^0.18.0",
+				"yargs-parser": "^20.2.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/meow/node_modules/type-fest": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/normalize-package-data": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^4.0.1",
+				"is-core-module": "^2.5.0",
+				"semver": "^7.3.4",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/read-pkg": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+			"dev": true,
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/read-pkg-up": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/read-pkg/node_modules/hosted-git-info": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"dev": true
+		},
+		"node_modules/conventional-commits-parser/node_modules/read-pkg/node_modules/normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/read-pkg/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/read-pkg/node_modules/type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/conventional-commits-parser/node_modules/through2": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "3"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -13609,21 +14216,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/css-select": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
@@ -14017,6 +14609,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/dargs": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/dashdash": {
@@ -14699,6 +15300,18 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"dependencies": {
+				"is-obj": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/dotenv": {
@@ -17914,6 +18527,180 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"node_modules/git-raw-commits": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
+			"integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
+			"dev": true,
+			"dependencies": {
+				"dargs": "^7.0.0",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
+			},
+			"bin": {
+				"git-raw-commits": "cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/hosted-git-info": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+			"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/meow": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+			"integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+			"dev": true,
+			"dependencies": {
+				"@types/minimist": "^1.2.0",
+				"camelcase-keys": "^6.2.2",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.0",
+				"read-pkg-up": "^7.0.1",
+				"redent": "^3.0.0",
+				"trim-newlines": "^3.0.0",
+				"type-fest": "^0.18.0",
+				"yargs-parser": "^20.2.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/meow/node_modules/type-fest": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/normalize-package-data": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^4.0.1",
+				"is-core-module": "^2.5.0",
+				"semver": "^7.3.4",
+				"validate-npm-package-license": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/read-pkg": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+			"dev": true,
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^2.5.0",
+				"parse-json": "^5.0.0",
+				"type-fest": "^0.6.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/read-pkg-up": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^4.1.0",
+				"read-pkg": "^5.2.0",
+				"type-fest": "^0.8.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/read-pkg/node_modules/hosted-git-info": {
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+			"dev": true
+		},
+		"node_modules/git-raw-commits/node_modules/read-pkg/node_modules/normalize-package-data": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^2.1.4",
+				"resolve": "^1.10.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/read-pkg/node_modules/semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/read-pkg/node_modules/type-fest": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/git-raw-commits/node_modules/through2": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "3"
+			}
+		},
 		"node_modules/git-revision-webpack-plugin": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.6.tgz",
@@ -20227,6 +21014,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
@@ -20380,6 +21176,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-text-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"dev": true,
+			"dependencies": {
+				"text-extensions": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-typedarray": {
@@ -23950,6 +24758,31 @@
 			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 			"engines": {
 				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			]
+		},
+		"node_modules/JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"dependencies": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			},
+			"bin": {
+				"JSONStream": "bin.js"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -31668,6 +32501,30 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/resolve-global": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+			"integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+			"dev": true,
+			"dependencies": {
+				"global-dirs": "^0.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/resolve-global/node_modules/global-dirs": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+			"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+			"dev": true,
+			"dependencies": {
+				"ini": "^1.3.4"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -32513,9 +33370,9 @@
 			"optional": true
 		},
 		"node_modules/semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"dependencies": {
 				"lru-cache": "^6.0.0"
 			},
@@ -33237,6 +34094,29 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/split2": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^3.0.0"
+			}
+		},
+		"node_modules/split2/node_modules/readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -34787,6 +35667,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/text-extensions": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -35470,6 +36359,19 @@
 			"dev": true,
 			"dependencies": {
 				"is-typedarray": "^1.0.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"devOptional": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/uglify-js": {
@@ -40864,6 +41766,304 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			}
+		},
+		"@commitlint/cli": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-14.1.0.tgz",
+			"integrity": "sha512-Orq62jkl9qAGvjFqhehtAqjGY/duJ8hIRPPIHmGR2jIB96D4VTmazS3ZvqJz2Q9kKr61mLAk/171zm0FVzQCYA==",
+			"dev": true,
+			"requires": {
+				"@commitlint/format": "^14.1.0",
+				"@commitlint/lint": "^14.1.0",
+				"@commitlint/load": "^14.1.0",
+				"@commitlint/read": "^14.0.0",
+				"@commitlint/types": "^14.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "5.0.0",
+				"resolve-global": "1.0.0",
+				"yargs": "^17.0.0"
+			},
+			"dependencies": {
+				"cliui": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+					"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^7.0.0"
+					}
+				},
+				"y18n": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+					"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "17.2.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+					"integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				}
+			}
+		},
+		"@commitlint/config-conventional": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-14.1.0.tgz",
+			"integrity": "sha512-JuhCqkEv8jyqmd54EpXPsQFpYc/8k7sfP1UziRdEvZSJUCLxz+8Pk4cNS0oF1BtjaWO7ITgXPlIZg47PyApGmg==",
+			"dev": true,
+			"requires": {
+				"conventional-changelog-conventionalcommits": "^4.3.1"
+			}
+		},
+		"@commitlint/ensure": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-14.1.0.tgz",
+			"integrity": "sha512-xrYvFdqVepT3XA1BmSh88eKbvYKtLuQu98QLfgxVmwS99Kj3yW0sT3D7jGvNsynbIx2dhbXofDyubf/DKkpFrQ==",
+			"dev": true,
+			"requires": {
+				"@commitlint/types": "^14.0.0",
+				"lodash": "^4.17.19"
+			}
+		},
+		"@commitlint/execute-rule": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-14.0.0.tgz",
+			"integrity": "sha512-Hh/HLpCBDlrD3Rx2x2pDBx6CU+OtVqGXh7mbFpNihAVx6B0zyZqm/vv0cdwdhfGW5OEn1BhCqHf1ZOvL/DwdWA==",
+			"dev": true
+		},
+		"@commitlint/format": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-14.1.0.tgz",
+			"integrity": "sha512-sF6engqqHjvxGctWRKjFs/HQeNowlpbVmmoP481b2UMQnVQnjjfXJvQsoLpaqFUvgc2sHM4L85F8BmAw+iHG1w==",
+			"dev": true,
+			"requires": {
+				"@commitlint/types": "^14.0.0",
+				"chalk": "^4.0.0"
+			}
+		},
+		"@commitlint/is-ignored": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-14.0.0.tgz",
+			"integrity": "sha512-nJltYjXTa+mk+6SPe35nOZCCvt3Gh5mbDz008KQ4OPcn1GX1NG+pEgz1Kx3agDp/pc+JGnsrr5GV00gygIoloA==",
+			"dev": true,
+			"requires": {
+				"@commitlint/types": "^14.0.0",
+				"semver": "7.3.5"
+			}
+		},
+		"@commitlint/lint": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-14.1.0.tgz",
+			"integrity": "sha512-CApGJEOtWU/CcuPD8HkOR1jdUYpjKutGPaeby9nSFzJhwl/UQOjxc4Nd+2g2ygsMi5l3N4j2sWQYEgccpFC3lA==",
+			"dev": true,
+			"requires": {
+				"@commitlint/is-ignored": "^14.0.0",
+				"@commitlint/parse": "^14.0.0",
+				"@commitlint/rules": "^14.1.0",
+				"@commitlint/types": "^14.0.0"
+			}
+		},
+		"@commitlint/load": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-14.1.0.tgz",
+			"integrity": "sha512-p+HbgjhkqLsnxyjOUdEYHztHCp8n2oLVUJTmRPuP5FXLNevh6Gwmxf+NYC2J0sgD084aV2CFi3qu1W4yHWIknA==",
+			"dev": true,
+			"requires": {
+				"@commitlint/execute-rule": "^14.0.0",
+				"@commitlint/resolve-extends": "^14.1.0",
+				"@commitlint/types": "^14.0.0",
+				"@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+				"chalk": "^4.0.0",
+				"cosmiconfig": "^7.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"typescript": "^4.4.3"
+			},
+			"dependencies": {
+				"cosmiconfig": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+					"integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+					"dev": true,
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.2.1",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.10.0"
+					}
+				}
+			}
+		},
+		"@commitlint/message": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-14.0.0.tgz",
+			"integrity": "sha512-316Pum+bwDcZamOQw0DXSY17Dq9EjvL1zKdYIZqneu4lnXN6uFfi53Y/sP5crW6zlLdnuTHe1MnuewXPLHfH1Q==",
+			"dev": true
+		},
+		"@commitlint/parse": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-14.0.0.tgz",
+			"integrity": "sha512-49qkk0TcwdxJPZUX8MElEzMlRFIL/cg64P4pk8HotFEm2HYdbxxZp6v3cbVw5WOsnRA0frrs+NNoOcIT83ccMQ==",
+			"dev": true,
+			"requires": {
+				"@commitlint/types": "^14.0.0",
+				"conventional-changelog-angular": "^5.0.11",
+				"conventional-commits-parser": "^3.2.2"
+			}
+		},
+		"@commitlint/read": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-14.0.0.tgz",
+			"integrity": "sha512-WXXcSLBqwXTqnEmB0lbU2TrayDJ2G3qI/lxy1ianVmpQol8p9BjodAA6bYxtYYHdQFVXUrIsclzFP/naWG+hlQ==",
+			"dev": true,
+			"requires": {
+				"@commitlint/top-level": "^14.0.0",
+				"@commitlint/types": "^14.0.0",
+				"fs-extra": "^10.0.0",
+				"git-raw-commits": "^2.0.0"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+					"integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+					"dev": true
+				}
+			}
+		},
+		"@commitlint/resolve-extends": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-14.1.0.tgz",
+			"integrity": "sha512-ko80k6QB6E6/OvGNWy4u7gzzWyluDT3VDNL2kfZaDywsnrYntUKyT4Do97gQ7orttITzj2GRtk3KWClVz4rUUQ==",
+			"dev": true,
+			"requires": {
+				"import-fresh": "^3.0.0",
+				"lodash": "^4.17.19",
+				"resolve-from": "^5.0.0",
+				"resolve-global": "^1.0.0"
+			}
+		},
+		"@commitlint/rules": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-14.1.0.tgz",
+			"integrity": "sha512-6jmv414/1JzGzDI/DS+snAMhcL6roQKPdg0WB3kWTWN52EvWXBFm0HIMGt2H/FlRKxozwVXlQN60/1fNIl98xA==",
+			"dev": true,
+			"requires": {
+				"@commitlint/ensure": "^14.1.0",
+				"@commitlint/message": "^14.0.0",
+				"@commitlint/to-lines": "^14.0.0",
+				"@commitlint/types": "^14.0.0",
+				"execa": "^5.0.0"
+			},
+			"dependencies": {
+				"execa": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+					"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.3",
+						"get-stream": "^6.0.0",
+						"human-signals": "^2.1.0",
+						"is-stream": "^2.0.0",
+						"merge-stream": "^2.0.0",
+						"npm-run-path": "^4.0.1",
+						"onetime": "^5.1.2",
+						"signal-exit": "^3.0.3",
+						"strip-final-newline": "^2.0.0"
+					}
+				},
+				"get-stream": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+					"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+					"dev": true
+				},
+				"human-signals": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+					"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+					"dev": true
+				}
+			}
+		},
+		"@commitlint/to-lines": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-14.0.0.tgz",
+			"integrity": "sha512-uIXk54oJDuYyLpI208s3+cGmJ323yvSJ9LB7yUDMWUeJi2LgRxE2EBZL995kLQdnoAsBBXcLq+VDyppg5bV/cg==",
+			"dev": true
+		},
+		"@commitlint/top-level": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-14.0.0.tgz",
+			"integrity": "sha512-MZDKZfWfl9g4KozgWBGTCrI2cXkMHnBFlhwvEfrAu5G8wd5aL1f2uWEUMnBMjUikmhVj99i1pzge4XFWHQ29wQ==",
+			"dev": true,
+			"requires": {
+				"find-up": "^5.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				}
+			}
+		},
+		"@commitlint/types": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-14.0.0.tgz",
+			"integrity": "sha512-sIls1nP2uSbGL466edYlh8mn7O/WP4i3bcvP+2DMhkscRCSgaPhNRWDilhYVsHt2Vu1HTQ27uT0Bj5/Lt2+EcQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.0.0"
 			}
 		},
 		"@contentful/rich-text-html-renderer": {
@@ -46763,6 +47963,12 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
 			"integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
 		},
+		"array-ify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+			"integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
+			"dev": true
+		},
 		"array-includes": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
@@ -49164,6 +50370,16 @@
 			"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
 			"dev": true
 		},
+		"compare-func": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+			"dev": true,
+			"requires": {
+				"array-ify": "^1.0.0",
+				"dot-prop": "^5.1.0"
+			}
+		},
 		"component-emitter": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -49379,6 +50595,166 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+		},
+		"conventional-changelog-angular": {
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+			"integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+			"dev": true,
+			"requires": {
+				"compare-func": "^2.0.0",
+				"q": "^1.5.1"
+			}
+		},
+		"conventional-changelog-conventionalcommits": {
+			"version": "4.6.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-4.6.1.tgz",
+			"integrity": "sha512-lzWJpPZhbM1R0PIzkwzGBCnAkH5RKJzJfFQZcl/D+2lsJxAwGnDKBqn/F4C1RD31GJNn8NuKWQzAZDAVXPp2Mw==",
+			"dev": true,
+			"requires": {
+				"compare-func": "^2.0.0",
+				"lodash": "^4.17.15",
+				"q": "^1.5.1"
+			}
+		},
+		"conventional-commits-parser": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.3.tgz",
+			"integrity": "sha512-YyRDR7On9H07ICFpRm/igcdjIqebXbvf4Cff+Pf0BrBys1i1EOzx9iFXNlAbdrLAR8jf7bkUYkDAr8pEy0q4Pw==",
+			"dev": true,
+			"requires": {
+				"is-text-path": "^1.0.1",
+				"JSONStream": "^1.0.4",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
+			},
+			"dependencies": {
+				"hosted-git-info": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+					"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"meow": {
+					"version": "8.1.2",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+					"integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^3.0.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.18.0",
+						"yargs-parser": "^20.2.3"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.18.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+							"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+							"dev": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.1",
+						"is-core-module": "^2.5.0",
+						"semver": "^7.3.4",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"hosted-git-info": {
+							"version": "2.8.9",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+							"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+							"dev": true
+						},
+						"normalize-package-data": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"resolve": "^1.10.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						},
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
+					}
+				}
+			}
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -50164,15 +51540,6 @@
 						"ajv": "^6.12.5",
 						"ajv-keywords": "^3.5.2"
 					}
-				},
-				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
 				}
 			}
 		},
@@ -50481,6 +51848,12 @@
 				"debug": "^4.1.1",
 				"lodash": "^4.17.15"
 			}
+		},
+		"dargs": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+			"integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+			"dev": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
@@ -51037,6 +52410,15 @@
 			"requires": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
+			}
+		},
+		"dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"requires": {
+				"is-obj": "^2.0.0"
 			}
 		},
 		"dotenv": {
@@ -53599,6 +54981,144 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"git-raw-commits": {
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
+			"integrity": "sha512-sHhX5lsbG9SOO6yXdlwgEMQ/ljIn7qMpAbJZCGfXX2fq5T8M5SrDnpYk9/4HswTildcIqatsWa91vty6VhWSaQ==",
+			"dev": true,
+			"requires": {
+				"dargs": "^7.0.0",
+				"lodash": "^4.17.15",
+				"meow": "^8.0.0",
+				"split2": "^3.0.0",
+				"through2": "^4.0.0"
+			},
+			"dependencies": {
+				"hosted-git-info": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
+					"integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"meow": {
+					"version": "8.1.2",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+					"integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+					"dev": true,
+					"requires": {
+						"@types/minimist": "^1.2.0",
+						"camelcase-keys": "^6.2.2",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^3.0.0",
+						"read-pkg-up": "^7.0.1",
+						"redent": "^3.0.0",
+						"trim-newlines": "^3.0.0",
+						"type-fest": "^0.18.0",
+						"yargs-parser": "^20.2.3"
+					},
+					"dependencies": {
+						"type-fest": {
+							"version": "0.18.1",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+							"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+							"dev": true
+						}
+					}
+				},
+				"normalize-package-data": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+					"dev": true,
+					"requires": {
+						"hosted-git-info": "^4.0.1",
+						"is-core-module": "^2.5.0",
+						"semver": "^7.3.4",
+						"validate-npm-package-license": "^3.0.1"
+					}
+				},
+				"read-pkg": {
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+					"dev": true,
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^2.5.0",
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
+					},
+					"dependencies": {
+						"hosted-git-info": {
+							"version": "2.8.9",
+							"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+							"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+							"dev": true
+						},
+						"normalize-package-data": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+							"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+							"dev": true,
+							"requires": {
+								"hosted-git-info": "^2.1.4",
+								"resolve": "^1.10.0",
+								"semver": "2 || 3 || 4 || 5",
+								"validate-npm-package-license": "^3.0.1"
+							}
+						},
+						"semver": {
+							"version": "5.7.1",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+							"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+							"dev": true
+						},
+						"type-fest": {
+							"version": "0.6.0",
+							"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+							"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+							"dev": true
+						}
+					}
+				},
+				"read-pkg-up": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+					"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.1.0",
+						"read-pkg": "^5.2.0",
+						"type-fest": "^0.8.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
+					}
+				}
+			}
+		},
 		"git-revision-webpack-plugin": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.6.tgz",
@@ -55392,6 +56912,12 @@
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
 			"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
 		},
+		"is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
+		},
 		"is-object": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
@@ -55497,6 +57023,15 @@
 			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
 			"requires": {
 				"has-symbols": "^1.0.1"
+			}
+		},
+		"is-text-path": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+			"integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
+			"dev": true,
+			"requires": {
+				"text-extensions": "^1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -58355,6 +59890,22 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
 				}
+			}
+		},
+		"jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+			"dev": true
+		},
+		"JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"requires": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
 			}
 		},
 		"jsonwebtoken": {
@@ -64367,6 +65918,26 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
 		},
+		"resolve-global": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+			"integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+			"dev": true,
+			"requires": {
+				"global-dirs": "^0.1.1"
+			},
+			"dependencies": {
+				"global-dirs": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+					"integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+					"dev": true,
+					"requires": {
+						"ini": "^1.3.4"
+					}
+				}
+			}
+		},
 		"resolve-url": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -65006,9 +66577,9 @@
 			"optional": true
 		},
 		"semver": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-			"integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+			"version": "7.3.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
 			"requires": {
 				"lru-cache": "^6.0.0"
 			}
@@ -65609,6 +67180,28 @@
 					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 					"dev": true
+				}
+			}
+		},
+		"split2": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^3.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
 				}
 			}
 		},
@@ -66821,6 +68414,12 @@
 				"minimatch": "^3.0.4"
 			}
 		},
+		"text-extensions": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+			"integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
+			"dev": true
+		},
 		"text-hex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -67362,6 +68961,12 @@
 			"requires": {
 				"is-typedarray": "^1.0.0"
 			}
+		},
+		"typescript": {
+			"version": "4.4.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+			"integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+			"devOptional": true
 		},
 		"uglify-js": {
 			"version": "3.13.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
 		"@babel/plugin-transform-modules-commonjs": "^7.10.1",
 		"@babel/plugin-transform-runtime": "^7.11.5",
 		"@babel/preset-env": "^7.10.1",
+		"@commitlint/cli": "^14.1.0",
+		"@commitlint/config-conventional": "^14.1.0",
 		"@storybook/addon-a11y": "^6.3.2",
 		"@storybook/addon-essentials": "^6.3.2",
 		"@storybook/addon-knobs": "^6.2.9",


### PR DESCRIPTION
Enforces conventional commit messages for those with husky hooks installed (run `npx husky install` in the ui repo to do that if you haven't already). If the commit message does not follow the conventional commits format, the commit will not happen and an error like this will be displayed:
```bash
> git ci -m 'not a valid commit message'
⧗   input: not a valid commit message
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

husky - commit-msg hook exited with code 1 (error)
```