### PR TITLE
chore: remove ml_loan_to_loan exp link entry

### DIFF
--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -4,7 +4,6 @@ import _set from 'lodash/set';
 // Experiment Ids from setting that will be passed in the X-Experiment Header
 const targetIds = [
 	'EXP-ML-Service-Bandit-LendByCategory',
-	'ml_loan_to_loan',
 ];
 
 function buildExpHeaders(cookieStore) {


### PR DESCRIPTION
This `ml_loan_to_loan` key was initially used for testing and is not currently being used for analysis.