### PR TITLE
feat: create gender-equality route and redirect own-the-chang-gender-equality to this new route

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -133,6 +133,13 @@ module.exports = [
 		}
 	},
 	{
+		path: '/gender-equality',
+		component: () => import('@/pages/ContentfulPage'),
+		meta: {
+			contentfulPage: () => 'gender-equality',
+		},
+	},
+	{
 		path: '/get-started',
 		component: () => import('@/pages/GetStarted/GetStarted'),
 		children: [
@@ -234,6 +241,10 @@ module.exports = [
 			excludeFromStaticSitemap: true,
 			unbounce: true,
 		},
+	},
+	{
+		path: '/lp/own-the-change-gender-equality',
+		redirect: '/gender-equality'
 	},
 	{
 		path: '/lp/:dynamicRoute',


### PR DESCRIPTION
This feature:

- adds a new route for new `/gender-equality` Contentful page
- redirects `/lp/own-the-chang-gender-equality` to `/gender-equality` route.

# Ticket
[MARS-110](https://kiva.atlassian.net/browse/MARS-110?atlOrigin=eyJpIjoiZTE2YjQyZTQ4N2JmNDA0NzgwYWFhOGFlMTFjNDBiODkiLCJwIjoiaiJ9)