### PR TITLE
VUE-1051, VUE-1046, VUE-1044

### DIFF
--- a/.storybook/stories/KvCheckboxList.stories.js
+++ b/.storybook/stories/KvCheckboxList.stories.js
@@ -12,7 +12,7 @@ const story = (args) => {
 		template: `<kv-checkbox-list
 			:show-select-all="showSelectAll"
 			:items="items"
-			:initial-selected="initialSelected" />`,
+			:selected-values="selectedValues" />`,
 	})
 	template.args = args;
 	return template;
@@ -24,6 +24,6 @@ export const Default = story({ items });
 
 export const ShowSelectAll = story({ items, showSelectAll: true });
 
-export const InitialSelected = story({ items, initialSelected: items.slice(0, 2).map(i => i.value) });
+export const SelectedValues = story({ items, selectedValues: items.slice(0, 2).map(i => i.value) });
 
 export const Disabled = story({ items: items.map(i => ({ ...i, disabled: true })) });

--- a/.storybook/stories/LoanSearchSectorFilter.stories.js
+++ b/.storybook/stories/LoanSearchSectorFilter.stories.js
@@ -1,0 +1,25 @@
+import LoanSearchSectorFilter from '@/components/Lend/LoanSearch/LoanSearchSectorFilter';
+
+export default {
+	title: 'Loan Search/Loan Search Sector Filter',
+	component: LoanSearchSectorFilter,
+};
+
+const story = (args = {}) => {
+	const template = (_, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { LoanSearchSectorFilter },
+		template: '<loan-search-sector-filter :sectors="sectors" :sector-ids="sectorIds" />',
+	})
+	template.args = args;
+	return template;
+};
+
+const items = (disabled = false) => [...Array(4)].map((_, i) => ({ id: i, name: `Option ${i}`, numLoansFundraising: disabled ? 0 : 5 }));
+
+export const Default = story({ sectors: items() });
+
+export const Selected = story({ sectors: items(), sectorIds: items().slice(0, 2).map(t => t.id) });
+
+// TODO: enable story when updating disabled status of sector filter is implemented
+// export const NoneFundraising = story({ sectors: items(true) });

--- a/.storybook/stories/LoanSearchSectorFilter.stories.js
+++ b/.storybook/stories/LoanSearchSectorFilter.stories.js
@@ -21,5 +21,4 @@ export const Default = story({ sectors: items() });
 
 export const Selected = story({ sectors: items(), sectorIds: items().slice(0, 2).map(t => t.id) });
 
-// TODO: enable story when updating disabled status of sector filter is implemented
-// export const NoneFundraising = story({ sectors: items(true) });
+export const NoneFundraising = story({ sectors: items(true) });

--- a/.storybook/stories/LoanSearchThemeFilter.stories.js
+++ b/.storybook/stories/LoanSearchThemeFilter.stories.js
@@ -9,7 +9,7 @@ const story = (args = {}) => {
 	const template = (_, { argTypes }) => ({
 		props: Object.keys(argTypes),
 		components: { LoanSearchThemeFilter },
-		template: '<loan-search-theme-filter :themes="themes" />',
+		template: '<loan-search-theme-filter :themes="themes" :theme-names="themeNames" />',
 	})
 	template.args = args;
 	return template;
@@ -18,5 +18,7 @@ const story = (args = {}) => {
 const items = (disabled = false) => [...Array(4)].map((_, i) => ({ id: i, name: `Option ${i}`, numLoansFundraising: disabled ? 0 : 5 }));
 
 export const Default = story({ themes: items() });
+
+export const Selected = story({ themes: items(), themeNames: items().slice(0, 2).map(t => t.name.toUpperCase()) });
 
 export const NoneFundraising = story({ themes: items(true) });

--- a/src/components/Kv/KvCheckboxList.vue
+++ b/src/components/Kv/KvCheckboxList.vue
@@ -6,7 +6,7 @@
 			</button>
 		</li>
 		<li v-for="(item, i) in items" :key="i">
-			<kv-checkbox :value="item.value" :disabled="item.disabled" v-model="selected">
+			<kv-checkbox :value="item.value" :disabled="item.disabled" v-model="selected" @change="updateSelected">
 				{{ item.title }}
 			</kv-checkbox>
 		</li>
@@ -38,17 +38,16 @@ export default {
 			required: true,
 		},
 		/**
-		 * The initially selected items
-		 * Expected format: { value: 'value', title: 'title', disabled: true }
+		 * The selected values (array of strings)
 		 */
-		initialSelected: {
+		selectedValues: {
 			type: Array,
 			default: () => []
 		},
 	},
 	data() {
 		return {
-			selected: this.initialSelected,
+			selected: this.selectedValues,
 		};
 	},
 	computed: {
@@ -66,12 +65,19 @@ export default {
 					if (exists) this.selected.splice(index, 1);
 				} else if (!exists) this.selected.push(item.value);
 			});
+			this.updateSelected(this.selected);
+		},
+		updateSelected(values) {
+			this.$emit('updated', [...values]);
 		},
 	},
 	watch: {
-		selected(next) {
-			this.$emit('updated', next);
-		}
-	},
+		selectedValues(next) {
+			if ([...next].sort().toString() !== [...this.selected].sort().toString()) {
+				// Don't emit when value is changed via the component prop
+				this.selected = next;
+			}
+		},
+	}
 };
 </script>

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -34,7 +34,11 @@
 					Sectors
 				</h2>
 			</template>
-			<loan-search-sector-filter :sectors="facets.sectors" @updated="handleUpdatedFilters" />
+			<loan-search-sector-filter
+				:sectors="facets.sectors"
+				:sector-ids="loanSearchState.sectorId"
+				@updated="handleUpdatedFilters"
+			/>
 		</kv-accordion-item>
 		<kv-accordion-item id="acc-attributes" :open="false">
 			<template #header>

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -46,7 +46,11 @@
 					Attributes
 				</h2>
 			</template>
-			<loan-search-theme-filter :themes="facets.themes" @updated="handleUpdatedFilters" />
+			<loan-search-theme-filter
+				:themes="facets.themes"
+				:theme-names="loanSearchState.theme"
+				@updated="handleUpdatedFilters"
+			/>
 		</kv-accordion-item>
 		<h2 class="tw-text-h4 tw-mt-2">
 			Advanced filters

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -104,6 +104,7 @@ export default {
 		 *     {
 		 *       id: 1,
 		 *       name: '',
+		 *       numLoansFundraising: 1,
 		 *     }
 		 *   ],
 		 *   themes: [

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -163,7 +163,7 @@ export default {
 				this.loanSearchState = data?.loanSearchState;
 
 				// Update the query string with the latest loan search state
-				updateQueryParams(this.loanSearchState, this.$router, this.queryType);
+				updateQueryParams(this.loanSearchState, this.$router, this.allFacets, this.queryType);
 
 				// Get filtered facet options from FLSS
 				// TODO: Prevent this from running on every query

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -66,6 +66,7 @@ import {
 	applyQueryParams,
 	updateQueryParams,
 	updateSearchState,
+	transformSectors,
 } from '@/util/loanSearchUtils';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
@@ -129,6 +130,7 @@ export default {
 			 *     {
 			 *       id: 1,
 			 *       name: '',
+			 *       numLoansFundraising: 1,
 			 *     }
 			 *   ],
 			 *   themes: [
@@ -167,12 +169,12 @@ export default {
 
 				// Get filtered facet options from FLSS
 				// TODO: Prevent this from running on every query
-				const { isoCodes, themes } = await runFacetsQueries(this.apollo, this.loanSearchState);
+				const { isoCodes, themes, sectors } = await runFacetsQueries(this.apollo, this.loanSearchState);
 
 				// Merge all facet options with filtered options
 				this.facets = {
 					regions: transformIsoCodes(isoCodes, this.allFacets?.countryFacets),
-					sectors: this.allFacets?.sectorFacets || [],
+					sectors: transformSectors(sectors, this.allFacets?.sectorFacets),
 					themes: transformThemes(themes, this.allFacets?.themeFacets),
 					sortOptions: formatSortOptions(this.allFacets?.standardSorts ?? [], this.allFacets?.flssSorts ?? [])
 				};

--- a/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
@@ -1,7 +1,7 @@
 <template>
 	<form class="tw-flex tw-flex-col tw-gap-1.5 tw-mb-2" @submit.prevent>
 		<fieldset>
-			<kv-checkbox-list :items="items" @updated="updateSectors" />
+			<kv-checkbox-list :items="items" :selected-values="selectedValues" @updated="updateSectors" />
 		</fieldset>
 	</form>
 </template>
@@ -28,31 +28,40 @@ export default {
 		sectors: {
 			type: Array,
 			default: () => []
-		}
+		},
+		sectorIds: {
+			type: Array,
+			default: () => []
+		},
 	},
 	data() {
 		return {
 			displayedSectors: this.sectors,
-			filterResults: []
+			selectedSectorIds: this.sectorIds,
 		};
 	},
 	computed: {
 		items() {
-			return this.displayedSectors.map(c => ({
-				value: c.id.toString(),
-				title: c.name,
-			}));
+			return this.displayedSectors.map(s => ({ value: s.id.toString(), title: s.name }));
+		},
+		selectedValues() {
+			return this.selectedSectorIds.map(s => s.toString());
 		}
 	},
 	methods: {
 		updateSectors(sectors) {
-			this.filterResults = sectors.map(sector => parseInt(sector, 10));
-			this.$emit('updated', { sectorId: this.filterResults });
+			this.$emit('updated', { sectorId: sectors.map(s => +s) });
 		}
 	},
 	watch: {
 		sectors(nextSectors) {
 			this.displayedSectors = getUpdatedSectors(this.displayedSectors, nextSectors);
+		},
+		sectorIds(next) {
+			if ([...next].sort().toString() !== [...this.selectedSectorIds].sort().toString()) {
+				// Don't emit when value is changed via the component prop
+				this.selectedSectorIds = next;
+			}
 		},
 	},
 };

--- a/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
@@ -8,7 +8,7 @@
 
 <script>
 import KvCheckboxList from '@/components/Kv/KvCheckboxList';
-import { getUpdatedSectors } from '@/util/loanSearchUtils';
+import { getUpdatedNumLoansFundraising, getCheckboxLabel } from '@/util/loanSearchUtils';
 
 export default {
 	name: 'LoanSearchSectorFilter',
@@ -18,12 +18,11 @@ export default {
 	props: {
 		/**
 		 * The sectors list to display has checkboxes. Expected format:
-		 *   sectors: [
-		 *     {
-		 *       id: 1,
-		 *       name: '',
-		 *     }
-		 *   ],
+		 * [{
+		 *   id: 1,
+		 *   name: '',
+		 *   numLoansFundraising: 1,
+		 * }],
 		 */
 		sectors: {
 			type: Array,
@@ -42,7 +41,11 @@ export default {
 	},
 	computed: {
 		items() {
-			return this.displayedSectors.map(s => ({ value: s.id.toString(), title: s.name }));
+			return this.displayedSectors.map(s => ({
+				value: s.id.toString(),
+				title: getCheckboxLabel(s),
+				disabled: s.numLoansFundraising === 0
+			}));
 		},
 		selectedValues() {
 			return this.selectedSectorIds.map(s => s.toString());
@@ -55,7 +58,7 @@ export default {
 	},
 	watch: {
 		sectors(nextSectors) {
-			this.displayedSectors = getUpdatedSectors(this.displayedSectors, nextSectors);
+			this.displayedSectors = getUpdatedNumLoansFundraising(this.displayedSectors, nextSectors);
 		},
 		sectorIds(next) {
 			if ([...next].sort().toString() !== [...this.selectedSectorIds].sort().toString()) {

--- a/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
@@ -8,7 +8,7 @@
 
 <script>
 import KvCheckboxList from '@/components/Kv/KvCheckboxList';
-import { getUpdatedThemes, getCheckboxLabel } from '@/util/loanSearchUtils';
+import { getUpdatedNumLoansFundraising, getCheckboxLabel } from '@/util/loanSearchUtils';
 
 export default {
 	name: 'LoanSearchThemeFilter',
@@ -41,11 +41,11 @@ export default {
 	},
 	computed: {
 		items() {
-			return this.displayedThemes.map(c => ({
+			return this.displayedThemes.map(t => ({
 				// TODO: change to theme IDs when the theme ID filter is on prod
-				value: c.name.toUpperCase(),
-				title: getCheckboxLabel(c),
-				disabled: c.numLoansFundraising === 0
+				value: t.name.toUpperCase(),
+				title: getCheckboxLabel(t),
+				disabled: t.numLoansFundraising === 0
 			}));
 		},
 	},
@@ -56,7 +56,7 @@ export default {
 	},
 	watch: {
 		themes(nextThemes) {
-			this.displayedThemes = getUpdatedThemes(this.displayedThemes, nextThemes);
+			this.displayedThemes = getUpdatedNumLoansFundraising(this.displayedThemes, nextThemes);
 		},
 		themeNames(next) {
 			if ([...next].sort().toString() !== [...this.selectedThemeNames].sort().toString()) {

--- a/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
@@ -1,7 +1,7 @@
 <template>
 	<form class="tw-flex tw-flex-col tw-gap-1.5 tw-mb-2" @submit.prevent>
 		<fieldset>
-			<kv-checkbox-list :items="items" @updated="updateThemes" />
+			<kv-checkbox-list :items="items" :selected-values="selectedThemeNames" @updated="updateThemes" />
 		</fieldset>
 	</form>
 </template>
@@ -27,21 +27,27 @@ export default {
 		themes: {
 			type: Array,
 			default: () => []
+		},
+		themeNames: {
+			type: Array,
+			default: () => [],
 		}
 	},
 	data() {
 		return {
 			displayedThemes: this.themes,
+			selectedThemeNames: this.themeNames,
 		};
 	},
 	computed: {
 		items() {
 			return this.displayedThemes.map(c => ({
-				value: c.name,
+				// TODO: change to theme IDs when the theme ID filter is on prod
+				value: c.name.toUpperCase(),
 				title: getCheckboxLabel(c),
 				disabled: c.numLoansFundraising === 0
 			}));
-		}
+		},
 	},
 	methods: {
 		updateThemes(themes) {
@@ -51,6 +57,12 @@ export default {
 	watch: {
 		themes(nextThemes) {
 			this.displayedThemes = getUpdatedThemes(this.displayedThemes, nextThemes);
+		},
+		themeNames(next) {
+			if ([...next].sort().toString() !== [...this.selectedThemeNames].sort().toString()) {
+				// Don't emit when value is changed via the component prop
+				this.selectedThemeNames = next;
+			}
 		},
 	},
 };

--- a/src/graphql/query/flssLoanFacetsQuery.graphql
+++ b/src/graphql/query/flssLoanFacetsQuery.graphql
@@ -9,6 +9,10 @@ query flssLoanFacets($filterObject: [FundraisingLoanSearchFilterInput!]) {
 				key
 				value
 			}
+			sectorId {
+				key
+				value
+			}
 		}
   	}
 }

--- a/src/graphql/query/flssLoanFacetsQuery.graphql
+++ b/src/graphql/query/flssLoanFacetsQuery.graphql
@@ -1,14 +1,26 @@
-query flssLoanFacets($filterObject: [FundraisingLoanSearchFilterInput!]) {
-	fundraisingLoans(filters: $filterObject) {
+query flssLoanFacets(
+	$isoCodeFilters: [FundraisingLoanSearchFilterInput!],
+	$themeFilters: [FundraisingLoanSearchFilterInput!],
+	$sectorFilters: [FundraisingLoanSearchFilterInput!]) {
+	isoCodes: fundraisingLoans(filters: $isoCodeFilters) {
 		facets {
 			isoCode {
 				key
 				value
 			}
+		}
+
+  	}
+	themes: fundraisingLoans(filters: $themeFilters) {
+		facets {
 			themes {
 				key
 				value
 			}
+		}
+	}
+	sectors: fundraisingLoans(filters: $sectorFilters) {
+		facets {
 			sectorId {
 				key
 				value

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -5,17 +5,19 @@ import flssLoanFacetsQuery from '@/graphql/query/flssLoanFacetsQuery.graphql';
  * Fetches the facets with number of fundraising loans from FLSS
  *
  * @param {Object} apollo The apollo client instance
- * @param {Object} loanQueryFilters The filters for the facets query
+ * @param {Object} isoCodeFilters The filters for the ISO code facets
+ * @param {Object} themeFilters The filters for the theme facets
+ * @param {Object} sectorFilters The filters for the sector facets
  * @returns {Promise<Array<Object>>} Promise for facets data
  */
-export async function fetchFacets(apollo, loanQueryFilters) {
+export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters) {
 	try {
 		const result = await apollo.query({
 			query: flssLoanFacetsQuery,
-			variables: { filterObject: loanQueryFilters },
+			variables: { isoCodeFilters, themeFilters, sectorFilters },
 			fetchPolicy: 'network-only',
 		});
-		return result.data?.fundraisingLoans?.facets;
+		return result.data;
 	} catch (e) {
 		console.log('Fetching facets failed:', e.message);
 	}

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -350,17 +350,17 @@ export function getFlssFilters(loanSearchState) {
  * @returns {Object} The filter facets
  */
 export async function runFacetsQueries(apollo, loanSearchState = {}) {
-	// Filtered ISO codes that match loan results without filtering on ISO code
 	const isoCodeFilters = { ...getFlssFilters(loanSearchState), countryIsoCode: undefined };
-	const isoCodes = (await fetchFacets(apollo, isoCodeFilters))?.isoCode || [];
-
 	const themeFilters = { ...getFlssFilters(loanSearchState), theme: undefined };
-	const themes = (await fetchFacets(apollo, themeFilters))?.themes || [];
-
 	const sectorFilters = { ...getFlssFilters(loanSearchState), sectorId: undefined };
-	const sectors = (await fetchFacets(apollo, sectorFilters))?.sectorId || [];
 
-	return { isoCodes, themes, sectors };
+	const facets = await fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters);
+
+	return {
+		isoCodes: facets?.isoCodes?.facets?.isoCode ?? [],
+		themes: facets?.themes?.facets?.themes ?? [],
+		sectors: facets?.sectors?.facets?.sectorId ?? [],
+	};
 }
 
 /**

--- a/test/unit/specs/components/Kv/KvCheckboxList.spec.js
+++ b/test/unit/specs/components/Kv/KvCheckboxList.spec.js
@@ -67,7 +67,7 @@ describe('KvCheckboxList', () => {
 			props: {
 				showSelectAll: true,
 				items,
-				initialSelected: items.map(i => i.value)
+				selectedValues: items.map(i => i.value)
 			}
 		});
 

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchSectorFilter.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchSectorFilter.spec.js
@@ -1,58 +1,69 @@
 import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import LoanSearchSectorFilter from '@/components/Lend/LoanSearch/LoanSearchSectorFilter';
+import { getCheckboxLabel } from '@/util/loanSearchUtils';
 
-const sectors = [
-	{
-		id: 1,
-		name: 'Option 1'
-	},
-	{
-		id: 2,
-		name: 'Option 2'
-	},
-	{
-		id: 3,
-		name: 'Option 3'
-	},
-	{
-		id: 4,
-		name: 'Option 4'
-	}
-];
+const getItems = disabled => [...Array(4)].map((_c, i) => ({
+	id: i,
+	name: `Option ${i}`,
+	numLoansFundraising: disabled ? 0 : 5,
+}));
 
 describe('LoanSearchSectorFilter', () => {
 	it('should display items', () => {
+		const sectors = getItems();
+
 		const { getByText } = render(LoanSearchSectorFilter, { props: { sectors } });
-		sectors.forEach(item => getByText(item.name));
+
+		sectors.forEach(item => getByText(getCheckboxLabel(item)));
 	});
 
 	it('should pre-select', () => {
-		const { getByLabelText } = render(LoanSearchSectorFilter, { props: { sectors, sectorIds: [1] } });
-		expect(getByLabelText('Option 1').checked).toBeTruthy();
+		const sectors = getItems();
+
+		const { getByLabelText } = render(LoanSearchSectorFilter, { props: { sectors, sectorIds: [0] } });
+
+		expect(getByLabelText(getCheckboxLabel(sectors[0])).checked).toBeTruthy();
 	});
 
 	it('should select based on prop', async () => {
+		const sectors = getItems();
+
 		const { getByLabelText, updateProps } = render(LoanSearchSectorFilter, { props: { sectors } });
 
-		await updateProps({ sectorIds: [1] });
-		expect(getByLabelText('Option 1').checked).toBeTruthy();
+		await updateProps({ sectorIds: [0] });
+		expect(getByLabelText(getCheckboxLabel(sectors[0])).checked).toBeTruthy();
 
-		await updateProps({ sectorIds: [1, 2] });
-		expect(getByLabelText('Option 1').checked).toBeTruthy();
-		expect(getByLabelText('Option 2').checked).toBeTruthy();
+		await updateProps({ sectorIds: [0, 1] });
+		expect(getByLabelText(getCheckboxLabel(sectors[0])).checked).toBeTruthy();
+		expect(getByLabelText(getCheckboxLabel(sectors[1])).checked).toBeTruthy();
 
 		await updateProps({ sectorIds: [] });
-		sectors.forEach(item => expect(getByLabelText(item.name).checked).toBeFalsy());
+		sectors.forEach(item => expect(getByLabelText(getCheckboxLabel(item)).checked).toBeFalsy());
 	});
 
 	it('should emit updated', async () => {
+		const sectors = getItems();
+
 		const user = userEvent.setup();
 		const { getByText, emitted } = render(LoanSearchSectorFilter, { props: { sectors } });
 
-		const sector = getByText(sectors[0].name);
+		const sector = getByText(getCheckboxLabel(sectors[0]));
 		await user.click(sector);
 
 		expect(emitted().updated[0]).toEqual([{ sectorId: [sectors[0].id] }]);
+	});
+
+	it('should disable checkboxes when no fundraising loans', async () => {
+		const initialSectors = getItems();
+
+		const { getByLabelText, updateProps } = render(LoanSearchSectorFilter, { props: { sectors: initialSectors } });
+
+		initialSectors.forEach(s => expect(getByLabelText(getCheckboxLabel(s)).disabled).toBeFalsy());
+
+		const sectors = getItems(true);
+		await updateProps({ sectors });
+
+		sectors.forEach(s => expect(getByLabelText(getCheckboxLabel(s)).disabled).toBeTruthy());
 	});
 });

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchSectorFilter.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchSectorFilter.spec.js
@@ -1,5 +1,4 @@
 import { render } from '@testing-library/vue';
-// eslint-disable-next-line import/no-unresolved
 import userEvent from '@testing-library/user-event';
 import LoanSearchSectorFilter from '@/components/Lend/LoanSearch/LoanSearchSectorFilter';
 
@@ -26,6 +25,25 @@ describe('LoanSearchSectorFilter', () => {
 	it('should display items', () => {
 		const { getByText } = render(LoanSearchSectorFilter, { props: { sectors } });
 		sectors.forEach(item => getByText(item.name));
+	});
+
+	it('should pre-select', () => {
+		const { getByLabelText } = render(LoanSearchSectorFilter, { props: { sectors, sectorIds: [1] } });
+		expect(getByLabelText('Option 1').checked).toBeTruthy();
+	});
+
+	it('should select based on prop', async () => {
+		const { getByLabelText, updateProps } = render(LoanSearchSectorFilter, { props: { sectors } });
+
+		await updateProps({ sectorIds: [1] });
+		expect(getByLabelText('Option 1').checked).toBeTruthy();
+
+		await updateProps({ sectorIds: [1, 2] });
+		expect(getByLabelText('Option 1').checked).toBeTruthy();
+		expect(getByLabelText('Option 2').checked).toBeTruthy();
+
+		await updateProps({ sectorIds: [] });
+		sectors.forEach(item => expect(getByLabelText(item.name).checked).toBeFalsy());
 	});
 
 	it('should emit updated', async () => {

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchThemeFilter.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchThemeFilter.spec.js
@@ -16,6 +16,29 @@ describe('LoanSearchThemeFilter', () => {
 		themes.forEach(item => getByText(getCheckboxLabel(item)));
 	});
 
+	it('should pre-select', () => {
+		const themes = getItems();
+
+		const { getByLabelText } = render(LoanSearchThemeFilter, { props: { themes, themeNames: ['OPTION 0'] } });
+
+		expect(getByLabelText(getCheckboxLabel(themes[0])).checked).toBeTruthy();
+	});
+
+	it('should select based on prop', async () => {
+		const themes = getItems();
+		const { getByLabelText, updateProps } = render(LoanSearchThemeFilter, { props: { themes } });
+
+		await updateProps({ themeNames: ['OPTION 0'] });
+		expect(getByLabelText(getCheckboxLabel(themes[0])).checked).toBeTruthy();
+
+		await updateProps({ themeNames: ['OPTION 0', 'OPTION 1'] });
+		expect(getByLabelText(getCheckboxLabel(themes[0])).checked).toBeTruthy();
+		expect(getByLabelText(getCheckboxLabel(themes[1])).checked).toBeTruthy();
+
+		await updateProps({ themeNames: [] });
+		themes.forEach(item => expect(getByLabelText(getCheckboxLabel(item)).checked).toBeFalsy());
+	});
+
 	it('should emit updated', async () => {
 		const user = userEvent.setup();
 		const themes = getItems();
@@ -26,7 +49,7 @@ describe('LoanSearchThemeFilter', () => {
 		await user.click(country);
 
 		// Expect theme name to be emitted
-		expect(emitted().updated[0]).toEqual([{ theme: [themes[0].name] }]);
+		expect(emitted().updated[0]).toEqual([{ theme: [themes[0].name.toUpperCase()] }]);
 	});
 
 	it('should disable checkboxes when no fundraising loans', async () => {

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -4,23 +4,20 @@ import flssLoanFacetsQuery from '@/graphql/query/flssLoanFacetsQuery.graphql';
 
 describe('flssUtils.js', () => {
 	describe('fetchFacets', () => {
-		const result = { isoCode: [] };
-		const dataObj = { data: { fundraisingLoans: { facets: result } } };
+		const result = {};
+		const dataObj = { data: result };
 		const apollo = { query: jest.fn(() => Promise.resolve(dataObj)) };
-		const loanQueryFilters = { any: ['US'] };
-		const apolloVariables = {
-			query: flssLoanFacetsQuery,
-			variables: { filterObject: loanQueryFilters },
-			fetchPolicy: 'network-only',
-		};
+		const filters = { gender: { any: ['FEMALE'] } };
+		const variables = { isoCodeFilters: filters, themeFilters: filters, sectorFilters: filters };
+		const apolloVariables = { query: flssLoanFacetsQuery, variables, fetchPolicy: 'network-only' };
 
 		it('should pass the correct query variables to apollo', async () => {
-			await fetchFacets(apollo, loanQueryFilters);
+			await fetchFacets(apollo, filters, filters, filters);
 			expect(apollo.query).toHaveBeenCalledWith(apolloVariables);
 		});
 
 		it('should return the fundraising facets data', async () => {
-			const data = await fetchFacets(apollo, loanQueryFilters);
+			const data = await fetchFacets(apollo, filters, filters, filters);
 			expect(data).toBe(result);
 		});
 	});

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -772,7 +772,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { gender: 'female' };
 			const router = { currentRoute: { name: 'name', query: { utm_test: 'test' } }, push: jest.fn() };
 
-			updateQueryParams(state, router);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
@@ -785,7 +785,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { gender: 'female' };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
-			updateQueryParams(state, router);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledWith({ name: 'name', query: state, params: { noScroll: true } });
 		});
@@ -794,7 +794,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { sectorId: [1, 2] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
-			updateQueryParams(state, router, mockAllFacets, STANDARD_QUERY_TYPE);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
@@ -807,7 +807,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { gender: 'female', sectorId: [] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
-			updateQueryParams(state, router, mockAllFacets, STANDARD_QUERY_TYPE);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
@@ -820,7 +820,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { theme: ['THEME 1', 'THEME 2'] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
-			updateQueryParams(state, router, mockAllFacets, STANDARD_QUERY_TYPE);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
@@ -833,7 +833,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { gender: 'female', theme: [] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
-			updateQueryParams(state, router, mockAllFacets, STANDARD_QUERY_TYPE);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
@@ -872,7 +872,7 @@ describe('loanSearchUtils.js', () => {
 			const state = { gender: 'female' };
 			const router = { currentRoute: { name: 'name', query: { gender: 'female' } }, push: jest.fn() };
 
-			updateQueryParams(state, router, mockAllFacets);
+			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
 			expect(router.push).toHaveBeenCalledTimes(0);
 		});

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -530,13 +530,16 @@ describe('loanSearchUtils.js', () => {
 
 	describe('runFacetsQueries', () => {
 		let spyFetchFacets;
-		const isoCode = [{ key: 'iso', value: 1 }];
-		const themes = [{ key: 'theme', value: 1 }];
-		const sectorId = [{ key: 'sector', value: 1 }];
+		const isoCodeFacets = [{ key: 'iso', value: 1 }];
+		const themeFacets = [{ key: 'theme', value: 1 }];
+		const sectorFacets = [{ key: 'sector', value: 1 }];
+		const isoCodes = { facets: { isoCode: isoCodeFacets } };
+		const themes = { facets: { themes: themeFacets } };
+		const sectors = { facets: { sectorId: sectorFacets } };
 
 		beforeEach(() => {
 			spyFetchFacets = jest.spyOn(flssUtils, 'fetchFacets')
-				.mockImplementation(() => Promise.resolve({ isoCode, themes, sectorId }));
+				.mockImplementation(() => Promise.resolve({ isoCodes, themes, sectors }));
 		});
 
 		afterEach(jest.restoreAllMocks);
@@ -544,9 +547,14 @@ describe('loanSearchUtils.js', () => {
 		it('should return facets', async () => {
 			const apollo = {};
 			const result = await runFacetsQueries(apollo);
-			expect(spyFetchFacets).toHaveBeenCalledWith(apollo, { countryIsoCode: undefined });
-			expect(spyFetchFacets).toHaveBeenCalledWith(apollo, { theme: undefined });
-			expect(result).toEqual({ isoCodes: isoCode, themes, sectors: sectorId });
+			expect(spyFetchFacets).toHaveBeenCalledWith(
+				apollo,
+				{ countryIsoCode: undefined },
+				{ theme: undefined },
+				{ sectorId: undefined }
+			);
+			expect(spyFetchFacets).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({ isoCodes: isoCodeFacets, themes: themeFacets, sectors: sectorFacets });
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1051
https://kiva.atlassian.net/browse/VUE-1046

- Sector filter can now be initialized via the query param
- Handles both FLSS/legacy "1,2" and Algolia "Arts~Agriculture" formats
- Algolia format will be replaced with the new FLSS format after page load
- Changing the sector filter now populates the query param
- `KvCheckboxList` selection can now be changed via a prop
- Fixed issue where `updateSearchState` could be comparing the wrong objects

![image](https://user-images.githubusercontent.com/16867161/172265372-b1ddb3c4-fb5f-427b-be27-e8e8d90d3e42.png)

Update: https://kiva.atlassian.net/browse/VUE-1044

- Theme filter can now be initialized via the query param
- Handles both FLSS/legacy "1,2" and Algolia "Rural Exclusion~Conflict Zones" formats
- Algolia format will be replaced with the new FLSS format after page load
- Changing the theme filter now populates the query param
- Because the theme ID FLSS filter is not yet on prod, the filtering uses theme name, but the query param uses theme ID
- Added missing `LoanSearchSectorFilter` stories
- Theme names in state now stored in upper case to make comparisons consistent, FLSS appears to use fuzzy matching, so caps don't change results

![image](https://user-images.githubusercontent.com/16867161/172483497-58876b05-6429-433d-b242-488b757aea53.png)

Update: https://kiva.atlassian.net/browse/VUE-1080

- Sector filter now has number of loans fundraising listed in parens, matching other filters

![image](https://user-images.githubusercontent.com/16867161/172506601-a62d18bc-9141-40c4-bf1f-990dc93aa29c.png)