### PR TITLE
feat: use transform/translate instead left for place holder animation

### DIFF
--- a/src/components/Kv/KvLoadingPlaceholder.vue
+++ b/src/components/Kv/KvLoadingPlaceholder.vue
@@ -1,8 +1,9 @@
 <template functional>
-	<div :class="[
+	<div
+		:class="[
 			'loading-placeholder tw-w-full tw-h-full tw-relative tw-overflow-hidden tw-bg-tertiary',
 			data.class,
-			data.staticClass
+			data.staticClass,
 		]"
 		:style="[data.style, data.staticStyle]"
 	></div>
@@ -19,7 +20,7 @@
 		height: 100%;
 		width: 100%;
 		top: 0;
-		left: -100%;
+		transform: translateX(100%);
 		background: linear-gradient(to right, transparent 0%, rgb(var(--bg-secondary)) 50%, transparent 100%);
 		animation: loading-placeholder 1.5s infinite cubic-bezier(0.4, 0, 0.2, 1);
 	}
@@ -27,11 +28,11 @@
 
 @keyframes loading-placeholder {
 	from {
-		left: -100%;
+		transform: translateX(-100%);
 	}
 
 	to {
-		left: 100%;
+		transform: translateX(100%);
 	}
 }
 </style>


### PR DESCRIPTION
Small css change to improve place holder animation on KvLoadingPlaceholder component


https://user-images.githubusercontent.com/102815442/165628944-f79a27c9-bdce-4785-a6d5-6c40566af40b.mp4

