### PR TITLE
feat: remove kiva us from lbc page experimental layout

### DIFF
--- a/src/pages/Lend/LoanChannelCategoryPage.vue
+++ b/src/pages/Lend/LoanChannelCategoryPage.vue
@@ -77,10 +77,12 @@ export default {
 		},
 		// categories to run ACK-247 experiment on
 		testCategories() {
+			/*	'kiva-u-s' was removed from this list after experiment launch.
+			Category properties and image asset still exist at:
+			src/pages/Lend/LoanChannelCategoryExperiment.vue */
 			return [
 				'loans-to-women',
 				'women',
-				'kiva-u-s',
 				'agriculture',
 				'eco-friendly',
 				'refugees-and-i-d-ps',


### PR DESCRIPTION
ACK-271

This will be hotfixed out. Hoping to release all of main. 

Removes `kiva-u-s` from this  experiment. I kept the image asset and category specs for `kiva-u-s`  incase it needs to be added back in in the future. 