### PR TITLE
fix: category control component overwriting meta title

### DIFF
--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -210,7 +210,6 @@ export default {
 	],
 	metaInfo() {
 		return {
-			title: this.pageTitle,
 			link: [
 				{
 					vmid: 'canonical',


### PR DESCRIPTION
This fix prevents `Loan Channel Category` meta title from being overwritten by  `Loan Channel Category Control `child component.