### PR TITLE
feat: allows StoryCards to be aligned with contentful field

### DIFF
--- a/src/components/Contentful/StoryCard.vue
+++ b/src/components/Contentful/StoryCard.vue
@@ -28,7 +28,6 @@
 				tw-flex-col
 				tw-h-full
 				tw-justify-between
-				tw-items-center
 				overflow-hidden
 				tw-text-primary
 				tw-px-4
@@ -42,14 +41,19 @@
 			v-else
 		>
 			<dynamic-rich-text
-				class="tw-text-center tw-text-h4 tw-text-action"
+				class="tw-text-h4 tw-text-action"
+				:class="`tw-text-${alignment}`"
 				:html="cardTitle"
 			/>
 			<dynamic-rich-text
-				class="story-card__content tw-text-center tw-h-full tw-pb-4 tw-pt-3"
+				class="story-card__content tw-h-full tw-pb-4 tw-pt-3"
+				:class="`story-card__content--${alignment} tw-text-${alignment}`"
 				:html="cardContent"
 			/>
-			<dynamic-rich-text class="tw-text-center" :html="footer" />
+			<dynamic-rich-text
+				:class="`tw-text-${alignment}`"
+				:html="footer"
+			/>
 		</div>
 	</kv-theme-provider>
 </template>
@@ -87,6 +91,13 @@ export default {
 		return {};
 	},
 	computed: {
+		/**
+		 * Aligns all items of the story card
+		* */
+		alignment() {
+			// Will always be one of: 'right', 'center', 'left'
+			return this.content?.alignment;
+		},
 		theme() {
 			const themeMapper = {
 				kivaCLassicLight: defaultTheme,
@@ -168,10 +179,21 @@ export default {
 
 	// Override default prose layout
 	.story-card__content >>> .tw-prose {
-		align-items: center;
 		display: flex;
 		flex-direction: column;
 		height: 100%;
+	}
+
+	.story-card__content--center >>> .tw-prose {
+		align-items: center;
+	}
+
+	.story-card__content--left >>> .tw-prose {
+		align-items: flex-start;
+	}
+
+	.story-card__content--right >>> .tw-prose {
+		align-items: flex-end;
 	}
 
 	.story-card >>> .tw-prose u {

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -214,7 +214,10 @@ export function formatCarousel(contentfulContent) {
 /**
  * Format StoryCard (contentful type id: storyCard)
  * Takes raw contentful content object and returns an object with targeted keys/values
- * TODO remove kickerHeadline once content field is fully deprecated from contentful
+ *
+ * Default alignment value is center. This is enforced in the contentful UI,
+ * but legacy story cards before the alignment field was added may have a null value
+ *
  * @param {array} contentfulContent data
  * @returns {object}
  */
@@ -226,7 +229,7 @@ export function formatStoryCard(contentfulContent) {
 		footer: contentfulContent.fields?.footer,
 		key: contentfulContent.fields?.key,
 		theme: contentfulContent.fields?.theme,
-		kickerHeadline: contentfulContent.fields?.kickerHeadline,
+		alignment: contentfulContent.fields?.alignment ?? 'center'
 	};
 }
 


### PR DESCRIPTION
GD-208

Supports 'right', 'center', 'left'. Content type changes in contentful dev, will add to production when this gets merged in. 

Examples:

![Screen Shot 2022-01-11 at 2 14 32 PM](https://user-images.githubusercontent.com/4371888/149031427-e3383bab-d971-403c-8720-997eeff966c3.png)


![Screen Shot 2022-01-11 at 2 15 12 PM](https://user-images.githubusercontent.com/4371888/149031420-c1baee69-9126-4729-b386-8e7e77669c5f.png)

![Screen Shot 2022-01-11 at 2 14 44 PM](https://user-images.githubusercontent.com/4371888/149031425-57337dc7-7394-47bb-ad62-7ceedb3a938d.png)
