### PR TITLE
feat: pre-set the gender filter using the query string param

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -5,7 +5,7 @@
 			Reset All
 		</p>
 		<hr class="tw-border-tertiary tw-my-1">
-		<loan-search-gender-filter @updated="handleUpdatedFilters" />
+		<loan-search-gender-filter :gender="loanSearchState.gender" @updated="handleUpdatedFilters" />
 		<hr class="tw-border-tertiary tw-my-1">
 		<kv-accordion-item id="acc-sort-by" :open="false">
 			<template #header>
@@ -120,6 +120,10 @@ export default {
 		facets: {
 			type: Object,
 			required: true
+		},
+		loanSearchState: {
+			type: Object,
+			default: () => {}
 		}
 	},
 	data() {

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -2,6 +2,7 @@ import orderBy from 'lodash/orderBy';
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
 import { fetchFacets, fetchLoans } from '@/util/flssUtils';
+import { FEMALE_KEY, MALE_KEY } from '@/components/Lend/LoanSearch/LoanSearchGenderFilter';
 
 /**
  * Updates the search state using the provided apollo client and filters
@@ -308,4 +309,16 @@ export async function fetchLoanFacets(apollo) {
  */
 export function getCheckboxLabel(item) {
 	return `${item.name || item.region} (${item.numLoansFundraising})`;
+}
+
+/**
+ * Pulls the query string params using the Vue Router and applies them to the search state
+ *
+ * @param {Object} apollo The Apollo client instance
+ * @param {Object} query The Vue Router query object (this.$route.query)
+ */
+export async function applyQueryParams(apollo, query) {
+	const filters = { ...(query.gender && [FEMALE_KEY, MALE_KEY].includes(query.gender) && { gender: query.gender }) };
+
+	await updateSearchState(apollo, filters);
 }

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -11,6 +11,7 @@ import {
 	transformThemes,
 	getUpdatedThemes,
 	getCheckboxLabel,
+	applyQueryParams,
 } from '@/util/loanSearchUtils';
 import * as flssUtils from '@/util/flssUtils';
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
@@ -445,6 +446,36 @@ describe('loanSearchUtils.js', () => {
 
 		it('should handle item', () => {
 			expect(getCheckboxLabel({ name: 'test', numLoansFundraising: 1 })).toBe('test (1)');
+		});
+	});
+
+	describe('applyQueryParams', () => {
+		it('should update cache', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const filters = { gender: 'female' };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: { searchParams: filters }
+			};
+			const query = { gender: 'female' };
+
+			await applyQueryParams(apollo, query);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should handle incorrect gender param', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const filters = {};
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: { searchParams: filters }
+			};
+			const query = { gender: 'asd' };
+
+			await applyQueryParams(apollo, query);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1050
https://kiva.atlassian.net/browse/VUE-1034

- `?gender=female` will now pre-set the gender filter
- This changeset also resolves the ticket of keeping filter state consistent between desktop + mobile filter components
- Work needed to get other filters to behave similarly

![image](https://user-images.githubusercontent.com/16867161/171276988-eecc5ed4-c8d8-4b88-b3a2-6bd0ce4947d8.png)
