### PR TITLE
feat: core-151 fixing bookmark placement for large screens

### DIFF
--- a/src/components/BorrowerProfile/RepaymentSchedule.vue
+++ b/src/components/BorrowerProfile/RepaymentSchedule.vue
@@ -34,8 +34,8 @@
 						:key="index"
 						class="tw-mb-1"
 					>
-						<td class=
-							"tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center
+						<td class="
+							tw-inline-block tw-w-full tw-bg-secondary tw-rounded tw-text-center
 							tw-mb-2 tw-pb-1.5"
 						>
 							<p class="tw-text-h4 tw-py-1.5">

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -46,7 +46,7 @@
 			:status="status"
 			:use="use"
 		/>
-		<div class="tw-flex-auto tw-inline-flex">
+		<div class="tw-flex-auto tw-inline-flex tw-w-full">
 			<summary-tag v-if="countryName">
 				<kv-material-icon
 					class="tw-h-2.5 tw-w-2.5 tw-mr-0.5"
@@ -63,7 +63,7 @@
 			<loan-bookmark
 				v-if="isLoggedIn"
 				:loan-id="loanId"
-				class="tw-hidden lg:tw-inline-flex tw-right-2.5 tw-absolute"
+				class="tw-hidden lg:tw-inline-flex tw-ml-auto"
 			/>
 		</div>
 		<!-- only show option to bookmark loan if user is logged in -->

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -46,13 +46,15 @@
 			:status="status"
 			:use="use"
 		/>
-		<div class="tw-flex-auto tw-inline-flex tw-w-full">
+		<div class="tw-flex-auto tw-inline-flex">
 			<summary-tag v-if="countryName">
 				<kv-material-icon
-					class="tw-h-2.5 tw-w-2.5 tw-mr-0.5"
+					class="tw-h-2.5 tw-w-2.5 tw-mr-0.5 tw-shrink-0"
 					:icon="mdiMapMarker"
 				/>
-				{{ formattedLocation }}
+				<span class="tw-flex-1">
+					{{ formattedLocation }}
+				</span>
 			</summary-tag>
 
 			<summary-tag v-if="activityName">
@@ -63,7 +65,7 @@
 			<loan-bookmark
 				v-if="isLoggedIn"
 				:loan-id="loanId"
-				class="tw-hidden lg:tw-inline-flex tw-ml-auto"
+				class="tw-hidden lg:tw-inline-flex tw-ml-auto tw-items-center"
 			/>
 		</div>
 		<!-- only show option to bookmark loan if user is logged in -->


### PR DESCRIPTION
During QA of the loan bookmark functionality I discovered an overlap issue I was causing by absolutely positioning an element. 

**Issue:**
<img width="1030" alt="Screen Shot 2022-01-11 at 2 59 21 PM" src="https://user-images.githubusercontent.com/1521381/149029858-cd4b6062-e4f6-4480-8300-48de63055bdb.png">


I removed the absolute positioning and handled the spacing with a 'tw-ml-auto'. 

**Fixed**
<img width="1071" alt="Screen Shot 2022-01-11 at 3 01 10 PM" src="https://user-images.githubusercontent.com/1521381/149029949-9c52d38e-0c54-4a89-ab99-cddd9e8427af.png">
<img width="1066" alt="Screen Shot 2022-01-11 at 3 01 26 PM" src="https://user-images.githubusercontent.com/1521381/149029950-ddfe6ec6-0f78-4d98-b22c-ef061f2d7905.png">


