### PR TITLE
feat: core-439 fixing opacity in monthly good cta boxes

### DIFF
--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -16,7 +16,7 @@
 			</template>
 			<template #overlayContent>
 				<div class="row">
-					<div class="overlay-column columns tw-bg-primary-inverse tw-bg-opacity-low medium-12 large-8">
+					<div class="overlay-column columns tw-bg-primary-inverse tw-bg-opacity-[75%] medium-12 large-8">
 						<h1 class="mg-headline tw-text-primary-inverse" v-html="heroHeadline"></h1>
 						<p class="mg-subhead tw-text-subhead tw-text-primary-inverse" v-html="heroBody"></p>
 						<landing-form

--- a/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
@@ -14,7 +14,7 @@
 				</template>
 				<template #overlayContent>
 					<form @submit.prevent.stop="submit" novalidate>
-						<div class="tw-bg-primary-inverse tw-bg-opacity-low
+						<div class="tw-bg-primary-inverse tw-bg-opacity-[75%]
 						md:tw-max-w-sm md:tw-ml-4
 						lg:tw-max-w-md lg:tw-ml-16"
 						>


### PR DESCRIPTION
[Core-439](https://kiva.atlassian.net/browse/CORE-439)

Made the cta box on the monthly good pages darker to pass accessibility tests.

<img width="1142" alt="Screen Shot 2022-02-10 at 7 00 38 PM" src="https://user-images.githubusercontent.com/1521381/153526853-a375d600-a435-4999-876c-59f3a7c0c9d2.png">
