### PR TITLE
feat: add video options for dynamicHeroClassic

### DIFF
--- a/src/components/Contentful/DynamicHeroClassic.vue
+++ b/src/components/Contentful/DynamicHeroClassic.vue
@@ -78,10 +78,11 @@
 							<video
 								:src="heroMedia[0].url"
 								class="tw-rounded tw-overflow-hidden"
-								autoplay
+								:autoplay="videoSettings.autoplay === false ? null : true"
+								:muted="videoSettings.muted === false ? null : true"
 								loop
-								muted
 								playsinline
+								:controls="showControls"
 							></video>
 						</template>
 					</div>
@@ -227,6 +228,15 @@ export default {
 			const imageSet = this.content?.contents?.find(({ contentType }) => contentType === 'responsiveImageSet');
 			return imageSet?.description ?? '';
 		},
+		videoSettings() {
+			return this.uiSetting?.dataObject?.video ?? {};
+		},
+		showControls() {
+			if (this.videoSettings.autoplay === false || this.videoSettings.muted === false) {
+				return true;
+			}
+			return null;
+		}
 	},
 };
 </script>


### PR DESCRIPTION
GD-199

Takes a uiSetting object like:

```
    "video": {
        "autoplay": true,
        "muted": true
    }
```

Default for component if setting is missing is our previous options of autoplay true and mute true. if Options are not default display the video controls (So user can mute video and/or click play)

TODO: 
Add to Setting details to: `admin-component-reference`
Add these changes to component in `cms-page-server`

Important note: _In some browsers (e.g. Chrome 70.0) autoplay doesn't work if no muted attribute is present._