### PR TITLE
feat: improved open graph/twitter meta properties for sharing borrowe…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -100,6 +100,7 @@ export default {
 				},
 				{
 					name: 'twitter:image',
+					vmid: 'twitter:image',
 					content: 'https://www-kiva-org.freetls.fastly.net/cms/kiva-ogtwitter-image.jpg'
 				},
 			]),

--- a/src/components/BorrowerProfile/LoanUse.vue
+++ b/src/components/BorrowerProfile/LoanUse.vue
@@ -21,6 +21,11 @@ export default {
 		return {
 			meta: [
 				{ property: 'og:description', vmid: 'og:description', content: this.loanUseFiltered },
+				{
+					name: 'twitter:description',
+					vmid: 'twitter:description',
+					content: this.loanUseFiltered
+				},
 			]
 		};
 	},

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -117,7 +117,15 @@ export default {
 					name: 'facebook_label',
 					content: this.pageLabel
 				},
-			] : [])
+			] : []).concat([
+				// Twitter Tags
+				{ name: 'twitter:title', vmid: 'twitter:title', content: `A loan to ${this.name}` },
+				{
+					name: 'twitter:image',
+					vmid: 'twitter:image',
+					content: this.imageShareUrl
+				},
+			])
 		};
 	},
 	data() {


### PR DESCRIPTION
…r profiles

ACK-252

After doing some research, it seems some platforms (looking at you Slack) will use either `twitter:` or `og:` or a combination of both, depending on what order they are rendered on the page. 

This PR does a couple of things: 
* Add vmid to `twitter:image` in App.vue. This allows this property to be replaced by the `twitter:image` from SummaryCard
* Add `twitter` equivalent meta tags to SummaryCard and LoanUse
