### PR TITLE
chore(deps): upgrade @kiva/kv-components to v3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.157.0",
+	"version": "2.173.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.157.0",
+			"version": "2.173.2",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.15.4",
@@ -18,7 +18,7 @@
 				"@godaddy/terminus": "^4.4.1",
 				"@graphql-tools/load": "^6.2.4",
 				"@graphql-tools/url-loader": "^6.3.0",
-				"@kiva/kv-components": "^3.0.3",
+				"@kiva/kv-components": "^3.0.5",
 				"@kiva/kv-tokens": "^2.0.1",
 				"@mdi/js": "^5.9.55",
 				"@sentry/tracing": "^6.13.3",
@@ -3951,9 +3951,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.0.4.tgz",
-			"integrity": "sha512-CPtFYpD6ywA57a2M/+coqzupNWGdcKTpvfzBdhY076wkv+p5s1EQOYq8vVeAQnXL/MtY5RayhrgIa2kY71iamQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.0.5.tgz",
+			"integrity": "sha512-VRtMDo38ps159MDfU+/J7s8oiskYcu7FsmLt6JlVHpa0V0w4ni4DF7JiVJJPhN/LqCqX8Z2NmhO/it1osqBmLA==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^2.0.1",
 				"@mdi/js": "^5.9.55",
@@ -42695,9 +42695,9 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.0.4.tgz",
-			"integrity": "sha512-CPtFYpD6ywA57a2M/+coqzupNWGdcKTpvfzBdhY076wkv+p5s1EQOYq8vVeAQnXL/MtY5RayhrgIa2kY71iamQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.0.5.tgz",
+			"integrity": "sha512-VRtMDo38ps159MDfU+/J7s8oiskYcu7FsmLt6JlVHpa0V0w4ni4DF7JiVJJPhN/LqCqX8Z2NmhO/it1osqBmLA==",
 			"requires": {
 				"@kiva/kv-tokens": "^2.0.1",
 				"@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@godaddy/terminus": "^4.4.1",
 		"@graphql-tools/load": "^6.2.4",
 		"@graphql-tools/url-loader": "^6.3.0",
-		"@kiva/kv-components": "^3.0.3",
+		"@kiva/kv-components": "^3.0.5",
 		"@kiva/kv-tokens": "^2.0.1",
 		"@mdi/js": "^5.9.55",
 		"@sentry/tracing": "^6.13.3",


### PR DESCRIPTION
This adds the change to KvCarousel that hides the control arrows when there is only one slide.