### PR TITLE
chore: update vue along with the compiler and server renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.95.0",
+	"version": "2.96.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.95.0",
+			"version": "2.96.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.15.4",
@@ -36727,9 +36727,9 @@
 			}
 		},
 		"node_modules/vue": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
-			"integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
 		"node_modules/vue-demi": {
 			"version": "0.12.1",
@@ -37094,9 +37094,9 @@
 			"integrity": "sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw=="
 		},
 		"node_modules/vue-server-renderer": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.12.tgz",
-			"integrity": "sha512-3LODaOsnQx7iMFTBLjki8xSyOxhCtbZ+nQie0wWY4iOVeEtTg1a3YQAjd82WvKxrWHHTshjvLb7OXMc2/dYuxw==",
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz",
+			"integrity": "sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==",
 			"dependencies": {
 				"chalk": "^1.1.3",
 				"hash-sum": "^1.0.2",
@@ -37258,9 +37258,9 @@
 			}
 		},
 		"node_modules/vue-template-compiler": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
-			"integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
+			"integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
 			"dev": true,
 			"dependencies": {
 				"de-indent": "^1.0.2",
@@ -68546,9 +68546,9 @@
 			"dev": true
 		},
 		"vue": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
-			"integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+			"integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
 		},
 		"vue-demi": {
 			"version": "0.12.1",
@@ -68831,9 +68831,9 @@
 			"integrity": "sha512-RRQNLT8Mzr8z7eL4p7BtKvRaTSGdCbTy2+Mm5HTJvLGYSSeG9gDzNasJPP/yOYKLy+/cLG/ftrqq5fvkFwBJEw=="
 		},
 		"vue-server-renderer": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.12.tgz",
-			"integrity": "sha512-3LODaOsnQx7iMFTBLjki8xSyOxhCtbZ+nQie0wWY4iOVeEtTg1a3YQAjd82WvKxrWHHTshjvLb7OXMc2/dYuxw==",
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue-server-renderer/-/vue-server-renderer-2.6.14.tgz",
+			"integrity": "sha512-HifYRa/LW7cKywg9gd4ZtvtRuBlstQBao5ZCWlg40fyB4OPoGfEXAzxb0emSLv4pBDOHYx0UjpqvxpiQFEuoLA==",
 			"requires": {
 				"chalk": "^1.1.3",
 				"hash-sum": "^1.0.2",
@@ -68966,9 +68966,9 @@
 			}
 		},
 		"vue-template-compiler": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
-			"integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
+			"version": "2.6.14",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
+			"integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
 			"dev": true,
 			"requires": {
 				"de-indent": "^1.0.2",


### PR DESCRIPTION
To replace https://github.com/kiva/ui/pull/3244 which doesn't sync vue or the template compiler versions