### PR TITLE
feat: add page description to contentful utils

### DIFF
--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -437,10 +437,13 @@ export function processPageContent(entryItem) {
 		path: entryItem.fields?.path,
 		pageTitle: entryItem.fields?.pageTitle,
 		pageType: entryItem.fields?.pageType,
+		pageDescription: entryItem.fields?.pageDescription,
+		canonicalUrl: entryItem.fields?.canonicalUrl,
 		pageLayout: {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
 			pageBackgroundColor: entryItem.fields?.pageLayout?.fields?.pageBackgroundColor,
+			pageDescription: entryItem.fields?.pageLayout?.fields?.pageDescription
 		},
 		settings: entryItem.fields?.settings
 			? formatContentTypes(entryItem.fields?.settings) : []

--- a/src/util/contentfulUtils.js
+++ b/src/util/contentfulUtils.js
@@ -486,14 +486,18 @@ export function processPageContentFlat(entryItem) {
 	if (!isPage) return { error: 'Non-Page Type Contentful Response' };
 
 	// extract top level items in the Page, initialize pageLayout and settings
+
 	contentfulContentObject.page = {
 		key: entryItem.fields?.key,
 		path: entryItem.fields?.path,
 		pageTitle: entryItem.fields?.pageTitle,
 		pageType: entryItem.fields?.pageType,
+		pageDescription: entryItem.fields?.pageDescription,
+		canonicalUrl: entryItem.fields?.canonicalUrl,
 		pageLayout: {
 			name: entryItem.fields?.pageLayout?.fields?.name,
 			pageTitle: entryItem.fields?.pageLayout?.fields?.pageTitle,
+			pageDescription: entryItem.fields?.pageLayout?.fields?.pageDescription
 		},
 		settings: entryItem.fields?.settings
 			? formatContentTypes(entryItem.fields?.settings) : []

--- a/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
+++ b/test/unit/fixtures/CorporateCampaignContentfulPageRaw.json
@@ -586,7 +586,8 @@
 						"type": "mlCampaignHero"
 					}
 				}],
-				"pageTitle": "Test Page Layout Title"
+				"pageTitle": "Test Page Layout Title",
+				"pageDescription": "Test Page Layout Description"
 			}
 		},
 		"settings": [{
@@ -687,6 +688,8 @@
 		}],
 		"path": "/cc/promo-campaign-test",
 		"pageType": "corporate-campaign",
-		"pageTitle": "Test Page Title"
+		"pageTitle": "Test Page Title",
+		"pageDescription": "Test Page Description",
+		"canonicalUrl": "https://test-canonical.kiva.org/contentful"
 	}
 }

--- a/test/unit/specs/util/contentfulUtils.spec.js
+++ b/test/unit/specs/util/contentfulUtils.spec.js
@@ -486,6 +486,7 @@ describe('contentfulUtils.js', () => {
 					pageBackgroundColor: undefined,
 					contentGroups: [{}],
 					pageTitle: 'Test Page Layout Title',
+					pageDescription: 'Test Page Layout Description'
 				},
 				settings: [{}]
 			}
@@ -527,8 +528,11 @@ describe('contentfulUtils.js', () => {
 						}]
 					}],
 					pageTitle: 'Test Page Layout Title',
+					pageDescription: 'Test Page Layout Description'
 				},
 				pageTitle: 'Test Page Title',
+				pageDescription: 'Test Page Description',
+				canonicalUrl: 'https://test-canonical.kiva.org/contentful'
 			}
 		};
 
@@ -563,6 +567,7 @@ describe('contentfulUtils.js', () => {
 				pageLayout: {
 					name: 'Promo Campaign Test',
 					pageTitle: 'Test Page Layout Title',
+					pageDescription: 'Test Page Layout Description'
 				},
 				settings: expect.any(Array),
 				contentGroups: expect.any(Object),
@@ -582,6 +587,7 @@ describe('contentfulUtils.js', () => {
 				pageLayout: {
 					name: 'Promo Campaign Test',
 					pageTitle: 'Test Page Layout Title',
+					pageDescription: 'Test Page Layout Description',
 				},
 				settings: expect.any(Array),
 				contentGroups: {
@@ -603,6 +609,8 @@ describe('contentfulUtils.js', () => {
 					}
 				},
 				pageTitle: 'Test Page Title',
+				pageDescription: 'Test Page Description',
+				canonicalUrl: 'https://test-canonical.kiva.org/contentful'
 			}
 		};
 


### PR DESCRIPTION
This change adds `pageDescription` and `canonicalUrl` fields to `contentfulObject`.