### PR TITLE
feat: add unbounce capture to additional routes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,12 +14,14 @@
 import '@/assets/scss/tailwind/tailwind.css';
 import TheTipMessage from '@/components/WwwFrame/TheTipMessage';
 import webmanifest from '@/manifest.webmanifest';
+import unbounceEventMixin from '@/plugins/unbounce-event-mixin';
 
 export default {
 	name: 'App',
 	components: {
 		TheTipMessage,
 	},
+	mixins: [unbounceEventMixin],
 	metaInfo() {
 		return {
 			title: 'Loans that change lives',

--- a/src/pages/Homepage/Homepage.vue
+++ b/src/pages/Homepage/Homepage.vue
@@ -64,16 +64,7 @@ export default {
 				return preFetchAll([component], client, args);
 			});
 		},
-		result({ data }) {
-			// Setup unbounce event trigger which is restricted to non-logged-in and unknown users
-			this.hasEverLoggedIn = data?.hasEverLoggedIn ?? true;
-			// Check for hasEverLoggedIn
-			if (!this.hasEverLoggedIn) {
-				// push data object if eligible + assigned
-				if (typeof window !== 'undefined') {
-					window.dataLayer.push({ event: 'activateUnbounceEvent' });
-				}
-			}
+		result() {
 			// Mobile Causes homepage experiment (GD-205)
 			const causesHomeExp = this.apollo.readFragment({
 				id: 'Experiment:home_mobile_causes',

--- a/src/plugins/unbounce-event-mixin.js
+++ b/src/plugins/unbounce-event-mixin.js
@@ -9,7 +9,11 @@ export default {
 
 		// Set cookie to disabled unbounce for future visits
 		if (utmEmailMedium) {
-			this.cookieStore.set('kvutm_medium_email', true);
+			this.cookieStore.set(
+				'kvutm_medium_email',
+				true,
+				{ expires: new Date(new Date().setFullYear(new Date().getFullYear() + 2)) }
+			);
 		}
 
 		const utmEmailMediumCookie = this.cookieStore.get('kvutm_medium_email');

--- a/src/plugins/unbounce-event-mixin.js
+++ b/src/plugins/unbounce-event-mixin.js
@@ -1,0 +1,29 @@
+import logReadQueryError from '@/util/logReadQueryError';
+import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql';
+
+export default {
+	inject: ['apollo', 'cookieStore'],
+	created() {
+		const unbounceEnabled = this.$route?.meta?.unbounce;
+
+		// Route meta contains unbounce: true
+		if (unbounceEnabled) {
+			try {
+				const data = this.apollo.readQuery({
+					query: hasEverLoggedInQuery
+				});
+				// Setup unbounce event trigger which is restricted to non-logged-in and unknown users
+				const hasEverLoggedIn = data?.hasEverLoggedIn ?? true;
+				// Check for hasEverLoggedIn
+				if (!hasEverLoggedIn) {
+					// push data object if eligible + assigned
+					if (typeof window !== 'undefined') {
+						window.dataLayer.push({ event: 'activateUnbounceEvent' });
+					}
+				}
+			} catch (err) {
+				logReadQueryError(err, 'unbounce-event-mixin');
+			}
+		}
+	}
+};

--- a/src/plugins/unbounce-event-mixin.js
+++ b/src/plugins/unbounce-event-mixin.js
@@ -4,9 +4,23 @@ import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql
 export default {
 	inject: ['apollo', 'cookieStore'],
 	created() {
-		const unbounceEnabled = this.$route?.meta?.unbounce;
+		const unbounceRoute = this.$route?.meta?.unbounce ?? false;
+		const utmEmailMedium = this.$route?.query?.utm_medium === 'email';
 
-		// Route meta contains unbounce: true
+		// Set cookie to disabled unbounce for future visits
+		if (utmEmailMedium) {
+			this.cookieStore.set('kvutm_medium_email', true);
+		}
+
+		const utmEmailMediumCookie = this.cookieStore.get('kvutm_medium_email');
+
+		/** Only attempt to fire unbounce event for users who do
+		* not currently have utm_medium=email in query params,
+		* do not have utm cookie signifying a previous visit with
+		* utm_medium=email in query params, and are on a route
+		* with unbounce: true
+		*/
+		const unbounceEnabled = unbounceRoute && !utmEmailMedium && !utmEmailMediumCookie;
 		if (unbounceEnabled) {
 			try {
 				const data = this.apollo.readQuery({

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -5,6 +5,7 @@ export default [
 		component: () => import('@/pages/Homepage/Homepage'),
 		meta: {
 			contentfulPage: () => 'home',
+			unbounce: true,
 		},
 	},
 	{ path: '/homepage-classic', redirect: '/' },
@@ -96,7 +97,13 @@ export default [
 		},
 	},
 	{ path: '/donate/support-kiva', component: () => import('@/pages/Donate/DonateFromMacro') },
-	{ path: '/donate/supportus', component: () => import('@/pages/Donate/DonateSupportUs') },
+	{
+		path: '/donate/supportus',
+		component: () => import('@/pages/Donate/DonateSupportUs'),
+		meta: {
+			unbounce: true,
+		},
+	},
 	{ path: '/error', component: () => import('@/pages/Error') },
 	{ path: '/flss', component: () => import('@/pages/FlssPrototypes/SampleLoanDisplay') },
 	{ path: '/funded/:id', component: () => import('@/pages/BorrowerProfile/fundedBorrowerProfile') },
@@ -145,13 +152,35 @@ export default [
 			},
 		]
 	},
-	{ path: '/lend-by-category', component: () => import('@/pages/Lend/LendByCategoryPage') },
-	{ path: '/lend-by-category/:category', component: () => import('@/pages/Lend/LoanChannelCategoryPage') },
-	{ path: '/lend/filter', component: () => import('@/pages/Lend/Filter/LendFilterPage') },
+	{
+		path: '/lend-by-category',
+		component: () => import('@/pages/Lend/LendByCategoryPage'),
+		meta: {
+			unbounce: true,
+		},
+	},
+	{
+		path: '/lend-by-category/:category',
+		component: () => import('@/pages/Lend/LoanChannelCategoryPage'),
+		meta: {
+			unbounce: true,
+		},
+	},
+	{
+		path: '/lend/filter',
+		component: () => import('@/pages/Lend/Filter/LendFilterPage'),
+		meta: {
+			unbounce: true,
+		},
+	},
 	{ path: '/lend/filter-alpha', component: () => import('@/pages/Lend/FilterAlpha/LendFilterAlpha') },
-
-	{ path: '/lend-beta/:id', component: () => import('@/pages/BorrowerProfile/BorrowerProfile') },
-
+	{
+		path: '/lend-beta/:id',
+		component: () => import('@/pages/BorrowerProfile/BorrowerProfile'),
+		meta: {
+			unbounce: true,
+		},
+	},
 	{
 		path: '/lp/:dynamicRoute',
 		component: () => import('@/pages/ContentfulPage'),
@@ -162,7 +191,10 @@ export default [
 	{
 		path: '/monthlygood',
 		component: () => import('@/pages/MonthlyGood/MonthlyGoodLandingPage'),
-		props: route => ({ category: route.query.category })
+		props: route => ({ category: route.query.category }),
+		meta: {
+			unbounce: true,
+		},
 	},
 	{
 		path: '/monthlygood/setup',
@@ -331,7 +363,13 @@ export default [
 			activeLoginRequired: true,
 		}
 	},
-	{ path: '/start', component: () => import('@/pages/Search/SentenceSearch') },
+	{
+		path: '/start',
+		component: () => import('@/pages/Search/SentenceSearch'),
+		meta: {
+			unbounce: true,
+		},
+	},
 	{
 		path: '/start-verification',
 		component: () => import('@/pages/StartVerification'),


### PR DESCRIPTION
ACK-223

I wasn't  sure about the best place to put the unbounce trigger to make sure it loads every time for the selected routes. So added it to App.vue created lifecycle hook.I had some trouble getting it to work in client-entry on initial page ssr load. 

See ticket for list of routes this should be added to. 