### PR TITLE
fix: replicate deep styles for mg hero contentful image

### DIFF
--- a/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/PersonalizedMonthlyGoodLandingPage.vue
@@ -335,3 +335,16 @@ export default {
 	}
 };
 </script>
+
+<style lang="scss" scoped>
+@import "settings";
+
+.hero.mg-hero {
+	::v-deep .kv-contentful-img,
+	::v-deep .kv-contentful-img__img {
+		display: block;
+		width: 100%;
+		height: auto;
+	}
+}
+</style>


### PR DESCRIPTION
The personalized mg page we're testing was a duplicate of the existing landing page. These `deep` styles help the hero image scale across larger viewports.