### PR TITLE
chore: pull in latest kv-tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.34.1",
+	"version": "2.35.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.34.1",
+			"version": "2.35.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.15.4",
@@ -18,7 +18,7 @@
 				"@graphql-tools/load": "^6.2.4",
 				"@graphql-tools/url-loader": "^6.3.0",
 				"@kiva/kv-components": "^1.4.3",
-				"@kiva/kv-tokens": "^1.3.0",
+				"@kiva/kv-tokens": "^1.3.1",
 				"@mdi/js": "^5.9.55",
 				"@sentry/tracing": "^6.13.3",
 				"@sentry/vue": "^6.13.3",
@@ -3965,9 +3965,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-tokens": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-1.3.0.tgz",
-			"integrity": "sha512-AE/SVsYfavC+M8qx+ueKGkm+zNso8rwYnNZ5r/dFyntv4N8TP+8bNlSs5dyi9gzIeIWr7nmu3SQu8G2aggAn1Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-1.3.1.tgz",
+			"integrity": "sha512-2YTdZ2y+6oyqyDV0qfezVOQEzhiiBnWPLbON06udmeq/jXTe6K1t47QngGl+mak3VmH7fVF/UHkfhho2pvpNkw==",
 			"dependencies": {
 				"@tailwindcss/typography": "^0.4.0",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"
@@ -43131,9 +43131,9 @@
 			}
 		},
 		"@kiva/kv-tokens": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-1.3.0.tgz",
-			"integrity": "sha512-AE/SVsYfavC+M8qx+ueKGkm+zNso8rwYnNZ5r/dFyntv4N8TP+8bNlSs5dyi9gzIeIWr7nmu3SQu8G2aggAn1Q==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-1.3.1.tgz",
+			"integrity": "sha512-2YTdZ2y+6oyqyDV0qfezVOQEzhiiBnWPLbON06udmeq/jXTe6K1t47QngGl+mak3VmH7fVF/UHkfhho2pvpNkw==",
 			"requires": {
 				"@tailwindcss/typography": "^0.4.0",
 				"tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.1.0"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"@graphql-tools/load": "^6.2.4",
 		"@graphql-tools/url-loader": "^6.3.0",
 		"@kiva/kv-components": "^1.4.3",
-		"@kiva/kv-tokens": "^1.3.0",
+		"@kiva/kv-tokens": "^1.3.1",
 		"@mdi/js": "^5.9.55",
 		"@sentry/tracing": "^6.13.3",
 		"@sentry/vue": "^6.13.3",


### PR DESCRIPTION
1.3.1 (2022-01-11)
Bug Fixes
allow buttons to inherit font weights (593b28f)