### PR TITLE
feat: update query string when filters change

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -55,6 +55,7 @@ import {
 	runLoansQuery,
 	fetchLoanFacets,
 	applyQueryParams,
+	updateQueryParams,
 } from '@/util/loanSearchUtils';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
@@ -147,6 +148,9 @@ export default {
 				// Utilize the results of the existing query of the loan search state for updating the filters
 				this.loanSearchState = data?.loanSearchState;
 
+				// Update the query string with the latest loan search state
+				updateQueryParams(this.loanSearchState, this.$router);
+
 				// Get all facet options from lend API. Only fetch once, since the options shouldn't change frequently.
 				if (!this.allFacets) this.allFacets = await fetchLoanFacets(this.apollo);
 
@@ -176,5 +180,11 @@ export default {
 			this.isLightboxVisible = toggle;
 		},
 	},
+	watch: {
+		$route(to) {
+			// Update the loan search state when the user clicks back/forward in the browser
+			applyQueryParams(this.apollo, to.query);
+		}
+	}
 };
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,7 +10,7 @@ export default function createRouter() {
 	return new Router({
 		mode: 'history',
 		routes,
-		scrollBehavior(to, from, savedPosition) {
+		scrollBehavior(to, _from, savedPosition) {
 			if (to.hash && !DISALLOW_SELECTOR_REGEX.test(to.hash)) {
 				const element = document.querySelector(to.hash);
 				if (element) {
@@ -21,6 +21,11 @@ export default function createRouter() {
 			}
 			if (savedPosition) {
 				return savedPosition;
+			}
+			// Enables the ability to disable scroll on navigation, such as when changing the query string for
+			// filtering. Pushed route requires the name property for the Vue Router to pass along the params.
+			if (to?.params?.noScroll) {
+				return;
 			}
 			return { x: 0, y: 0 };
 		}

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -236,6 +236,7 @@ module.exports = [
 		},
 	},
 	{
+		name: 'filter-alpha',
 		path: '/lend/filter-alpha',
 		component: () => import('@/pages/Lend/LoanSearchPage'),
 		meta: {

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -12,6 +12,7 @@ import {
 	getUpdatedThemes,
 	getCheckboxLabel,
 	applyQueryParams,
+	updateQueryParams,
 } from '@/util/loanSearchUtils';
 import * as flssUtils from '@/util/flssUtils';
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
@@ -466,7 +467,7 @@ describe('loanSearchUtils.js', () => {
 
 		it('should handle incorrect gender param', async () => {
 			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
-			const filters = {};
+			const filters = { gender: '' };
 			const params = {
 				mutation: updateLoanSearchMutation,
 				variables: { searchParams: filters }
@@ -476,6 +477,39 @@ describe('loanSearchUtils.js', () => {
 			await applyQueryParams(apollo, query);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+	});
+
+	describe('updateQueryParams', () => {
+		it('should push new route', async () => {
+			const state = { gender: 'female' };
+			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
+
+			updateQueryParams(state, router);
+
+			expect(router.push).toHaveBeenCalledWith({ name: 'name', query: state, params: { noScroll: true } });
+		});
+
+		it('should preserve UTM params', async () => {
+			const state = { gender: 'female' };
+			const router = { currentRoute: { name: 'name', query: { utm_test: 'test' } }, push: jest.fn() };
+
+			updateQueryParams(state, router);
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: { ...state, utm_test: 'test' },
+				params: { noScroll: true }
+			});
+		});
+
+		it('should not push identical query string', async () => {
+			const state = { gender: 'female' };
+			const router = { currentRoute: { name: 'name', query: { gender: 'female' } }, push: jest.fn() };
+
+			updateQueryParams(state, router);
+
+			expect(router.push).toHaveBeenCalledTimes(0);
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1045

- Gender filter now updates the query string params
- Updated router to allow an optional param to prevent auto-scroll to top when route changes
- Using the browser back/forward buttons also now apply the gender filter