### PR TITLE
feat: core-251 adding previous loan link to borrower profile

### DIFF
--- a/src/components/BorrowerProfile/LoanDescription.vue
+++ b/src/components/BorrowerProfile/LoanDescription.vue
@@ -30,6 +30,7 @@
 				v-if="previousLoanId"
 				:loan-id="loanId"
 				:previous-loan-id="previousLoanId"
+				:borrower-or-group-name="borrowerOrGroupName"
 			/>
 
 			<section v-if="storyTranslation">
@@ -128,8 +129,8 @@ export default {
 			default: () => {},
 		},
 		previousLoanId: { // LoanBasic.previousLoanId
-			type: Number,
-			default: 0,
+			type: String,
+			default: '',
 		},
 		loanId: {
 			type: Number,

--- a/src/components/BorrowerProfile/PreviousLoanDescription.vue
+++ b/src/components/BorrowerProfile/PreviousLoanDescription.vue
@@ -1,7 +1,6 @@
 <template>
 	<section>
 		<kv-text-link
-			v-if="previousLoanId"
 			v-kv-track-event="['Borrower profile', 'click-Loan details', 'Show previous loan details', this.loanId]"
 			@click.prevent="performClick"
 		>
@@ -25,6 +24,19 @@
 					v-html="paragraph"
 				>
 				</p>
+
+				<router-link
+					v-if="previousLoanId && this.borrowerOrGroupName !== ''"
+					:to="`/lend/${previousLoanId}`"
+					v-kv-track-event="[
+						'Borrower profile',
+						'Loan details',
+						'Borrower\'s previous loan',
+						previousLoanId
+					]"
+				>
+					{{ this.borrowerOrGroupName }}'s previous loan
+				</router-link>
 			</div>
 		</kv-expandable>
 	</section>
@@ -67,8 +79,12 @@ export default {
 			default: 0,
 		},
 		previousLoanId: {
-			type: Number,
-			default: 0,
+			type: String,
+			default: '',
+		},
+		borrowerOrGroupName: {
+			type: String,
+			default: ''
 		}
 	},
 	computed: {


### PR DESCRIPTION
[Core-251](https://kiva.atlassian.net/browse/CORE-251)

On the borrower profile, I've added a link to a borrower's previous loan if there's a previousLoanId related to a loan. Tracking task Core-274 included in these changes.


<img width="1164" alt="Screen Shot 2021-11-15 at 2 01 20 PM" src="https://user-images.githubusercontent.com/1521381/141853548-4b488ddb-5857-44f8-a8f6-415ba0746d2c.png">


