### PR TITLE
fix: core-308 fixing data points that were not hooked up, avgProfitab…

### DIFF
--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -51,6 +51,7 @@
 						:partner-id="partner.id"
 						:partner-name="partner.name"
 						:risk-rating="partner.riskRating"
+						:currency-exchange-loss-rate="partner.currencyExchangeLossRate"
 						@show-definition="showDefinition"
 					/>
 				</kv-tab-panel>
@@ -265,12 +266,14 @@ export default {
 									arrearsRate
 									avgBorrowerCost
 									avgBorrowerCostType
+									avgProfitability
 									chargesFeesInterest
 									defaultRate
 									id
 									loansAtRiskRate
 									name
 									riskRating
+									currencyExchangeLossRate
 								}
 							}
 						}
@@ -303,6 +306,7 @@ export default {
 				this.partner.loansAtRiskRate = partner?.loansAtRiskRate ?? 0;
 				this.partner.name = partner?.name ?? '';
 				this.partner.riskRating = partner?.riskRating ?? 0;
+				this.partner.currencyExchangeLossRate = partner?.currencyExchangeLossRate ?? 0;
 
 				this.trustee.endorsement = loan?.endorsement ?? '';
 				this.trustee.id = trustee?.id ?? 0;

--- a/src/components/BorrowerProfile/FieldPartnerDetails.vue
+++ b/src/components/BorrowerProfile/FieldPartnerDetails.vue
@@ -136,6 +136,10 @@ export default {
 			type: Number,
 			default: 0,
 		},
+		currencyExchangeLossRate: { // Partner.currencyExchangeLossRate
+			type: Number,
+			default: 0,
+		}
 	},
 	computed: {
 		avgBorrowerCostFormatted() {


### PR DESCRIPTION
…ilty & currencyExchangeLossRate

[Core-308](https://kiva.atlassian.net/browse/CORE-308)

Finished hooking up the avgProfitability and currencyExchangeLossRate in the borrower profile.

Rendered:
<img width="811" alt="Screen Shot 2021-12-01 at 1 51 59 PM" src="https://user-images.githubusercontent.com/1521381/144312314-c926f415-fc41-4d94-9ddc-97f61f6bd15b.png">
 
