### PR TITLE
build: update token for release

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -19,5 +19,5 @@ jobs:
           node-version: '16.x'
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PUBLISH_PAT }}
         run: npx --yes -p conventional-changelog-conventionalcommits@4 -p @semantic-release/changelog@6 -p @semantic-release/git@10 -p semantic-release@18 semantic-release


### PR DESCRIPTION
Need to use a token that is allowed to push to protected branches to avoid errors during the release action. This technically allows the branch protection rules to be bypassed by anyone with write access to the repo. However, we don't hand out write access to many people, and actually bypassing branch protections takes determined effort (a new workflow is required to be made, configured with this new token, and it needs to run git push commands). Pull requests from outside contributors won't be able to run actions, so there is no concern there.