### PR TITLE
refactor: remove unused theme props

### DIFF
--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -3,7 +3,6 @@
 		<the-banner-area v-show="!isKivaAppReferral" />
 		<the-header v-show="!isKivaAppReferral"
 			:hide-search-in-header="hideSearchInHeader"
-			:theme="headerTheme"
 		/>
 		<slot name="secondary" v-if="!isKivaAppReferral"></slot>
 
@@ -11,9 +10,7 @@
 			<slot name="tertiary"></slot>
 			<slot></slot>
 		</main>
-		<the-footer
-			:theme="footerTheme"
-		/>
+		<the-footer	/>
 		<the-basket-bar />
 		<cookie-banner />
 	</div>
@@ -53,14 +50,6 @@ export default {
 		hideSearchInHeader: {
 			type: Boolean,
 			default: false,
-		},
-		headerTheme: {
-			type: Object,
-			default: null,
-		},
-		footerTheme: {
-			type: Object,
-			default: null,
 		},
 		mainClass: {
 			type: [Object, String],

--- a/src/components/WwwFrame/WwwPageCorporate.vue
+++ b/src/components/WwwFrame/WwwPageCorporate.vue
@@ -2,7 +2,6 @@
 	<div class="tw-relative">
 		<the-browser-check ref="theBrowserCheck" />
 		<the-header
-			:theme="headerTheme"
 			:corporate="true"
 			:corporate-logo-url="corporateLogoUrl"
 			class="tw-sticky tw-z-sticky tw-top-0"
@@ -11,7 +10,6 @@
 			<slot></slot>
 		</main>
 		<the-footer-corporate
-			:theme="footerTheme"
 			:corporate-logo-url="corporateLogoUrl"
 		/>
 		<the-basket-bar
@@ -45,14 +43,6 @@ export default {
 		TheHeader,
 	},
 	props: {
-		headerTheme: {
-			type: Object,
-			default() {},
-		},
-		footerTheme: {
-			type: Object,
-			default() {},
-		},
 		corporateLogoUrl: {
 			type: String,
 			default: ''

--- a/src/components/WwwFrame/WwwPageMinimal.vue
+++ b/src/components/WwwFrame/WwwPageMinimal.vue
@@ -1,15 +1,12 @@
 <template>
 	<div class="www-page">
 		<the-header
-			:theme="headerTheme"
 			:minimal="true"
 		/>
 		<main>
 			<slot></slot>
 		</main>
-		<the-footer
-			:theme="footerTheme"
-		/>
+		<the-footer />
 		<the-basket-bar />
 		<cookie-banner />
 	</div>
@@ -39,16 +36,6 @@ export default {
 	mixins: [
 		appInstallMixin
 	],
-	props: {
-		headerTheme: {
-			type: Object,
-			default() {},
-		},
-		footerTheme: {
-			type: Object,
-			default() {},
-		},
-	},
 	apollo: {
 		preFetch(config, client, args) {
 			return Promise.all([

--- a/src/pages/15Years/15Years.vue
+++ b/src/pages/15Years/15Years.vue
@@ -1,7 +1,5 @@
 <template>
 	<www-page
-		:header-theme="headerTheme"
-		:footer-theme="footerTheme"
 		class="fifteen-years-page"
 	>
 		<div class="page-wrap">
@@ -29,7 +27,6 @@
 
 <script>
 
-import { fifteenYearHeaderTheme, fifteenYearFooterTheme } from '@/util/siteThemes';
 import FifteenYearsHeader from '@/components/15Years/15YearsHeader';
 import FifteenYearsHowKivaWorks from '@/components/15Years/15YearsHowKivaWorks';
 import FifteenYearsIndividuals from '@/components/15Years/15YearsIndividuals';
@@ -50,12 +47,6 @@ export default {
 	},
 	metaInfo: {
 		title: '15 Years'
-	},
-	data() {
-		return {
-			headerTheme: fifteenYearHeaderTheme,
-			footerTheme: fifteenYearFooterTheme,
-		};
 	},
 };
 </script>

--- a/src/pages/Autolending/AutolendingPage.vue
+++ b/src/pages/Autolending/AutolendingPage.vue
@@ -2,7 +2,6 @@
 	<www-page
 		class="autolending"
 		:gray-background="true"
-		:header-theme="greenHeader"
 	>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
@@ -26,14 +25,8 @@
 import KvDefaultWrapper from '@/components/Kv/KvDefaultWrapper';
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 
 export default {
-	data() {
-		return {
-			greenHeader,
-		};
-	},
 	components: {
 		KvDefaultWrapper,
 		TheMyKivaSecondaryMenu,

--- a/src/pages/Build/BuildPage.vue
+++ b/src/pages/Build/BuildPage.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -45,14 +43,8 @@
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import BuildPageWrapper from '@/components/Build/BuildPageWrapper';
-import { greenHeader } from '@/util/siteThemes';
 
 export default {
-	data() {
-		return {
-			greenHeader,
-		};
-	},
 	components: {
 		DeveloperSecondaryMenu,
 		BuildPageWrapper,

--- a/src/pages/Build/CodeOfConductPage.vue
+++ b/src/pages/Build/CodeOfConductPage.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -123,16 +121,10 @@
 
 <script>
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import BuildPageWrapper from '@/components/Build/BuildPageWrapper';
 
 export default {
-	data() {
-		return {
-			greenHeader,
-		};
-	},
 	components: {
 		DeveloperSecondaryMenu,
 		BuildPageWrapper,

--- a/src/pages/Build/DataPage.vue
+++ b/src/pages/Build/DataPage.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -69,7 +67,6 @@
 </template>
 
 <script>
-import { greenHeader } from '@/util/siteThemes';
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import KvCodeBlock from '@/components/Kv/KvCodeBlock';
 import BuildPageWrapper from '@/components/Build/BuildPageWrapper';
@@ -87,7 +84,6 @@ export default {
 	},
 	data() {
 		return {
-			greenHeader,
 			fileStructure:
 `kiva_ds_json/
 	lenders.json

--- a/src/pages/Build/DocsPage.vue
+++ b/src/pages/Build/DocsPage.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -51,7 +49,6 @@
 </template>
 
 <script>
-import { greenHeader } from '@/util/siteThemes';
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import KvCodeBlock from '@/components/Kv/KvCodeBlock';
 import KvMultiCodeBlock from '@/components/Kv/KvMultiCodeBlock';
@@ -71,7 +68,6 @@ export default {
 	},
 	data() {
 		return {
-			greenHeader,
 			sampleJson:
 `{'data': {'lend': {'loan': {'id': 1568001,
 			   'name': 'Leydi'} } } }`,

--- a/src/pages/Build/GettingStartedPage.vue
+++ b/src/pages/Build/GettingStartedPage.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -62,14 +60,8 @@
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import BuildPageWrapper from '@/components/Build/BuildPageWrapper';
-import { greenHeader } from '@/util/siteThemes';
 
 export default {
-	data() {
-		return {
-			greenHeader,
-		};
-	},
 	components: {
 		DeveloperSecondaryMenu,
 		BuildPageWrapper,

--- a/src/pages/Build/Research.vue
+++ b/src/pages/Build/Research.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -42,7 +40,6 @@
 </template>
 
 <script>
-import { greenHeader } from '@/util/siteThemes';
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import BuildPageWrapper from '@/components/Build/BuildPageWrapper';
 import WwwPage from '@/components/WwwFrame/WwwPage';
@@ -58,7 +55,6 @@ export default {
 	},
 	data() {
 		return {
-			greenHeader,
 			topics: ['Creation of Synthetic Datasets', 'Recommendation systems', 'Social Good ML Applications',
 				'Pro-Social Behaviorial Psychology', 'Fairness Research', 'Social Impact Assessments'],
 			years: [2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010],

--- a/src/pages/Build/TermsOfService.vue
+++ b/src/pages/Build/TermsOfService.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<developer-secondary-menu />
 		</template>
@@ -170,17 +168,11 @@
 </template>
 
 <script>
-import { greenHeader } from '@/util/siteThemes';
 import DeveloperSecondaryMenu from '@/components/WwwFrame/Menus/DeveloperSecondaryMenu';
 import BuildPageWrapper from '@/components/Build/BuildPageWrapper';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 
 export default {
-	data() {
-		return {
-			greenHeader,
-		};
-	},
 	components: {
 		DeveloperSecondaryMenu,
 		BuildPageWrapper,

--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -1,7 +1,5 @@
 <template>
 	<component :is="pageFrame"
-		:header-theme="headerTheme"
-		:footer-theme="footerTheme"
 		:main-class="pageBackgroundColor"
 	>
 		<component
@@ -39,7 +37,6 @@ To use, simply create a route that defines contentfulPage in the meta data, e.g.
 import { preFetchAll } from '@/util/apolloPreFetch';
 import { processPageContent } from '@/util/contentfulUtils';
 import logFormatter from '@/util/logFormatter';
-import * as siteThemes from '@/util/siteThemes';
 import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
 
 // Page frames
@@ -177,8 +174,6 @@ export default {
 		return {
 			pageBackgroundColor: '',
 			contentGroups: [],
-			footerTheme: {},
-			headerTheme: {},
 			pageError: false,
 			pageFrame: WwwPage,
 			title: undefined,
@@ -240,8 +235,6 @@ export default {
 			} else {
 				this.title = (pageData?.page?.pageLayout?.pageTitle || pageData?.page?.pageTitle) ?? undefined;
 				this.pageBackgroundColor = pageData?.page?.pageLayout?.pageBackgroundColor ?? '';
-				this.headerTheme = siteThemes[pageData?.page?.pageLayout?.headerTheme] || {};
-				this.footerTheme = siteThemes[pageData?.page?.pageLayout?.footerTheme] || {};
 				this.pageFrame = getPageFrameFromType(pageData?.page?.pageType);
 				this.contentGroups = getContentGroups(pageData);
 			}

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -1,8 +1,6 @@
 <template>
 	<www-page-corporate
 		:corporate-logo-url="corporateLogoUrl"
-		:header-theme="lightHeader"
-		:footer-theme="lightFooter"
 	>
 		<div class="corporate-campaign-landing">
 			<kv-loading-overlay
@@ -233,7 +231,6 @@ import logFormatter from '@/util/logFormatter';
 import { processPageContentFlat } from '@/util/contentfulUtils';
 import { validateQueryParams, getPromoFromBasket } from '@/util/campaignUtils';
 import LoanSearchFilters, { getSearchableFilters } from '@/api/fixtures/LoanSearchFilters';
-import { lightHeader, lightFooter } from '@/util/siteThemes';
 import syncDate from '@/util/syncDate';
 import trackTransactionEvent from '@/util/trackTransactionEvent';
 import checkoutUtils from '@/plugins/checkout-utils-mixin';
@@ -544,8 +541,6 @@ export default {
 			verificationSumbitted: false,
 			loadingPage: false,
 			showVerifyRemovePromoCredit: false,
-			lightHeader,
-			lightFooter,
 		};
 	},
 	metaInfo() {

--- a/src/pages/LendingStats/LendingStatsPage.vue
+++ b/src/pages/LendingStats/LendingStatsPage.vue
@@ -1,7 +1,5 @@
 <template>
-	<www-page
-		:header-theme="greenHeader"
-	>
+	<www-page>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
 		</template>
@@ -83,7 +81,6 @@ import _map from 'lodash/map';
 import _sortBy from 'lodash/sortBy';
 import lendingStatsQuery from '@/graphql/query/myLendingStats.graphql';
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import ThePortfolioTertiaryMenu from '@/components/WwwFrame/Menus/ThePortfolioTertiaryMenu';
 import KvDefaultWrapper from '@/components/Kv/KvDefaultWrapper';
@@ -113,7 +110,6 @@ export default {
 			partnersLentTo: [],
 			partnersNotLentTo: [],
 			totalPartners: 0,
-			greenHeader,
 		};
 	},
 	apollo: {

--- a/src/pages/Settings/EmailSettings.vue
+++ b/src/pages/Settings/EmailSettings.vue
@@ -2,7 +2,6 @@
 	<www-page
 		class="email-settings"
 		:gray-background="true"
-		:header-theme="greenHeader"
 	>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
@@ -341,7 +340,6 @@ import PushRepaymentUpdates from '@/components/Settings/PushRepaymentUpdates';
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import KvDefaultWrapper from '@/components/Kv/KvDefaultWrapper';
-import { greenHeader } from '@/util/siteThemes';
 
 const pageQuery = gql`
 	query communicationPreferences {
@@ -457,7 +455,6 @@ export default {
 			hasTeams: false,
 			teamsShown: false,
 			isMonthlyGoodSubscriber: false,
-			greenHeader,
 		};
 	},
 	apollo: {

--- a/src/pages/Settings/PaymentSettings.vue
+++ b/src/pages/Settings/PaymentSettings.vue
@@ -2,7 +2,6 @@
 	<www-page
 		class="payments"
 		:gray-background="true"
-		:header-theme="greenHeader"
 	>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
@@ -181,7 +180,6 @@ import KvRadio from '@/components/Kv/KvRadio';
 import KvSettingsCard from '@/components/Kv/KvSettingsCard';
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 
 const pageQuery = gql`query paymentMethodVault {
   my {
@@ -228,7 +226,6 @@ export default {
 			showRemoveLightbox: false,
 			enableAddCardButton: false,
 			dropInComponentKey: new Date().getTime(),
-			greenHeader,
 		};
 	},
 	mixins: [

--- a/src/pages/Settings/SecuritySettings.vue
+++ b/src/pages/Settings/SecuritySettings.vue
@@ -2,7 +2,6 @@
 	<www-page
 		class="security-login-page"
 		:gray-background="true"
-		:header-theme="greenHeader"
 	>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
@@ -33,14 +32,8 @@ import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSeconda
 import Password from '@/components/Settings/Password';
 import TwoStepVerification from '@/components/Settings/TwoStepVerification';
 import TwoStepFaq from '@/components/Settings/TwoStepFaq';
-import { greenHeader } from '@/util/siteThemes';
 
 export default {
-	data() {
-		return {
-			greenHeader
-		};
-	},
 	components: {
 		KvDefaultWrapper,
 		WwwPage,

--- a/src/pages/Settings/SettingsPage.vue
+++ b/src/pages/Settings/SettingsPage.vue
@@ -1,6 +1,5 @@
 <template>
 	<www-page
-		:header-theme="greenHeader"
 		:gray-background="true"
 	>
 		<template #secondary>
@@ -181,7 +180,6 @@ import gql from 'graphql-tag';
 import KvDefaultWrapper from '@/components/Kv/KvDefaultWrapper';
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 
 const pageQuery = gql`query settingsQuery {
 	my {
@@ -213,7 +211,6 @@ export default {
 		return {
 			isMfaActive: false,
 			isSubscriber: false,
-			greenHeader,
 		};
 	},
 	apollo: {

--- a/src/pages/Settings/SubscriptionsSettings.vue
+++ b/src/pages/Settings/SubscriptionsSettings.vue
@@ -2,7 +2,6 @@
 	<www-page
 		class="subscriptions"
 		:gray-background="true"
-		:header-theme="greenHeader"
 	>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
@@ -21,16 +20,10 @@
 <script>
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 import SubscriptionsSettingsCards from '@/components/Settings/SubscriptionsSettingsCards';
 import KvDefaultWrapper from '@/components/Kv/KvDefaultWrapper';
 
 export default {
-	data() {
-		return {
-			greenHeader,
-		};
-	},
 	components: {
 		KvDefaultWrapper,
 		SubscriptionsSettingsCards,

--- a/src/pages/Settings/TwoStepVerificationPage.vue
+++ b/src/pages/Settings/TwoStepVerificationPage.vue
@@ -2,7 +2,6 @@
 	<www-page
 		class="two-step-verification"
 		:gray-background="true"
-		:header-theme="greenHeader"
 	>
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
@@ -143,7 +142,6 @@ import KvSettingsCard from '@/components/Kv/KvSettingsCard';
 import KvLoadingPlaceholder from '@/components/Kv/KvLoadingPlaceholder';
 import TheMyKivaSecondaryMenu from '@/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import WwwPage from '@/components/WwwFrame/WwwPage';
-import { greenHeader } from '@/util/siteThemes';
 import mfaQuery from '@/graphql/query/mfa/mfaQuery.graphql';
 import removeMfa from '@/graphql/mutation/mfa/removeMfa.graphql';
 import removeOneMfaMethod from '@/graphql/mutation/mfa/removeOneMfaMethod.graphql';
@@ -159,7 +157,6 @@ export default {
 			mfaMethods: [],
 			isLoading: true,
 			pageError: '',
-			greenHeader
 		};
 	},
 	components: {

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -441,8 +441,6 @@ export function processPageContent(entryItem) {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
 			pageBackgroundColor: entryItem.fields?.pageLayout?.fields?.pageBackgroundColor,
-			headerTheme: entryItem.fields?.pageLayout?.fields?.headerTheme,
-			footerTheme: entryItem.fields?.pageLayout?.fields?.footerTheme,
 		},
 		settings: entryItem.fields?.settings
 			? formatContentTypes(entryItem.fields?.settings) : []
@@ -496,8 +494,6 @@ export function processPageContentFlat(entryItem) {
 		pageLayout: {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
-			headerTheme: entryItem.fields?.pageLayout?.fields?.headerTheme,
-			footerTheme: entryItem.fields?.pageLayout?.fields?.footerTheme,
 		},
 		settings: entryItem.fields?.settings
 			? formatContentTypes(entryItem.fields?.settings) : []

--- a/test/unit/specs/util/contentfulUtils.spec.js
+++ b/test/unit/specs/util/contentfulUtils.spec.js
@@ -484,9 +484,7 @@ describe('contentfulUtils.js', () => {
 				pageLayout: {
 					name: 'Promo Campaign Test',
 					pageBackgroundColor: undefined,
-					headerTheme: 'lightHeader',
 					contentGroups: [{}],
-					footerTheme: undefined,
 					pageTitle: 'Test Page Layout Title',
 				},
 				settings: [{}]
@@ -505,7 +503,6 @@ describe('contentfulUtils.js', () => {
 				pageLayout: {
 					name: 'Promo Campaign Test',
 					pageBackgroundColor: undefined,
-					headerTheme: 'lightHeader',
 					contentGroups: [{
 						key: 'promo-campaign-test-cg',
 						name: 'Promo Campaign Test Content Groups',
@@ -529,7 +526,6 @@ describe('contentfulUtils.js', () => {
 							images: expect.any(Array)
 						}]
 					}],
-					footerTheme: undefined,
 					pageTitle: 'Test Page Layout Title',
 				},
 				pageTitle: 'Test Page Title',
@@ -566,7 +562,6 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
-					headerTheme: 'lightHeader',
 					pageTitle: 'Test Page Layout Title',
 				},
 				settings: expect.any(Array),
@@ -586,7 +581,6 @@ describe('contentfulUtils.js', () => {
 				pageType: 'corporate-campaign',
 				pageLayout: {
 					name: 'Promo Campaign Test',
-					headerTheme: 'lightHeader',
 					pageTitle: 'Test Page Layout Title',
 				},
 				settings: expect.any(Array),
@@ -642,7 +636,6 @@ describe('contentfulUtils.js', () => {
 				pageType: expect.any(String),
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
-					headerTheme: expect.any(String),
 					pageTitle: expect.any(String)
 				}),
 				settings: expect.any(Array),
@@ -662,7 +655,6 @@ describe('contentfulUtils.js', () => {
 				pageType: expect.any(String),
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
-					headerTheme: expect.any(String),
 					pageTitle: expect.any(String)
 				}),
 				settings: expect.any(Array),
@@ -726,8 +718,6 @@ describe('contentfulUtils.js', () => {
 				pageType: undefined,
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
-					headerTheme: undefined,
-					footerTheme: undefined,
 					pageTitle: undefined
 				}),
 				settings: [],
@@ -747,8 +737,6 @@ describe('contentfulUtils.js', () => {
 				pageType: undefined,
 				pageLayout: expect.objectContaining({
 					name: expect.any(String),
-					headerTheme: undefined,
-					footerTheme: undefined,
 					pageTitle: undefined
 				}),
 				settings: [],


### PR DESCRIPTION
The latest header and footer do not theme via a theme object like before, since they use the new themable tailwind colors. This PR just removes those objects which aren't doing anything on prod right now. For example http://www.kiva.org/build does not have a green header.

If we'd like to make theming the header/footer an option again, a way to do it would be to wrap whatever needs to be themed with a `kv-theme-provider` component and then pass either a predefined theme from kv-tokens/kivaColors to it, or a custom one.

roughly
```
import {
  defaultTheme, darkTheme, darkGreenTheme, mintTheme,
} from '@kiva/kv-tokens/configs/kivaColors.cjs';

data() {
   darkGreenTheme
}

<kv-theme-provider :theme="darkGreenTheme"><the-header /></kv-theme-provider>
```

