### PR TITLE
fix: prevent content from breaking mobile layout

### DIFF
--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -287,8 +287,8 @@ export default {
 				this.loan.loanTermLenderRepaymentTerm = loan?.terms?.lenderRepaymentTerm ?? 0;
 				this.loan.lossLiabilityCurrencyExchange = loan?.terms?.lossLiabilityCurrencyExchange ?? '';
 				this.loan.repaymentInterval = loan?.repaymentInterval ?? '';
-				this.loan.disbursalDate = loan.disbursalDate ?? '';
-				this.loan.status = loan.status ?? '';
+				this.loan.disbursalDate = loan?.disbursalDate ?? '';
+				this.loan.status = loan?.status ?? '';
 
 				this.partner.arrearsRate = partner?.arrearsRate ?? 0;
 				this.partner.avgBorrowerCost = partner?.avgBorrowerCost ?? 0;

--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -1,6 +1,6 @@
 <template>
 	<section>
-		<div class="tw-prose">
+		<div class="tw-prose tw-overflow-auto">
 			<h2>
 				More about this loan
 			</h2>

--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -1,6 +1,6 @@
 <template>
 	<section>
-		<div class="tw-prose tw-overflow-auto">
+		<div class="tw-prose tw-break-words">
 			<h2>
 				More about this loan
 			</h2>


### PR DESCRIPTION
Following up on an email from Google's search console today, 

```
Content wider than screen
We recommend that you fix these issues when possible to enable the best experience and coverage in Google Search.
```

<img width="1711" alt="Screen Shot 2021-11-22 at 10 16 52 AM" src="https://user-images.githubusercontent.com/187937/142915445-2aabbfe7-c80f-4eb3-a99a-9e32eaef47f7.png">

This doesn't fix the root problem, something's odd with the content coming in and adding a bunch of `&nbsp;`
![image](https://user-images.githubusercontent.com/187937/142915566-01eb8b06-b605-4bec-b462-249b94f2a80c.png)

but it does prevent the layout from breaking in those cases.

https://www.kiva.org/lend-beta/2272570