### PR TITLE
fix: type name should not be part of id argument MARS-89

### DIFF
--- a/src/graphql/query/lendMenuData.graphql
+++ b/src/graphql/query/lendMenuData.graphql
@@ -8,7 +8,7 @@ query lendMenuData {
 			}
 		}
 	}
-	experiment(id: "Experiment:lend_menu_category_sort") @client {
+	experiment(id: "lend_menu_category_sort") @client {
 		id
 		version
 	}


### PR DESCRIPTION
The `experiment` resolver `id` argument is not meant to include the `Experiment` typename. This caused the version to always resolve to `null` because the experiment setting could not be found.