### PR TITLE
fix:  layout of the borrower profile loan progress section

### DIFF
--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -6,7 +6,7 @@
 			:value="progressPercent * 100"
 		/>
 		<figcaption class="tw-flex">
-			<div v-if="!fundedPage">
+			<template v-if="!fundedPage">
 				<p class="tw-flex-auto" data-testid="bp-summary-timeleft">
 					<countdown-timer
 						v-if="urgency"
@@ -29,8 +29,8 @@
 						{{ progressPercent | numeral('0%') }} funded
 					</p>
 				</div>
-			</div>
-			<div v-else>
+			</template>
+			<template v-else>
 				<p class="tw-text-h3 tw-m-0" data-testid="bp-summary-amount-to-go">
 					This loan is fully funded!
 				</p>
@@ -47,7 +47,7 @@
 						</router-link>
 					</p>
 				</div>
-			</div>
+			</template>
 		</figcaption>
 	</figure>
 </template>

--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -30,7 +30,7 @@
 					</p>
 				</div>
 			</template>
-			<template v-else>
+			<div v-else>
 				<p class="tw-text-h3 tw-m-0" data-testid="bp-summary-amount-to-go">
 					This loan is fully funded!
 				</p>
@@ -47,7 +47,7 @@
 						</router-link>
 					</p>
 				</div>
-			</template>
+			</div>
 		</figcaption>
 	</figure>
 </template>


### PR DESCRIPTION
This pr fix the broken layout of `Loan Progress` in `Borrower Profile` caused by the conditional section of the experiment.