### PR TITLE
fix: for proper mounting after ssr App.vue root element must have id `app`

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,11 @@
 <template>
 	<div
-		class="tw-flex tw-flex-col tw-h-full tw-w-full"
+		id="app"
+		class="tw-h-full tw-bg-primary"
 	>
-		<div id="app" class="tw-bg-primary tw-flex-grow">
-			<router-view />
-			<vue-progress-bar />
-			<the-tip-message />
-		</div>
+		<router-view />
+		<vue-progress-bar />
+		<the-tip-message />
 	</div>
 </template>
 


### PR DESCRIPTION
This was causing the re-rendering issue in the browser. When checking if the page was server rendered, Vue checks if the element being mounted has the data attribute that the vue server renderer applies. If that attribute isn't present, the entire page is re-rendered. That attribute is applied automatically to the root element of the root component (App.vue), and in client-entry.js we mount the element with the id "app". So when kv-theme-provider was added as a wrapper around #app, #app was no longer the root element of App.vue, meaning it didn't get the ssr data attribute, and therefore Vue re-rendered the entire app. kv-theme-provider was later replaced with a div, though it could have been removed, leaving just the #app div. This PR removes the wrapping div and the extra flexbox styles that were only needed because there was a wrapping div, making the #app div the root element again, which fixes the re-render problem.