### PR TITLE
feat: restrict Causes users from seeing MG and AD signups

### DIFF
--- a/src/components/MonthlyGood/AlreadySubscribedNotice.vue
+++ b/src/components/MonthlyGood/AlreadySubscribedNotice.vue
@@ -1,7 +1,7 @@
 <template functional>
 	<div v-if="!props.onetime">
 		<h1 class="tw-text-center tw-text-h2 tw-mb-2">
-			You're already signed up for Monthly Good
+			You're already signed up for a subscription
 		</h1>
 		<p class="tw-text-center">
 			Changes to this contribution can be made in your

--- a/src/components/Settings/SubscriptionsSettingsCards.vue
+++ b/src/components/Settings/SubscriptionsSettingsCards.vue
@@ -10,7 +10,7 @@
 
 		<!-- Monthly Good Settings -->
 		<subscriptions-monthly-good
-			v-if="!isOnetime"
+			v-if="!isOnetime && !hasModernSub"
 			@cancel-subscription="cancelSubscription"
 			@unsaved-changes="setUnsavedChanges"
 			ref="subscriptionsMonthlyGoodComponent"
@@ -26,7 +26,7 @@
 
 		<!-- Auto Deposit Settings -->
 		<subscriptions-auto-deposit
-			v-if="!isOnetime && !isMonthlyGoodSubscriber && !isLegacySubscriber"
+			v-if="!isOnetime && !isMonthlyGoodSubscriber && !isLegacySubscriber && !hasModernSub"
 			@cancel-subscription="showConfirmationPrompt('Auto Deposit')"
 			@unsaved-changes="setUnsavedChanges"
 			ref="subscriptionsAutoDepositComponent"
@@ -139,10 +139,11 @@ export default {
 			isMonthlyGoodSubscriber: false,
 			isOnetime: false,
 			isSaving: false,
-			mySubscriptions: [],
 			showLightbox: false,
 			showLoadingOverlay: false,
 			hasActiveCauseSubscription: false,
+			hasModernSub: false,
+
 		};
 	},
 	apollo: {
@@ -154,13 +155,13 @@ export default {
 
 			const legacySubs = data?.my?.subscriptions?.values ?? [];
 			this.isLegacySubscriber = legacySubs.length > 0;
-			this.mySubscriptions = data?.mySubscriptions?.values ?? [];
-			const causesSubscriptions = this.mySubscriptions.filter(
+
+			const modernSubscriptions = data?.mySubscriptions?.values ?? [];
+			this.hasModernSub = modernSubscriptions.length !== 0;
+			const causesSubscriptions = modernSubscriptions.filter(
 				subscription => subscription.category.subscriptionType === 'CAUSES'
 			);
-			this.hasActiveCauseSubscription = !!causesSubscriptions.find(
-				subscription => subscription.enabled
-			);
+			this.hasActiveCauseSubscription = causesSubscriptions.length !== 0;
 		},
 	},
 	mounted() {

--- a/src/graphql/query/thanksPage.graphql
+++ b/src/graphql/query/thanksPage.graphql
@@ -98,6 +98,12 @@ query checkoutReceipt($checkoutId: Int!, $visitorId: String) {
 			inviterName
 		}
 	}
+	mySubscriptions(includeDisabled: false) {
+		values {
+			id
+			enabled
+		}
+	}
 	contentful {
 		entries(contentType: "page", contentKey: "thanks")
 	}

--- a/src/pages/AutoDeposit/AutoDepositLandingPage.vue
+++ b/src/pages/AutoDeposit/AutoDepositLandingPage.vue
@@ -46,8 +46,20 @@
 				</div>
 			</div>
 
-			<!-- Auto Deposit What To Expect -->
+			<!-- Modern Sub Notice -->
+			<div class="row" v-if="hasModernSub">
+				<div class="small-12 columns">
+					<div class="tw-p-2 tw-mb-4 tw-bg-caution tw-text-black">
+						<p class="tw-text-h3">
+							Auto Deposit is not available to current subscribers.
+							Changes can be made in your
+							<a href="/settings/subscriptions">subscription settings</a>.
+						</p>
+					</div>
+				</div>
+			</div>
 		</section>
+		<!-- Auto Deposit What To Expect -->
 		<section class="tw-py-4 md:tw-py-6 lg:tw-py-8 tw-text-center tw-bg-secondary">
 			<div class="row">
 				<h2 class="small-12 column tw-mb-4">
@@ -117,6 +129,12 @@ const pageQuery = gql`query autoDepositLandingPage {
 			isSubscriber
 		}
 	}
+	mySubscriptions(includeDisabled: false) {
+		values {
+			id
+			enabled
+		}
+	}
 	contentful {
 		entries(contentType: "page", contentKey: "auto-deposit")
 	}
@@ -140,6 +158,7 @@ export default {
 			hasAutoDeposits: false,
 			hasLegacySubscription: false,
 			pageData: null,
+			hasModernSub: false,
 		};
 	},
 	inject: ['apollo', 'cookieStore'],
@@ -156,6 +175,9 @@ export default {
 
 			const legacySubs = data?.my?.subscriptions?.values ?? [];
 			this.hasLegacySubscription = legacySubs.length > 0;
+
+			const modernSubscriptions = data?.mySubscriptions?.values ?? [];
+			this.hasModernSub = modernSubscriptions.length !== 0;
 		},
 	},
 	computed: {
@@ -163,7 +185,10 @@ export default {
 			return this.pageData?.page?.pageLayout?.contentGroups ?? [];
 		},
 		canDisplayForm() {
-			return !this.isMonthlyGoodSubscriber && !this.hasAutoDeposits && !this.hasLegacySubscription;
+			return !this.isMonthlyGoodSubscriber
+				&& !this.hasAutoDeposits
+				&& !this.hasLegacySubscription
+				&& !this.hasModernSub;
 		},
 		faqContentGroup() {
 			return this.contentGroups?.find(({ type }) => {

--- a/src/pages/LandingPages/MGCovid19/MGCovid19.vue
+++ b/src/pages/LandingPages/MGCovid19/MGCovid19.vue
@@ -50,8 +50,6 @@ export default {
 	},
 	data() {
 		return {
-			isExperimentActive: true,
-			isMonthlyGoodSubscriber: false,
 		};
 	},
 };

--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -24,21 +24,21 @@
 							:selected-group.sync="selectedGroup"
 							key="top"
 							:button-text="heroPrimaryCtaText"
-							v-if="!isMonthlyGoodSubscriber && !isExperimentActive"
+							v-if="!isMonthlyGoodSubscriber && !isExperimentActive && !hasModernSub"
 						/>
 						<landing-form-experiment
 							:amount.sync="monthlyGoodAmount"
 							:selected-group.sync="selectedGroup"
 							key="top"
 							:button-text="heroPrimaryCtaText"
-							v-if="!isMonthlyGoodSubscriber && isExperimentActive"
+							v-if="!isMonthlyGoodSubscriber && isExperimentActive && !hasModernSub"
 						/>
 						<div
 							class="tw-p-2 tw-bg-caution tw-text-black tw-mt-4"
-							v-if="isMonthlyGoodSubscriber"
+							v-if="isMonthlyGoodSubscriber || hasModernSub"
 						>
 							<p class="tw-font-medium tw-mb-2">
-								You're already signed up for Monthly Good. Changes to this
+								You're already signed up for a subscription. Changes to this
 								contribution can be made in your
 								<a href="/settings/subscriptions">subscription settings</a>.
 							</p>
@@ -55,15 +55,15 @@
 					:amount.sync="monthlyGoodAmount"
 					:selected-group.sync="selectedGroup"
 					key="bottom"
-					v-if="!isMonthlyGoodSubscriber"
+					v-if="!isMonthlyGoodSubscriber && !hasModernSub"
 					:button-text="heroPrimaryCtaText"
 				/>
 				<div
 					class="tw-p-2 tw-bg-caution tw-text-black tw-mt-4"
-					v-if="isMonthlyGoodSubscriber"
+					v-if="isMonthlyGoodSubscriber || hasModernSub"
 				>
-					<p class="tw-font-medium">
-						You're already signed up for Monthly Good. Changes to this
+					<p class="tw-font-medium tw-mb-2">
+						You're already signed up for a subscription. Changes to this
 						contribution can be made in your
 						<a href="/settings/subscriptions">subscription settings</a>.
 					</p>
@@ -122,6 +122,12 @@ const pageQuery = gql`
 		}
 		contentful {
 			entries(contentType: "page", contentKey: "monthlygood")
+		}
+		mySubscriptions(includeDisabled: false) {
+			values {
+				id
+				enabled
+			}
 		}
 	}
 `;
@@ -182,6 +188,7 @@ export default {
 					media: 'min-width: 0px',
 				},
 			],
+			hasModernSub: false,
 		};
 	},
 	inject: ['apollo', 'cookieStore'],
@@ -201,6 +208,9 @@ export default {
 		},
 		result({ data }) {
 			this.isMonthlyGoodSubscriber = data?.my?.autoDeposit?.isSubscriber ?? false;
+
+			const modernSubscriptions = data?.mySubscriptions?.values ?? [];
+			this.hasModernSub = modernSubscriptions.length !== 0;
 
 			// Monthly Good Amount Selector Experiment - EXP-GROW-11-Apr2020
 			const mgAmountSelectorExperiment = this.apollo.readFragment({

--- a/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodSetupPage.vue
@@ -29,7 +29,7 @@
 			</div>
 			<div class="row align-center">
 				<div class="small-12 medium-11 large-10 column"
-					v-if="!isMonthlyGoodSubscriber && !hasLegacySubscription"
+					v-if="!isMonthlyGoodSubscriber && !hasLegacySubscription && !hasModernSub"
 				>
 					<h1 class="tw-text-center tw-mb-2">
 						Confirm your Good
@@ -280,7 +280,7 @@
 				</div>
 				<already-subscribed-notice
 					class="small-12 medium-11 large-8 column"
-					v-if="isMonthlyGoodSubscriber"
+					v-if="isMonthlyGoodSubscriber || hasModernSub"
 					:onetime="isOnetime"
 				/>
 				<legacy-subscriber-notice
@@ -354,6 +354,12 @@ const pageQuery = gql`query monthlyGoodSetupPageControl {
 		userAccount {
 			id
 			balance
+		}
+	}
+	mySubscriptions(includeDisabled: false) {
+		values {
+			id
+			enabled
 		}
 	}
 }`;
@@ -433,6 +439,7 @@ export default {
 			hasAutoDeposits: false,
 			hasAutoLending: false,
 			hasLegacySubscription: false,
+			hasModernSub: false,
 			isMGTaglineActive: false,
 			hasActiveLogin: false,
 			balance: 0,
@@ -528,6 +535,8 @@ export default {
 			this.hasLegacySubscription = this.legacySubs.length > 0;
 			this.hasActiveLogin = !!pageQueryResult?.my;
 			this.balance = Math.floor(pageQueryResult?.my?.userAccount?.balance ?? 0);
+			const modernSubscriptions = pageQueryResult?.mySubscriptions?.values ?? [];
+			this.hasModernSub = modernSubscriptions.length !== 0;
 		} catch (e) {
 			logReadQueryError(e, 'MonthlyGoodSetupPage pageQuery');
 		}

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -42,8 +42,8 @@
 		</div>
 
 		<thanks-layout-v2
-			:show-mg-cta="!isMonthlyGoodSubscriber && !isGuest && !showAutoDepositUpsell"
-			:show-auto-deposit-upsell="!isAutoDepositSubscriber && showAutoDepositUpsell"
+			:show-mg-cta="!isMonthlyGoodSubscriber && !isGuest && !showAutoDepositUpsell && !hasModernSub"
+			:show-auto-deposit-upsell="!isAutoDepositSubscriber && showAutoDepositUpsell && !hasModernSub"
 			:show-guest-upsell="isGuest"
 			:show-share="loans.length > 0"
 		>
@@ -132,6 +132,7 @@ export default {
 			],
 			isAutoDepositSubscriber: false,
 			isMonthlyGoodSubscriber: false,
+			hasModernSub: false,
 			isGuest: false,
 			pageData: {},
 		};
@@ -162,6 +163,9 @@ export default {
 			this.isMonthlyGoodSubscriber = data?.my?.autoDeposit?.isSubscriber ?? false;
 			const hasAutoDeposit = data?.my?.autoDeposit?.id ?? false;
 			this.isAutoDepositSubscriber = !!(hasAutoDeposit && !this.isMonthlyGoodSubscriber);
+
+			const modernSubscriptions = data?.mySubscriptions?.values ?? [];
+			this.hasModernSub = modernSubscriptions.length !== 0;
 
 			// The default empty object and the v-if will prevent the
 			// receipt from rendering in the rare cases this query fails.


### PR DESCRIPTION
ACK-219
ACK-220

I tested all instances of this. 

We're now doing this in quite a few places. A future improvement would be better to centralize all this business logic somewhere. Maybe straight from the API? my.userAccount.isEligibleForMonthlyGood or maybe a local resolver of some sort? 