### PR TITLE
fix: core-185 replacing borrowerName with TrusteeName

### DIFF
--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -57,6 +57,7 @@
 				</kv-tab-panel>
 				<kv-tab-panel :id="trusteeTabId" v-if="hasTrustee">
 					<trustee-details
+						:borrower-name="loan.name"
 						:endorsement="trustee.endorsement"
 						:num-defaulted-loans="trustee.numDefaultedLoans"
 						:num-loans-endorsed-public="trustee.numLoansEndorsedPublic"
@@ -128,6 +129,7 @@ export default {
 			lightboxContent: null,
 			lightboxTitle: '',
 			loan: {
+				name: '',
 				currency: '',
 				flexibleFundraisingEnabled: false,
 				loanLenderRepaymentTerm: 0,
@@ -237,6 +239,7 @@ export default {
 					lend {
 						loan(id: $loanId) {
 							id
+							name
 							status
 							lenderRepaymentTerm
 							repaymentInterval
@@ -295,6 +298,7 @@ export default {
 				this.loan.repaymentInterval = loan?.repaymentInterval ?? '';
 				this.loan.disbursalDate = loan?.disbursalDate ?? '';
 				this.loan.status = loan?.status ?? '';
+				this.loan.name = loan?.name ?? '';
 
 				this.partner.arrearsRate = partner?.arrearsRate ?? 0;
 				this.partner.avgBorrowerCost = partner?.avgBorrowerCost ?? 0;

--- a/src/components/BorrowerProfile/TrusteeDetails.vue
+++ b/src/components/BorrowerProfile/TrusteeDetails.vue
@@ -63,6 +63,10 @@ export default {
 		KvTextLink,
 	},
 	props: {
+		borrowerName: {
+			type: String,
+			default: '',
+		},
 		endorsement: { // endorsement
 			type: String,
 			default: '',
@@ -99,7 +103,7 @@ export default {
 	},
 	computed: {
 		endorsementTitle() {
-			return `Why are you endorsing ${this.trusteeName}?`;
+			return `Why are you endorsing ${this.borrowerName}?`;
 		},
 		noTrusteeState() {
 			return this.trusteeName === 'No Trustee Endorsement';


### PR DESCRIPTION
[Core-185](https://kiva.atlassian.net/browse/CORE-185)

We had the trusteeName in a spot where we actually wanted borrowerName. I've added name to the graphql query and passed the data into TrusteeDetails.vue to be rendered.

Corrected text now reads "Why are you endorsing Alan?"


<img width="1095" alt="Screen Shot 2021-12-01 at 3 02 00 PM" src="https://user-images.githubusercontent.com/1521381/144321237-cde55b5c-84ff-4b0d-9685-7caf813663f2.png">

