### PR TITLE
support for switching default branch name to `main`

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,0 +1,23 @@
+name: Release
+on:
+  push:
+    branches:
+      - main
+      - next
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npx --yes -p conventional-changelog-conventionalcommits@4 -p @semantic-release/changelog@6 -p @semantic-release/git@10 -p semantic-release@18 semantic-release

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -3,12 +3,12 @@ name: Ui Tests
 on:
   push:
     branches:
-      - master
-      - 'release-*'
+      - main
+      - next
   pull_request:
     branches:
-      - master
-      - 'release-*'
+      - main
+      - next
 
 jobs:
   build:

--- a/.github/workflows/storybook-to-gh-pages.yml
+++ b/.github/workflows/storybook-to-gh-pages.yml
@@ -3,10 +3,10 @@
 name: Deploy Storybook to GitHub Pages
 
 # Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# events but only for the main branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,15 @@
+{
+  "branches": ["main", {"name": "next", "prerelease": true}],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    ["@semantic-release/npm", {
+      "npmPublish": false
+    }],
+    ["@semantic-release/git", {
+      "assets": ["CHANGELOG.md", "package.json"]
+    }]
+  ],
+  "preset": "conventionalcommits"
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
 @Library('web-ui-ci') _
-kivaUIServerPipeline()
+marketplaceWebUiPipeline([ appName: 'ui', lighthouseConfig: 'lighthouserc-dev.js' ])

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 > a.k.a. Uue Lewis and the Views
 
-[![Build Status](https://github.com/kiva/ui/workflows/Ui%20Tests/badge.svg?branch=master)](https://github.com/kiva/ui/actions)
-[![Coverage Status](https://coveralls.io/repos/github/kiva/ui/badge.svg?branch=master)](https://coveralls.io/github/kiva/ui?branch=master)
+[![Build Status](https://github.com/kiva/ui/workflows/Ui%20Tests/badge.svg?branch=main)](https://github.com/kiva/ui/actions)
+[![Coverage Status](https://coveralls.io/repos/github/kiva/ui/badge.svg?branch=main)](https://coveralls.io/github/kiva/ui?branch=main)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=kiva/ui)](https://dependabot.com)
 [![Known Vulnerabilities](https://snyk.io/test/github/kiva/ui/badge.svg)](https://snyk.io/test/github/kiva/ui)
 
@@ -90,4 +90,3 @@ $ npm test
 ```
 
 For some more details, checkout the [template this is based on](http://vuejs-templates.github.io/webpack/) and the [docs for vue-loader](http://vuejs.github.io/vue-loader).
-

--- a/deploy/charts/templates/deployment.yaml
+++ b/deploy/charts/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       restartPolicy: Always
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}" # In Jenkins, need to call helm with --set image.tag=master-XY
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}" # In Jenkins, need to call helm with --set image.tag=vX.Y.Z
         command: ["tini"]
         args: ["--", "node", "server/index.js", "--port={{ .Values.service.port }}", "--config={{ .Values.deployenv.environment }}"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/src/components/Styleguide/StyleguideIntro.vue
+++ b/src/components/Styleguide/StyleguideIntro.vue
@@ -14,7 +14,7 @@
 			<a href="https://foundation.zurb.com/sites/docs/sass.html#the-settings-file" target="_blank">
 				_settings.scss</a>
 			file. The nice thing about the settings file is that you can override it with your own
-			<a href="https://github.com/kiva/ui/blob/master/src/assets/scss/_settings.scss" target="_blank">
+			<a href="https://github.com/kiva/ui/blob/main/src/assets/scss/_settings.scss" target="_blank">
 				_settings.scss</a>
 			file.
 		</p>


### PR DESCRIPTION
This will only be merged after the `master` branch has been renamed `main`. GitHub will automatically switch the base for this and other pull requests after the renaming. See https://github.com/github/renaming#renaming-existing-branches for more details about how Github handles renamed branches.