### PR TITLE
Vue 1006 basic loan search state

### DIFF
--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -1,0 +1,61 @@
+import loanSearchStateQuery from '@/graphql/query/loanSearchState.graphql';
+// import gql from 'graphql-tag';
+
+// eslint-disable-next-line no-underscore-dangle
+const __typename = 'LoanSearchState';
+
+// Using a fragment is an alternative way to access the cache, requires gql or a new fragment file
+// const loanSearchStateFragment = gql`
+// 	fragment loanSearchState on LoanSearchState @client {
+// 		gender
+// 		countryIsoCode
+// 		sectorId
+// 		sortBy
+// 		theme
+// 	}
+// `;
+
+// export queries, resolvers and defaults for LoanSearchState
+export default () => {
+	return {
+		defaults: {
+			loanSearchState: {
+				id: 'SearchData', // using a hard-coded id for now to enable cache
+				gender: '', // expects a string
+				countryIsoCode: [], // expects an array of strings
+				sectorId: [], // expects an array of ints
+				sortBy: '', // expects a string
+				theme: [], // expects an array of strings
+				__typename,
+			},
+		},
+		resolvers: {
+			Query: {
+				loanSearchState(_, args, { cache }) {
+					// Retrieve current LoanSearchState from the Apollo cache
+					// - If it's missing the default values will be used to create it
+					const cachedData = cache.readQuery({ query: loanSearchStateQuery });
+					return cachedData;
+				},
+			},
+			Mutation: {
+				updateLoanSearch(_, variables = {}, { cache }) {
+					// For now we're using a fixed cache key
+					// - this is built from the id and __typename of the object
+					const id = 'LoanSearchState:SearchData';
+					// Fetch previous state from the cache
+					const previousState = cache.readQuery({ query: loanSearchStateQuery });
+					// Patch the new params into the existing state
+					const data = { ...previousState?.loanSearchState, ...variables.searchParams };
+					// Write the new state to the cache
+					cache.writeData({ data, id });
+					// We could pull the data from the newly set cache and return that...
+					// const newState = cache.readQuery({ query: loanSearchStateQuery });
+					// console.log(newState);
+					// Return the latest state
+					return data;
+				}
+			}
+		}
+	};
+};

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -34,7 +34,7 @@ extend type Mutation {
 	autolending: AutolendingMutation
 	showVerificationLightbox: Boolean
 	closeVerificationLightbox: Boolean
-	updateLoanSearch(searchParams: Object): LoanSearchState
+	updateLoanSearch(searchParams: JSONObject): LoanSearchState
 }
 
 extend type Query {

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -80,7 +80,7 @@ type LoanSearchState {
 	countryIsoCode: [Int]
 	sectorId: [Int]
 	sortBy: String
-	themes: [String]
+	theme: [String]
 }
 
 type TipMessage {

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -34,6 +34,7 @@ extend type Mutation {
 	autolending: AutolendingMutation
 	showVerificationLightbox: Boolean
 	closeVerificationLightbox: Boolean
+	updateLoanSearch(searchParams: Object): LoanSearchState
 }
 
 extend type Query {
@@ -45,6 +46,7 @@ extend type Query {
 	autolending: Autolending
 	verificationLightbox: VerificationLightbox
 	hasEverLoggedIn: Boolean
+	loanSearchState: LoanSearchState
 }
 
 extend type My {
@@ -70,6 +72,15 @@ extend type LoanDirect {
 	fundraisingTimeLeft: String!
 	fundraisingTimeLeftMilliseconds: String!
 	unreservedAmount: Money!
+}
+
+type LoanSearchState {
+	id: String
+	gender: String
+	countryIsoCode: [Int]
+	sectorId: [Int]
+	sortBy: String
+	themes: [String]
 }
 
 type TipMessage {

--- a/src/graphql/query/loanSearchState.graphql
+++ b/src/graphql/query/loanSearchState.graphql
@@ -1,0 +1,10 @@
+query loanSearchStateQuery {
+	loanSearchState @client {
+		id
+		gender
+		sectorId
+		countryIsoCode
+		theme
+		sortBy
+	}
+}

--- a/test/unit/specs/api/localResolvers/loanSearch.spec.js
+++ b/test/unit/specs/api/localResolvers/loanSearch.spec.js
@@ -1,0 +1,60 @@
+import loanSearchFactory from '@/api/localResolvers/loanSearch';
+
+const defaultLoanSearchState = {
+	loanSearchState: {
+		id: 'SearchData',
+		gender: '',
+		countryIsoCode: [],
+		sectorId: [],
+		sortBy: '',
+		theme: [],
+		__typename: 'LoanSearchState',
+	}
+};
+
+describe('loanSearch.js', () => {
+	describe('Query.loanSearchState', () => {
+		it('Returns a default loan search object', () => {
+			const { resolvers } = loanSearchFactory();
+			const context = {
+				cache: {
+					readQuery: jest.fn().mockReturnValue(defaultLoanSearchState),
+				},
+			};
+
+			const result = resolvers.Query.loanSearchState(null, null, context);
+
+			expect(context.cache.readQuery.mock.calls.length).toBe(1);
+			expect(result).toEqual(defaultLoanSearchState);
+		});
+	});
+
+	describe('Mutation.updateLoanSearch', () => {
+		it('Returns a default loan search object with gender set', () => {
+			const { resolvers } = loanSearchFactory();
+
+			// The updateLoanSearch mutation checks the cache
+			// then blends new variables into the previous state
+			const loanSearchPlusGender = {
+				loanSearchState: {
+					...defaultLoanSearchState.loanSearchState,
+					...{ gender: 'male' }
+				}
+			};
+
+			const context = {
+				cache: {
+					readQuery: jest.fn().mockReturnValue(defaultLoanSearchState),
+					writeData: jest.fn().mockReturnValue(loanSearchPlusGender),
+				},
+			};
+
+			const result = resolvers.Mutation.updateLoanSearch(null, { searchParams: { gender: 'male' } }, context);
+
+			expect(context.cache.readQuery.mock.calls.length).toBe(1);
+			expect(context.cache.writeData.mock.calls.length).toBe(1);
+
+			expect(result).toEqual(loanSearchPlusGender.loanSearchState);
+		});
+	});
+});


### PR DESCRIPTION
This may prove to be a temporary construct, but for now it provides a place to hold, way to transport and subscribe to changes of a generic search state object. It will need to be kept in sync with any/all filters we may use across the standard `lend > loans` and `flss` queries.