### PR TITLE
feat: added property to enable rounded corners on the list loan card

### DIFF
--- a/.storybook/stories/ListLoanCard.stories.js
+++ b/.storybook/stories/ListLoanCard.stories.js
@@ -1,0 +1,32 @@
+import StoryRouter from 'storybook-vue-router';
+import apolloStoryMixin from '../mixins/apollo-story-mixin';
+import ListLoanCard from '@/components/LoanCards/ListLoanCard';
+import { mockLoansArray } from '../utils';
+
+const loan = mockLoansArray(1)[0];
+
+export default {
+	title: 'Loan Cards/List Loan Card',
+	component: ListLoanCard,
+	decorators: [StoryRouter()],
+	args: { loan },
+};
+
+export const Default = (_args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	mixins: [apolloStoryMixin()],
+	components: { ListLoanCard },
+	template: `<list-loan-card :loan="loan" />`,
+});
+
+export const RoundedCorners = (_args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	mixins: [apolloStoryMixin()],
+	components: { ListLoanCard },
+	template: `
+		<list-loan-card
+			:loan="loan"
+			rounded-corners="true"
+		/>
+	`,
+});

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -30,6 +30,7 @@
 					:key="loan.id"
 					:loan="loan"
 					loan-card-type="ListLoanCard"
+					rounded-corners="true"
 				/>
 			</kv-grid>
 		</div>

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -1,6 +1,9 @@
 <template>
-	<div class="row list-loan-card">
-		<div class="list-loan-card-desktop-column show-for-large large-4 xlarge-4 columns">
+	<div class="row list-loan-card" :class="{ 'tw-rounded': roundedCorners }">
+		<div
+			class="list-loan-card-desktop-column show-for-large large-4 xlarge-4 columns"
+			:class="{ 'tw-rounded-l': roundedCorners }"
+		>
 			<div class="list-loan-card-desktop-column-container row">
 				<div class="small-12 columns">
 					<div class="list-loan-card-desktop-column-image-wrapper">
@@ -11,6 +14,7 @@
 							:standard-image-url="loan.image.default"
 							:is-visitor="isVisitor"
 							:is-favorite="isFavorite"
+							:class="{ 'tw-rounded-tl': roundedCorners }"
 
 							@track-loan-card-interaction="trackInteraction"
 							@favorite-toggled="toggleFavorite"
@@ -50,6 +54,7 @@
 						:is-visitor="isVisitor"
 						:is-favorite="isFavorite"
 						class="list-loan-card-mobile-borrower-image"
+						:class="{ 'tw-rounded': roundedCorners }"
 
 						@track-loan-card-interaction="trackInteraction"
 						@favorite-toggled="toggleFavorite"
@@ -232,6 +237,10 @@ export default {
 			type: Number,
 			default: 0,
 		},
+		roundedCorners: {
+			type: Boolean,
+			default: false
+		}
 	},
 	computed: {
 		lessThan25() {

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -1,9 +1,6 @@
 <template>
-	<div class="row list-loan-card" :class="{ 'tw-rounded': roundedCorners }">
-		<div
-			class="list-loan-card-desktop-column show-for-large large-4 xlarge-4 columns"
-			:class="{ 'tw-rounded-l': roundedCorners }"
-		>
+	<div class="row list-loan-card tw-overflow-hidden" :class="{ 'tw-rounded': roundedCorners }">
+		<div class="list-loan-card-desktop-column show-for-large large-4 xlarge-4 columns">
 			<div class="list-loan-card-desktop-column-container row">
 				<div class="small-12 columns">
 					<div class="list-loan-card-desktop-column-image-wrapper">

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -33,6 +33,7 @@
 		:row-number="rowNumber"
 		:right-arrow-position="rightArrowPosition"
 		:left-arrow-position="leftArrowPosition"
+		:rounded-corners="roundedCorners"
 
 		:detailed-loan-index="detailedLoanIndex"
 		:hover-loan-index="hoverLoanIndex"
@@ -149,6 +150,10 @@ export default {
 		leftArrowPosition: {
 			type: Number,
 			default: undefined,
+		},
+		roundedCorners: {
+			type: Boolean,
+			default: false
 		},
 		detailedLoanIndex: {
 			type: Number,


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1008

- Added new prop to enable rounded corners on loan card
- Added true to new filter alpha
- Added stories for loan card variations

Without rounded (default)

![image](https://user-images.githubusercontent.com/16867161/167948624-64bc836e-bf21-4958-80d0-4aea8659354e.png)

![image](https://user-images.githubusercontent.com/16867161/167948678-37946ec0-1566-462b-a9fb-f1d712f36997.png)

With rounded

![image](https://user-images.githubusercontent.com/16867161/167948744-bcc4749c-49d8-4b6c-91fb-1489ccff64f3.png)

![image](https://user-images.githubusercontent.com/16867161/167948721-de276c1a-4f74-4ccb-9c95-4f0ae394858d.png)