### PR TITLE
Vue 1052 initialize the page with a sort by option when the query param is present on page load

### DIFF
--- a/.storybook/stories/LoanSearchGenderFilter.stories.js
+++ b/.storybook/stories/LoanSearchGenderFilter.stories.js
@@ -17,8 +17,6 @@ const story = (args = {}) => {
 
 export const Default = story();
 
-export const Both = story({ gender: 'both' });
-
 export const Female = story({ gender: 'female' });
 
 export const Male = story({ gender: 'male' });

--- a/.storybook/stories/LoanSearchSortBy.stories.js
+++ b/.storybook/stories/LoanSearchSortBy.stories.js
@@ -1,4 +1,5 @@
 import LoanSearchSortBy from '@/components/Lend/LoanSearch/LoanSearchSortBy';
+import { FLSS_QUERY_TYPE, STANDARD_QUERY_TYPE } from '@/util/loanSearchUtils';
 
 export default {
 	title: 'Loan Search/Loan Search Sort Order',
@@ -6,25 +7,25 @@ export default {
 };
 
 const allSortOptions = [
-	{ name: 'amountLeft', sortSrc: 'standard' },
-	{ name: 'expiringSoon', sortSrc: 'standard' },
-	{ name: 'loanAmount', sortSrc: 'standard' },
-	{ name: 'loanAmountDesc', sortSrc: 'standard' },
-	{ name: 'newest', sortSrc: 'standard' },
-	{ name: 'popularity', sortSrc: 'standard' },
-	{ name: 'random', sortSrc: 'standard' },
-	{ name: 'repaymentTerm', sortSrc: 'standard' },
-	{ name: 'amountHighToLow', sortSrc: 'flss' },
-	{ name: 'amountLowToHigh', sortSrc: 'flss' },
-	{ name: 'expiringSoon', sortSrc: 'flss' },
-	{ name: 'personalized', sortSrc: 'flss' }
+	{ name: 'amountLeft', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'expiringSoon', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'loanAmount', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'loanAmountDesc', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'newest', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'popularity', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'random', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'repaymentTerm', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'amountHighToLow', sortSrc: FLSS_QUERY_TYPE },
+	{ name: 'amountLowToHigh', sortSrc: FLSS_QUERY_TYPE },
+	{ name: 'expiringSoon', sortSrc: FLSS_QUERY_TYPE },
+	{ name: 'personalized', sortSrc: FLSS_QUERY_TYPE }
 ];
 
 const story = (args = {}) => {
 	const template = (_args, { argTypes }) => ({
 		props: Object.keys(argTypes),
 		components: { LoanSearchSortBy },
-		template: '<loan-search-sort-by :all-sort-options="allSortOptions" />',
+		template: '<loan-search-sort-by :all-sort-options="allSortOptions" :sort="sort" />',
 	})
 	template.args = args;
 	return template;
@@ -32,4 +33,4 @@ const story = (args = {}) => {
 
 export const Default = story({ allSortOptions });
 
-// TODO: Add initialSort story when that feature exists
+export const ExpiringSoon = story({ allSortOptions, sort: 'expiringSoon' });

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -1,5 +1,4 @@
 import loanSearchStateQuery from '@/graphql/query/loanSearchState.graphql';
-// import gql from 'graphql-tag';
 
 // eslint-disable-next-line no-underscore-dangle
 const __typename = 'LoanSearchState';
@@ -24,14 +23,14 @@ export default () => {
 				gender: '', // expects a string
 				countryIsoCode: [], // expects an array of strings
 				sectorId: [], // expects an array of ints
-				sortBy: null, // expects a string
+				sortBy: null, // expects a string that matches the SortEnum
 				theme: [], // expects an array of strings
 				__typename,
 			},
 		},
 		resolvers: {
 			Query: {
-				loanSearchState(_, args, { cache }) {
+				loanSearchState(_, _args, { cache }) {
 					// Retrieve current LoanSearchState from the Apollo cache
 					// - If it's missing the default values will be used to create it
 					const cachedData = cache.readQuery({ query: loanSearchStateQuery });

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -15,7 +15,8 @@
 			</template>
 			<loan-search-sort-by
 				:all-sort-options="facets.sortOptions"
-				:initial-sort="null"
+				:sort="loanSearchState.sortBy"
+				:query-type="queryType"
 				@updated="handleUpdatedFilters"
 			/>
 		</kv-accordion-item>
@@ -58,7 +59,7 @@ import LoanSearchLocationFilter from '@/components/Lend/LoanSearch/LoanSearchLoc
 import LoanSearchSectorFilter from '@/components/Lend/LoanSearch/LoanSearchSectorFilter';
 import LoanSearchThemeFilter from '@/components/Lend/LoanSearch/LoanSearchThemeFilter';
 import LoanSearchSortBy from '@/components/Lend/LoanSearch/LoanSearchSortBy';
-import { updateSearchState } from '@/util/loanSearchUtils';
+import { FLSS_QUERY_TYPE } from '@/util/loanSearchUtils';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
 export default {
@@ -113,26 +114,24 @@ export default {
 		loanSearchState: {
 			type: Object,
 			default: () => {}
+		},
+		queryType: {
+			type: String,
+			default: FLSS_QUERY_TYPE
 		}
 	},
 	data() {
 		return {
 			mdiClose,
 			mdiArrowRight,
-			queryFilters: {},
 		};
 	},
 	methods: {
 		resetFilter() {
-			// this.queryFilters = {};
+			// this.$emit('reset');
 		},
 		handleUpdatedFilters(payload) {
-			this.queryFilters = { ...this.queryFilters, ...payload };
-		}
-	},
-	watch: {
-		async queryFilters(newFilters) {
-			await updateSearchState(this.apollo, newFilters);
+			this.$emit('updated', payload);
 		}
 	},
 };

--- a/src/components/Lend/LoanSearch/LoanSearchGenderFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchGenderFilter.vue
@@ -15,13 +15,11 @@
 <script>
 import KvRadio from '~/@kiva/kv-components/vue/KvRadio';
 
-export const BOTH_KEY = 'both';
 export const BOTH_TITLE = 'All genders';
 export const FEMALE_KEY = 'female';
 export const FEMALE_TITLE = 'Women';
 export const MALE_KEY = 'male';
 export const MALE_TITLE = 'Men';
-const GENDER_KEYS = [BOTH_KEY, FEMALE_KEY, MALE_KEY];
 
 export default {
 	name: 'LoanSearchGenderFilter',
@@ -31,16 +29,16 @@ export default {
 	props: {
 		gender: {
 			type: String,
-			default: BOTH_KEY
+			default: ''
 		}
 	},
 	data() {
 		return {
-			selectedGender: this.gender || BOTH_KEY,
+			selectedGender: this.gender,
 			genderOptions: [
 				{
 					title: BOTH_TITLE,
-					key: BOTH_KEY,
+					key: '',
 				},
 				{
 					title: FEMALE_TITLE,
@@ -54,20 +52,22 @@ export default {
 		};
 	},
 	methods: {
-		setGender(nextGender) {
-			if (nextGender !== this.selectedGender) {
-				this.selectedGender = nextGender;
-				this.$emit('updated', { gender: this.selectedGender === BOTH_KEY ? null : this.selectedGender });
+		setGender(gender) {
+			if (gender !== this.selectedGender) {
+				this.selectedGender = gender;
+				// Return null as default to match GraphQL enum default
+				this.$emit('updated', { gender: this.selectedGender || null });
 			}
 		},
 	},
 	watch: {
-		gender(nextGender) {
-			if (!GENDER_KEYS.includes(nextGender)) {
-				// Fallback to both if the prop isn't a valid key
-				this.selectedGender = BOTH_KEY;
-			} else {
-				this.setGender(nextGender);
+		gender(next) {
+			// The KvRadio component can't handle a null value
+			const nextGender = this.genderOptions.map(g => g.key).includes(next) ? next : '';
+
+			if (nextGender !== this.selectedGender) {
+				// Don't emit when value is changed via the component prop
+				this.selectedGender = nextGender;
 			}
 		},
 	},

--- a/src/graphql/query/loanFacetsQuery.graphql
+++ b/src/graphql/query/loanFacetsQuery.graphql
@@ -16,6 +16,11 @@ query loanFacets {
 			name
 		}
 	}
+	genderOptions: __type(name: "GenderEnum") {
+		enumValues {
+			name
+		}
+	}
 	standardSorts: __type(name: "LoanSearchSortByEnum") {
 		enumValues {
 			name

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -2,21 +2,92 @@ import orderBy from 'lodash/orderBy';
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
 import { fetchFacets, fetchLoans } from '@/util/flssUtils';
-import { FEMALE_KEY, MALE_KEY } from '@/components/Lend/LoanSearch/LoanSearchGenderFilter';
+
+/**
+ * API query types, FLSS and lend (standard)
+ */
+export const FLSS_QUERY_TYPE = 'flss';
+export const STANDARD_QUERY_TYPE = 'standard';
+
+/**
+ * Map used to convert lend <> FLSS sort option values
+ */
+const lendToFlssSort = new Map([
+	['expiringSoon', 'expiringSoon'],
+	['popularity', 'personalized'],
+	['loanAmountDesc', 'amountHighToLow'],
+	['loanAmount', 'amountLowToHigh'],
+]);
+
+/**
+ * Used to map the sort value to display value
+ */
+export const sortByNameToDisplay = {
+	// Shared
+	expiringSoon: 'Ending soon',
+	// Standard (lend)
+	amountLeft: 'Amount left',
+	loanAmount: 'Amount: Low to High',
+	loanAmountDesc: 'Amount: High to Low',
+	newest: 'Most recent',
+	popularity: 'Trending now',
+	random: 'Random',
+	repaymentTerm: 'Loan length',
+	// FLSS specific
+	amountHighToLow: 'Amount: High to Low',
+	amountLowToHigh: 'Amount: Low to High',
+	personalized: 'Recommended'
+};
+
+/**
+ * Returns loan search state that has been validated against the available facets
+ *
+ * @param {Object} loanSearchState The current loan search state from Apollo cache
+ * @param {Object} allFacets All available facets from the APIs
+ * @param {string} queryType The current query type (lend vs FLSS)
+ * @returns {Object} Validated search state, including default enum null values expected by GraphQL
+ */
+export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
+	const validSorts = queryType === FLSS_QUERY_TYPE ? allFacets.flssSorts : allFacets.standardSorts;
+
+	const validatedGender = allFacets.genders.includes(loanSearchState?.gender?.toUpperCase())
+		? loanSearchState.gender : null;
+	const validatedIsoCodes = loanSearchState?.countryIsoCode
+		?.filter(c => allFacets.countryIsoCodes.includes(c.toUpperCase())) ?? [];
+	const validatedSectorIds = loanSearchState?.sectorId?.filter(s => allFacets.sectorIds.includes(s)) ?? [];
+	const validatedSortBy = validSorts.some(s => s.name === loanSearchState.sortBy) ? loanSearchState.sortBy : null;
+	const validatedThemes = loanSearchState?.theme?.filter(t => allFacets.themes.includes(t.toUpperCase())) ?? [];
+
+	return {
+		gender: validatedGender,
+		countryIsoCode: validatedIsoCodes,
+		sectorId: validatedSectorIds,
+		sortBy: validatedSortBy,
+		theme: validatedThemes
+	};
+}
 
 /**
  * Updates the search state using the provided apollo client and filters
  *
  * @param {Object} apollo The Apollo client instance
  * @param {Object} loanQueryFilters The filters for the loan query
+ * @param {Object} allFacets All available facets from the APIs
+ * @param {string} queryType The current query type (lend vs FLSS)
+ * @param {Object} previousState The previous search state
  * @returns {Promise<Array>} Promise for the results of the mutation
  */
-export async function updateSearchState(apollo, loanQueryFilters) {
+export async function updateSearchState(apollo, loanQueryFilters, allFacets, queryType, previousState) {
+	const validatedFilters = getValidatedSearchState(loanQueryFilters, allFacets, queryType);
+
+	// Quick JSON compare works because both states are results of getValidatedSearchState
+	if (JSON.stringify(previousState) === JSON.stringify(validatedFilters)) return;
+
 	return apollo.mutate({
 		mutation: updateLoanSearchMutation,
 		variables: {
 			searchParams: {
-				...loanQueryFilters
+				...validatedFilters
 			}
 		}
 	});
@@ -25,21 +96,21 @@ export async function updateSearchState(apollo, loanQueryFilters) {
 /**
  * Categorizes Sort Options
  *
- * @param {Array<Object>} standardSorts
- * @param {Array<Object>} flssSorts
+ * @param {Array<Object>} standardSorts Sort options from the lend API
+ * @param {Array<Object>} flssSorts Sort options from the FLSS API
  * @returns New formatted array
  */
 export function formatSortOptions(standardSorts, flssSorts) {
 	const labeledStandardSorts = standardSorts.map(sort => {
 		return {
 			name: sort.name,
-			sortSrc: 'standard',
+			sortSrc: STANDARD_QUERY_TYPE,
 		};
 	});
 	const labeledFlssSorts = flssSorts.map(sort => {
 		return {
 			name: sort.name,
-			sortSrc: 'flss',
+			sortSrc: FLSS_QUERY_TYPE,
 		};
 	});
 	return [...labeledStandardSorts, ...labeledFlssSorts];
@@ -49,7 +120,7 @@ export function formatSortOptions(standardSorts, flssSorts) {
  * Sorts the provided regions and countries of regions
  *
  * @param {Array<Object>} regions The regions to sort
- * @returns New sorted array
+ * @returns {Array<Object>} New sorted array
  */
 export function sortRegions(regions) {
 	const sorted = orderBy(regions, 'region');
@@ -304,7 +375,7 @@ export async function runLoansQuery(apollo, loanSearchState = {}) {
 }
 
 /**
- * Fetches the facets data from the lend API
+ * Fetches the facets data for the lend and FLSS APIs
  *
  * @param {Object} apollo The apollo client instance
  * @returns {Promise<Array<Object>>} Promise for facets data
@@ -313,10 +384,20 @@ export async function fetchLoanFacets(apollo) {
 	try {
 		const result = await apollo.query({ query: loanFacetsQuery, fetchPolicy: 'network-only' });
 
+		const countryFacets = result.data?.lend?.countryFacets ?? [];
+		const sectorFacets = result.data?.lend?.sector ?? [];
+		const themeFacets = result.data?.lend?.loanThemeFilter ?? [];
+		const genderFacets = result.data?.genderOptions?.enumValues ?? [];
+
 		return {
-			countryFacets: result.data?.lend?.countryFacets || [],
-			sectorFacets: result.data?.lend?.sector || [],
-			themeFacets: result.data?.lend?.loanThemeFilter || [],
+			countryFacets,
+			countryIsoCodes: countryFacets.map(c => c.country.isoCode.toUpperCase()),
+			sectorFacets,
+			sectorIds: sectorFacets.map(s => s.id),
+			themeFacets,
+			themes: themeFacets.map(t => t.name.toUpperCase()),
+			genderFacets,
+			genders: genderFacets.map(g => g.name.toUpperCase()),
 			flssSorts: result.data?.flssSorts?.enumValues ?? [],
 			standardSorts: result.data?.standardSorts?.enumValues ?? [],
 		};
@@ -340,11 +421,23 @@ export function getCheckboxLabel(item) {
  *
  * @param {Object} apollo The Apollo client instance
  * @param {Object} query The Vue Router query object (this.$route.query)
+ * @param {Object} allFacets All available facets from the APIs
+ * @param {string} queryType The current query type (lend vs FLSS)
+ * @param {Object} previousState The previous search state
  */
-export async function applyQueryParams(apollo, query) {
-	const filters = { gender: [FEMALE_KEY, MALE_KEY].includes(query.gender) ? query.gender : '' };
+export async function applyQueryParams(apollo, query, allFacets, queryType, previousState = {}) {
+	const filters = {
+		gender: query.gender,
+		sortBy: queryType === FLSS_QUERY_TYPE ? lendToFlssSort.get(query.sortBy) : query.sortBy,
+		// TODO: replace previous state usage as query param support expands
+		...(previousState && {
+			countryIsoCode: previousState.countryIsoCode,
+			sectorId: previousState.sectorId,
+			theme: previousState.theme,
+		})
+	};
 
-	await updateSearchState(apollo, filters);
+	await updateSearchState(apollo, filters, allFacets, queryType, previousState);
 }
 
 /**
@@ -353,8 +446,9 @@ export async function applyQueryParams(apollo, query) {
  *
  * @param {Object} loanSearchState The current loan search state from Apollo
  * @param {Object} router The Vue Router object
+ * @param {string} queryType The current query type (lend vs FLSS)
  */
-export function updateQueryParams(loanSearchState, router) {
+export function updateQueryParams(loanSearchState, router, queryType) {
 	const oldParamKeys = Object.keys(router.currentRoute.query);
 
 	// Preserve UTM params
@@ -365,9 +459,17 @@ export function updateQueryParams(loanSearchState, router) {
 		}
 	});
 
+	// The query param uses the standard sort values, so map from FLSS as needed
+	const queryParamSortBy = queryType === FLSS_QUERY_TYPE
+		// eslint-disable-next-line no-unused-vars
+		? [...lendToFlssSort].find(([_, value]) => value === loanSearchState.sortBy)?.[0]
+		: loanSearchState.sortBy;
+
 	// Create new query params object
 	const newParams = {
 		...(loanSearchState.gender && { gender: loanSearchState.gender }),
+		...(queryParamSortBy && { sortBy: queryParamSortBy }),
+		// TODO: add params as query param support expands
 		...utmParams,
 	};
 

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchGenderFilter.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchGenderFilter.spec.js
@@ -2,7 +2,6 @@ import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import LoanSearchGenderFilter,
 {
-	BOTH_KEY,
 	BOTH_TITLE,
 	FEMALE_KEY,
 	FEMALE_TITLE,
@@ -18,7 +17,7 @@ describe('LoanSearchGenderFilter', () => {
 	});
 
 	it('should select based on prop', async () => {
-		const { getByLabelText, updateProps } = render(LoanSearchGenderFilter, { props: { gender: BOTH_KEY } });
+		const { getByLabelText, updateProps } = render(LoanSearchGenderFilter);
 
 		let radio = getByLabelText(BOTH_TITLE);
 		expect(radio.checked).toBeTruthy();
@@ -38,11 +37,15 @@ describe('LoanSearchGenderFilter', () => {
 		await updateProps({ gender: 'asd' });
 		radio = getByLabelText(BOTH_TITLE);
 		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ gender: null });
+		radio = getByLabelText(BOTH_TITLE);
+		expect(radio.checked).toBeTruthy();
 	});
 
 	it('should select based on click', async () => {
 		const user = userEvent.setup();
-		const { getByLabelText } = render(LoanSearchGenderFilter, { props: { gender: BOTH_KEY } });
+		const { getByLabelText } = render(LoanSearchGenderFilter);
 
 		let radio = getByLabelText(BOTH_TITLE);
 		expect(radio.checked).toBeTruthy();

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchSortBy.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchSortBy.spec.js
@@ -1,21 +1,22 @@
 import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import LoanSearchSortBy from '@/components/Lend/LoanSearch/LoanSearchSortBy';
+import { FLSS_QUERY_TYPE, STANDARD_QUERY_TYPE } from '@/util/loanSearchUtils';
 
 // Prospective sort options from both APIs (values for flss will expand)
 const allSortOptions = [
-	{ name: 'amountLeft', sortSrc: 'standard' },
-	{ name: 'expiringSoon', sortSrc: 'standard' },
-	{ name: 'loanAmount', sortSrc: 'standard' },
-	{ name: 'loanAmountDesc', sortSrc: 'standard' },
-	{ name: 'newest', sortSrc: 'standard' },
-	{ name: 'popularity', sortSrc: 'standard' },
-	{ name: 'random', sortSrc: 'standard' },
-	{ name: 'repaymentTerm', sortSrc: 'standard' },
-	{ name: 'amountHighToLow', sortSrc: 'flss' },
-	{ name: 'amountLowToHigh', sortSrc: 'flss' },
-	{ name: 'expiringSoon', sortSrc: 'flss' },
-	{ name: 'personalized', sortSrc: 'flss' }
+	{ name: 'amountLeft', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'expiringSoon', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'loanAmount', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'loanAmountDesc', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'newest', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'popularity', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'random', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'repaymentTerm', sortSrc: STANDARD_QUERY_TYPE },
+	{ name: 'amountHighToLow', sortSrc: FLSS_QUERY_TYPE },
+	{ name: 'amountLowToHigh', sortSrc: FLSS_QUERY_TYPE },
+	{ name: 'expiringSoon', sortSrc: FLSS_QUERY_TYPE },
+	{ name: 'personalized', sortSrc: FLSS_QUERY_TYPE }
 ];
 
 describe('LoanSearchSortBy', () => {
@@ -40,6 +41,29 @@ describe('LoanSearchSortBy', () => {
 
 		const recommendedSort = getByLabelText('Recommended', { selector: 'input' });
 		expect(recommendedSort.checked).toBeTruthy();
+	});
+
+	it('should select based on prop', async () => {
+		const { getByLabelText, updateProps } = render(LoanSearchSortBy, { props: { allSortOptions } });
+
+		const recommendedSort = getByLabelText('Recommended', { selector: 'input' });
+		expect(recommendedSort.checked).toBeTruthy();
+
+		await updateProps({ sort: 'expiringSoon' });
+		let radio = getByLabelText('Ending soon');
+		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ sort: '' });
+		radio = getByLabelText('Recommended');
+		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ sort: 'asd' });
+		radio = getByLabelText('Recommended');
+		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ sort: null });
+		radio = getByLabelText('Recommended');
+		expect(radio.checked).toBeTruthy();
 	});
 
 	it('should change sort option when clicked', async () => {

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -13,10 +13,34 @@ import {
 	getCheckboxLabel,
 	applyQueryParams,
 	updateQueryParams,
+	getValidatedSearchState,
+	FLSS_QUERY_TYPE,
+	STANDARD_QUERY_TYPE,
 } from '@/util/loanSearchUtils';
 import * as flssUtils from '@/util/flssUtils';
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
+
+const mockState = {
+	gender: 'female',
+	countryIsoCode: ['US'],
+	sectorId: [1],
+	sortBy: 'expiringSoon',
+	theme: ['test theme']
+};
+
+const mockAllFacets = {
+	countryFacets: [{ country: { isoCode: 'US' } }],
+	countryIsoCodes: ['US'],
+	sectorFacets: [{ id: 1 }],
+	sectorIds: [1],
+	themeFacets: [{ name: 'test theme' }],
+	themes: ['TEST THEME'],
+	genderFacets: [{ name: 'female' }, { name: 'male' }],
+	genders: ['FEMALE', 'MALE'],
+	flssSorts: [{ name: 'expiringSoon' }, { name: 'personalized' }],
+	standardSorts: [{ name: 'expiringSoon' }, { name: 'popularity' }],
+};
 
 const mockTransformedMiddleEast = (numLoansFundraising = 44) => ({
 	region: 'Middle East',
@@ -63,20 +87,83 @@ const mockBTheme = (numLoansFundraising = 4) => ({ id: 3, name: 'b', numLoansFun
 const mockTransformedThemes = [mockATheme(), mockBTheme()];
 
 describe('loanSearchUtils.js', () => {
-	describe('updateSearchState', () => {
-		it('should call apollo with the provided filters and return results', async () => {
-			const mockResult = 1;
-			const apollo = { mutate: jest.fn(() => Promise.resolve(mockResult)) };
-			const filters = { countryIsoCode: ['US'], sectorId: [9] };
-			const params = {
-				mutation: updateLoanSearchMutation,
-				variables: { searchParams: filters }
-			};
+	describe('getValidatedSearchState', () => {
+		it('should return valid state', () => {
+			const result = getValidatedSearchState(mockState, mockAllFacets, FLSS_QUERY_TYPE);
 
-			const result = await updateSearchState(apollo, filters);
+			expect(result).toEqual(mockState);
+		});
+
+		it('should validate gender', () => {
+			const state = { ...mockState, gender: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, gender: null });
+		});
+
+		it('should validate country ISO code', () => {
+			const state = { ...mockState, countryIsoCode: ['asd'] };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, countryIsoCode: [] });
+		});
+
+		it('should validate sector ID', () => {
+			const state = { ...mockState, sectorId: [-1] };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, sectorId: [] });
+		});
+
+		it('should validate FLSS sortBy', () => {
+			const state = { ...mockState, sortBy: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, sortBy: null });
+		});
+
+		it('should validate standard sortBy', () => {
+			const state = { ...mockState, sortBy: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, sortBy: null });
+		});
+
+		it('should validate theme', () => {
+			const state = { ...mockState, theme: ['asd'] };
+
+			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, theme: [] });
+		});
+	});
+
+	describe('updateSearchState', () => {
+		const mockResult = 1;
+		const apollo = { mutate: jest.fn(() => Promise.resolve(mockResult)) };
+		const params = {
+			mutation: updateLoanSearchMutation,
+			variables: { searchParams: mockState }
+		};
+
+		afterEach(jest.clearAllMocks);
+
+		it('should call apollo with the provided filters and return results', async () => {
+			const result = await updateSearchState(apollo, mockState, mockAllFacets, FLSS_QUERY_TYPE, {});
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 			expect(result).toBe(mockResult);
+		});
+
+		it('should check if state has changed', async () => {
+			await updateSearchState(apollo, mockState, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -390,11 +477,12 @@ describe('loanSearchUtils.js', () => {
 	});
 
 	describe('fetchLoanFacets', () => {
-		const countryFacets = ['a'];
-		const sector = ['b'];
-		const loanThemeFilter = ['c'];
-		const standardSorts = [];
-		const flssSorts = [];
+		const countryFacets = [{ country: { isoCode: 'a' } }];
+		const sector = [{ id: 1 }];
+		const loanThemeFilter = [{ name: 'c' }];
+		const genderOptions = { enumValues: [{ name: 'female' }] };
+		const flssSorts = { enumValues: [{ name: 'expiringSoon' }] };
+		const standardSorts = { enumValues: [{ name: 'expiringSoon' }] };
 
 		it('should pass the correct query variables to apollo', async () => {
 			const apollo = { query: jest.fn(() => Promise.resolve({})) };
@@ -404,15 +492,21 @@ describe('loanSearchUtils.js', () => {
 		});
 
 		it('should handle undefined', async () => {
-			const dataObj = { data: { lend: { } } };
+			const dataObj = { data: { } };
 			const apollo = { query: jest.fn(() => Promise.resolve(dataObj)) };
 			const data = await fetchLoanFacets(apollo);
+
 			expect(data).toEqual({
 				countryFacets: [],
+				countryIsoCodes: [],
 				sectorFacets: [],
+				sectorIds: [],
 				themeFacets: [],
-				standardSorts: [],
-				flssSorts: []
+				themes: [],
+				genderFacets: [],
+				genders: [],
+				flssSorts: [],
+				standardSorts: []
 			});
 		});
 
@@ -423,19 +517,27 @@ describe('loanSearchUtils.js', () => {
 						countryFacets,
 						sector,
 						loanThemeFilter,
-						standardSorts,
-						flssSorts
-					}
+					},
+					genderOptions,
+					flssSorts,
+					standardSorts,
 				}
 			};
+
 			const apollo = { query: jest.fn(() => Promise.resolve(dataObj)) };
 			const data = await fetchLoanFacets(apollo);
+
 			expect(data).toEqual({
 				countryFacets,
+				countryIsoCodes: ['A'],
 				sectorFacets: sector,
+				sectorIds: [1],
 				themeFacets: loanThemeFilter,
-				standardSorts,
-				flssSorts
+				themes: ['C'],
+				genderFacets: [{ name: 'female' }],
+				genders: ['FEMALE'],
+				flssSorts: [{ name: 'expiringSoon' }],
+				standardSorts: [{ name: 'expiringSoon' }],
 			});
 		});
 	});
@@ -453,30 +555,69 @@ describe('loanSearchUtils.js', () => {
 	describe('applyQueryParams', () => {
 		it('should update cache', async () => {
 			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
-			const filters = { gender: 'female' };
 			const params = {
 				mutation: updateLoanSearchMutation,
-				variables: { searchParams: filters }
+				variables: {
+					searchParams: {
+						gender: 'female',
+						countryIsoCode: [],
+						sectorId: [],
+						sortBy: 'expiringSoon',
+						theme: []
+					}
+				}
 			};
-			const query = { gender: 'female' };
 
-			await applyQueryParams(apollo, query);
+			await applyQueryParams(apollo, mockState, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
 
-		it('should handle incorrect gender param', async () => {
+		it('should fallback to previous state', async () => {
 			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
-			const filters = { gender: '' };
 			const params = {
 				mutation: updateLoanSearchMutation,
-				variables: { searchParams: filters }
+				variables: { searchParams: { ...mockState, gender: 'male', sortBy: 'personalized' } },
 			};
-			const query = { gender: 'asd' };
+			const query = { gender: 'male', sortBy: 'popularity' };
 
-			await applyQueryParams(apollo, query);
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should map lend to FLSS sort', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: { searchParams: { ...mockState, gender: null, sortBy: 'personalized' } },
+			};
+			const query = { sortBy: 'popularity' };
+
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should support standard sort', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: { searchParams: { ...mockState, gender: null, sortBy: 'popularity' } },
+			};
+			const query = { sortBy: 'popularity' };
+
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should not update cache when state unchanged', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+
+			await applyQueryParams(apollo, mockState, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledTimes(0);
 		});
 	});
 
@@ -510,6 +651,32 @@ describe('loanSearchUtils.js', () => {
 			updateQueryParams(state, router);
 
 			expect(router.push).toHaveBeenCalledTimes(0);
+		});
+
+		it('should push mapped FLSS sort value', async () => {
+			const state = { sortBy: 'personalized' };
+			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
+
+			updateQueryParams(state, router, FLSS_QUERY_TYPE);
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: { sortBy: 'popularity' },
+				params: { noScroll: true }
+			});
+		});
+
+		it('should push standard sort value', async () => {
+			const state = { sortBy: 'personalized' };
+			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
+
+			updateQueryParams(state, router, STANDARD_QUERY_TYPE);
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: { sortBy: 'personalized' },
+				params: { noScroll: true }
+			});
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1052
https://kiva.atlassian.net/browse/VUE-1047

- The sortBy filter can now be initialized via the query param
- Changing the sortBy filter now gets applied to the query params
- Added filter validation against available facets before the search state is stored
- Filter validation ensures that bad values in the query params don't result in empty searches
- Bad values result in default filter values being used instead for the problem query param(s)
- Consolidated all interactions with the search state to `LoanSearchInterface` for easier maintenance
- Added `TODO` placeholders for clarity for where future query params can be added
- While not absolutely necessary due to the simple filter options, pulled gender options from the API
- Added `queryType` to `LoanSearchInterface` as a temp location for that value until we need it in the search state
- Updated `LoanSearchSortBy` to handle selection change via prop (needed for query param initialization)
- Storing uppercase facet values as a minor simplification and optimization for validating search state

![image](https://user-images.githubusercontent.com/16867161/171947837-e77ddf22-3b2c-46f7-b9d4-ac8b02102952.png)
