### PR TITLE
Vue 1032 add loading state overlay for loan section of the page

### DIFF
--- a/.storybook/stories/KvSectionModalLoader.stories.js
+++ b/.storybook/stories/KvSectionModalLoader.stories.js
@@ -1,0 +1,32 @@
+import KvSectionModalLoader from '@/components/Kv/KvSectionModalLoader';
+
+export default {
+	title: 'Kv/KvSectionModalLoader',
+	component: KvSectionModalLoader,
+};
+
+const story = (args) => {
+	const template = (_args, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { KvSectionModalLoader },
+		template: `
+			<div style="height: 200px; width: 200px; background: gray; position: relative;">
+				<kv-section-modal-loader
+					:loading="true"
+					:bg-color="bgColor"
+					:rounded="rounded"
+					:size="size" />
+			</div>
+		`,
+	})
+	template.args = args;
+	return template;
+};
+
+export const Default = story();
+
+export const BgColor = story({ bgColor: 'danger' });
+
+export const Rounded = story({ rounded: true });
+
+export const Large = story({ size: 'large' });

--- a/src/components/Kv/KvSectionModalLoader.vue
+++ b/src/components/Kv/KvSectionModalLoader.vue
@@ -3,7 +3,7 @@
 		v-if="loading"
 		:aria-label="LOADING_LABEL"
 		class="tw-absolute tw-w-full tw-h-full tw-bg-opacity-[65%] tw-z-1 tw-top-0 tw-left-0"
-		:class="{ [`tw-bg-${bgColor}`]: bgColor, 'tw-rounded': rounded }"
+		:class="[`tw-bg-${bgColor}`, {'tw-rounded': rounded }]"
 	>
 		<div class="tw-absolute tw-top-5 tw-left-1/2 tw--translate-x-1/2">
 			<kv-loading-spinner :size="size" />

--- a/src/components/Kv/KvSectionModalLoader.vue
+++ b/src/components/Kv/KvSectionModalLoader.vue
@@ -36,7 +36,8 @@ export default {
 		},
 		size: {
 			type: String,
-			default: 'medium'
+			default: 'medium',
+			validator: value => ['small', 'medium', 'large'].includes(value)
 		},
 	},
 	data() {

--- a/src/components/Kv/KvSectionModalLoader.vue
+++ b/src/components/Kv/KvSectionModalLoader.vue
@@ -1,0 +1,48 @@
+<template>
+	<div
+		v-if="loading"
+		:aria-label="LOADING_LABEL"
+		class="tw-absolute tw-w-full tw-h-full tw-bg-opacity-[65%] tw-z-1 tw-top-0 tw-left-0"
+		:class="{ [`tw-bg-${bgColor}`]: bgColor, 'tw-rounded': rounded }"
+	>
+		<div class="tw-absolute tw-top-5 tw-left-1/2 tw--translate-x-1/2">
+			<kv-loading-spinner :size="size" />
+		</div>
+	</div>
+</template>
+
+<script>
+import KvLoadingSpinner from '~/@kiva/kv-components/vue/KvLoadingSpinner';
+
+export const LOADING_LABEL = 'Section modal loader';
+
+export default {
+	name: 'KvSectionModalLoader',
+	components: {
+		KvLoadingSpinner,
+	},
+	props: {
+		loading: {
+			type: Boolean,
+			default: false
+		},
+		bgColor: {
+			type: String,
+			default: 'white'
+		},
+		rounded: {
+			type: Boolean,
+			default: false
+		},
+		size: {
+			type: String,
+			default: 'medium'
+		},
+	},
+	data() {
+		return {
+			LOADING_LABEL,
+		};
+	},
+};
+</script>

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -1,5 +1,6 @@
 <template>
-	<div class="tw-bg-white tw-border-primary-inverse tw-rounded tw-p-3 filter-min-w tw-relative">
+	<div class="tw-bg-white tw-border-primary-inverse tw-rounded tw-p-3 tw-relative">
+		<kv-section-modal-loader :loading="loading" :rounded="true" />
 		<kv-material-icon :icon="mdiClose" class="tw-w-2.5 tw-h-2.5" />
 		<p class="tw-text-h4 tw-inline-block tw-ml-3 tw-absolute">
 			Reset All
@@ -68,6 +69,7 @@ import LoanSearchSectorFilter from '@/components/Lend/LoanSearch/LoanSearchSecto
 import LoanSearchThemeFilter from '@/components/Lend/LoanSearch/LoanSearchThemeFilter';
 import LoanSearchSortBy from '@/components/Lend/LoanSearch/LoanSearchSortBy';
 import { FLSS_QUERY_TYPE } from '@/util/loanSearchUtils';
+import KvSectionModalLoader from '@/components/Kv/KvSectionModalLoader';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
 export default {
@@ -81,8 +83,13 @@ export default {
 		LoanSearchSectorFilter,
 		LoanSearchThemeFilter,
 		LoanSearchSortBy,
+		KvSectionModalLoader,
 	},
 	props: {
+		loading: {
+			type: Boolean,
+			default: false
+		},
 		/**
 		 * Facet options based on the loans available. Format:
 		 * {
@@ -145,9 +152,3 @@ export default {
 	},
 };
 </script>
-
-<style lang="scss" scoped>
-	.filter-min-w {
-		min-width: 285px;
-	}
-</style>

--- a/test/unit/specs/components/Kv/KvSectionModalLoader.spec.js
+++ b/test/unit/specs/components/Kv/KvSectionModalLoader.spec.js
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/vue';
+import KvSectionModalLoader, { LOADING_LABEL } from '@/components/Kv/KvSectionModalLoader';
+
+describe('KvSectionModalLoader', () => {
+	it('should hide loader by default', () => {
+		const { queryByLabelText } = render(KvSectionModalLoader);
+		expect(queryByLabelText(LOADING_LABEL)).toBe(null);
+	});
+
+	it('should show loader', () => {
+		const { getByLabelText } = render(KvSectionModalLoader, { props: { loading: true } });
+		getByLabelText(LOADING_LABEL);
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1032
https://kiva.atlassian.net/browse/VUE-1072

- Created new `KvSectionModalLoader` component that displays a green `KvLoadingSpinner` centered horizontally slightly below the top of the relative parent, with a white slightly transparent background
- Replaced last CSS section with Tailwind JIT classname
- Fixed constrained filter width in mobile view
- Updated `LoanSearchInterface` to use `Promise.all` for graphql queries that aren't interdependent

Initial load:
![image](https://user-images.githubusercontent.com/16867161/172738743-13a14e69-50d9-4614-9d23-a148029baa93.png)

Filter change:
![image](https://user-images.githubusercontent.com/16867161/172738764-5e9fa632-2093-43f7-a8d7-8773598bbb81.png)

Mobile filters now full width:
![image](https://user-images.githubusercontent.com/16867161/172738849-44c1a92a-1ba2-456a-810f-e406ef3b0f59.png)
