### PR TITLE
feat: core-357 adding anonmizationLevel check for repayment schedule,…

### DIFF
--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -50,6 +50,7 @@
 						@show-definition="showDefinition"
 					/>
 					<repayment-schedule
+						v-if="loan.status !== 'fundraising' || loan.amonimizationLevel !== 'none'"
 						:loan-id="loanId"
 						:status="loan.status"
 					/>
@@ -260,6 +261,7 @@ export default {
 							lenderRepaymentTerm
 							repaymentInterval
 							disbursalDate
+							anonymizationLevel
 							terms {
 								currency
 								flexibleFundraisingEnabled
@@ -315,6 +317,7 @@ export default {
 				this.loan.disbursalDate = loan?.disbursalDate ?? '';
 				this.loan.status = loan?.status ?? '';
 				this.loan.name = loan?.name ?? '';
+				this.loan.anonymizationLevel = loan?.anonymizationLevel ?? 'none';
 
 				this.partner.arrearsRate = partner?.arrearsRate ?? 0;
 				this.partner.avgBorrowerCost = partner?.avgBorrowerCost ?? 0;

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -50,7 +50,7 @@
 						@show-definition="showDefinition"
 					/>
 					<repayment-schedule
-						v-if="loan.amonimizationLevel !== 'none'"
+						v-if="loan.anonymizationLevel !== 'full'"
 						:loan-id="loanId"
 						:status="loan.status"
 					/>

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -99,7 +99,6 @@
 <script>
 import gql from 'graphql-tag';
 import { formatContentGroupsFlat } from '@/util/contentfulUtils';
-import { createIntersectionObserver } from '@/util/observerUtils';
 // TODO: replace the loading placeholder with component from kv-components when available.
 import KvLoadingPlaceholder from '@/components/Kv/KvLoadingPlaceholder';
 import { documentToHtmlString } from '~/@contentful/rich-text-html-renderer';

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -50,7 +50,7 @@
 						@show-definition="showDefinition"
 					/>
 					<repayment-schedule
-						v-if="loan.status !== 'fundraising' || loan.amonimizationLevel !== 'none'"
+						v-if="loan.amonimizationLevel !== 'none'"
 						:loan-id="loanId"
 						:status="loan.status"
 					/>

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -207,31 +207,6 @@ export default {
 			this.lightboxTitle = '';
 			this.lightboxContent = null;
 		},
-		createObserver() {
-			// Watch for this element being close to entering the viewport
-			this.observer = createIntersectionObserver({
-				targets: [this.$el],
-				rootMargin: '500px',
-				callback: entries => {
-					entries.forEach(entry => {
-						if (entry.target === this.$el && entry.intersectionRatio > 0) {
-							// This element is close to being in the viewport, so load the data.
-							// Because of the apollo cache it's safe to call this repeatedly.
-							this.loadData();
-						}
-					});
-				}
-			});
-			if (!this.observer) {
-				// Observer was not created, so call loadData right away as a fallback.
-				this.loadData();
-			}
-		},
-		destroyObserver() {
-			if (this.observer) {
-				this.observer.disconnect();
-			}
-		},
 		loadContentfulDefintions(contentEntryKey) {
 			this.apollo.query({
 				query: gql`query contentfulDefinitions {
@@ -395,10 +370,8 @@ export default {
 		},
 	},
 	mounted() {
-		this.createObserver();
+		this.loadData();
 	},
-	beforeDestroy() {
-		this.destroyObserver();
-	},
+
 };
 </script>

--- a/src/components/BorrowerProfile/JumpLinks.vue
+++ b/src/components/BorrowerProfile/JumpLinks.vue
@@ -2,7 +2,7 @@
 	<div class="tw-text-primary tw-text-center">
 		<hr class="tw-border-tertiary">
 		<a
-			class="tw-text-primary tw-pr-1 tw-font-medium"
+			class="tw-text-primary tw-pr-1 tw-font-medium tw-cursor-pointer"
 			v-kv-track-event="['Borrower profile', 'click-jump-link', 'Borrower story']"
 			@click="scrollToSection('#loanStory')"
 		>
@@ -13,7 +13,7 @@
 			Borrower story
 		</a>
 		<a
-			class="tw-text-primary tw-pl-1 tw-pr-1 tw-font-medium"
+			class="tw-text-primary tw-pl-1 tw-pr-1 tw-font-medium tw-cursor-pointer"
 			v-kv-track-event="['Borrower profile', 'click-jump-link', 'Loan details']"
 			@click="scrollToSection('#loanDetails')"
 		>

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -11,8 +11,7 @@
 			title="Loan repayment schedule"
 			@lightbox-closed="closeLightbox"
 		>
-			<!-- Field Partner loan fundraising -->
-			<div v-if="isPartnerLoan || !isPartnerLoan && this.status !== 'fundraising'">
+			<div v-if="isPartnerLoan || !isPartnerLoan && loanDisbursed">
 				<p class="tw-inline-block tw-pb-3">
 					Repayments {{ statusLanguageCheck }} in
 				</p>
@@ -79,15 +78,15 @@
 						</td>
 					</tr>
 				</table>
-				<p v-if="!isPartnerLoan && this.status !== 'fundraising'">
+				<p v-if="!isPartnerLoan && loanDisbursed">
 					<!-- eslint-disable-next-line max-len -->
 					Disbursement and repayments will be made via PayPal, a web-based payment system. Repayments made on delinquent loans will be applied toward the oldest payment due until the loan becomes current.
 				</p>
 			</div>
 
-			<!-- direct loan in the status="fundraising" -->
+			<!-- direct loan before disbursal" -->
 			<div
-				v-if="!isPartnerLoan && this.status === 'fundraising'"
+				v-if="!isPartnerLoan && !loanDisbursed"
 				class="tw-prose"
 			>
 				<p>
@@ -197,7 +196,7 @@ export default {
 				this.repaidAmount = data?.lend?.loan?.paidAmount || 0;
 				this.loanAmount = data?.lend?.loan?.loanAmount || 0;
 				this.lenderRepaymentTerm = data?.lend?.loan?.terms?.lenderRepaymentTerm || 0;
-				this.firstRepaymentDate = this.repaymentSchedule[0].dueToKivaDate || '';
+				this.firstRepaymentDate = this.repaymentSchedule[0]?.dueToKivaDate || '';
 			});
 		},
 	},
@@ -296,6 +295,9 @@ export default {
 			// used for calculating the monthly payment of a direct loan
 			return numeral(this.loanAmount / this.lenderRepaymentTerm).format('$0,0.00');
 		},
+		loanDisbursed() {
+			return this.disbursalDate !== '' && isBefore(parseISO(this.disbursalDate), new Date());
+		}
 	},
 	mounted() {
 		this.calculateRepaymentSchedule();

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -1,10 +1,7 @@
 <template>
 	<div>
-		<!-- showing a repayment schedule on all fundraising loans
-		and field partner loans in the status of payingBack -->
 		<button class="tw-text-h4 tw-text-link tw-mt-3"
 			@click="openLightbox"
-			v-if="this.status === 'fundraising' || this.status === 'payingBack' && isPartnerLoan"
 			v-kv-track-event="['Borrower Profile', 'click-repayment schedule', 'Detailed repayment schedule']"
 		>
 			Detailed repayment schedule >
@@ -15,7 +12,7 @@
 			@lightbox-closed="closeLightbox"
 		>
 			<!-- Field Partner loan fundraising -->
-			<div v-if="isPartnerLoan">
+			<div v-if="isPartnerLoan || !isPartnerLoan && this.status !== 'fundraising'">
 				<p class="tw-inline-block tw-pb-3">
 					Repayments {{ statusLanguageCheck }} in
 				</p>
@@ -82,10 +79,17 @@
 						</td>
 					</tr>
 				</table>
+				<p v-if="!isPartnerLoan && this.status !== 'fundraising'">
+					<!-- eslint-disable-next-line max-len -->
+					Disbursement and repayments will be made via PayPal, a web-based payment system. Repayments made on delinquent loans will be applied toward the oldest payment due until the loan becomes current.
+				</p>
 			</div>
 
 			<!-- direct loan in the status="fundraising" -->
-			<div v-if="!isPartnerLoan" class="tw-prose">
+			<div
+				v-if="!isPartnerLoan && this.status === 'fundraising'"
+				class="tw-prose"
+			>
 				<p>
 					This loan is for {{ loanAmountFormatted }}.
 				</p>
@@ -193,9 +197,7 @@ export default {
 				this.repaidAmount = data?.lend?.loan?.paidAmount || 0;
 				this.loanAmount = data?.lend?.loan?.loanAmount || 0;
 				this.lenderRepaymentTerm = data?.lend?.loan?.terms?.lenderRepaymentTerm || 0;
-				if (this.isPartnerLoan) {
-					this.firstRepaymentDate = this.repaymentSchedule[0].dueToKivaDate || '';
-				}
+				this.firstRepaymentDate = this.repaymentSchedule[0].dueToKivaDate || '';
 			});
 		},
 	},


### PR DESCRIPTION
… removing isPartnerLoan checks

[Core-357](https://kiva.atlassian.net/browse/CORE-357)

In this PR: 
- I've added an additional check in the detailsTabs.vue component to check the anonomization level of the loan before loading any of the repayment schedule component/data.
- I've removed all checks preventing a "Detailed repayment schedule" link from displaying on direct loans.
- I've added some conditional text under the table for direct loans in repayment to bring it in line with the one in production.
- I've verified that all data should be in place for directLoans in payingBack status to the best of my abilities without actually having access to what the expected repayments looks like on a direct loan
