### PR TITLE
fix: prevent unreservedAmount from being less than zero

### DIFF
--- a/src/api/localResolvers/loan.js
+++ b/src/api/localResolvers/loan.js
@@ -151,7 +151,12 @@ function unreservedAmount(loan) {
 
 	// Calculate unfunded and unreserved amounts
 	const unfunded = loanAmount - fundedAmount;
-	const unreserved = unfunded - reservedAmount;
+	let unreserved = unfunded - reservedAmount;
+
+	// For presentational purposes we prevent a negative unreservedAmoount from showing
+	if (unreserved <= 0) {
+		unreserved = 0;
+	}
 
 	// Format as string to match Money type
 	return numeral(unreserved).format('0.00');

--- a/test/unit/specs/api/localResolvers/loan.spec.js
+++ b/test/unit/specs/api/localResolvers/loan.spec.js
@@ -93,6 +93,19 @@ describe('loan.js', () => {
 			});
 		});
 
+		it('Returns 1 if loan is over-reserved', () => {
+			testFundraisingPercent({
+				loan: {
+					loanAmount: '200.00',
+					loanFundraisingInfo: {
+						fundedAmount: '185.00',
+						reservedAmount: '20.00'
+					},
+				},
+				expected: 1,
+			});
+		});
+
 		describe('Returns 0 if required fields are missing', () => {
 			function testConsoleError(field) {
 				expect(console.error.mock.calls.length).toBe(1);
@@ -260,6 +273,19 @@ describe('loan.js', () => {
 					loanFundraisingInfo: {
 						fundedAmount: '90.00',
 						reservedAmount: '10.00'
+					},
+				},
+				expected: '0.00',
+			});
+		});
+
+		it('Returns the 0.00 if loan is over-reserved', () => {
+			testUnreservedAmount({
+				loan: {
+					loanAmount: '200.00',
+					loanFundraisingInfo: {
+						fundedAmount: '185.00',
+						reservedAmount: '20.00'
 					},
 				},
 				expected: '0.00',


### PR DESCRIPTION
<img width="666" alt="image" src="https://user-images.githubusercontent.com/1862756/164990669-88e7cdc5-debc-47f1-813b-0a01a664de4f.png">

Based on this code, I think this will also resolve the "add to basket button" still being shown which is part of how extra reservations are being made.