### PR TITLE
fix: swapping link type to get the right font.

### DIFF
--- a/src/components/Checkout/DonateRepaymentsToggle.vue
+++ b/src/components/Checkout/DonateRepaymentsToggle.vue
@@ -44,12 +44,13 @@
 			v-if="showToggle"
 			class="tw-flex tw-mt-2"
 		>
-			<kv-text-link
+			<button
+				class="tw-text-link tw-text-left md:tw-text-right tw-w-full"
 				@click="isLightboxVisible = true;"
-				class="tw-text-left md:tw-text-right tw-w-full"
+				v-kv-track-event="['basket', 'Donation Info Lightbox', 'Open Lightbox']"
 			>
 				Learn more
-			</kv-text-link>
+			</button>
 		</div>
 	</div>
 </template>


### PR DESCRIPTION
During QA I noticed that the Donate loan Repayments component was built with the wrong link type which resulted in the wrong front on the front end. Simple fix to get it right. 

Error:
<img width="275" alt="Screen Shot 2022-01-28 at 10 03 58 AM" src="https://user-images.githubusercontent.com/1521381/151590658-97932466-9034-4e61-8090-33366b044ea0.png">

Fixed:
<img width="941" alt="Screen Shot 2022-01-28 at 10 06 01 AM" src="https://user-images.githubusercontent.com/1521381/151590685-a1860b1d-7729-4ea3-a20d-0ac7bc604af4.png">

