### PR TITLE
feat: core-399 Monthlygood appeal personalized experiment setup

### DIFF
--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -213,13 +213,12 @@ export default {
 				id: 'EXP-VUE-399-subscription-appeal-personalization',
 				fragment: experimentVersionFragment,
 			}) || {};
-			if (
-				subscriptionAppealPersonalization.version
-				&& subscriptionAppealPersonalization.version.version !== 'unassigned'
+			if (subscriptionAppealPersonalization.version
+				&& subscriptionAppealPersonalization.version !== 'unassigned'
 			) {
 				if (this.subscriptionAppealPersonalization === 'shown') {
 					// Direct users to new monthly good page here
-					this.$router.push({ path: '/lp/monthlygood/personalized' });
+					this.$router.push({ path: '/monthlygood/personalized' });
 				} else {
 					this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'a');
 				}

--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -200,15 +200,32 @@ export default {
 					query: pageQuery,
 				})
 				.then(() => {
-					return client.query({
-						query: experimentQuery,
-						variables: { id: 'mg_amount_selector' },
-					});
+					return Promise.all([
+						client.query({ query: experimentQuery, variables: { id: 'mg_amount_selector' } }),
+						// eslint-disable-next-line max-len
+						client.query({ query: experimentQuery, variables: { id: 'EXP-VUE-399-subscription-appeal-personalization' } })
+					]);
 				});
 		},
 		result({ data }) {
-			this.isMonthlyGoodSubscriber = data?.my?.autoDeposit?.isSubscriber ?? false;
+			// Core-399 Subscriptions Appeal Personalization Experiment
+			const subscriptionAppealPersonalization = this.apollo.readFragment({
+				id: 'EXP-VUE-399-subscription-appeal-personalization',
+				fragment: experimentVersionFragment,
+			}) || {};
+			if (
+				subscriptionAppealPersonalization.version
+				&& subscriptionAppealPersonalization.version.version !== 'unassigned'
+			) {
+				if (this.subscriptionAppealPersonalization === 'shown') {
+					// Direct users to new monthly good page here
+					this.$router.push({ path: '/lp/monthlygood/personalized' });
+				} else {
+					this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'a');
+				}
+			}
 
+			this.isMonthlyGoodSubscriber = data?.my?.autoDeposit?.isSubscriber ?? false;
 			// TODO! Add this back in when service supports non-logged in users
 			// const modernSubscriptions = data?.mySubscriptions?.values ?? [];
 			// this.hasModernSub = modernSubscriptions.length !== 0;

--- a/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
@@ -59,7 +59,7 @@ export default {
 				&& subscriptionAppealPersonalization.version !== 'unassigned'
 				&& this.subscriptionAppealPersonalization === 'shown'
 			) {
-				this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'a');
+				this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'b');
 			}
 		},
 	},

--- a/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
@@ -6,6 +6,8 @@
 
 <script>
 import gql from 'graphql-tag';
+import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
+import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 
 const pageQuery = gql`
@@ -38,14 +40,28 @@ export default {
 					query: pageQuery,
 				})
 				.then(() => {
+					return Promise.all([
+						// eslint-disable-next-line max-len
+						client.query({ query: experimentQuery, variables: { id: 'EXP-VUE-399-subscription-appeal-personalization' } })
+					]);
 				});
 		},
 		result({ data }) {
 			console.log('data', data);
+
+			// Core-399 Subscriptions Appeal Personalization Experiment
+			const subscriptionAppealPersonalization = this.apollo.readFragment({
+				id: 'EXP-VUE-399-subscription-appeal-personalization',
+				fragment: experimentVersionFragment,
+			}) || {};
+
+			if (subscriptionAppealPersonalization.version
+				&& subscriptionAppealPersonalization.version !== 'unassigned'
+				&& this.subscriptionAppealPersonalization === 'shown'
+			) {
+				this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'a');
+			}
 		},
 	},
-	mounted() {
-		this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'b');
-	}
 };
 </script>

--- a/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
@@ -1,0 +1,51 @@
+<template>
+	<www-page>
+		TESTING
+	</www-page>
+</template>
+
+<script>
+import gql from 'graphql-tag';
+import WwwPage from '@/components/WwwFrame/WwwPage';
+
+const pageQuery = gql`
+	query monthlyGoodPersonalizedLandingPage {
+		contentful {
+			entries(contentType: "page", contentKey: "/lp/monthlygood/personalized")
+		}
+	}
+`;
+
+export default {
+	metaInfo: {
+		title: 'Personalized Monthly Good',
+	},
+	components: {
+		WwwPage,
+	},
+	props: {
+	},
+	data() {
+		return {
+		};
+	},
+	inject: ['apollo', 'cookieStore'],
+	apollo: {
+		query: pageQuery,
+		preFetch(config, client) {
+			return client
+				.query({
+					query: pageQuery,
+				})
+				.then(() => {
+				});
+		},
+		result({ data }) {
+			console.log('data', data);
+		},
+	},
+	mounted() {
+		this.$kvTrackEvent('MonthlyGood', 'EXP-CORE-399-Feb2022', 'b');
+	}
+};
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -186,6 +186,11 @@ export default [
 		}
 	},
 	{
+		path: '/monthlygood/personalized',
+		component: () => import('@/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage'),
+		props: route => ({ category: route.query.category })
+	},
+	{
 		path: '/portfolio/lending-stats',
 		component: () => import('@/pages/LendingStats/LendingStatsPage'),
 		meta: {


### PR DESCRIPTION
[Core-399](https://kiva.atlassian.net/browse/CORE-399) EXPERIMENT TICKET
- Added a new uiexp to settingsManager in Admin. 
- Created new page with <www-page> component.

[Core-398](https://kiva.atlassian.net/browse/CORE-398) TRACKING TICKET
- Added the EXP to the MonthlyGoodLandingPage.vue file
- If EXP is active and user is in group B -> direct users to new PersonalizedMonthlyGoodLandingPage.vue where the Tracking is fired in the mounted hook currently (I can move this to a read query if wanted)
- If EXP is active and user is in group A -> leave user on /monthlygood and fire tracking for group A.