### PR TITLE
feat: modifies cause hp experiment to include non mobile users as well.

### DIFF
--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -38,6 +38,7 @@ import { preFetchAll } from '@/util/apolloPreFetch';
 import { processPageContent } from '@/util/contentfulUtils';
 import logFormatter from '@/util/logFormatter';
 import contentfulEntries from '@/graphql/query/contentfulEntries.graphql';
+import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 
 // Page frames
 const WwwPage = () => import('@/components/WwwFrame/WwwPage');
@@ -237,6 +238,24 @@ export default {
 				this.pageBackgroundColor = pageData?.page?.pageLayout?.pageBackgroundColor ?? '';
 				this.pageFrame = getPageFrameFromType(pageData?.page?.pageType);
 				this.contentGroups = getContentGroups(pageData);
+			}
+		}
+	},
+	created() {
+		// Trigger route specific functions
+		if (this.$route.path === '/lp/causes') {
+			// Mobile Causes homepage experiment (GD-205)
+			const causesHomeExp = this.apollo.readFragment({
+				id: 'Experiment:home_mobile_causes',
+				fragment: experimentVersionFragment,
+			}) || {};
+			// Fire Event for EXP-GD-205
+			if (causesHomeExp.version && causesHomeExp.version !== 'unassigned') {
+				this.$kvTrackEvent(
+					'Causes',
+					'EXP-GD-205-Jan2022',
+					causesHomeExp.version === 'shown' ? 'b' : 'a',
+				);
 			}
 		}
 	},

--- a/src/pages/Homepage/Homepage.vue
+++ b/src/pages/Homepage/Homepage.vue
@@ -4,9 +4,9 @@
 
 <script>
 import gql from 'graphql-tag';
+import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 import { preFetchAll } from '@/util/apolloPreFetch';
-import { parseExpCookie } from '@/util/experimentUtils';
 
 const ContentfulPage = () => import('@/pages/ContentfulPage');
 
@@ -39,16 +39,24 @@ export default {
 	apollo: {
 		query: homePageQuery,
 		preFetch(config, client, args) {
-			const assignments = parseExpCookie(args.cookieStore.get('uiab'));
-			if (assignments?.home_mobile_causes?.version === 'shown') {
-				// cancel the promise, returning a route for redirect
-				return Promise.reject({
-					path: '/lp/causes'
-				});
-			}
 			return client.query({
 				query: homePageQuery
-			}).then(() => {
+			}).then(pageQueryResult => {
+				if (!pageQueryResult?.data?.hasEverLoggedIn) {
+					return client.query({
+						query: experimentAssignmentQuery,
+						variables: { id: 'home_mobile_causes' },
+					}).then(expResult => {
+						// Redirect to path: '/lp/causes' if experiment is active
+						if (expResult?.data?.experiment?.version === 'shown') {
+							// cancel the promise, returning a route for redirect
+							return Promise.reject({
+								path: '/lp/causes'
+							});
+						}
+						return ContentfulPage();
+					});
+				}
 				return ContentfulPage();
 			}).then(resolvedImport => {
 				// Call preFetch for the active homepage
@@ -66,44 +74,19 @@ export default {
 					window.dataLayer.push({ event: 'activateUnbounceEvent' });
 				}
 			}
-		}
-	},
-	created() {
-		// Mobile Causes homepage experiment (GD-205)
-		// Only mobile new users are eligible to be in experiment
-		if (this.isMobile && this.isNewUser) {
-			// Assign Experiment
-			this.apollo.query({
-				query: experimentAssignmentQuery,
-				variables: { id: 'home_mobile_causes' }
-			}).then(({ data }) => {
-				// track exp
-				// Fire Event for (GD-205)
-				if (data?.experiment?.version) {
-					this.$kvTrackEvent(
-						'Causes',
-						'EXP-GD-205-Jan2022',
-						data?.experiment?.version === 'shown' ? 'b' : 'a'
-					);
-					if (data?.experiment?.version === 'shown') {
-						// redirect user
-						this.$router.push({
-							path: '/lp/causes'
-						});
-					}
-				}
-			});
-		}
-	},
-	computed: {
-		isMobile() {
-			if (!this.$isServer) {
-				return document?.documentElement?.clientWidth < 735 ?? false;
+			// Mobile Causes homepage experiment (GD-205)
+			const causesHomeExp = this.apollo.readFragment({
+				id: 'Experiment:home_mobile_causes',
+				fragment: experimentVersionFragment,
+			}) || {};
+			// Fire Event for EXP-GD-205
+			if (causesHomeExp.version && causesHomeExp.version !== 'unassigned') {
+				this.$kvTrackEvent(
+					'Causes',
+					'EXP-GD-205-Jan2022',
+					causesHomeExp.version === 'shown' ? 'b' : 'a',
+				);
 			}
-			return false;
-		},
-		isNewUser() {
-			return !this.hasEverLoggedIn;
 		}
 	},
 };


### PR DESCRIPTION
ACK-249

Since we no longer need to check this on the client, we can do the experiment assignment in prefetch and route accordingly. Also added a check for the experiment on Contentful page. This will allow the tracking event to fire for users who are in the shown group when they get rerouted to lp/causes. 

ACK team wants this hotfixed asap to try to increase the rate at which users are funnelled into the experiment to gather statistical significance