### PR TITLE
fix: typo in tag name

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -133,7 +133,7 @@
 			class="tw-rounded tw-self-start" :style="{width: '9rem', height: '3rem'}"
 		/>
 
-		<kv-button
+		<kv-ui-button
 			v-if="!isLoading && !allSharesReserved && !inBorrowerProfilePage"
 			class="tw-mb-2 tw-self-start"
 			:state="`${allSharesReserved ? 'disabled' : ''}`"
@@ -145,7 +145,7 @@
 				class="tw-w-3 tw-h-3 tw-align-middle"
 				:icon="mdiChevronRight"
 			/>
-		</kv-button>
+		</kv-ui-button>
 
 		<!-- Lend button -->
 		<kv-ui-button


### PR DESCRIPTION
This typo causes the 'view loan' button to not render and to not be interactive.
<img width="387" alt="Screen Shot 2022-06-08 at 12 08 30 PM" src="https://user-images.githubusercontent.com/4149025/172697304-3de142b5-4cf5-4c07-b573-e4ee9bddc1a2.png">
