### PR TITLE
refactor: remove code from lend menu experiment

### DIFF
--- a/src/components/WwwFrame/LendMenu/TheLendMenu.vue
+++ b/src/components/WwwFrame/LendMenu/TheLendMenu.vue
@@ -39,14 +39,8 @@ import gql from 'graphql-tag';
 import { indexIn } from '@/util/comparators';
 import publicLendMenuQuery from '@/graphql/query/lendMenuData.graphql';
 import privateLendMenuQuery from '@/graphql/query/lendMenuPrivateData.graphql';
-import {
-	getExperimentSettingCached,
-	trackExperimentVersion
-} from '@/util/experimentUtils';
 import LendListMenu from './LendListMenu';
 import LendMegaMenu from './LendMegaMenu';
-
-const lendMenuExpKey = 'lend_menu_category_sort';
 
 const pageQuery = gql`query lendMenu {
 		my {
@@ -83,8 +77,7 @@ export default {
 			isRegionsLoading: true,
 			isChannelsLoading: true,
 			showMGUpsellLink: false,
-			swapLendMenuMgCopy: false,
-			weighedCategoriesExp: false
+			swapLendMenuMgCopy: false
 		};
 	},
 	apollo: {
@@ -119,7 +112,7 @@ export default {
 				updatedCat.url = updatedCat.url.replace('lend', 'lend-by-category');
 				return updatedCat;
 			});
-			return this.weighedCategoriesExp ? categories : _sortBy(categories, 'name');
+			return _sortBy(categories, 'name');
 		},
 		hasUserId() {
 			return !!this.userId;
@@ -156,18 +149,6 @@ export default {
 			});
 			this.apollo.watchQuery({ query: publicLendMenuQuery }).subscribe({
 				next: ({ data }) => {
-					const version = _get(data, 'experiment.version');
-					const { enabled } = getExperimentSettingCached(this.apollo, lendMenuExpKey);
-					if (enabled) {
-						trackExperimentVersion(
-							this.apollo,
-							this.$kvTrackEvent,
-							'TopNav',
-							lendMenuExpKey,
-							'EXP-MARS-89-Apr2022'
-						);
-						this.weighedCategoriesExp = version === 'b';
-					}
 					this.categories = _get(data, 'lend.loanChannels.values');
 					this.isChannelsLoading = false;
 				}

--- a/src/graphql/query/lendMenuData.graphql
+++ b/src/graphql/query/lendMenuData.graphql
@@ -8,8 +8,4 @@ query lendMenuData {
 			}
 		}
 	}
-	experiment(id: "lend_menu_category_sort") @client {
-		id
-		version
-	}
 }

--- a/src/graphql/query/wwwHeader.graphql
+++ b/src/graphql/query/wwwHeader.graphql
@@ -47,12 +47,4 @@ query wwwHeader($basketId: String) {
 			id
 		}
 	}
-	general {
-		lend_menu_category_sort_exp: uiExperimentSetting(
-			key: "lend_menu_category_sort"
-		) {
-			key
-			value
-		}
-	}
 }


### PR DESCRIPTION
Removing code from Lend Menu experiment that ordered categories' list depending on a setted weight in Admin, leaving categories sorted by name (winning version).