### PR TITLE
feat(auth): set dev graphql query params when fake authentication cookie is present

### DIFF
--- a/config/dev-vm.js
+++ b/config/dev-vm.js
@@ -48,6 +48,7 @@ module.exports = merge(base, {
 				ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF: 'https://dev-vm-01.kiva.org/ui-login?force=true',
 			},
 			enable: true,
+			checkFakeAuth: true,
 			apiAudience: 'https://api.dev.kivaws.org/graphql',
 			mfaAudience: 'https://kiva-dev.auth0.com/mfa/',
 			browserClientID: 'ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF',

--- a/config/dev.js
+++ b/config/dev.js
@@ -42,6 +42,7 @@ module.exports = merge(base, {
 				ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF: 'https://www.dev.kiva.org/ui-login?force=true',
 			},
 			enable: true,
+			checkFakeAuth: true,
 			apiAudience: 'https://api.dev.kivaws.org/graphql',
 			mfaAudience: 'https://kiva-dev.auth0.com/mfa/',
 			browserClientID: 'ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF',

--- a/config/index.js
+++ b/config/index.js
@@ -41,6 +41,7 @@ module.exports = {
 				AEnMbebwn6LBvxg1iMYczZKoAgdUt37K: 'https://www.kiva.org/ui-login?force=true',
 			},
 			enable: true,
+			checkFakeAuth: false,
 			apiAudience: 'https://api.kivaws.org/graphql',
 			mfaAudience: 'https://kiva-prod.auth0.com/mfa/',
 			browserClientID: 'AEnMbebwn6LBvxg1iMYczZKoAgdUt37K',

--- a/config/stage.js
+++ b/config/stage.js
@@ -41,6 +41,7 @@ module.exports = merge(base, {
 				pK7XVUBouUjPEFm9bz5MN7sjU5HACqqe: 'https://www.stage.kiva.org/ui-login?force=true',
 			},
 			enable: true,
+			checkFakeAuth: true,
 			apiAudience: 'https://api.stage.kivaws.org/graphql',
 			mfaAudience: 'https://kiva-stage.auth0.com/mfa/',
 			browserClientID: 'pK7XVUBouUjPEFm9bz5MN7sjU5HACqqe',

--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -3,6 +3,7 @@ const express = require('express');
 const passport = require('passport');
 const Auth0Strategy = require('passport-auth0');
 const { isExpired } = require('./util/jwt');
+const { info, warn } = require('./util/log');
 const {
 	clearNotedLoginState,
 	getSyncCookie,
@@ -31,11 +32,7 @@ module.exports = function authRouter(config = {}) {
 
 	// If no server-side auth0 secret is provided, skip setting up auth routes
 	if (!process.env.UI_AUTH0_CLIENT_SECRET) {
-		console.warn(JSON.stringify({
-			meta: {},
-			level: 'warn',
-			message: 'UI server-side authentication setup skipped because UI_AUTH0_CLIENT_SECRET is not defined!'
-		}));
+		warn('UI server-side authentication setup skipped because UI_AUTH0_CLIENT_SECRET is not defined!');
 		return router;
 	}
 
@@ -99,21 +96,14 @@ module.exports = function authRouter(config = {}) {
 		if (req.query.doneUrl) {
 			req.session.doneUrl = req.query.doneUrl;
 		}
-		console.log(JSON.stringify({
-			meta: {},
-			level: 'log',
-			message: `LoginUI: attempt login, session id:${req.sessionID}, cookie:${getSyncCookie(req)}, done url:${req.query.doneUrl}` // eslint-disable-line max-len
-		}));
+
+		info(`LoginUI: attempt login, session id:${req.sessionID}, cookie:${getSyncCookie(req)}, done url:${req.query.doneUrl}`); // eslint-disable-line max-len
 		passport.authenticate('auth0', options)(req, res, next);
 	});
 
 	// Handle logout request
 	router.get('/ui-logout', (req, res) => {
-		console.log(JSON.stringify({
-			meta: {},
-			level: 'log',
-			message: `LoginUI: execute logout, session id:${req.sessionID}, cookie:${getSyncCookie(req)}, user id:${req.user && req.user.id}` // eslint-disable-line max-len
-		}));
+		info(`LoginUI: execute logout, session id:${req.sessionID}, cookie:${getSyncCookie(req)}, user id:${req.user && req.user.id}`); // eslint-disable-line max-len
 		const returnUrl = encodeURIComponent(`https://${config.host}`);
 		const logoutUrl = `https://${config.auth0.domain}/v2/logout?returnTo=${returnUrl}`;
 		req.logout(); // removes req.user
@@ -123,13 +113,9 @@ module.exports = function authRouter(config = {}) {
 
 	// Callback redirected to after Auth0 authentication
 	router.get('/process-ssr-auth', (req, res, next) => {
-		passport.authenticate('auth0', (authErr, user, info) => {
+		passport.authenticate('auth0', (authErr, user, authInfo) => {
 			if (authErr) {
-				console.log(JSON.stringify({
-					meta: {},
-					level: 'log',
-					message: `LoginUI: auth error, session id:${req.sessionID}, error: ${authErr}`,
-				}));
+				info(`LoginUI: auth error, session id:${req.sessionID}, error: ${authErr}`, { error: authErr });
 
 				const { profileRetried } = req.session;
 				delete req.session.profileRetried;
@@ -169,28 +155,16 @@ module.exports = function authRouter(config = {}) {
 
 			if (!user) {
 				if (req.user) {
-					console.warn(JSON.stringify({
-						meta: {},
-						level: 'warn',
-						message: `LoginSyncUI: login was attempted despite already having user, user id:${req.user.id}, session id:${req.sessionID}, state:${req.query.state}, last state:${req.session.lastUsedState}` // eslint-disable-line max-len
-					}));
+					warn(`LoginSyncUI: login was attempted despite already having user, user id:${req.user.id}, session id:${req.sessionID}, state:${req.query.state}, last state:${req.session.lastUsedState}`); // eslint-disable-line max-len
 					doneUrl = req.session.lastUsedDoneUrl;
 				} else {
 					clearNotedLoginState(res);
 				}
-				console.log(JSON.stringify({
-					meta: {},
-					level: 'log',
-					message: `LoginSyncUI: user failed to login, session id:${req.sessionID}, previous cookie:${getSyncCookie(req)}, info:${JSON.stringify(info)}` // eslint-disable-line max-len
-				}));
+				info(`LoginSyncUI: user failed to login, session id:${req.sessionID}, previous cookie:${getSyncCookie(req)}, info:${JSON.stringify(authInfo)}`); // eslint-disable-line max-len
 				return res.redirect(doneUrl || '/');
 			}
 
-			console.log(JSON.stringify({
-				meta: {},
-				level: 'log',
-				message: `LoginSyncUI: user logged in, session id:${req.sessionID}, previous cookie:${getSyncCookie(req)}, user id:${user.id}` // eslint-disable-line max-len
-			}));
+			info(`LoginSyncUI: user logged in, session id:${req.sessionID}, previous cookie:${getSyncCookie(req)}, user id:${user.id}`); // eslint-disable-line max-len
 			noteLoggedIn(res, user);
 			req.session.lastUsedDoneUrl = doneUrl;
 			req.session.lastUsedState = req.query && req.query.state;
@@ -223,34 +197,18 @@ module.exports = function authRouter(config = {}) {
 			next();
 		} else if ((req.headers?.cookie ?? '').includes('kvfa=')) {
 			// Skip login sync check if a fake authentication cookie is set
-			console.log(JSON.stringify({
-				meta: {},
-				level: 'log',
-				message: `LoginSyncUI: FakeAuthentication cookie present, skipping sync, session id:${req.sessionID}`,
-			}));
+			info(`LoginSyncUI: FakeAuthentication cookie present, skipping sync, session id:${req.sessionID}`);
 			next();
 		} else if (isNotedLoggedIn(req) && !req.user) {
-			console.log(JSON.stringify({
-				meta: {},
-				level: 'log',
-				message: `LoginSyncUI: attempt silent login, session id:${req.sessionID}, uri:${req.originalUrl}, cookie:${getSyncCookie(req)}, user:${req.user}` // eslint-disable-line max-len
-			}));
+			info(`LoginSyncUI: attempt silent login, session id:${req.sessionID}, uri:${req.originalUrl}, cookie:${getSyncCookie(req)}, user:${req.user}`); // eslint-disable-line max-len
 			attemptSilentAuth(req, res, next);
 		} else if (isNotedLoggedIn(req) && !isNotedUserRequestUser(req)) {
-			console.log(JSON.stringify({
-				meta: {},
-				level: 'log',
-				message: `LoginSyncUI: user id mismatch, session id:${req.sessionID}, uri:${req.originalUrl}, cookie:${getSyncCookie(req)}, user:${req.user.id}` // eslint-disable-line max-len
-			}));
+			info(`LoginSyncUI: user id mismatch, session id:${req.sessionID}, uri:${req.originalUrl}, cookie:${getSyncCookie(req)}, user:${req.user.id}`); // eslint-disable-line max-len
 			req.logout(); // removes req.user
 			attemptSilentAuth(req, res, next);
 		} else {
 			if (isNotedLoggedOut(req) && req.user) {
-				console.log(JSON.stringify({
-					meta: {},
-					level: 'log',
-					message: `LoginSyncUI: execute logout, session id:${req.sessionID}, uri:${req.originalUrl}, cookie:${getSyncCookie(req)}, user id:${req.user.id}` // eslint-disable-line max-len
-				}));
+				info(`LoginSyncUI: execute logout, session id:${req.sessionID}, uri:${req.originalUrl}, cookie:${getSyncCookie(req)}, user id:${req.user.id}`); // eslint-disable-line max-len
 				req.logout(); // removes req.user
 			}
 			next();

--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const log = require('./util/log');
+const { error } = require('./util/log');
 const memJsUtils = require('./util/memJsUtils');
 const drawLoanCard = require('./util/live-loan/live-loan-draw');
 const fetchLoansByType = require('./util/live-loan/live-loan-fetch');
@@ -12,7 +12,7 @@ async function fetchRecommendedLoans(type, id, cache) {
 			return JSON.parse(cachedLoanData);
 		}
 	} catch (err) {
-		log(`Error reading from memjs, ${err}`, 'error');
+		error(`Error reading from memjs, ${err}`, { error: err });
 	}
 
 	// Otherwise we need to hit the graphql endpoint.
@@ -23,7 +23,7 @@ async function fetchRecommendedLoans(type, id, cache) {
 		const expires = 10 * 60; // 10 minutes
 		memJsUtils.setToCache(`recommendations-by-${type}-id-${id}`, JSON.stringify(loanData), expires, cache)
 			.catch(err => {
-				log(`Error setting loan data to cache, ${err}`, 'error');
+				error(`Error setting loan data to cache, ${err}`, { error: err });
 			});
 		// Return before setting to the cache completes to speed up response times
 		return loanData;
@@ -65,7 +65,7 @@ async function redirectToUrl(type, cache, req, res) {
 		}
 		res.redirect(302, redirect);
 	} catch (err) {
-		log(`Error redirecting to url, ${err}`, 'error');
+		error(`Error redirecting to url, ${err}`, { error: err });
 		res.redirect(302, '/lend-by-category/');
 	}
 }
@@ -82,7 +82,7 @@ async function serveImg(type, cache, req, res) {
 			loanImg = await drawLoanCard(loan);
 			const expires = 10 * 60; // 10 minutes
 			memJsUtils.setToCache(`loan-card-img-${loan.id}`, loanImg, expires, cache).catch(err => {
-				log(`Error setting loan data to cache, ${err}`, 'error');
+				error(`Error setting loan data to cache, ${err}`, { error: err });
 			});
 			// Continue before setting to the cache completes to speed up response times
 		}
@@ -94,7 +94,7 @@ async function serveImg(type, cache, req, res) {
 		]);
 		res.send(loanImg);
 	} catch (err) {
-		log(`Error serving image, ${err}`, 'error');
+		error(`Error serving image, ${err}`, { error: err });
 		res.sendStatus(500);
 	}
 }

--- a/server/util/fakeAuthentication.js
+++ b/server/util/fakeAuthentication.js
@@ -1,0 +1,12 @@
+function fakeAuthEnabled(config) {
+	return config?.auth0?.checkFakeAuth ?? false;
+}
+
+function usingFakeAuth(config, req) {
+	return fakeAuthEnabled(config) && (req.headers?.cookie ?? '').includes('kvfa=');
+}
+
+module.exports = {
+	fakeAuthEnabled,
+	usingFakeAuth,
+};

--- a/server/util/live-loan/live-loan-fetch.js
+++ b/server/util/live-loan/live-loan-fetch.js
@@ -2,7 +2,7 @@ const get = require('lodash/get');
 const argv = require('../argv');
 const config = require('../../../config/selectConfig')(argv.config);
 const fetch = require('../fetch');
-const log = require('../log');
+const { warn, error } = require('../log');
 
 // Number of loans to fetch
 const loanCount = 4;
@@ -45,7 +45,7 @@ async function fetchGraphQL(request, resultPath) {
 		}
 		return [];
 	} catch (err) {
-		log(`Error fetching loans: ${err}`, 'error');
+		error(`Error fetching loans: ${err}`, { error: err });
 	}
 }
 
@@ -186,7 +186,7 @@ const supportedFilterFLSS = name => {
 		case 'sector':
 			return true;
 		default:
-			log(`Unsupported FLSS filter "${name}"`, 'warning');
+			warn(`Unsupported FLSS filter "${name}"`);
 			return false;
 	}
 };
@@ -237,7 +237,7 @@ const supportedFilterLegacy = name => {
 		case 'theme':
 			return true;
 		default:
-			log(`Unsupported legacy filter "${name}"`, 'warning');
+			warn(`Unsupported legacy filter "${name}"`);
 			return false;
 	}
 };
@@ -263,7 +263,7 @@ async function parseFilterStringLegacy(filterString) {
 	const findFilterOption = (options, name, value) => {
 		const option = options.find(o => o?.name?.toLowerCase() === value);
 		if (!option) {
-			log(`Unknown ${name} "${value}"`, 'warning');
+			warn(`Unknown ${name} "${value}"`);
 		}
 		return option;
 	};

--- a/server/util/log.js
+++ b/server/util/log.js
@@ -2,18 +2,54 @@
  * Logs a message to the console formatted nicely
  * @param {String} message
  * @param {('info'|'warning'|'error')} level
- *  */
-module.exports = function log(message, level = 'info') {
+ * @param {object} meta
+ */
+function log(message, level = 'info', meta = {}) {
 	const payload = JSON.stringify({
-		meta: {},
+		meta,
 		level,
 		message
 	});
-	if (level === 'warning') {
+	if (level === 'warn') {
 		console.warn(payload);
 	} else if (level === 'error') {
 		console.error(payload);
 	} else {
 		console.info(payload);
 	}
+}
+
+/**
+ * Logs an info message to the console
+ * @param {String} message
+ * @param {object} meta
+ */
+function info(message, meta) {
+	log(message, 'info', meta);
+}
+
+/**
+ * Logs a warning message to the console
+ * @param {String} message
+ * @param {object} meta
+ */
+function warn(message, meta) {
+	log(message, 'warn', meta);
+}
+
+/**
+ * Logs an error message to the console
+ * @param {String} message
+ * @param {object} meta
+ */
+function error(message, meta) {
+	log(message, 'error', meta);
+}
+
+module.exports = {
+	log,
+	info,
+	warn,
+	warning: warn,
+	error,
 };

--- a/src/api/Auth0Link.js
+++ b/src/api/Auth0Link.js
@@ -15,6 +15,9 @@ export default ({ kvAuth0 }) => {
 		// If auth0 is not enabled, don't add anything to the context
 		if (!kvAuth0.enabled) return getAuthContext(previousContext);
 
+		// If using fake authentication, don't add anything to the context
+		if (kvAuth0.getFakeAuthCookieValue()) return getAuthContext(previousContext);
+
 		// If we already have user info, and we don't need to check login, just add that to the context
 		if (kvAuth0.getKivaId() && !kvAuth0.getSyncCookieValue()) {
 			return getAuthContext(previousContext, kvAuth0.user, kvAuth0.accessToken);

--- a/src/api/HttpLink.js
+++ b/src/api/HttpLink.js
@@ -28,10 +28,10 @@ export default ({ kvAuth0, uri = '' }) => {
 		fetchOptions: { agent }
 	};
 
-	// Add Fake Authentication info to the server URI if it is provided.
+	// Add Fake Authentication info to the server URI if it is provided and allowed.
 	try {
 		const fakeAuthInfo = kvAuth0.getFakeAuthCookieValue();
-		if (fakeAuthInfo) {
+		if (kvAuth0.fakeAuthAllowed() && fakeAuthInfo) {
 			// add params to uri
 			const fakeUri = new URL(uri);
 			fakeUri.searchParams.set('user_id', fakeAuthInfo.userId);

--- a/src/api/HttpLink.js
+++ b/src/api/HttpLink.js
@@ -1,10 +1,11 @@
+import * as Sentry from '@sentry/vue';
 import { BatchHttpLink } from 'apollo-link-batch-http';
 import fetch from 'isomorphic-fetch';
 // http is a nodejs dep only used during development mode (there is no http npm package as of July 2020)
 import { Agent as HttpAgent } from 'http'; // eslint-disable-line import/no-extraneous-dependencies
 import { Agent as SslAgent } from 'https';
 
-export default ({ uri = '' }) => {
+export default ({ kvAuth0, uri = '' }) => {
 	const onVm = uri.indexOf('vm') > -1;
 	const usingLocal = uri.indexOf('localhost') > -1;
 	const secure = uri.indexOf('https') === 0;
@@ -26,6 +27,23 @@ export default ({ uri = '' }) => {
 		credentials: 'same-origin',
 		fetchOptions: { agent }
 	};
+
+	// Add Fake Authentication info to the server URI if it is provided.
+	try {
+		const fakeAuthInfo = kvAuth0.getFakeAuthCookieValue();
+		if (fakeAuthInfo) {
+			// add params to uri
+			const fakeUri = new URL(uri);
+			fakeUri.searchParams.set('user_id', fakeAuthInfo.userId);
+			fakeUri.searchParams.set('scopes', fakeAuthInfo.scopes.join(' '));
+			fakeUri.searchParams.set('app_id', kvAuth0.clientID || 'org.kiva.www');
+
+			options.uri = fakeUri.href;
+		}
+	} catch (e) {
+		console.error(e);
+		Sentry.captureException(e);
+	}
 
 	return new BatchHttpLink(options);
 };

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -51,7 +51,7 @@ export default function createApolloClient({
 			Auth0LinkCreator({ cookieStore, kvAuth0 }),
 			BasketLinkCreator({ cookieStore }),
 			ContentfulPreviewLink({ cookieStore }),
-			HttpLinkCreator({ uri }),
+			HttpLinkCreator({ kvAuth0, uri }),
 		]),
 		cache,
 		resolvers,

--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -30,6 +30,7 @@ let kvAuth0;
 if (config.auth0.enable) {
 	kvAuth0 = new KvAuth0({
 		audience: config.auth0.apiAudience,
+		checkFakeAuth: config.auth0.checkFakeAuth,
 		clientID: config.auth0.browserClientID,
 		cookieStore,
 		domain: config.auth0.domain,

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -54,6 +54,7 @@ export default context => {
 		if (config.auth0.enable) {
 			kvAuth0 = new KvAuth0({
 				accessToken,
+				checkFakeAuth: config.auth0.checkFakeAuth,
 				cookieStore,
 				user: profile,
 			});

--- a/src/util/KvAuth0.js
+++ b/src/util/KvAuth0.js
@@ -1,4 +1,4 @@
-import { differenceInMilliseconds } from 'date-fns';
+import { differenceInMilliseconds, sub } from 'date-fns';
 import _get from 'lodash/get';
 import _over from 'lodash/over';
 import * as Sentry from '@sentry/vue';
@@ -9,6 +9,10 @@ const isServer = typeof window === 'undefined';
 // only require auth0-js if we are not in a server environment
 const auth0js = !isServer ? require('auth0-js') : null;
 
+export const KIVA_ID_KEY = 'https://www.kiva.org/kiva_id';
+export const LAST_LOGIN_KEY = 'https://www.kiva.org/last_login';
+export const USED_MFA_KEY = 'https://www.kiva.org/used_mfa';
+const FAKE_AUTH_NAME = 'kvfa';
 const SYNC_NAME = 'kvls';
 const LOGOUT_VALUE = 'o';
 const COOKIE_OPTIONS = { path: '/', secure: true };
@@ -50,6 +54,7 @@ export default class KvAuth0 {
 		this.accessToken = accessToken;
 		this.isServer = isServer;
 		this.cookieStore = cookieStore;
+		this.clientID = clientID;
 		if (!this.isServer) {
 			// Setup Auth0 WebAuth client for authentication
 			this.webAuth = new auth0js.WebAuth({
@@ -69,6 +74,13 @@ export default class KvAuth0 {
 				responseType: 'token',
 				scope: 'enroll read:authenticators remove:authenticators',
 			});
+		}
+
+		// Set user from fake auth cookie if available
+		const idTokenPayload = this.getFakeIdTokenPayload();
+		if (idTokenPayload) {
+			this[setAuthData]({ idTokenPayload });
+			this[noteLoggedIn]();
 		}
 	}
 
@@ -126,24 +138,65 @@ export default class KvAuth0 {
 
 	// Return the kiva id for the current user (or undefined)
 	getKivaId() {
-		const kivaIdKey = 'https://www.kiva.org/kiva_id';
-		return _get(this, `user["${kivaIdKey}"]`)
-			|| _get(this, `user._json["${kivaIdKey}"]`);
+		return _get(this, `user["${KIVA_ID_KEY}"]`)
+			|| _get(this, `user._json["${KIVA_ID_KEY}"]`);
 	}
 
 	// Return the last login timestamp for the current user (or 0)
 	getLastLogin() {
-		const lastLoginKey = 'https://www.kiva.org/last_login';
-		return _get(this, `user["${lastLoginKey}"]`)
-			|| _get(this, `user._json["${lastLoginKey}"]`)
+		return _get(this, `user["${LAST_LOGIN_KEY}"]`)
+			|| _get(this, `user._json["${LAST_LOGIN_KEY}"]`)
 			|| 0;
 	}
 
 	isMfaAuthenticated() {
-		const usedMfaKey = 'https://www.kiva.org/used_mfa';
-		return _get(this, `user["${usedMfaKey}"]`)
-			|| _get(this, `user._json["${usedMfaKey}"]`)
+		return _get(this, `user["${USED_MFA_KEY}"]`)
+			|| _get(this, `user._json["${USED_MFA_KEY}"]`)
 			|| false;
+	}
+
+	getFakeAuthCookieValue() {
+		const cookieValue = this.cookieStore.get(FAKE_AUTH_NAME) ?? '';
+
+		const cookieParts = cookieValue.split(':');
+		const userId = parseInt(cookieParts[0], 10);
+
+		if (userId) {
+			const scopes = (cookieParts[1] ?? '').split('/').filter(x => x);
+
+			return { userId, scopes };
+		}
+	}
+
+	getFakeIdTokenPayload() {
+		const { userId, scopes } = this.getFakeAuthCookieValue() ?? {};
+
+		if (userId) {
+			try {
+				let lastLogin;
+				const now = new Date();
+				if (scopes.includes('recent')) {
+					// current time
+					lastLogin = now.getTime();
+				} else if (scopes.includes('active')) {
+					// current time - 5:01
+					lastLogin = sub(now, { minutes: 5, seconds: 1 }).getTime();
+				} else {
+					// current time - 1:00:01
+					lastLogin = sub(now, { hours: 1, seconds: 1 }).getTime();
+				}
+
+				return {
+					[KIVA_ID_KEY]: userId,
+					[LAST_LOGIN_KEY]: lastLogin,
+					[USED_MFA_KEY]: scopes.includes('mfa'),
+					scopes,
+				};
+			} catch (e) {
+				console.error(e);
+				Sentry.captureException(e);
+			}
+		}
 	}
 
 	getSyncCookieValue() {
@@ -352,6 +405,8 @@ export const MockKvAuth0 = {
 	getKivaId: () => undefined,
 	getLastLogin: () => 0,
 	getMfaEnrollToken: () => Promise.resolve({}),
+	getFakeAuthCookieValue: () => undefined,
+	getFakeIdTokenPayload: () => undefined,
 	getSyncCookieValue: () => null,
 	isNotedLoggedIn: () => false,
 	isNotedLoggedOut: () => false,

--- a/test/unit/specs/util/KvAuth0.spec.js
+++ b/test/unit/specs/util/KvAuth0.spec.js
@@ -1,0 +1,117 @@
+import KvAuth0, { KIVA_ID_KEY, LAST_LOGIN_KEY, USED_MFA_KEY } from '@/util/KvAuth0';
+
+function getKvAuth0WithFACookie(cookieValue) {
+	return new KvAuth0({
+		domain: '',
+		clientID: '',
+		cookieStore: {
+			get: () => cookieValue,
+			set: () => {},
+		},
+	});
+}
+
+describe('KvAuth0', () => {
+	describe('Fake authentication', () => {
+		describe('constructor', () => {
+			it('does not set anything auth related when the cookie is undefined', () => {
+				const kvAuth0 = getKvAuth0WithFACookie(undefined);
+				expect(kvAuth0.user).toEqual(null);
+				expect(kvAuth0.accessToken).toEqual('');
+			});
+
+			it('simulates being logged in when a user id is in the cookie', () => {
+				const kvAuth0 = getKvAuth0WithFACookie('123');
+				expect(kvAuth0.user[KIVA_ID_KEY]).toEqual(123);
+				expect(kvAuth0.isMfaAuthenticated()).toEqual(false);
+				expect(kvAuth0.isNotedLoggedIn()).toEqual(true);
+				expect(kvAuth0.isNotedUserSessionUser()).toEqual(true);
+			});
+
+			it('makes isMfaAuthenticated return true when mfa is included in the cookie', () => {
+				const kvAuth0 = getKvAuth0WithFACookie('456:recent/mfa');
+				expect(kvAuth0.isMfaAuthenticated()).toEqual(true);
+			});
+		});
+
+		describe('getFakeAuthCookieValue', () => {
+			function expectValuesForCookie(cookie, expected) {
+				const kvAuth0 = getKvAuth0WithFACookie(cookie);
+				const fakeAuthInfo = kvAuth0.getFakeAuthCookieValue();
+				expect(fakeAuthInfo).toEqual(expected);
+			}
+
+			it('returns undefined when no cookie is present', () => {
+				expectValuesForCookie(undefined, undefined);
+			});
+
+			it('returns undefined when cookie does not have a valid user id', () => {
+				expectValuesForCookie('abc', undefined);
+				expectValuesForCookie('a12b', undefined);
+				expectValuesForCookie(':recent', undefined);
+			});
+
+			it('returns user id and scopes when cookie contains a valid user id', () => {
+				expectValuesForCookie('1a', { userId: 1, scopes: [] });
+				expectValuesForCookie('123', { userId: 123, scopes: [] });
+				expectValuesForCookie('456:', { userId: 456, scopes: [] });
+				expectValuesForCookie('789:active', { userId: 789, scopes: ['active'] });
+				expectValuesForCookie('123:recent/active', { userId: 123, scopes: ['recent', 'active'] });
+				expectValuesForCookie('123:recent/active/mfa', { userId: 123, scopes: ['recent', 'active', 'mfa'] });
+			});
+		});
+
+		describe('getFakeIdTokenPayload', () => {
+			function expectUndefinedForCookie(cookie) {
+				const kvAuth0 = getKvAuth0WithFACookie(cookie);
+				const fakeIdTokenPayload = kvAuth0.getFakeIdTokenPayload();
+				expect(fakeIdTokenPayload).not.toBeDefined();
+			}
+			function expectValuesForCookie(cookie, {
+				id, lastLogin, mfa, scopes
+			}) {
+				const kvAuth0 = getKvAuth0WithFACookie(cookie);
+				const fakeIdTokenPayload = kvAuth0.getFakeIdTokenPayload();
+				expect(fakeIdTokenPayload[KIVA_ID_KEY]).toEqual(id);
+				expect(fakeIdTokenPayload[LAST_LOGIN_KEY] / 1000).toBeCloseTo(lastLogin / 1000, 1);
+				expect(fakeIdTokenPayload[USED_MFA_KEY]).toEqual(mfa);
+				expect(fakeIdTokenPayload.scopes).toEqual(scopes);
+			}
+
+			it('returns undefined when no cookie is present', () => {
+				expectUndefinedForCookie(undefined);
+			});
+
+			it('returns undefined when cookie does not have a valid user id', () => {
+				expectUndefinedForCookie('abc');
+				expectUndefinedForCookie('a12b');
+				expectUndefinedForCookie(':recent');
+			});
+
+			it('returns user id, last login time, mfa status, and scopes when cookie contains a valid user id', () => {
+				const recent = Date.now();
+				const active = Date.now() - (1 + (5 * 60)) * 1000; // 5 minutes and 1 second before now
+				const passive = Date.now() - (1 + (60 * 60)) * 1000; // 1 hour and 1 second before now
+
+				expectValuesForCookie('1a', {
+					id: 1, lastLogin: passive, mfa: false, scopes: []
+				});
+				expectValuesForCookie('123', {
+					id: 123, lastLogin: passive, mfa: false, scopes: []
+				});
+				expectValuesForCookie('456:', {
+					id: 456, lastLogin: passive, mfa: false, scopes: []
+				});
+				expectValuesForCookie('789:active', {
+					id: 789, lastLogin: active, mfa: false, scopes: ['active']
+				});
+				expectValuesForCookie('123:recent/active', {
+					id: 123, lastLogin: recent, mfa: false, scopes: ['recent', 'active']
+				});
+				expectValuesForCookie('456:recent/active/mfa', {
+					id: 456, lastLogin: recent, mfa: true, scopes: ['recent', 'active', 'mfa']
+				});
+			});
+		});
+	});
+});


### PR DESCRIPTION
Allows for faking authentication in development and testing. If this fake authentication is attempted in environments that do not allow it (like prod) there will be odd behavior, like the login sync not happening and baskets being lost, but no protected information will be exposed by the api.