### PR TITLE
fix: core-218 updating Starred loans -> Saved loans in lend menu

### DIFF
--- a/src/components/WwwFrame/LendMenu/LendListMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendListMenu.vue
@@ -107,12 +107,12 @@
 								class="lend-link"
 								v-kv-track-event="['TopNav','click-Lend-Favorites']"
 							>
-								Starred loans
+								Saved loans
 							</router-link>
 							<span
 								v-else
 								class="tw-block tw-py-1 tw-text-tertiary"
-							>Starred loans</span>
+							>Saved loans</span>
 						</li>
 						<li
 							v-if="hasSearches"

--- a/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
@@ -91,13 +91,13 @@
 											class="tw-text-primary tw-text-left hover:tw-text-action-highlight
 												tw-py-1 tw-inline-block"
 										>
-											Starred loans
+											Saved loans
 										</router-link>
 										<span
 											v-else
 											class="tw-text-secondary tw-py-1 tw-inline-block"
 										>
-											Starred loans
+											Saved loans
 										</span>
 									</li>
 									<li>


### PR DESCRIPTION
[Core-218](https://kiva.atlassian.net/browse/CORE-218)

There will be more changes coming related to this ticket in the other repos, this covers the changes for /kiva/ui.

Text change from "Starred loans" -> "Saved loans"