### PR TITLE
feat: update LBC to accommodate less than 25 lend button + add tracking

### DIFF
--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -6,6 +6,8 @@
 		:loan="loan"
 		:minimal-checkout-button="minimalCheckoutButton"
 		@add-to-basket="handleAddToBasketEvent"
+		:show-now="showNow"
+		:amount-left="amountLeft"
 	/>
 </template>
 
@@ -71,6 +73,14 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		showNow: {
+			type: Boolean,
+			default: null
+		},
+		amountLeft: {
+			type: Number,
+			default: null,
+		}
 	},
 	data() {
 		return {};

--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -75,11 +75,11 @@ export default {
 		},
 		showNow: {
 			type: Boolean,
-			default: null
+			default: false
 		},
 		amountLeft: {
 			type: Number,
-			default: null,
+			default: 0,
 		}
 	},
 	data() {

--- a/src/components/LoanCards/Buttons/LendAmountButton.vue
+++ b/src/components/LoanCards/Buttons/LendAmountButton.vue
@@ -2,7 +2,7 @@
 	<lend-button
 		price="amountLeft"
 		:loan-id="loanId"
-		:is-partial-share="true"
+		v-kv-track-event="['Lending', 'Add to basket (Partial Share)', 'lend-button-click', loanId, amountLeft]"
 		@add-to-basket="$emit('add-to-basket', $event)"
 	>
 		Lend ${{ amountLeft }}<span v-if="showNow"> now</span>

--- a/src/components/LoanCards/Buttons/LendAmountButton.vue
+++ b/src/components/LoanCards/Buttons/LendAmountButton.vue
@@ -2,7 +2,6 @@
 	<lend-button
 		price="amountLeft"
 		:loan-id="loanId"
-		v-kv-track-event="['Lending', 'Add to basket (Partial Share)', 'lend-button-click', loanId, amountLeft]"
 		@add-to-basket="addToBasket($event)"
 	>
 		Lend ${{ amountLeft }}<span v-if="showNow"> now</span>

--- a/src/components/LoanCards/Buttons/LendAmountButton.vue
+++ b/src/components/LoanCards/Buttons/LendAmountButton.vue
@@ -3,7 +3,7 @@
 		price="amountLeft"
 		:loan-id="loanId"
 		v-kv-track-event="['Lending', 'Add to basket (Partial Share)', 'lend-button-click', loanId, amountLeft]"
-		@add-to-basket="$emit('add-to-basket', $event)"
+		@add-to-basket="addToBasket($event)"
 	>
 		Lend ${{ amountLeft }}<span v-if="showNow"> now</span>
 	</lend-button>
@@ -34,5 +34,12 @@ export default {
 			default: 20
 		}
 	},
+	methods: {
+		addToBasket(event) {
+			// eslint-disable-next-line max-len
+			this.$kvTrackEvent('Lending', 'Add to basket (Partial Share)', 'lend-button-click', this.loanId, this.amountLeft);
+			this.$emit('add-to-basket', event);
+		}
+	}
 };
 </script>

--- a/src/components/LoanCards/Buttons/LendAmountButton.vue
+++ b/src/components/LoanCards/Buttons/LendAmountButton.vue
@@ -2,6 +2,7 @@
 	<lend-button
 		price="amountLeft"
 		:loan-id="loanId"
+		:is-partial-share="true"
 		@add-to-basket="$emit('add-to-basket', $event)"
 	>
 		Lend ${{ amountLeft }}<span v-if="showNow"> now</span>
@@ -27,19 +28,11 @@ export default {
 		showNow: {
 			type: Boolean,
 			default: false
+		},
+		amountLeft: {
+			type: Number,
+			default: 20
 		}
 	},
-	computed: {
-		// TODO: we should swap this out for a prop if the parent component needs to calculate this anyway
-		amountLeft() {
-			const { loanAmount, loanFundraisingInfo } = this.loan;
-			const { isExpiringSoon, fundedAmount, reservedAmount } = loanFundraisingInfo;
-			let remainingAmount = parseFloat(loanAmount) - parseFloat(fundedAmount);
-			if (!isExpiringSoon) {
-				remainingAmount -= parseFloat(reservedAmount);
-			}
-			return parseInt(remainingAmount, 10);
-		}
-	}
 };
 </script>

--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -1,6 +1,6 @@
 <template>
 	<kv-button
-		v-kv-track-event="['Lending', eventInfo, 'lend-button-click', loanId, loanId]"
+		v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
 		:state="buttonState"
 		@click="addToBasket"
 	>
@@ -31,10 +31,6 @@ export default {
 			type: [Number, String],
 			default: 25,
 		},
-		isPartialShare: {
-			type: Boolean,
-			default: false,
-		}
 	},
 	data() {
 		return {
@@ -106,9 +102,6 @@ export default {
 		buttonState() {
 			if (this.loading) return 'loading';
 			return '';
-		},
-		eventInfo() {
-			return this.isPartialShare ? 'Add to basket (Partial Share)' : 'Add to basket';
 		},
 	}
 };

--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -1,6 +1,6 @@
 <template>
 	<kv-button
-		v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
+		v-kv-track-event="['Lending', eventInfo, 'lend-button-click', loanId, loanId]"
 		:state="buttonState"
 		@click="addToBasket"
 	>
@@ -31,6 +31,10 @@ export default {
 			type: [Number, String],
 			default: 25,
 		},
+		isPartialShare: {
+			type: Boolean,
+			default: false,
+		}
 	},
 	data() {
 		return {
@@ -102,7 +106,10 @@ export default {
 		buttonState() {
 			if (this.loading) return 'loading';
 			return '';
-		}
+		},
+		eventInfo() {
+			return this.isPartialShare ? 'Add to basket (Partial Share)' : 'Add to basket';
+		},
 	}
 };
 

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -47,7 +47,10 @@
 					:is-lent-to="loan.userProperties.lentTo"
 					:is-funded="isFunded"
 					:is-selected-by-another="isSelectedByAnother"
-					class="tw-mt-2"
+					:is-amount-lend-button="lessThan25"
+					:amount-left="amountLeft"
+					:show-now="true"
+					class="tw-mt-2 tw-w-full"
 					:class="{'tw-mb-2' : !isMatchAtRisk && !isFunded}"
 					@click.native="trackInteraction({
 						interactionType: 'addToBasket',
@@ -139,6 +142,11 @@ export default {
 			type: String,
 			default: ''
 		},
+	},
+	computed: {
+		lessThan25() {
+			return this.amountLeft < 25 && this.amountLeft !== 0;
+		}
 	},
 	methods: {
 		toggleFavorite() {

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -98,6 +98,9 @@
 							:is-selected-by-another="isSelectedByAnother"
 							:is-simple-lend-button="false"
 							:disable-redirects="disableRedirects"
+							:is-amount-lend-button="lessThan25"
+							:amount-left="amountLeft"
+							:show-now="true"
 							@click.native="trackInteraction({
 								interactionType: 'addToBasket',
 								interactionElement: 'Lend25'
@@ -328,6 +331,9 @@ export default {
 		mobileSections() {
 			return this.tabs.filter(({ component }) => component);
 		},
+		lessThan25() {
+			return this.amountLeft < 25 && this.amountLeft !== 0;
+		}
 	},
 	methods: {
 		trackInteraction(args) {

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -63,7 +63,8 @@
 					:is-selected-by-another="isSelectedByAnother"
 					:is-simple-lend-button="true"
 					:minimal-checkout-button="true"
-
+					:is-amount-lend-button="lessThan25"
+					:amount-left="amountLeft"
 					@click.native="trackInteraction({
 						interactionType: 'addToBasket',
 						interactionElement: 'Lend25'
@@ -137,6 +138,11 @@ export default {
 			type: Boolean,
 			default: false
 		},
+	},
+	computed: {
+		lessThan25() {
+			return this.amountLeft < 25 && this.amountLeft !== 0;
+		}
 	},
 	methods: {
 		toggleFavorite() {

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -186,7 +186,8 @@ export default {
 				fundedAmount,
 				reservedAmount
 			} = this.loan.loanFundraisingInfo;
-			return this.loan.loanAmount - fundedAmount - reservedAmount;
+			const amountLeft = this.loan.loanAmount - fundedAmount - reservedAmount;
+			return amountLeft < 0 ? 0 : amountLeft;
 		},
 		isFunded() {
 			return this.loan.status === 'funded';

--- a/src/components/LoansByCategory/FeaturedHeroLoan.vue
+++ b/src/components/LoansByCategory/FeaturedHeroLoan.vue
@@ -61,7 +61,9 @@
 									:is-lent-to="loan.userProperties.lentTo"
 									:is-funded="isFunded"
 									:is-selected-by-another="isSelectedByAnother"
-
+									:is-amount-lend-button="lessThan25"
+									:amount-left="amountLeft"
+									:show-now="true"
 									@click.native="trackInteraction({
 										interactionType: 'addToBasket',
 										interactionElement: 'Lend25'
@@ -169,6 +171,9 @@ export default {
 		showReadMore() {
 			return !!(this.loanUse.length > this.loanUseMaxLength);
 		},
+		lessThan25() {
+			return this.amountLeft < 25 && this.amountLeft !== 0;
+		}
 	},
 	methods: {
 		toggleFavorite() {


### PR DESCRIPTION
this PR updates Lend by Category loan cards to use the `LendAmountButton` when there is <$25 less to be funded on a single loan. this PR also:
* updates tracking for `LendAmountButton`
* removes `amountLeft` computed prop since it now is coming from the parent component(s)
* updates `amountLeft` computed prop on `LoanCardController` such that a negative value is never returned, fixing progress meters that display a negative amount

![Screen Shot 2022-04-27 at 12 31 42 PM](https://user-images.githubusercontent.com/15318176/165570962-e9b7fb91-6be1-4179-9d67-1a6ade0c7183.png)
![Screen Shot 2022-04-27 at 12 33 17 PM](https://user-images.githubusercontent.com/15318176/165570966-c294204c-ac01-422b-a1e5-7b658cddf0a4.png)
![Screen Shot 2022-04-27 at 12 35 10 PM](https://user-images.githubusercontent.com/15318176/165570972-728a09f7-771e-4df9-8967-00005ab6e16a.png)
![Screen Shot 2022-04-27 at 12 35 57 PM](https://user-images.githubusercontent.com/15318176/165570975-e71fa228-e468-43de-af3b-08c65af78613.png)
