### PR TITLE
fix: bump spacing between borrower image and name in LoanStory component

### DIFF
--- a/src/components/BorrowerProfile/LoanStory.vue
+++ b/src/components/BorrowerProfile/LoanStory.vue
@@ -22,6 +22,7 @@
 			]"
 		/>
 		<loan-description
+			class="tw-pt-4"
 			:loan-id="loanId"
 			:anonymization-level="anonymizationLevel"
 			:borrower-count="borrowerCount"


### PR DESCRIPTION
This has been bugging me for a while and affects all viewports.

Prod Broken:
![image](https://user-images.githubusercontent.com/1862756/150426750-0f4e758c-66f9-40c0-b7f7-7d611acf2fd0.png)


Fixed:
![image](https://user-images.githubusercontent.com/1862756/150426653-95843c1c-cda2-4cab-8f7b-93d6339e8416.png)
