### PR TITLE
feat: kiva classic lend now and lend 25 buttons

### DIFF
--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -1,11 +1,9 @@
 <template>
 	<component
 		:is="currentButtonState"
-		class="action-button smaller"
 		:disable-redirects="disableRedirects"
 		:loan-id="loanId"
 		:loan="loan"
-		:hide-adding-to-basket-text="hideAddingToBasketText"
 		:minimal-checkout-button="minimalCheckoutButton"
 		@add-to-basket="handleAddToBasketEvent"
 	/>
@@ -78,10 +76,6 @@ export default {
 		isSimpleLendButton: {
 			type: Boolean,
 			default: false
-		},
-		hideAddingToBasketText: {
-			type: Boolean,
-			default: false,
 		},
 		minimalCheckoutButton: {
 			type: Boolean,
@@ -186,13 +180,3 @@ export default {
 };
 
 </script>
-
-<style lang="scss" scoped>
-@import 'settings';
-
-.action-button {
-	margin-top: rem-calc(30);
-	margin-bottom: rem-calc(10);
-	width: 100%;
-}
-</style>

--- a/src/components/LoanCards/Buttons/CheckoutNowButton.vue
+++ b/src/components/LoanCards/Buttons/CheckoutNowButton.vue
@@ -1,23 +1,34 @@
 <template>
 	<kv-button
-		class="checkout-now-button secondary"
-		v-kv-track-event="['Lending', 'click-Read more', 'checkout-now-button-click', loanId, loanId]"
+		class="tw-w-full tw-mb-2 tw-align-middle"
 		:to="disableRedirects ? null : '/basket'"
-		@click.native="checkoutBtnAction"
+		variant="secondary"
+		v-kv-track-event="['Lending', 'click-Read more', 'checkout-now-button-click', loanId, loanId]"
+		@click="checkoutBtnAction"
 	>
-		<kv-icon class="icon" name="checkmark" v-if="!minimalCheckoutButton" />
+		<kv-material-icon
+			v-if="!minimalCheckoutButton"
+			class="tw-w-3 tw-mr-0.5 tw-align-middle"
+			:icon="mdiCheckboxMarkedCircleOutline"
+		/>
 		Checkout<span v-if="!minimalCheckoutButton"> now</span>
 	</kv-button>
 </template>
 
 <script>
-import KvIcon from '@/components/Kv/KvIcon';
-import KvButton from '@/components/Kv/KvButton';
+import { mdiCheckboxMarkedCircleOutline } from '@mdi/js';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
 export default {
 	components: {
-		KvIcon,
 		KvButton,
+		KvMaterialIcon
+	},
+	data() {
+		return {
+			mdiCheckboxMarkedCircleOutline
+		};
 	},
 	props: {
 		disableRedirects: {

--- a/src/components/LoanCards/Buttons/Lend25Button.vue
+++ b/src/components/LoanCards/Buttons/Lend25Button.vue
@@ -2,8 +2,6 @@
 	<lend-button
 		price="25"
 		:loan-id="loanId"
-		class="lend-25-button"
-		:hide-adding-to-basket-text="hideAddingToBasketText"
 		@add-to-basket="$emit('add-to-basket', $event)"
 	>
 		Lend $25
@@ -21,10 +19,6 @@ export default {
 		loanId: {
 			type: Number,
 			default: null
-		},
-		hideAddingToBasketText: {
-			type: Boolean,
-			default: false,
 		},
 	},
 };

--- a/src/components/LoanCards/Buttons/LendAgainButton.vue
+++ b/src/components/LoanCards/Buttons/LendAgainButton.vue
@@ -2,7 +2,6 @@
 	<lend-button
 		price="25"
 		:loan-id="loanId"
-		class="lend-again-button secondary"
 		@add-to-basket="$emit('add-to-basket', $event)"
 	>
 		Lend again

--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -1,34 +1,25 @@
 <template>
-	<kv-button @click.native="addToBasket"
-		v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
-		v-if="!loading"
-		class="lend-button"
-	>
-		<slot>Lend now</slot>
-	</kv-button>
 	<kv-button
-		v-else
-		class="lend-button adding-to-basket"
-		:class="{'hide-adding-to-basket-text': hideAddingToBasketText}"
+		v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
+		:state="buttonState"
+		@click="addToBasket"
 	>
-		<kv-loading-spinner />
-		<span v-if="!hideAddingToBasketText">Adding to basket</span>
+		<slot v-if="!loading">
+			Lend now
+		</slot>
 	</kv-button>
 </template>
 
 <script>
-import _forEach from 'lodash/forEach';
 import numeral from 'numeral';
 import * as Sentry from '@sentry/vue';
 import updateLoanReservation from '@/graphql/mutation/updateLoanReservation.graphql';
 import loanCardBasketed from '@/graphql/query/loanCardBasketed.graphql';
-import KvButton from '@/components/Kv/KvButton';
-import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 export default {
 	components: {
 		KvButton,
-		KvLoadingSpinner,
 	},
 	inject: ['apollo'],
 	props: {
@@ -39,10 +30,6 @@ export default {
 		price: {
 			type: [Number, String],
 			default: 25,
-		},
-		hideAddingToBasketText: {
-			type: Boolean,
-			default: false,
 		},
 	},
 	data() {
@@ -67,7 +54,7 @@ export default {
 
 				if (errors) {
 					// Handle errors from adding to basket
-					_forEach(errors, error => {
+					errors.forEach(error => {
 						this.$showTipMsg(error.message, 'error');
 						try {
 							this.$kvTrackEvent(
@@ -111,45 +98,12 @@ export default {
 			this.$emit('update:loading', isLoading);
 		},
 	},
+	computed: {
+		buttonState() {
+			if (this.loading) return 'loading';
+			return '';
+		}
+	}
 };
 
 </script>
-
-<style lang="scss" scoped>
-@import 'settings';
-
-.loading-spinner {
-	width: 1.5rem;
-	height: 1.5rem;
-	vertical-align: middle;
-	margin-right: 3px;
-}
-
-.lend-by-category-page .loading-spinner {
-	width: 1.25rem;
-	height: 1.25rem;
-}
-
-.loading-spinner >>> .line {
-	background-color: $white;
-}
-
-.secondary .loading-spinner >>> .line {
-	background-color: $charcoal;
-}
-
-.secondary:hover .loading-spinner >>> .line {
-	background-color: $kiva-accent-blue;
-}
-
-.lend-by-category-page .adding-to-basket.button.smaller {
-	font-size: 1rem;
-
-	&.hide-adding-to-basket-text {
-		.loading-spinner {
-			height: 1.125rem;
-			width: 1.125rem;
-		}
-	}
-}
-</style>

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -1,8 +1,8 @@
 <template>
-	<div class="lend-increment-container">
-		<div class="lend-increment-dropdown-container" v-if="!loading">
-			<select
-				class="lend-increment-dropdown"
+	<div class="tw-flex tw-justify-between sm:tw-gap-1 md:tw-gap-2">
+		<div class="tw-w-12" v-if="!loading">
+			<kv-select
+				id="lend-increment-amount"
 				v-model="selectedOption"
 			>
 				<option
@@ -12,11 +12,12 @@
 				>
 					${{ price }}
 				</option>
-			</select>
+			</kv-select>
 		</div>
+
 		<lend-button
-			class="lend-increment-button smaller"
-			:class="{ 'is-loading': loading }"
+			class="tw-grow"
+			:class="{ 'tw-w-full': loading }"
 			:price="selectedOption"
 			:loan-id="loanId"
 			:loading.sync="loading"
@@ -28,9 +29,11 @@
 <script>
 import LendButton from '@/components/LoanCards/Buttons/LendButton';
 import { buildPriceArray } from '@/util/loanUtils';
+import KvSelect from '~/@kiva/kv-components/vue/KvSelect';
 
 export default {
 	components: {
+		KvSelect,
 		LendButton,
 	},
 	data() {
@@ -83,46 +86,3 @@ export default {
 	},
 };
 </script>
-
-<style lang="scss" scoped>
-@import 'settings';
-
-.lend-increment-container {
-	display: flex;
-	justify-content: space-between;
-
-	.lend-increment-dropdown-container {
-		width: 6rem;
-
-		.lend-increment-dropdown {
-			margin: 0;
-			height: 54px;
-			box-shadow: 0 2px #333;
-			border: 1px solid #333;
-			border-bottom: none;
-			color: #484848;
-		}
-
-		@include breakpoint(340px down) {
-			width: 4.75rem;
-		}
-
-		@include breakpoint(medium) {
-			width: 5rem;
-		}
-	}
-
-	.lend-increment-button {
-		margin-bottom: 0;
-		flex-grow: 1;
-		margin-left: 0.8rem;
-		// override only left + right padding
-		padding-right: 1rem;
-		padding-left: 1rem;
-
-		&.is-loading {
-			width: 100%;
-		}
-	}
-}
-</style>

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -47,7 +47,8 @@
 					:is-lent-to="loan.userProperties.lentTo"
 					:is-funded="isFunded"
 					:is-selected-by-another="isSelectedByAnother"
-
+					class="tw-mt-2"
+					:class="{'tw-mb-2' : !isMatchAtRisk}"
 					@click.native="trackInteraction({
 						interactionType: 'addToBasket',
 						interactionElement: 'Lend25'

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -89,7 +89,7 @@
 				<div class="row">
 					<div class="columns small-12 large-expand">
 						<action-button
-							class="expandable-loan-card-action-button"
+							class="tw-mt-2"
 							:loan-id="loan.id"
 							:loan="loan"
 							:items-in-basket="itemsInBasket"

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -51,33 +51,27 @@
 				@read-more-link="updateDetailedLoanIndex"
 				@track-loan-card-interaction="trackInteraction"
 			/>
-			<div class="action-row">
-				<div
-					class="action-button-container"
-					:class="{'full-width': isFunded || isExpired || isSelectedByAnother}"
-				>
-					<action-button
-						class="hover-loan-card-action-button"
-						:loan-id="loan.id"
-						:loan="loan"
-						:items-in-basket="itemsInBasket"
-						:is-lent-to="loan.userProperties.lentTo"
-						:is-funded="isFunded"
-						:is-expired="isExpired"
-						:is-selected-by-another="isSelectedByAnother"
-						:is-simple-lend-button="true"
-						:hide-adding-to-basket-text="true"
-						:minimal-checkout-button="true"
+			<div class="tw-gap-1 tw-flex tw-w-full">
+				<action-button
+					class="tw-py-1 tw-px-0 tw-m-0 tw-w-2/4 tw-shrink-0"
+					:loan-id="loan.id"
+					:loan="loan"
+					:items-in-basket="itemsInBasket"
+					:is-lent-to="loan.userProperties.lentTo"
+					:is-funded="isFunded"
+					:is-expired="isExpired"
+					:is-selected-by-another="isSelectedByAnother"
+					:is-simple-lend-button="true"
+					:minimal-checkout-button="true"
 
-						@click.native="trackInteraction({
-							interactionType: 'addToBasket',
-							interactionElement: 'Lend25'
-						})"
+					@click.native="trackInteraction({
+						interactionType: 'addToBasket',
+						interactionElement: 'Lend25'
+					})"
 
-						@add-to-basket="handleAddToBasket"
-					/>
-				</div>
-				<div v-if="!isMatchAtRisk" class="matching-text-container" :class="{hide: isFunded || isExpired}">
+					@add-to-basket="handleAddToBasket"
+				/>
+				<div v-if="!isMatchAtRisk" class="tw-mt-1" :class="{hide: isFunded || isExpired}">
 					<matching-text
 						:matching-text="loan.matchingText"
 						:match-ratio="loan.matchRatio"
@@ -214,28 +208,6 @@ export default {
 		.flag {
 			width: rem-calc(20);
 			margin-right: 0.25rem;
-		}
-
-		.action-row {
-			display: flex;
-
-			.action-button-container {
-				width: rem-calc(126);
-				flex-shrink: 0;
-
-				.hover-loan-card-action-button {
-					margin: 0;
-					padding: 0.5rem 1.5rem;
-				}
-
-				&.full-width {
-					width: 100%;
-				}
-			}
-
-			.matching-text-container {
-				padding-left: 1rem;
-			}
 		}
 	}
 

--- a/src/components/LoanCards/LendHomepageLoanCard.vue
+++ b/src/components/LoanCards/LendHomepageLoanCard.vue
@@ -55,7 +55,6 @@
 			/>
 			<div class="lend-homepage-loan-card__action-row">
 				<div
-					class="lend-homepage-loan-card__action-button-container"
 					:class="{'full-width': isFunded || isExpired}"
 				>
 					<kv-button
@@ -83,7 +82,6 @@
 						:is-expired="isExpired"
 						:is-selected-by-another="isSelectedByAnother"
 						:is-simple-lend-button="true"
-						:hide-adding-to-basket-text="true"
 						:minimal-checkout-button="true"
 
 						@click.native="trackInteraction({
@@ -309,9 +307,6 @@ export default {
 	}
 
 	&__action-button-container {
-		width: rem-calc(150);
-		flex-grow: 1;
-
 		&.full-width {
 			width: 100%;
 		}

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -73,8 +73,7 @@
 						:is-funded="isFunded"
 						:is-selected-by-another="isSelectedByAnother"
 						:is-expired="isExpired"
-						class="list-loan-card-action-button"
-
+						class="tw-mt-0"
 						@click.native="trackInteraction({
 							interactionType: 'addToBasket',
 							interactionElement: 'Lend25'
@@ -128,7 +127,7 @@
 						:is-funded="isFunded"
 						:is-selected-by-another="isSelectedByAnother"
 						:is-expired="isExpired"
-						class="list-loan-card-action-button"
+						class="tw-mt-0"
 
 						@click.native="trackInteraction({
 							interactionType: 'addToBasket',
@@ -288,11 +287,6 @@ export default {
 				.country {
 					margin-bottom: 0;
 				}
-			}
-
-			.list-loan-card-action-button {
-				margin-top: rem-calc(20);
-				margin-bottom: 0;
 			}
 		}
 

--- a/src/components/LoanCards/PromoGridLoanCard.vue
+++ b/src/components/LoanCards/PromoGridLoanCard.vue
@@ -22,8 +22,7 @@
 					We’ll make a loan for you every month with a Monthly Good subscription.
 				</p>
 				<kv-button
-					:class="compact ? 'smallest' : 'small'"
-					:href="categoryUrl"
+					:to="categoryUrl"
 					v-kv-track-event="['Lending', 'PromoGridCard-click-Learn more', 'CASH-1426 Dec2019']"
 				>
 					Learn more
@@ -36,8 +35,8 @@
 <script>
 import { paramCase } from 'change-case';
 
-import KvButton from '@/components/Kv/KvButton';
 import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 const promoLoanImageRequire = require.context('@/assets/images/mg-promo-loan-card/', true);
 


### PR DESCRIPTION
ACK-229

Applies Kiva Classic styling to the "Lend" buttons. 

Pages affected:
/lend-by-category/women (And all other categories)
/lend-by-category
/lend/filter
/cc/groupon (and other corporate campaign pages)

There may be other pages? It's pretty hard to track down these buttons in a maze of loan card controllers and dynamic components...

I double checked with design about the new design of the "Checkout Now" button. and also the removal of the "Adding to basket" text displayed while loading.

A picture is worth 1000 words so here are the screenshots:
![Screen Shot 2022-02-09 at 10 13 26 AM](https://user-images.githubusercontent.com/4371888/153284472-b88e2404-573a-412a-8ab0-d94d3a41218a.png)
<img width="315" alt="Screen Shot 2022-02-08 at 3 44 51 PM" src="https://user-images.githubusercontent.com/4371888/153284481-dcf2737c-74a9-4002-8809-8eb541a2c97e.png">
<img width="531" alt="Screen Shot 2022-02-08 at 12 57 25 PM" src="https://user-images.githubusercontent.com/4371888/153284483-712e6f67-72de-45bf-9f06-c876bfd032ff.png">
<img width="1005" alt="Screen Shot 2022-02-08 at 12 57 00 PM" src="https://user-images.githubusercontent.com/4371888/153284486-9d7df2a4-962b-4d80-8bcd-71b4068d0c6e.png">
<img width="663" alt="Screen Shot 2022-02-08 at 12 54 36 PM" src="https://user-images.githubusercontent.com/4371888/153284490-78872869-0a4c-435e-9d3c-3f8fa7c7dfd1.png">
<img width="372" alt="Screen Shot 2022-02-08 at 12 54 19 PM" src="https://user-images.githubusercontent.com/4371888/153284495-fe6e25ec-f671-4e7c-acdd-5eaa513bb9b6.png">
<img width="1076" alt="Screen Shot 2022-02-08 at 12 54 01 PM" src="https://user-images.githubusercontent.com/4371888/153284498-ba53bad3-ad6a-43aa-972b-bf362545fa2d.png">
<img width="326" alt="Screen Shot 2022-02-09 at 12 29 54 PM" src="https://user-images.githubusercontent.com/4371888/153284906-b25422e0-fa28-49da-aa43-c5e2bb98e209.png">

