### PR TITLE
fix: ensure link tracking is active on router-links

### DIFF
--- a/src/components/WwwFrame/LendMenu/LendListMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendListMenu.vue
@@ -3,12 +3,11 @@
 		<router-link
 			to="/monthlygood"
 			class="tw-inline-flex tw-gap-0.5 tw-py-2 tw-mb-2 tw-border-b tw-border-tertiary tw-font-medium"
-			@click="trackMgLinkClick"
+			@click.native="trackMgLinkClick"
 		>
 			{{ mgLinkText }}
-			<kv-material-icon class="tw-w-3 tw-h-3" :icon="mdiArrowRight" />
+			<kv-material-icon :icon="mdiArrowRight" class="tw-w-3 tw-h-3" />
 		</router-link>
-
 		<kv-tabs ref="navLendCategories">
 			<template #tabNav>
 				<kv-tab for="nav-lend-categories">
@@ -51,12 +50,20 @@
 							</li>
 						</template>
 						<li class="tw-border-t tw-border-tertiary">
-							<router-link to="/lend" class="lend-link">
+							<router-link
+								to="/lend"
+								class="lend-link"
+								v-kv-track-event.native="['TopNav','click-Lend-All_Loans']"
+							>
 								All loans
 							</router-link>
 						</li>
 						<li>
-							<router-link to="/categories" class="lend-link">
+							<router-link
+								to="/categories"
+								class="lend-link"
+								v-kv-track-event.native="['TopNav','click-Lend-All_Categories']"
+							>
 								All categories
 							</router-link>
 						</li>
@@ -106,7 +113,7 @@
 								v-if="favorites > 0"
 								:to="{ path: '/lend', query: { lenderFavorite: userId } }"
 								class="lend-link"
-								v-kv-track-event="['TopNav','click-Lend-Favorites']"
+								v-kv-track-event.native="['TopNav','click-Lend-Favorites']"
 							>
 								Saved loans
 							</router-link>
@@ -137,7 +144,7 @@
 							<router-link
 								to="/lend/countries-not-lent"
 								class="lend-link"
-								v-kv-track-event="['TopNav','click-Lend-Countries_Not_Lent']"
+								v-kv-track-event.native="['TopNav','click-Lend-Countries_Not_Lent']"
 							>
 								Countries I haven't lent to
 							</router-link>

--- a/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
@@ -3,7 +3,7 @@
 		<router-link
 			to="/monthlygood"
 			class="tw-inline-flex tw-gap-0.5 tw-py-2 tw-mb-2 tw-font-medium"
-			@click="trackMgLinkClick"
+			@click.native="trackMgLinkClick"
 		>
 			{{ mgLinkText }}
 			<kv-material-icon :icon="mdiArrowRight" class="tw-w-3 tw-h-3" />
@@ -58,7 +58,7 @@
 										to="/categories"
 										class="tw-text-primary
 									hover:tw-text-action-highlight tw-inline-block tw-py-1"
-										v-kv-track-event="['TopNav','click-Lend-All_Categories']"
+										v-kv-track-event.native="['TopNav','click-Lend-All_Categories']"
 									>
 										All categories
 									</router-link>
@@ -68,7 +68,7 @@
 										class="tw-text-primary
 									hover:tw-text-action-highlight tw-inline-block tw-py-1"
 										to="/lend"
-										v-kv-track-event="['TopNav','click-Lend-All_Loans']"
+										v-kv-track-event.native="['TopNav','click-Lend-All_Loans']"
 									>
 										All loans
 									</router-link>
@@ -87,7 +87,7 @@
 										<router-link
 											v-if="favorites > 0"
 											:to="{ path: '/lend', query: { lenderFavorite: userId } }"
-											v-kv-track-event="['TopNav','click-Lend-Favorites']"
+											v-kv-track-event.native="['TopNav','click-Lend-Favorites']"
 											class="tw-text-primary tw-text-left hover:tw-text-action-highlight
 												tw-py-1 tw-inline-block"
 										>
@@ -120,7 +120,7 @@
 									<li>
 										<router-link
 											to="/lend/countries-not-lent"
-											v-kv-track-event="['TopNav','click-Lend-Countries_Not_Lent']"
+											v-kv-track-event.native="['TopNav','click-Lend-Countries_Not_Lent']"
 											class="tw-text-primary tw-text-left hover:tw-text-action-highlight
 												tw-py-1 tw-inline-block"
 										>


### PR DESCRIPTION
Found several links in the LendMenu's that weren't triggering their click events. This seems to work. Also, I realize the `.native` modifier is a Vue2 construct and won't transfer to Vue3.