### PR TITLE
docs: workaround storybook console errors when stories are named Pages

### DIFF
--- a/.storybook/stories/15years.stories.js
+++ b/.storybook/stories/15years.stories.js
@@ -74,7 +74,7 @@ const recentFundedLoans = {
 };
 
 export default {
-	title: 'Pages/15Years',
+	title: 'Page/15Years',
 	component: FifteenYears,
 	args: {
 		appealBannerContent: appealBanner,

--- a/.storybook/stories/BorrowerProfile.stories.js
+++ b/.storybook/stories/BorrowerProfile.stories.js
@@ -12,7 +12,7 @@ import kvAuth0StoryMixin from '../mixins/kv-auth0-story-mixin';
 
 
 export default {
-	title: '/Pages/Borrower Profile',
+	title: 'Page/Borrower Profile',
 	component: BorrowerProfile,
 	parameters: {
 		layout: 'fullscreen',

--- a/.storybook/stories/CorporateCampaign.stories.js
+++ b/.storybook/stories/CorporateCampaign.stories.js
@@ -14,7 +14,7 @@ import CampaignHero from '@/components/CorporateCampaign/CampaignHero';
 import CampaignStatus from '@/components/CorporateCampaign/CampaignStatus';
 
 export default {
-	title: 'Pages/CorporateCampaignLanding',
+	title: 'Page/CorporateCampaignLanding',
 	component: CorporateCampaignLanding,
 	args: {
 		heroAreaContent: {

--- a/.storybook/stories/GetStarted.stories.js
+++ b/.storybook/stories/GetStarted.stories.js
@@ -12,7 +12,7 @@ import apolloStoryMixin from '../mixins/apollo-story-mixin';
 import cookieStoreStoryMixin from '../mixins/cookie-store-story-mixin';
 
 export default {
-	title: 'Pages/GetStarted',
+	title: 'Page/GetStarted',
 	component: GetStartedCauses,
 	decorators: [StoryRouter()],
 };

--- a/.storybook/stories/MGCovid19Response.stories.js
+++ b/.storybook/stories/MGCovid19Response.stories.js
@@ -10,7 +10,7 @@ import apolloStoryMixin from '../mixins/apollo-story-mixin';
 import kvAuth0StoryMixin from '../mixins/kv-auth0-story-mixin';
 
 export default {
-	title: 'Pages/MGCovid19Response',
+	title: 'Page/MGCovid19Response',
 	component: MGCovid19,
 	decorators: [StoryRouter()],
 };

--- a/.storybook/stories/SecuritySettings.stories.js
+++ b/.storybook/stories/SecuritySettings.stories.js
@@ -13,7 +13,7 @@ import SecuritySettingsPage from '@/pages/Settings/SecuritySettings';
 import TwoStepVerificationPage from '@/pages/Settings/TwoStepVerificationPage';
 
 export default {
-	title: 'Pages/Security Settings',
+	title: 'Page/Security Settings',
 	component: SecuritySettingsPage,
 	decorators: [StoryRouter()],
 };

--- a/.storybook/stories/TwelveDaysCalendar.stories.js
+++ b/.storybook/stories/TwelveDaysCalendar.stories.js
@@ -3,7 +3,7 @@ import { number, boolean } from '@storybook/addon-knobs';
 import TwelveDaysCalendar from '@/pages/Possibility/TwelveDaysCalendar';
 
 export default {
-	title: 'Pages/12Days',
+	title: 'Page/12Days',
 	component: TwelveDaysCalendar,
 	decorators: [StoryRouter()],
 };


### PR DESCRIPTION
Really not sure why this is happening but there's tons of console errors that look like
<img width="1118" alt="Screen Shot 2021-12-09 at 5 29 09 PM" src="https://user-images.githubusercontent.com/187937/145502129-da228eb8-33a8-42a1-9adb-340eda4b4ef9.png">

Renaming from Pages to Page makes them all disappear 🤷
