### PR TITLE
kv-material-icon Safari fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.27.0",
+	"version": "2.34.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.27.0",
+			"version": "2.34.1",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.15.4",
@@ -17,7 +17,7 @@
 				"@godaddy/terminus": "^4.4.1",
 				"@graphql-tools/load": "^6.2.4",
 				"@graphql-tools/url-loader": "^6.3.0",
-				"@kiva/kv-components": "^1.4.2",
+				"@kiva/kv-components": "^1.4.3",
 				"@kiva/kv-tokens": "^1.3.0",
 				"@mdi/js": "^5.9.55",
 				"@sentry/tracing": "^6.13.3",
@@ -3951,9 +3951,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-1.4.2.tgz",
-			"integrity": "sha512-Ta6xVx/6lKgvGJgzANwJjc5e1AyhC3HHzkf/ILQ/vU4SPaePHM3CqJQudeXPEMBd1cRh300LQYV0aY6zgAZBLQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-1.4.3.tgz",
+			"integrity": "sha512-/5AczrNSoqFKT/4QE6goue83nXJFIfMNNY+GWFr6c97Y97xUEOqyLBCYPUvg2ZVlWQyxNocf8Qmw44vztRIc6Q==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^1.3.0",
 				"@mdi/js": "^5.9.55",
@@ -43117,9 +43117,9 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-1.4.2.tgz",
-			"integrity": "sha512-Ta6xVx/6lKgvGJgzANwJjc5e1AyhC3HHzkf/ILQ/vU4SPaePHM3CqJQudeXPEMBd1cRh300LQYV0aY6zgAZBLQ==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-1.4.3.tgz",
+			"integrity": "sha512-/5AczrNSoqFKT/4QE6goue83nXJFIfMNNY+GWFr6c97Y97xUEOqyLBCYPUvg2ZVlWQyxNocf8Qmw44vztRIc6Q==",
 			"requires": {
 				"@kiva/kv-tokens": "^1.3.0",
 				"@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"@godaddy/terminus": "^4.4.1",
 		"@graphql-tools/load": "^6.2.4",
 		"@graphql-tools/url-loader": "^6.3.0",
-		"@kiva/kv-components": "^1.4.2",
+		"@kiva/kv-components": "^1.4.3",
 		"@kiva/kv-tokens": "^1.3.0",
 		"@mdi/js": "^5.9.55",
 		"@sentry/tracing": "^6.13.3",

--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
 		"ora": "^4.0.2",
 		"postcss": "^8.3.0",
 		"postcss-loader": "^4.3.0",
-		"postcss-prepend-selector": "^0.3.1",
 		"rimraf": "^3.0.2",
 		"sass": "^1.32.13",
 		"sass-loader": "^10.2.0",

--- a/src/components/BorrowerProfile/FieldPartnerDetails.vue
+++ b/src/components/BorrowerProfile/FieldPartnerDetails.vue
@@ -83,7 +83,7 @@
 						<kv-material-icon
 							v-for="i in 5"
 							:key="i"
-							class="tw-text-primary"
+							class="tw-text-primary tw-w-3 tw-h-3"
 							:icon="getStarIcon(i)"
 						/>
 					</div>

--- a/src/components/BorrowerProfile/JumpLinks.vue
+++ b/src/components/BorrowerProfile/JumpLinks.vue
@@ -7,7 +7,7 @@
 			@click="scrollToSection('#loanStory')"
 		>
 			<kv-material-icon
-				class="tw-my-3 tw-align-middle tw-mr-0.5"
+				class="tw-w-3 tw-h-3 tw-my-3 tw-align-middle tw-mr-0.5"
 				:icon="mdiAccount"
 			/>
 			Borrower story
@@ -18,7 +18,7 @@
 			@click="scrollToSection('#loanDetails')"
 		>
 			<kv-material-icon
-				class="tw-my-3 tw-align-middle tw-mr-0.5"
+				class="tw-w-3 tw-h-3 tw-my-3 tw-align-middle tw-mr-0.5"
 				:icon="mdiFormatListBulleted"
 			/>
 			Loan details

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -226,7 +226,7 @@
 								v-if="statScrollAnimation"
 							>
 								<kv-material-icon
-									class="tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
+									class="tw-w-2.5 tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
 									:icon="mdiLightningBolt"
 								/>
 								powered by {{ numLenders }} lenders

--- a/src/components/BorrowerProfile/LendersAndTeams.vue
+++ b/src/components/BorrowerProfile/LendersAndTeams.vue
@@ -8,7 +8,7 @@
 
 			<div class="tw-mb-3">
 				<kv-material-icon
-					class="tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
+					class="tw-w-2.5 tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
 					:icon="mdiLightningBolt"
 				/>
 
@@ -86,7 +86,7 @@
 				</h2>
 				<div class="tw-mb-3">
 					<kv-material-icon
-						class="tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
+						class="tw-w-2.5 tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
 						:icon="mdiLightningBolt"
 					/>
 					<span>{{ poweredByText }}</span>

--- a/src/components/BorrowerProfile/PreviousLoanDescription.vue
+++ b/src/components/BorrowerProfile/PreviousLoanDescription.vue
@@ -7,7 +7,7 @@
 			Show previous loan details
 			<kv-material-icon
 				:icon="mdiChevronDown"
-				class="tw-align-middle tw-mb-0.5 tw-transition-transform tw-ease-in-out tw-duration-500"
+				class="tw-w-3 tw-h-3 tw-align-middle tw-mb-0.5 tw-transition-transform tw-ease-in-out tw-duration-500"
 				:class="{'tw-rotate-180' : previousLoanDetailsOpen}"
 			/>
 		</kv-text-link>

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -59,8 +59,7 @@
 						>
 							<kv-material-icon
 								:icon="mdiCheckboxMarkedCircle"
-								name="check-mark"
-								class="tw-text-brand-700 tw-align-middle"
+								class="tw-w-3 tw-h-3 tw-text-brand-700 tw-align-middle"
 							/>
 							Repayment received
 						</td>
@@ -70,8 +69,7 @@
 							v-if="!repayment.repaid && repayment.delinquent"
 						>
 							<kv-material-icon
-								name="minus-circle"
-								class="tw-text-danger tw-align-middle"
+								class="tw-w-3 tw-h-3 tw-text-danger tw-align-middle"
 								:icon="mdiMinusCircle"
 							/>
 							Delinquent

--- a/src/components/Kv/KvExpandableQuestion.vue
+++ b/src/components/Kv/KvExpandableQuestion.vue
@@ -7,7 +7,7 @@
 				{{ title }}
 			</h3>
 			<kv-material-icon
-				class="tw-h-4"
+				class="tw-w-4 tw-h-4"
 				@click="open = !open"
 				:icon="open ? mdiChevronUp : mdiChevronDown"
 			/>

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -142,7 +142,7 @@
 		>
 			View loan
 			<kv-material-icon
-				class="tw-align-middle"
+				class="tw-w-3 tw-h-3 tw-align-middle"
 				:icon="mdiChevronRight"
 			/>
 		</kv-button>

--- a/src/components/LoanCards/WhySpecial.vue
+++ b/src/components/LoanCards/WhySpecial.vue
@@ -8,7 +8,7 @@
 		<div class="tw-bg-tertiary tw-p-1 tw-flex-shrink-0 tw-flex tw-items-center">
 			<kv-material-icon
 				:icon="mdiStar"
-				class="tw-fill-current tw-text-primary-inverse"
+				class="tw-w-3 tw-h-3 tw-fill-current tw-text-primary-inverse"
 			/>
 		</div>
 		<p class="tw-bg-primary tw-p-2 tw-flex-1">

--- a/src/components/WwwFrame/LendMenu/LendListMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendListMenu.vue
@@ -2,11 +2,11 @@
 	<div>
 		<router-link
 			to="/monthlygood"
-			class="tw-flex tw-gap-0.5 tw-py-2 tw-mb-2 tw-border-b tw-border-tertiary tw-font-medium"
+			class="tw-inline-flex tw-gap-0.5 tw-py-2 tw-mb-2 tw-border-b tw-border-tertiary tw-font-medium"
 			v-kv-track-event="['TopNav','click-Find-a-Cause', 'Find a cause']"
 		>
 			Find a cause
-			<kv-material-icon :icon="mdiArrowRight" />
+			<kv-material-icon class="tw-w-3 tw-h-3" :icon="mdiArrowRight" />
 		</router-link>
 
 		<kv-tabs>

--- a/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
@@ -2,11 +2,11 @@
 	<div class="lend-mega-menu tw-overflow-hidden tw-hidden lg:tw-block tw-pb-2.5 lg:tw-pt-3">
 		<router-link
 			to="/monthlygood"
-			class="tw-flex tw-gap-0.5 tw-py-2 tw-mb-2 tw-font-medium"
+			class="tw-inline-flex tw-gap-0.5 tw-py-2 tw-mb-2 tw-font-medium"
 			v-kv-track-event="['TopNav','click-Find-a-Cause', 'Find a cause']"
 		>
 			Find a cause
-			<kv-material-icon :icon="mdiArrowRight" />
+			<kv-material-icon :icon="mdiArrowRight" class="tw-w-3 tw-h-3" />
 		</router-link>
 		<div
 			:style="computedStyle"
@@ -141,7 +141,7 @@
 						v-if="sectionOpen"
 						@click="openedSection = ''"
 					>
-						<kv-material-icon class="tw-flex-shrink-0" :icon="mdiChevronLeft" />
+						<kv-material-icon class="tw-flex-shrink-0 tw-w-3 tw-h-3" :icon="mdiChevronLeft" />
 						<span class="tw-text-base">
 							Back
 						</span>

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -114,7 +114,7 @@
 						>
 							<span class="tw-flex tw-items-center">Lend
 								<kv-material-icon
-									class="tw-w-3 tw-transition-transform tw-duration-300"
+									class="tw-w-3 tw-h-3 tw-transition-transform tw-duration-300"
 									:icon="mdiChevronDown"
 									:class="{'tw-rotate-180' : isLendMenuVisible}"
 								/>
@@ -183,7 +183,7 @@
 									<span class="tw-flex">
 										About
 										<kv-material-icon
-											class="tw-w-3
+											class="tw-w-3 tw-h-3
 											tw-transition-transform tw-duration-300 group-hover:tw-rotate-180"
 											:icon="mdiChevronDown"
 										/>
@@ -273,7 +273,7 @@
 								@click="toggleMobileSearch"
 								v-kv-track-event="['TopNav','click-search-toggle']"
 							>
-								<kv-material-icon :icon="mdiMagnify" />
+								<kv-material-icon class="tw-w-3 tw-h-3" :icon="mdiMagnify" />
 							</button>
 
 							<!-- Basket -->

--- a/src/components/WwwFrame/WwwPageDesign.vue
+++ b/src/components/WwwFrame/WwwPageDesign.vue
@@ -102,7 +102,7 @@
 											class="tw-inline-flex tw-gap-1"
 										>
 											<span>Type</span>
-											<kv-material-icon class="tw-w-2" :icon="mdiEmailOutline" />
+											<kv-material-icon class="tw-w-2 tw-h-2" :icon="mdiEmailOutline" />
 										</a>
 									</li>
 								</ul>

--- a/src/pages/Borrow/BorrowIntro.vue
+++ b/src/pages/Borrow/BorrowIntro.vue
@@ -25,7 +25,7 @@
 					<p class="tw-flex tw-content-center tw-justify-center">
 						<kv-material-icon
 							:icon="mdiClock"
-							class="tw-fill-current tw-text-tertiary tw-w-3 tw-mr-1"
+							class="tw-fill-current tw-text-tertiary tw-w-3 tw-h-3 tw-mr-1"
 						/>
 						<span>5 minutes</span>
 					</p>
@@ -45,7 +45,7 @@
 					<p class="tw-flex tw-content-center tw-justify-center">
 						<kv-material-icon
 							:icon="mdiClock"
-							class="tw-fill-current tw-text-tertiary tw-w-3 tw-mr-1"
+							class="tw-fill-current tw-text-tertiary tw-w-3 tw-h-3 tw-mr-1"
 						/>
 						<span>5 minutes</span>
 					</p>
@@ -65,7 +65,7 @@
 					<p class="tw-flex tw-content-center tw-justify-center">
 						<kv-material-icon
 							:icon="mdiClock"
-							class="tw-fill-current tw-text-tertiary tw-w-3 tw-mr-1"
+							class="tw-fill-current tw-text-tertiary tw-w-3 tw-h-3 tw-mr-1"
 						/>
 						<span>25 minutes</span>
 					</p>


### PR DESCRIPTION
Adds a width and height classes to all `<kv-material-icon>`s.  If a width and height class aren't specified Safari lets the SVG icon take all available space, where Chrome and Firefox use the SVG's intrinsic size. 

Brings in latest kv-components which has these same fixes.

Fixes stuff like this happening on Safari (mobile and desktop I believe)
![image](https://user-images.githubusercontent.com/187937/148300758-2100c573-febc-4813-bd7b-16736ad62ed9.png)