### PR TITLE
feat: core-148 mobile view of repayment schedule

### DIFF
--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -34,7 +34,7 @@
 						:key="index"
 						class="tw-mb-1"
 					>
-						<div class="tw-bg-secondary tw-rounded tw-text-center tw-mb-2 tw-pb-1.5">
+						<td class="tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center tw-mb-2 tw-pb-1.5">
 							<p class="tw-text-h4 tw-py-1.5">
 								{{ repayment.formattedRepaymentDate }}
 							</p>
@@ -47,7 +47,8 @@
 							</p>
 							<!-- if payment is received -->
 							<p
-								class="tw-bg-primary tw-mx-auto tw-w-[11.5rem] tw-py-1 tw-rounded"
+								class="tw-bg-primary tw-mx-auto tw-py-1 tw-rounded"
+								style="width: 11.5rem;"
 								v-if="repayment.repaid && !repayment.delinquent"
 							>
 								<kv-material-icon
@@ -58,7 +59,8 @@
 							</p>
 							<!-- if payment is not received on time -->
 							<p
-								class="tw-bg-primary tw-mx-auto tw-w-[7.5rem] tw-py-1 tw-rounded"
+								class="tw-bg-primary tw-mx-auto tw-py-1 tw-rounded"
+								style="width: 7.5rem;"
 								v-if="!repayment.repaid && repayment.delinquent"
 							>
 								<kv-material-icon
@@ -67,7 +69,7 @@
 								/>
 								Delinquent
 							</p>
-						</div>
+						</td>
 					</tr>
 				</table>
 

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -26,7 +26,51 @@
 						{{ repaymentStatusCheck }}.
 					</p>
 				</span>
-				<table class="tw-table-auto">
+
+				<!-- Table for small screens -->
+				<table class="md:tw-hidden tw-w-full">
+					<tr
+						v-for="(repayment, index) in parsedRepaymentSchedule"
+						:key="index"
+						class="tw-mb-1"
+					>
+						<div class="tw-bg-secondary tw-rounded tw-text-center tw-mb-2 tw-pb-1.5">
+							<p class="tw-text-h4 tw-py-1.5">{{ repayment.formattedRepaymentDate }}</p>
+							<hr class="tw-mb-1.5 tw-mx-1.5">
+							<p class="tw-mb-1.5">
+								Expected: {{ repayment.formattedMonthlyPayment }}
+							</p>
+							<p v-if="!repayment.repaid && !repayment.delinquent">
+								Available {{ repayment.formattedRepaymentDate }}
+							</p>
+							<!-- if payment is received -->
+							<p
+								class="tw-bg-primary tw-mx-auto tw-w-[11.5rem] tw-py-1 tw-rounded"
+								v-if="repayment.repaid && !repayment.delinquent"
+							>
+								<kv-material-icon
+									:icon="mdiCheckboxMarkedCircle"
+									class="tw-w-3 tw-h-3 tw-text-brand-700 tw-align-middle"
+								/>
+								Repayment received
+							</p>
+							<!-- if payment is not received on time -->
+							<p
+								class="tw-bg-primary tw-mx-auto tw-w-[7.5rem] tw-py-1 tw-rounded"
+								v-if="!repayment.repaid && repayment.delinquent"
+							>
+								<kv-material-icon
+									class="tw-w-3 tw-h-3 tw-text-danger tw-align-middle"
+									:icon="mdiMinusCircle"
+								/>
+								Delinquent
+							</p>
+						</div>
+					</tr>
+				</table>
+
+				<!-- Table for medium and up screens -->
+				<table class="tw-table-auto tw-hidden md:tw-table">
 					<tr class="tw-bg-secondary tw-text-left">
 						<th><span class="tw-sr-only">Date</span></th>
 						<th class="table-heading-spacing">
@@ -53,6 +97,7 @@
 						>
 							Available {{ repayment.formattedRepaymentDate }}
 						</td>
+						<!-- if payment is received -->
 						<td
 							class="table-data-spacing"
 							v-if="repayment.repaid && !repayment.delinquent"

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -34,10 +34,10 @@
 						:key="index"
 						class="tw-mb-1"
 					>
-						<td class="
-							tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center
-							tw-mb-2 tw-pb-1.5
-						">
+						<td class=
+							"tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center
+							tw-mb-2 tw-pb-1.5"
+						>
 							<p class="tw-text-h4 tw-py-1.5">
 								{{ repayment.formattedRepaymentDate }}
 							</p>

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -35,7 +35,9 @@
 						class="tw-mb-1"
 					>
 						<div class="tw-bg-secondary tw-rounded tw-text-center tw-mb-2 tw-pb-1.5">
-							<p class="tw-text-h4 tw-py-1.5">{{ repayment.formattedRepaymentDate }}</p>
+							<p class="tw-text-h4 tw-py-1.5">
+								{{ repayment.formattedRepaymentDate }}
+							</p>
 							<hr class="tw-mb-1.5 tw-mx-1.5">
 							<p class="tw-mb-1.5">
 								Expected: {{ repayment.formattedMonthlyPayment }}

--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -34,7 +34,10 @@
 						:key="index"
 						class="tw-mb-1"
 					>
-						<td class="tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center tw-mb-2 tw-pb-1.5">
+						<td class="
+							tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center
+							tw-mb-2 tw-pb-1.5
+						">
 							<p class="tw-text-h4 tw-py-1.5">
 								{{ repayment.formattedRepaymentDate }}
 							</p>


### PR DESCRIPTION
[Core-148](https://kiva.atlassian.net/browse/CORE-148) These changes get the mobile view of the repayment schedule in place.

[Figma spec](https://www.figma.com/file/EI9I5sR9mATRxIV8hBWKwm/Repayment-Schedule---Borrower-Profile-v2-Nov.2021%5BNT%5D?node-id=1%3A8)

A few different versions of this to take a look at. 
**Loan payment incoming:**
<img width="359" alt="Screen Shot 2022-01-10 at 4 24 36 PM" src="https://user-images.githubusercontent.com/1521381/148855307-c76ae7d8-17a1-4e16-ba3f-207c52cd1e7c.png">

**Loan payment made**
<img width="359" alt="Screen Shot 2022-01-10 at 4 25 11 PM" src="https://user-images.githubusercontent.com/1521381/148855339-1c5a7e6f-d3ed-4b92-8b99-5e95cbed6798.png">

**Loan payment deliquent**
<img width="361" alt="Screen Shot 2022-01-10 at 4 25 35 PM" src="https://user-images.githubusercontent.com/1521381/148855378-b3d12401-4acc-4e8e-ba74-7ff69c6389ed.png">


