### PR TITLE
fix: mobile styles for kiva card updated

### DIFF
--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -22,9 +22,9 @@
 				v-show="open"
 				class="accordion-info row small-12 columns"
 			>
-				<div class="small-9 small-offset-3 large-10 large-offset-2 columns">
+				<div class="small-12 large-10 large-offset-2 columns">
 					<div class="row">
-						<div class="small-9 large-5 columns">
+						<div class="small-12 large-5 columns">
 							<label for="kiva_card_input" class="tw-sr-only">Kiva Card Code</label>
 							<kv-text-input
 								id="kiva_card_input"
@@ -35,18 +35,19 @@
 								@keyup.enter.prevent="updateKivaCard('redemption_code')"
 							/>
 						</div>
-						<div class="small-4 large-3 xlarge-2 columns">
+						<div class="small-12 large-3 xlarge-2 columns">
 							<kv-button variant="secondary"
 								@click="updateKivaCard('redemption_code')"
 								data-testid="apply-card"
+								class="tw-w-full"
 							>
 								Apply
 							</kv-button>
 						</div>
-						<div class="small-4 columns align-self-middle">
+						<div class="small-12 columns align-self-middle">
 							<!-- This lightbox will be replaced with a Popper tip message. -->
 							<button
-								class="help-lightbox-trigger tw-text-link tw-font-medium"
+								class="help-lightbox-trigger tw-text-link tw-font-medium tw-mt-3 md:tw-mt-0"
 								@click="triggerDefaultLightbox"
 								data-testid="basket-code-entry-help-text-button"
 							>


### PR DESCRIPTION
**Ticket:**

[https://kiva.atlassian.net/jira/software/projects/CORE/boards/248?selectedIssue=CORE-376](https://kiva.atlassian.net/jira/software/projects/CORE/boards/248?selectedIssue=CORE-376)

**Steps to test:**

1. Login
2. Go to http://localhost:8888/checkout
3. Resize the screen to 320px
4. Open the "Have a Kiva card ?" option
5. Each one of the 3 elements should be in it's own row like is shown in the figma design [https://www.figma.com/file/KHkcWqBeHNuPIxLifrkUkg/Checkout-2021---Kiva-Classic-%5BJoice.Aug.2021%5D?node-id=665%3A2028](https://www.figma.com/file/KHkcWqBeHNuPIxLifrkUkg/Checkout-2021---Kiva-Classic-%5BJoice.Aug.2021%5D?node-id=665%3A2028)