### PR TITLE
feat: causes homepage redirect experiment

### DIFF
--- a/src/pages/Homepage/Homepage.vue
+++ b/src/pages/Homepage/Homepage.vue
@@ -4,12 +4,20 @@
 
 <script>
 import gql from 'graphql-tag';
+import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 import { preFetchAll } from '@/util/apolloPreFetch';
+import { parseExpCookie } from '@/util/experimentUtils';
 
 const ContentfulPage = () => import('@/pages/ContentfulPage');
 
-const homePageLoginStatus = gql`query homepageFrame {
+const homePageQuery = gql`query homepageFrame {
 	hasEverLoggedIn @client
+	general {
+		causesHomeExp: uiExperimentSetting(key: "home_mobile_causes") {
+			key
+			value
+		}
+	}
 }`;
 
 export default {
@@ -25,13 +33,21 @@ export default {
 	data() {
 		return {
 			activeHomepage: ContentfulPage,
+			hasEverLoggedIn: false
 		};
 	},
 	apollo: {
-		query: homePageLoginStatus,
+		query: homePageQuery,
 		preFetch(config, client, args) {
+			const assignments = parseExpCookie(args.cookieStore.get('uiab'));
+			if (assignments?.home_mobile_causes?.version === 'shown') {
+				// cancel the promise, returning a route for redirect
+				return Promise.reject({
+					path: '/lp/causes'
+				});
+			}
 			return client.query({
-				query: homePageLoginStatus
+				query: homePageQuery
 			}).then(() => {
 				return ContentfulPage();
 			}).then(resolvedImport => {
@@ -42,15 +58,53 @@ export default {
 		},
 		result({ data }) {
 			// Setup unbounce event trigger which is restricted to non-logged-in and unknown users
-			const hasEverLoggedIn = data?.hasEverLoggedIn ?? true;
+			this.hasEverLoggedIn = data?.hasEverLoggedIn ?? true;
 			// Check for hasEverLoggedIn
-			if (!hasEverLoggedIn) {
+			if (!this.hasEverLoggedIn) {
 				// push data object if eligible + assigned
 				if (typeof window !== 'undefined') {
 					window.dataLayer.push({ event: 'activateUnbounceEvent' });
 				}
 			}
 		}
-	}
+	},
+	created() {
+		// Mobile Causes homepage experiment (GD-205)
+		// Only mobile new users are eligible to be in experiment
+		if (this.isMobile && this.isNewUser) {
+			// Assign Experiment
+			this.apollo.query({
+				query: experimentAssignmentQuery,
+				variables: { id: 'home_mobile_causes' }
+			}).then(({ data }) => {
+				// track exp
+				// Fire Event for (GD-205)
+				if (data?.experiment?.version) {
+					this.$kvTrackEvent(
+						'Causes',
+						'EXP-GD-205-Jan2022',
+						data?.experiment?.version === 'shown' ? 'b' : 'a'
+					);
+					if (data?.experiment?.version === 'shown') {
+						// redirect user
+						this.$router.push({
+							path: '/lp/causes'
+						});
+					}
+				}
+			});
+		}
+	},
+	computed: {
+		isMobile() {
+			if (!this.$isServer) {
+				return document?.documentElement?.clientWidth < 735 ?? false;
+			}
+			return false;
+		},
+		isNewUser() {
+			return !this.hasEverLoggedIn;
+		}
+	},
 };
 </script>


### PR DESCRIPTION
GD-205

~~Is this the best approach for this?~~

~~Unfortunately, this loads the homepage, then the created hook will redirect to the landing page. I could not find a way to avoid this. Trying to handle the experiment in preFetch doesn't work because the experiment depends on the user being on mobile, which the server does not know about in preFetch.~~

When the homepage loads, if new user and is mobile, assign the experiment, fire the event and redirect to '/lp/causes/' if experiment version is shown

On repeated visits, we can read the session cookie and redirect in the preFetch to avoid having to load the homepage. This should work as expected since only  eligible users should have the experiment assignment.

If a user is assigned to the experiment and they sign up (becoming a known user) they will still have the experiment assignment and will get redirected on prefetch on a repeated visit, this is an acceptable behavior (see GD-205)


