### PR TITLE
fix(FakeAuthentication): set auth domain from server entry

### DIFF
--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -56,6 +56,7 @@ export default context => {
 				accessToken,
 				checkFakeAuth: config.auth0.checkFakeAuth,
 				cookieStore,
+				domain: config.auth0.domain,
 				user: profile,
 			});
 		} else {


### PR DESCRIPTION
Because the domain was not defined, fake authentication was never allowed.