### PR TITLE
Vue 1074 setup and fire the loans shown event on every loan query execution

### DIFF
--- a/src/components/Kv/KvCheckboxList.vue
+++ b/src/components/Kv/KvCheckboxList.vue
@@ -6,7 +6,12 @@
 			</button>
 		</li>
 		<li v-for="(item, i) in items" :key="i">
-			<kv-checkbox :value="item.value" :disabled="item.disabled" v-model="selected" @change="updateSelected">
+			<kv-checkbox
+				:value="item.value"
+				:disabled="item.disabled"
+				v-model="selected"
+				@change="updateSelected($event, item.value)"
+			>
 				{{ item.title }}
 			</kv-checkbox>
 		</li>
@@ -65,10 +70,10 @@ export default {
 					if (exists) this.selected.splice(index, 1);
 				} else if (!exists) this.selected.push(item.value);
 			});
-			this.updateSelected(this.selected);
+			this.updateSelected(this.selected, undefined, true);
 		},
-		updateSelected(values) {
-			this.$emit('updated', [...values]);
+		updateSelected(values, changed, wasSelectAll) {
+			this.$emit('updated', { values: [...values], changed, wasSelectAll });
 		},
 	},
 	watch: {

--- a/src/components/Lend/LoanSearch/LoanSearchGenderFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchGenderFilter.vue
@@ -55,8 +55,11 @@ export default {
 		setGender(gender) {
 			if (gender !== this.selectedGender) {
 				this.selectedGender = gender;
+
 				// Return null as default to match GraphQL enum default
 				this.$emit('updated', { gender: this.selectedGender || null });
+
+				this.$kvTrackEvent?.('Lending', 'click-gender-filter', this.selectedGender);
 			}
 		},
 	},

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -214,8 +214,8 @@ export default {
 	},
 	methods: {
 		trackLoans() {
-			// Check for matching hits, for example when sorting a single page of results
-			const hits = this.loans.map(l => l.id).sort().join();
+			const hits = this.loans.map(l => l.id).join();
+
 			if (hits !== this.trackedHits) {
 				this.$kvTrackEvent(
 					'Lending',

--- a/src/components/Lend/LoanSearch/LoanSearchLocationFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchLocationFilter.vue
@@ -85,8 +85,10 @@ export default {
 				this.openRegions.splice(existingIndex, 1);
 			}
 		},
-		updateRegion(region, countries) {
-			this.$set(this.selectedCountries, region, countries);
+		updateRegion(region, { values, changed, wasSelectAll }) {
+			this.$set(this.selectedCountries, region, values);
+
+			this.$kvTrackEvent?.('Lending', 'click-location-filter', wasSelectAll ? region : changed);
 		},
 	},
 	watch: {

--- a/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
@@ -52,8 +52,8 @@ export default {
 		}
 	},
 	methods: {
-		updateSectors(sectors) {
-			this.$emit('updated', { sectorId: sectors.map(s => +s) });
+		updateSectors({ values }) {
+			this.$emit('updated', { sectorId: values.map(s => +s) });
 		}
 	},
 	watch: {

--- a/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSectorFilter.vue
@@ -52,8 +52,14 @@ export default {
 		}
 	},
 	methods: {
-		updateSectors({ values }) {
+		updateSectors({ values, changed }) {
 			this.$emit('updated', { sectorId: values.map(s => +s) });
+
+			const sector = this.displayedSectors.find(s => s.id === +changed);
+
+			if (sector) {
+				this.$kvTrackEvent?.('Lending', 'click-sector-filter', sector.name);
+			}
 		}
 	},
 	watch: {

--- a/src/components/Lend/LoanSearch/LoanSearchSortBy.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSortBy.vue
@@ -101,7 +101,10 @@ export default {
 		setSortBy(sortBy) {
 			if (sortBy !== this.selectedSort) {
 				this.selectedSort = sortBy;
+
 				this.$emit('updated', { sortBy: this.selectedSort });
+
+				this.$kvTrackEvent?.('Lending', 'click-sortBy-filter', this.selectedSort);
 			}
 		}
 	},

--- a/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
@@ -50,8 +50,11 @@ export default {
 		},
 	},
 	methods: {
-		updateThemes({ values }) {
+		updateThemes({ values, changed }) {
 			this.$emit('updated', { theme: values });
+
+			// TODO: handle theme ID (converting to theme name) when theme ID filter used
+			this.$kvTrackEvent?.('Lending', 'click-theme-filter', changed);
 		}
 	},
 	watch: {

--- a/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchThemeFilter.vue
@@ -50,8 +50,8 @@ export default {
 		},
 	},
 	methods: {
-		updateThemes(themes) {
-			this.$emit('updated', { theme: themes });
+		updateThemes({ values }) {
+			this.$emit('updated', { theme: values });
 		}
 	},
 	watch: {

--- a/test/unit/specs/components/Kv/KvCheckboxList.spec.js
+++ b/test/unit/specs/components/Kv/KvCheckboxList.spec.js
@@ -85,7 +85,24 @@ describe('KvCheckboxList', () => {
 
 		await user.click(getByLabelText(items[0].title));
 
-		expect(emitted().updated[0]).toEqual([[items[0].value]]);
+		const payload = emitted().updated[0][0];
+
+		expect(payload.values).toEqual([items[0].value]);
+		expect(payload.changed).toEqual(items[0].value);
+		expect(payload.wasSelectAll).toBeFalsy();
+	});
+
+	it('should emit select all', async () => {
+		const user = userEvent.setup();
+		const { getByText, emitted } = render(KvCheckboxList, { props: { showSelectAll: true, items } });
+
+		await user.click(getByText('Select all'));
+
+		const payload = emitted().updated[0][0];
+
+		expect(payload.values).toEqual(items.map(item => item.value));
+		expect(payload.changed).toBeFalsy();
+		expect(payload.wasSelectAll).toBeTruthy();
 	});
 
 	it('should disable checkboxes', () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1074
https://kiva.atlassian.net/browse/VUE-1075
https://kiva.atlassian.net/browse/VUE-1076
https://kiva.atlassian.net/browse/VUE-1077
https://kiva.atlassian.net/browse/VUE-1078
https://kiva.atlassian.net/browse/VUE-1079

- Added loan results/hits analytics
- Added gender filter analytics
- Added sort by analytics
- Added location filter analytics
- Added sector filter analytics
- Added theme filter analytics
- `KvCheckboxList` now emits more change event data to allow analytics to be more detailed