### PR TITLE
feat: enhance borrower profile meta previews

### DIFF
--- a/src/components/BorrowerProfile/JumpLinks.vue
+++ b/src/components/BorrowerProfile/JumpLinks.vue
@@ -14,7 +14,7 @@
 			Borrower story
 		</a>
 		<a
-			class="tw-text-primary tw-pl-1 tw-pr-1 tw-font-medium tw-cursor-pointer"
+			class="tw-text-primary tw-pl-1 tw-pr-1 tw-font-medium tw-cursor-pointer tw-whitespace-nowrap"
 			data-testid="bp-jump-link-loan-details"
 			v-kv-track-event="['Borrower profile', 'click-jump-link', 'Loan details']"
 			@click="scrollToSection('#loanDetails')"

--- a/src/components/BorrowerProfile/LoanUse.vue
+++ b/src/components/BorrowerProfile/LoanUse.vue
@@ -17,18 +17,6 @@ import KvTextLink from '~/@kiva/kv-components/vue/KvTextLink';
 const loanUseFilter = require('../../plugins/loan-use-filter');
 
 export default {
-	metaInfo() {
-		return {
-			meta: [
-				{ property: 'og:description', vmid: 'og:description', content: this.loanUseFiltered },
-				{
-					name: 'twitter:description',
-					vmid: 'twitter:description',
-					content: this.loanUseFiltered
-				},
-			]
-		};
-	},
 	components: {
 		KvTextLink,
 	},

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -94,7 +94,6 @@
 <script>
 import gql from 'graphql-tag';
 import { mdiMapMarker } from '@mdi/js';
-import { getKivaImageUrl } from '@/util/imageUtils';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import BorrowerImage from './BorrowerImage';
 import BorrowerName from './BorrowerName';
@@ -116,34 +115,6 @@ export default {
 		LoanBookmark,
 		JumpLinks,
 	},
-	metaInfo() {
-		return {
-			title: this.pageTitle,
-			meta: [
-				{ property: 'og:title', vmid: 'og:title', content: `A loan to ${this.name}` },
-				{ property: 'og:type', vmid: 'og:type', content: 'kivadotorg:loan' },
-				{
-					property: 'og:image',
-					vmid: 'og:image',
-					content: this.imageShareUrl
-				},
-			].concat(this.$appConfig.enableFB ? [
-				{
-					vmid: 'facebook_label',
-					name: 'facebook_label',
-					content: this.pageLabel
-				},
-			] : []).concat([
-				// Twitter Tags
-				{ name: 'twitter:title', vmid: 'twitter:title', content: `A loan to ${this.name}` },
-				{
-					name: 'twitter:image',
-					vmid: 'twitter:image',
-					content: this.imageShareUrl
-				},
-			])
-		};
-	},
 	data() {
 		return {
 			isLoggedIn: false,
@@ -151,7 +122,6 @@ export default {
 			activityName: '',
 			borrowerCount: 0,
 			countryName: '',
-			fallbackImage: '',
 			fundraisingPercent: 0,
 			hash: '',
 			loanAmount: '0',
@@ -168,26 +138,6 @@ export default {
 		};
 	},
 	computed: {
-		imageShareUrl() {
-			if (!this.hash) return '';
-			return getKivaImageUrl({
-				height: 630,
-				width: 1200,
-				base: this.$appConfig.photoPath,
-				hash: this.hash,
-			});
-		},
-		pageLabel() {
-			return `Kiva - ${this.pageTitle}`;
-		},
-		pageTitle() {
-			// eslint-disable-next-line prefer-destructuring
-			let name = this.name;
-			if (this.businessName) {
-				name = `${name}, ${this.businessName}`;
-			}
-			return `${name} - ${this.countryName}`;
-		},
 		formattedLocation() {
 			if (this.distributionModel === 'direct') {
 				const formattedString = `${this.city}, ${this.state}, ${this.countryName}`;
@@ -269,9 +219,7 @@ export default {
 			this.loanId = loan?.id ?? 0;
 			this.activityName = loan?.activity?.name ?? '';
 			this.borrowerCount = loan?.borrowerCount ?? 0;
-			this.businessName = loan?.businessName ?? '';
 			this.countryName = loan?.geocode?.country?.name ?? '';
-			this.fallbackImage = loan?.image?.urlSm1x ?? '';
 			this.fundraisingPercent = loan?.fundraisingPercent ?? 0;
 			this.hash = loan?.image?.hash ?? '';
 			this.loanAmount = loan?.loanAmount ?? '0';
@@ -284,7 +232,6 @@ export default {
 			this.city = loan?.geocode?.city ?? '';
 			this.state = loan?.geocode?.state ?? '';
 			this.anonymizationLevel = loan?.anonymizationLevel ?? 'none';
-
 			// If all shares are reserved in baskets, set the fundraising meter to 100%
 			if (this.unreservedAmount === '0') {
 				this.fundraisingPercent = 1;

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -62,6 +62,9 @@
 </template>
 
 <script>
+import { getKivaImageUrl } from '@/util/imageUtils';
+import { format, parseISO } from 'date-fns';
+import gql from 'graphql-tag';
 
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import ContentContainer from '@/components/BorrowerProfile/ContentContainer';
@@ -76,8 +79,10 @@ import LendersAndTeams from '@/components/BorrowerProfile/LendersAndTeams';
 import MoreAboutLoan from '@/components/BorrowerProfile/MoreAboutLoan';
 import WhySpecial from '@/components/BorrowerProfile/WhySpecial';
 
+const loanUseFilter = require('../../plugins/loan-use-filter');
+
 export default {
-	inject: ['cookieStore'],
+	inject: ['apollo', 'cookieStore'],
 	components: {
 		BorrowerCountry,
 		ContentContainer,
@@ -92,12 +97,138 @@ export default {
 		WhySpecial,
 		WwwPage,
 	},
+	metaInfo() {
+		return {
+			title: this.pageTitle,
+			meta: [
+				{ property: 'og:title', vmid: 'og:title', content: `Lend as little as $25 to ${this.name}` },
+				{ property: 'og:type', vmid: 'og:type', content: 'kivadotorg:loan' },
+				{
+					property: 'og:image',
+					vmid: 'og:image',
+					content: this.imageShareUrl
+				},
+			].concat(this.$appConfig.enableFB ? [
+				{
+					vmid: 'facebook_label',
+					name: 'facebook_label',
+					content: this.pageLabel
+				},
+			] : []).concat([
+				// Twitter Tags
+				{ name: 'twitter:title', vmid: 'twitter:title', content: `Lend as little as $25 to ${this.name}` },
+				{
+					name: 'twitter:image',
+					vmid: 'twitter:image',
+					content: this.imageShareUrl
+				},
+				{
+					name: 'twitter:label1',
+					vmid: 'twitter:label1',
+					content: 'Supporters'
+				},
+				{
+					name: 'twitter:data1',
+					vmid: 'twitter:data1',
+					content: this.numLenders
+				},
+				{
+					name: 'twitter:label2',
+					vmid: 'twitter:label2',
+					content: 'End Date'
+				},
+				{
+					name: 'twitter:data2',
+					vmid: 'twitter:data2',
+					content: this.endDate
+				},
+				{ property: 'og:description', vmid: 'og:description', content: this.descriptionMetaContent },
+				{
+					name: 'twitter:description',
+					vmid: 'twitter:description',
+					content: this.descriptionMetaContent
+				},
+			])
+		};
+	},
 	data() {
 		return {
 			loanId: Number(this.$route.params.id || 0),
 			showLenders: true,
 			showTeams: true,
+
+			// meta fields
+			endDate: '',
+			numLenders: 0,
+			name: '',
+			hash: '',
+			borrowerCount: 0,
+			anonymizationLevel: 'none',
+			loanAmount: '0',
+			status: '',
+			use: '',
+			description: '',
 		};
+	},
+	apollo: {
+		query: gql`
+			query borrowerProfileMeta($loanId: Int!) {
+				lend {
+					loan(id: $loanId) {
+						id
+						borrowerCount
+						name
+						... on LoanDirect {
+							businessName
+						}
+						geocode {
+							country {
+								name
+							}
+						}
+						image {
+							id
+							hash
+						}
+						plannedExpirationDate
+						lenders {
+							totalCount
+						}
+						anonymizationLevel
+						loanAmount
+						status
+						use
+						description
+					}
+				}
+			}
+		`,
+		preFetch: true,
+		preFetchVariables({ route }) {
+			return {
+				loanId: Number(route?.params?.id ?? 0),
+			};
+		},
+		variables() {
+			return {
+				loanId: Number(this.$route?.params?.id ?? 0),
+			};
+		},
+		result(result) {
+			const loan = result?.data?.lend?.loan;
+			this.businessName = loan?.businessName ?? '';
+			this.name = loan?.name ?? '';
+			this.countryName = loan?.geocode?.country?.name ?? '';
+			this.hash = loan?.image?.hash ?? '';
+			this.numLenders = loan?.lenders?.totalCount ?? 0;
+			this.endDate = format(parseISO(loan.plannedExpirationDate), 'M/d') ?? '';
+			this.borrowerCount = loan?.borrowerCount ?? 0;
+			this.anonymizationLevel = loan?.anonymizationLevel ?? 'none';
+			this.loanAmount = loan?.loanAmount ?? '0';
+			this.status = loan?.status ?? '';
+			this.use = loan?.use ?? '';
+			this.description = loan?.description ?? '';
+		},
 	},
 	mounted() {
 		// EXP-GROW-655-Aug2021
@@ -106,6 +237,37 @@ export default {
 		if (expCookieSignifier === 'b') {
 			this.$kvTrackEvent('Borrower Profile', 'EXP-GROW-655-Aug2021', expCookieSignifier);
 		}
-	}
+	},
+	computed: {
+		imageShareUrl() {
+			if (!this.hash) return '';
+			return getKivaImageUrl({
+				height: 630,
+				width: 1200,
+				base: this.$appConfig.photoPath,
+				hash: this.hash,
+			});
+		},
+		pageLabel() {
+			return `Kiva - ${this.pageTitle}`;
+		},
+		pageTitle() {
+			// eslint-disable-next-line prefer-destructuring
+			let name = this.name;
+			if (this.businessName) {
+				name = `${name}, ${this.businessName}`;
+			}
+			return `${name} - ${this.countryName}`;
+		},
+		descriptionMetaContent() {
+			if (this.anonymizationLevel !== 'full') {
+				// eslint-disable-next-line max-len
+				const loanUse = loanUseFilter(this.use, this.name, this.status, this.loanAmount, this.borrowerCount,
+					this.loanUseMaxLength);
+				return `${loanUse}\n\n${this.description.substring(0, 120)}...`;
+			}
+			return 'For the borrower\'s privacy, this loan has been made anonymous.';
+		}
+	},
 };
 </script>


### PR DESCRIPTION
ACK-273

The goal of this work is to make the profile page previews look like: 
![c219cbe9-a7f2-40e9-b4d8-58dced908d03](https://user-images.githubusercontent.com/4371888/162481774-951c2668-fe0b-4309-b38b-1128fda0eb2c.png)

