### PR TITLE
fix: core-151 setting width to full, so margin can have space

### DIFF
--- a/src/components/BorrowerProfile/LoanBookmark.vue
+++ b/src/components/BorrowerProfile/LoanBookmark.vue
@@ -2,7 +2,7 @@
 	<div>
 		<button
 			v-if="!isBookmarked"
-			class="tw-text-action tw-inline-flex tw-p-1 tw-cursor-pointer tw-whitespace-nowrap"
+			class="tw-text-action tw-inline-flex tw-p-1 tw-cursor-pointer tw-whitespace-nowrap tw-font-medium"
 			@click="toggleBookmark()"
 		>
 			<kv-material-icon
@@ -13,7 +13,7 @@
 		</button>
 		<button
 			v-if="isBookmarked"
-			class="tw-text-action tw-inline-flex tw-p-1 tw-cursor-pointer"
+			class="tw-text-action tw-inline-flex tw-p-1 tw-cursor-pointer tw-font-medium"
 			@click="toggleBookmark()"
 		>
 			<kv-material-icon

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -46,7 +46,7 @@
 			:status="status"
 			:use="use"
 		/>
-		<div class="tw-flex-auto tw-inline-flex">
+		<div class="tw-flex-auto tw-inline-flex tw-w-full">
 			<summary-tag v-if="countryName">
 				<kv-material-icon
 					class="tw-h-2.5 tw-w-2.5 tw-mr-0.5 tw-shrink-0"


### PR DESCRIPTION
In my code review yesterday, I was testing on a loan who's location and activity were so long it pushed my bookmark into the right place like this.
<img width="630" alt="Screen Shot 2022-01-12 at 9 23 38 AM" src="https://user-images.githubusercontent.com/1521381/149180140-862a13e4-ea81-4738-8c5c-da9a38b36487.png">
 
Once things got up to dev, I realized that I forgot to set the 'tw-w-full' class on the parent component allowing it to take up the full width of the container and then giving space for my 'tw-ml-auto' on the bookmark component.to work.

**Error state:**
<img width="672" alt="Screen Shot 2022-01-12 at 9 23 00 AM" src="https://user-images.githubusercontent.com/1521381/149180610-a2d926ee-372b-4d3c-9f07-a3bde3eb9ff8.png">

**After 'tw-w-full' class is added:** FIXED
<img width="622" alt="Screen Shot 2022-01-12 at 9 27 44 AM" src="https://user-images.githubusercontent.com/1521381/149180922-a8f3ec60-def5-4041-8d65-e33be883ca3f.png">

