### PR TITLE
feat: clickable imageCard theme story cards

### DIFF
--- a/src/components/Contentful/StoryCard.vue
+++ b/src/components/Contentful/StoryCard.vue
@@ -8,14 +8,21 @@
 			:class="themeClass"
 			v-if="hasBackgroundImage"
 		>
-			<kv-contentful-img
-				class="kv-contentful-img tw-h-full tw-w-full tw-object-cover"
-				:width="520"
-				fallback-format="jpg"
-				:contentful-src="backgroundImage.url"
-				:alt="backgroundImage.description"
-			/>
-			<p class="story-card__imageCard-title tw-text-h4">
+			<component
+				:is="cardLink ? 'a' : 'div'"
+				:href="cardLink ? cardLink : null"
+				v-kv-track-event="cardAnalytics"
+				class="tw-block"
+			>
+				<kv-contentful-img
+					class="kv-contentful-img tw-h-full tw-w-full tw-object-cover"
+					:width="520"
+					fallback-format="jpg"
+					:contentful-src="backgroundImage.url"
+					:alt="backgroundImage.description"
+				/>
+			</component>
+			<p class="story-card__imageCard-title tw-text-h4" v-if="!cardLink">
 				{{ backgroundImage.title }}
 			</p>
 		</div>
@@ -122,6 +129,13 @@ export default {
 		footer() {
 			const text = this.content?.footer ?? '';
 			return text ? richTextRenderer(text) : '';
+		},
+		cardLink() {
+			return this.content?.link ?? '';
+		},
+		cardAnalytics() {
+			const contentfulAnalyticsEvent = this.content?.analyticsClickEvent ?? null;
+			return contentfulAnalyticsEvent;
 		},
 		backgroundImage() {
 			return {

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -230,7 +230,9 @@ export function formatStoryCard(contentfulContent) {
 		footer: contentfulContent.fields?.footer,
 		key: contentfulContent.fields?.key,
 		theme: contentfulContent.fields?.theme,
-		alignment: contentfulContent.fields?.alignment ?? 'center'
+		alignment: contentfulContent.fields?.alignment ?? 'center',
+		link: contentfulContent.fields?.link,
+		analyticsClickEvent: contentfulContent.fields?.analyticsClickEvent
 	};
 }
 


### PR DESCRIPTION
ACK-206

Allows for a layout similar to the one in ACK-206 ticket. Cards with link can be put into card rows. they will be the height of the background image. Analytics is also supported. 

We'll be reusing the StoryCard 'link' field for mobile needs as well (will support a deep link for mobile)

See sample cards at bottom of:  `/lp/eddie-test-page`