### PR TITLE
fix: prevent carousel slides from floating above the CC header

### DIFF
--- a/src/components/WwwFrame/WwwPageCorporate.vue
+++ b/src/components/WwwFrame/WwwPageCorporate.vue
@@ -5,7 +5,7 @@
 			:theme="headerTheme"
 			:corporate="true"
 			:corporate-logo-url="corporateLogoUrl"
-			class="tw-sticky tw-top-0"
+			class="tw-sticky tw-z-sticky tw-top-0"
 		/>
 		<main>
 			<slot></slot>


### PR DESCRIPTION
Fixes this on the managed lending page:
![image](https://user-images.githubusercontent.com/187937/150024982-095b149d-0027-45cd-a8f0-dfb16c361a21.png)
