### PR TITLE
fix: richTextRenderer should handle undefined content more gracefully

### DIFF
--- a/src/util/contentful/richTextRenderer.js
+++ b/src/util/contentful/richTextRenderer.js
@@ -32,21 +32,24 @@ function htmlSafeStringify(value) {
  * @returns {object} RTF object containing RTF nodes without trailing empty <p> tag
  */
 export function removeTrailingParagraphTag(content) {
-	// Remove empty <p> inserted by contentful
-	const innerContent = content.content;
-	const lastRTFElement = innerContent[innerContent.length - 1];
+	if (content) {
+		// Remove empty <p> inserted by contentful
+		const innerContent = content?.content;
+		const lastRTFElement = innerContent[innerContent.length - 1];
 
-	const contentWithoutTrailingEmptyParagraph = { ...content };
+		const contentWithoutTrailingEmptyParagraph = { ...content };
 
-	// If last item is an empty paragraph, which contains an empty text node, remove it
-	if (lastRTFElement.nodeType === 'paragraph'
-		&& Object.keys(lastRTFElement.data).length === 0
-		&& lastRTFElement.content.length === 1
-		&& lastRTFElement.content?.[0]?.value === ''
-		&& lastRTFElement.content?.[0]?.nodeType === 'text') {
-		contentWithoutTrailingEmptyParagraph.content = contentWithoutTrailingEmptyParagraph.content.slice(0, -1);
+		// If last item is an empty paragraph, which contains an empty text node, remove it
+		if (lastRTFElement.nodeType === 'paragraph'
+			&& Object.keys(lastRTFElement.data).length === 0
+			&& lastRTFElement.content.length === 1
+			&& lastRTFElement.content?.[0]?.value === ''
+			&& lastRTFElement.content?.[0]?.nodeType === 'text') {
+			contentWithoutTrailingEmptyParagraph.content = contentWithoutTrailingEmptyParagraph.content.slice(0, -1);
+		}
+		return contentWithoutTrailingEmptyParagraph;
 	}
-	return contentWithoutTrailingEmptyParagraph;
+	return content;
 }
 
 /**


### PR DESCRIPTION
VUE-916

Our custom richTextRenderer was causing a 500 error, when processing a rich text field with no content