### PR TITLE
fix: core-400 altering contentful to read subHeadline instead of Headline

### DIFF
--- a/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
@@ -325,7 +325,7 @@ export default {
 			});
 		},
 		valueHeadline() {
-			return this.valueText?.headline ?? 'Automatically support borrower picked for you.';
+			return this.valueText?.subHeadline ?? 'Automatically support borrowers picked for you.';
 		},
 		valueBody() {
 			// eslint-disable-next-line max-len


### PR DESCRIPTION
Lauren noticed that there was a typo in one of the headings on /monthlygood/personalized. That revealed that the connection to the contentful piece wasn't quite connected properly. This change fixes that connection as well as fixes a typo in the fall back text. 

