### PR TITLE
Core 148 fix

### DIFF
--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -198,7 +198,7 @@ export default {
 			return `tab-panel-${this.name}-trustee`;
 		},
 		isSupporter() {
-			return this.loan.lentTo;
+			return this.loan?.lentTo;
 		},
 		displayRepaymentSchedule() {
 			// check anonymization of loan, if it's not set to

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -207,12 +207,11 @@ export default {
 				// if loan is fundraising, always display the repayment schedule
 				if (this.loan.status === 'fundraising') {
 					return true;
-				} else {
-					// otherwise look at the isSupporter flag to determine if
-					// the repayment schedule should be shown to current user,
-					// if they are logged in
-					return this.isSupporter;
 				}
+				// otherwise look at the isSupporter flag to determine if
+				// the repayment schedule should be shown to current user,
+				// if they are logged in
+				return this.isSupporter;
 			}
 			// if loan is set to full anonymization, return false
 			// because the repayment schedule should not be shown.

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -198,7 +198,7 @@ export default {
 			return `tab-panel-${this.name}-trustee`;
 		},
 		isSupporter() {
-			return this.loan?.lentTo;
+			return this.loan?.lentTo || false;
 		},
 		displayRepaymentSchedule() {
 			// check anonymization of loan, if it's not set to

--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -50,7 +50,7 @@
 						@show-definition="showDefinition"
 					/>
 					<repayment-schedule
-						v-if="loan.anonymizationLevel !== 'full'"
+						v-if="displayRepaymentSchedule"
 						:loan-id="loanId"
 						:status="loan.status"
 					/>
@@ -197,6 +197,27 @@ export default {
 		trusteeTabId() {
 			return `tab-panel-${this.name}-trustee`;
 		},
+		isSupporter() {
+			return this.loan.lentTo;
+		},
+		displayRepaymentSchedule() {
+			// check anonymization of loan, if it's not set to
+			// full anonymization, continue
+			if (this.loan.anonymizationLevel !== 'full') {
+				// if loan is fundraising, always display the repayment schedule
+				if (this.loan.status === 'fundraising') {
+					return true;
+				} else {
+					// otherwise look at the isSupporter flag to determine if
+					// the repayment schedule should be shown to current user,
+					// if they are logged in
+					return this.isSupporter;
+				}
+			}
+			// if loan is set to full anonymization, return false
+			// because the repayment schedule should not be shown.
+			return false;
+		}
 	},
 	methods: {
 		closeLightbox() {
@@ -236,6 +257,9 @@ export default {
 							repaymentInterval
 							disbursalDate
 							anonymizationLevel
+							userProperties {
+								lentTo
+							}
 							terms {
 								currency
 								flexibleFundraisingEnabled
@@ -292,6 +316,7 @@ export default {
 				this.loan.status = loan?.status ?? '';
 				this.loan.name = loan?.name ?? '';
 				this.loan.anonymizationLevel = loan?.anonymizationLevel ?? 'none';
+				this.loan.lentTo = loan?.userProperties?.lendTo ?? false;
 
 				this.partner.arrearsRate = partner?.arrearsRate ?? 0;
 				this.partner.avgBorrowerCost = partner?.avgBorrowerCost ?? 0;


### PR DESCRIPTION
During QA of the repayment schedule Lauren happened to look at a "Funded" loan in development while being logged out, in that situation she was getting this result, as the check to show the repayment schedule was only looking at the loans "anonymizationLevel".
[Loan](https://www.dev.kiva.org/lend-beta/2293062) 
<img width="1125" alt="Screen Shot 2022-01-12 at 9 43 35 AM" src="https://user-images.githubusercontent.com/1521381/149203218-217fecd7-8daa-406f-9fda-c0b178f342bd.png">
So I was showing the repayment schedule but no data was coming through for it.  

I compared the older borrower profile, logged in and logged out states and noticed that for funded loans we were only showing the repayment schedule while being logged in. 

The check I've now put in place: 
```
displayRepaymentSchedule() {
	// check anonymization of loan, if it's not set to
	// full anonymization, continue
	if (this.loan.anonymizationLevel !== 'full') {
		// if loan is fundraising, always display the repayment schedule
		if (this.loan.status === 'fundraising') {
			return true;
		}
		// otherwise look at the isSupporter flag to determine if
		// the repayment schedule should be shown to current user,
		// if they are logged in
		return this.isSupporter;
	}
	// if loan is set to full anonymization, return false
	// because the repayment schedule should not be shown.
	return false;
}
```

Now we're only showing the repayment schedule: 
- if the loan.anonymizationLevel !== 'full'
& if the loan is fundrasing
& if the loan is not fundraising, if the user is a supporter of that loan