### PR TITLE
fix: filters now transformed case insensitive

### DIFF
--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -71,9 +71,12 @@ export function transformIsoCodes(filteredIsoCodes, allCountryFacets = []) {
 
 	filteredIsoCodes.forEach(({ key: isoCode, value: numLoansFundraising }) => {
 		// Create company object based on country defined by lend API
-		const lookupCountry = allCountryFacets.find(({ country }) => country.isoCode === isoCode);
+		const lookupCountry = allCountryFacets.find(({ country }) => {
+			// Case insensitive matching just in case lend and FLSS APIs have different casing
+			return country.isoCode.toUpperCase() === isoCode.toUpperCase();
+		});
 		if (!lookupCountry) return;
-		const country = { ...lookupCountry.country, numLoansFundraising };
+		const country = { ...lookupCountry.country, isoCode, numLoansFundraising };
 
 		// Find existing transformed region or add a new region
 		const region = transformed.find(t => t.region === country.region);
@@ -99,9 +102,10 @@ export function transformThemes(filteredThemes, allThemes = []) {
 	const transformed = [];
 
 	filteredThemes.forEach(({ key: name, value: numLoansFundraising }) => {
-		const lookupTheme = allThemes.find(a => a.name === name);
+		// Case insensitive matching since lend and FLSS APIs can use different casing for themes
+		const lookupTheme = allThemes.find(a => a.name.toUpperCase() === name.toUpperCase());
 		if (!lookupTheme) return;
-		const theme = { ...lookupTheme, numLoansFundraising };
+		const theme = { id: lookupTheme.id, name, numLoansFundraising };
 		transformed.push(theme);
 	});
 

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -139,6 +139,49 @@ describe('loanSearchUtils.js', () => {
 
 			expect(result).toEqual(mockTransformedRegions);
 		});
+
+		it('should transform ISO codes case insensitive', () => {
+			const mockCountryFacets = [
+				{
+					country: {
+						name: 'Zambia',
+						isoCode: 'zm',
+						numLoansFundraising: 100,
+						region: 'Africa',
+					},
+				},
+				{
+					country: {
+						name: 'Colombia',
+						isoCode: 'co',
+						numLoansFundraising: 100,
+						region: 'South America',
+					},
+				},
+				{
+					country: {
+						name: 'Chile',
+						isoCode: 'cl',
+						numLoansFundraising: 100,
+						region: 'South America',
+					},
+				},
+				{
+					country: {
+						name: 'Jordan',
+						isoCode: 'jo',
+						numLoansFundraising: 100,
+						region: 'Middle East',
+					},
+				}
+			];
+
+			const filteredIsoCodes = [{ key: 'JO', value: 44 }, { key: 'CO', value: 152 }, { key: 'CL', value: 20 }];
+
+			const result = transformIsoCodes(filteredIsoCodes, mockCountryFacets);
+
+			expect(result).toEqual(mockTransformedRegions);
+		});
 	});
 
 	describe('transformThemes', () => {
@@ -170,6 +213,38 @@ describe('loanSearchUtils.js', () => {
 				{
 					id: 6,
 					name: 'a',
+				},
+			];
+
+			const result = transformThemes(mockFilteredThemes, mockAllThemes);
+
+			expect(result).toEqual(mockTransformedThemes);
+		});
+
+		it('should filter transform themes case insensitive', () => {
+			const mockFilteredThemes = [
+				{
+					key: 'b',
+					value: 4,
+				},
+				{
+					key: 'a',
+					value: 5,
+				},
+			];
+
+			const mockAllThemes = [
+				{
+					id: 3,
+					name: 'B',
+				},
+				{
+					id: 7,
+					name: 'C',
+				},
+				{
+					id: 6,
+					name: 'A',
 				},
 			];
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1070

- Theme filter options are still sourced from lend API, but they are now filtered using case insensitive matching against the FLSS loan results
- There were casing differences between lend and FLSS APIs
- Also added case insensitive matching to ISO codes just in case

![image](https://user-images.githubusercontent.com/16867161/170792022-721359ca-cf04-4ee7-9498-b1ec00546f76.png)