### PR TITLE
fix: catch redirection errors from router.push

### DIFF
--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -90,8 +90,8 @@ export default context => {
 		context.renderedNoscript = noscriptTemplate(config);
 		context.renderedExternals = `<script>(${serialize(headScript)})(window.__KV_CONFIG__);</script>`;
 
-		// set router's location
-		router.push(url);
+		// set router's location, ignoring any errors about redirection
+		router.push(url).catch(() => {});
 
 		// wait until router has resolved possible async hooks
 		return router.onReady(() => {


### PR DESCRIPTION
Fixes `Error: Redirected when going from "/" to "/register/social" via a navigation guard` by catching and ignoring it, as recommended in solution 2.1 of https://stackoverflow.com/a/65326844