### PR TITLE
feat: core-216 updating icon in FavoriteStar.vue replaced with new bo…

### DIFF
--- a/src/components/LoanCards/FavoriteStar.vue
+++ b/src/components/LoanCards/FavoriteStar.vue
@@ -1,18 +1,50 @@
 <template>
-	<button
-		v-kv-track-event="['Lending', 'click-Favorite star', 'Favorite', loanId, loanId]"
-		@click.prevent.stop="toggleFavorite"
-	>
-		<kv-icon name="star" :from-sprite="true" class="icon-star" :class="{ 'is-favorite': isFavorite }" />
-	</button>
+	<!--
+	*
+	*
+	*
+	*
+	*
+		This is a old file, we don't want to use moving forward
+		if you're looking to implement loan bookmarking behavior
+		please use:
+			src/components/BorrowerProfile/LoanBookmark.vue
+	*
+	*
+	*
+	*
+	*-->
+	<span>
+		<button
+			v-if="!isFavorite"
+			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
+			@click="toggleFavorite()"
+		>
+			<kv-material-icon
+				class="tw-text-action tw-w-3"
+				:icon="mdiBookmarkOutline"
+			/>
+		</button>
+		<button
+			v-if="isFavorite"
+			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
+			@click="toggleFavorite()"
+		>
+			<kv-material-icon
+				class="tw-text-action tw-w-3"
+				:icon="mdiBookmark"
+			/>
+		</button>
+	</span>
 </template>
 
 <script>
-import KvIcon from '@/components/Kv/KvIcon';
+import { mdiBookmarkOutline, mdiBookmark } from '@mdi/js';
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
 export default {
 	components: {
-		KvIcon
+		KvMaterialIcon,
 	},
 	props: {
 		isFavorite: {
@@ -24,6 +56,12 @@ export default {
 			default: null
 		},
 	},
+	data() {
+		return {
+			mdiBookmarkOutline,
+			mdiBookmark,
+		};
+	},
 	methods: {
 		toggleFavorite() {
 			this.$emit('favorite-toggled');
@@ -31,27 +69,3 @@ export default {
 	}
 };
 </script>
-
-<style lang="scss" scoped>
-	@import 'settings';
-
-	button {
-		outline-style: none;
-	}
-
-	.icon-star {
-		height: 2rem;
-		width: 2rem;
-		fill: transparent;
-		color: $white;
-		opacity: 0.5;
-		background-color: $kiva-text-dark;
-		padding: 0.5rem;
-		vertical-align: bottom;
-	}
-
-	.is-favorite {
-		opacity: 1;
-		color: $kiva-alert-yellow;
-	}
-</style>

--- a/src/components/LoanCards/FavoriteStar.vue
+++ b/src/components/LoanCards/FavoriteStar.vue
@@ -18,7 +18,8 @@
 		<button
 			v-if="!isFavorite"
 			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
-			@click="toggleFavorite()"
+			@click.prevent.stop="toggleFavorite()"
+			v-kv-track-event="['Lending', 'click-Favorite star', 'Favorite', loanId, loanId]"
 		>
 			<kv-material-icon
 				class="tw-text-action tw-w-3"
@@ -28,7 +29,8 @@
 		<button
 			v-if="isFavorite"
 			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
-			@click="toggleFavorite()"
+			@click.prevent.stop="toggleFavorite()"
+			v-kv-track-event="['Lending', 'click-Favorite star', 'Favorite', loanId, loanId]"
 		>
 			<kv-material-icon
 				class="tw-text-action tw-w-3"

--- a/src/components/LoanCards/FavoriteStar.vue
+++ b/src/components/LoanCards/FavoriteStar.vue
@@ -19,22 +19,17 @@
 			v-if="!isFavorite"
 			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
 			@click.prevent.stop="toggleFavorite()"
-			v-kv-track-event="['Lending', 'click-Favorite star', 'Favorite', loanId, loanId]"
+			:v-kv-track-event="`[
+				'Lending',
+				'click-Favorite star',
+				${isFavorite ? 'Favorite' : 'Remove favorite',
+				loanId,
+				loanId
+			}]`"
 		>
 			<kv-material-icon
 				class="tw-text-action tw-w-3"
-				:icon="mdiBookmarkOutline"
-			/>
-		</button>
-		<button
-			v-if="isFavorite"
-			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
-			@click.prevent.stop="toggleFavorite()"
-			v-kv-track-event="['Lending', 'click-Favorite star', 'Favorite', loanId, loanId]"
-		>
-			<kv-material-icon
-				class="tw-text-action tw-w-3"
-				:icon="mdiBookmark"
+				:icon="`${isFavorite ? mdiBookmark : mdiBookmarkOutline}`"
 			/>
 		</button>
 	</span>

--- a/src/components/LoanCards/FavoriteStar.vue
+++ b/src/components/LoanCards/FavoriteStar.vue
@@ -16,7 +16,6 @@
 	*-->
 	<span>
 		<button
-			v-if="!isFavorite"
 			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
 			@click.prevent.stop="toggleFavorite()"
 			:v-kv-track-event="`[

--- a/src/components/LoanCards/LoanCardImage.vue
+++ b/src/components/LoanCards/LoanCardImage.vue
@@ -21,7 +21,7 @@
 				loading="lazy"
 			>
 
-			<favorite-star class="favorite-star"
+			<favorite-star class="tw-absolute tw-bottom-0 tw-right-0"
 				v-if="!isVisitor"
 				:is-favorite="isFavorite"
 				:loan-id="loanId"
@@ -114,12 +114,6 @@ export default {
 
 		.borrower-image {
 			position: absolute;
-		}
-
-		.favorite-star {
-			position: absolute;
-			bottom: 0;
-			right: 0;
 		}
 	}
 


### PR DESCRIPTION
…okmark icon

[Core-216](https://kiva.atlassian.net/browse/CORE-216)

- I've removed the old icon from the FavoriteStar.vue component and replaced it with a new Material Design icon.
- I've translated a few of the css declarations into tailwind classes and cleaned that up in LoanCardImage.vue
- Added a note in FavoriteStar.vue about not using that component moving forward. 

**Finished product:** 
<img width="822" alt="Screen Shot 2022-01-12 at 1 39 03 PM" src="https://user-images.githubusercontent.com/1521381/149218566-6026bcaa-2368-4d8b-8aae-ffb1e562daac.png">

