### PR TITLE
fix: core-151 updating style of bookmark, decreased padding, increase…

### DIFF
--- a/src/components/LoanCards/FavoriteStar.vue
+++ b/src/components/LoanCards/FavoriteStar.vue
@@ -16,7 +16,7 @@
 	*-->
 	<span>
 		<button
-			class="tw-inline-flex tw-p-1 tw-cursor-pointer tw-bg-primary tw-rounded tw-m-0.5"
+			class="tw-inline-flex tw-p-0.5 tw-cursor-pointer tw-bg-primary tw-rounded-full tw-m-0.5"
 			@click.prevent.stop="toggleFavorite()"
 			:v-kv-track-event="`[
 				'Lending',


### PR DESCRIPTION
… rounded corners

During flipping through [figma](https://www.figma.com/file/jIOAjGpmKbdVMB5xRtI5fm/Borrower-Profile-V2---Q4-Initiatives?node-id=1272%3A8113) yesterday I noticed we had a mock of the updated bookmark, which I had not previously seen. Just made a few small tweaks to make it look like the mock. 

**Older:**
<img width="289" alt="Screen Shot 2022-01-14 at 10 47 37 AM" src="https://user-images.githubusercontent.com/1521381/149561648-3f5780f9-8601-4599-ba98-bfe490b034fb.png">


**New:**
<img width="341" alt="Screen Shot 2022-01-14 at 10 51 24 AM" src="https://user-images.githubusercontent.com/1521381/149561857-2292d5a5-54b0-42c6-ad5c-583d3465ccac.png">

