### PR TITLE
PBJ-263: Adding a flag to allow migrated monthly good subscriptions r…

### DIFF
--- a/src/components/Settings/SubscriptionsSettingsCards.vue
+++ b/src/components/Settings/SubscriptionsSettingsCards.vue
@@ -10,7 +10,7 @@
 
 		<!-- Monthly Good Settings -->
 		<subscriptions-monthly-good
-			v-if="!isOnetime && (!hasModernSub || hasActiveMonthlyGoodSubscription)"
+			v-if="!isOnetime && !hasActiveCauseSubscription"
 			@cancel-subscription="cancelSubscription"
 			@unsaved-changes="setUnsavedChanges"
 			ref="subscriptionsMonthlyGoodComponent"
@@ -142,7 +142,6 @@ export default {
 			showLightbox: false,
 			showLoadingOverlay: false,
 			hasActiveCauseSubscription: false,
-			hasActiveMonthlyGoodSubscription: false,
 			hasModernSub: false,
 
 		};
@@ -163,12 +162,6 @@ export default {
 				subscription => subscription.category.subscriptionType === 'CAUSES'
 			);
 			this.hasActiveCauseSubscription = causesSubscriptions.length !== 0;
-			// Temporarily allow migrated records to be modified in the UI using the monolith API.
-			// TODO: during phase 2, this can be removed in favor of UI that interacts directly with Subscriptions API
-			const monthlyGoodSubscriptions = modernSubscriptions.filter(
-				subscription => subscription.category.subscriptionType === 'MG'
-			);
-			this.hasActiveMonthlyGoodSubscription = monthlyGoodSubscriptions.length !== 0;
 		},
 	},
 	mounted() {

--- a/src/components/Settings/SubscriptionsSettingsCards.vue
+++ b/src/components/Settings/SubscriptionsSettingsCards.vue
@@ -10,7 +10,7 @@
 
 		<!-- Monthly Good Settings -->
 		<subscriptions-monthly-good
-			v-if="!isOnetime && !hasModernSub"
+			v-if="!isOnetime && (!hasModernSub || hasActiveMonthlyGoodSubscription)"
 			@cancel-subscription="cancelSubscription"
 			@unsaved-changes="setUnsavedChanges"
 			ref="subscriptionsMonthlyGoodComponent"
@@ -142,6 +142,7 @@ export default {
 			showLightbox: false,
 			showLoadingOverlay: false,
 			hasActiveCauseSubscription: false,
+			hasActiveMonthlyGoodSubscription: false,
 			hasModernSub: false,
 
 		};
@@ -162,6 +163,12 @@ export default {
 				subscription => subscription.category.subscriptionType === 'CAUSES'
 			);
 			this.hasActiveCauseSubscription = causesSubscriptions.length !== 0;
+			// Temporarily allow migrated records to be modified in the UI using the monolith API.
+			// TODO: during phase 2, this can be removed in favor of UI that interacts directly with Subscriptions API
+			const monthlyGoodSubscriptions = modernSubscriptions.filter(
+				subscription => subscription.category.subscriptionType === 'MG'
+			);
+			this.hasActiveMonthlyGoodSubscription = monthlyGoodSubscriptions.length !== 0;
 		},
 	},
 	mounted() {


### PR DESCRIPTION
…ecords to be modified using monolith API and existing UI until phase 2 of the migration starts using the Subscription API directly.

I'm totally open to other options/suggestions, but we need to be able to continue to modify migrated monthly good records in the existing UI for now.