### PR TITLE
fix: fixes campaign page loan carousel not scrolling on page load

### DIFF
--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -33,7 +33,7 @@
 			<kv-carousel-slide
 				v-for="(loan, index) in loans"
 				:key="`loan-${loan.id}-${index}`"
-				class="column cards-wrap"
+				class="loan-row-slide"
 			>
 				<loan-card-controller
 					class="cards-loan-card"
@@ -57,7 +57,7 @@
 
 			<kv-carousel-slide
 				v-if="hasMoreLoansAvailable"
-				class="column cards-wrap"
+				class="loan-row-slide"
 			>
 				<button
 					class="see-all-card"
@@ -167,7 +167,7 @@ export default {
 			}
 		},
 		filters(next) {
-			// TODO: Review process for reseting loans after applying filters
+			// TODO: Review process for resetting loans after applying filters
 			// reset offset
 			this.offset = 0;
 			// reset loans
@@ -177,7 +177,9 @@ export default {
 			this.loanQueryFilters = next;
 
 			// Reset carousel position after applying loan filters
-			this.$refs.campaignLoanCarousel.goToSlide(0);
+			if (this.$refs.campaignLoanCarousel) {
+				this.$refs.campaignLoanCarousel.goToSlide(0);
+			}
 		},
 		isVisible(next) {
 			if (next && this.showLoans) {
@@ -269,10 +271,8 @@ export default {
 	justify-content: center;
 	position: relative;
 
-	// extra specificity to ensure width: auto is respected when bundling css
-	.cards-wrap {
-		display: flex;
-		width: auto;
+	.loan-row-slide {
+		width: rem-calc(328);
 	}
 }
 
@@ -296,6 +296,7 @@ $card-half-space: rem-calc(14/2);
 }
 
 .see-all-card {
+	min-height: rem-calc(475);
 	display: block;
 
 	&:hover {


### PR DESCRIPTION

On `www.kiva.org/cc/sage` on first page load the loan carousel would not scroll right. Taking an action to reinit the embla carousel would fix the issue, such as: 

- resizing the page
- modifying filters
- switching to grid display then back to row

I narrowed down the issue to `this.embla.slidesInView(true)` returning an incorrect value in KvCarousel when the page loads. (It returns 16, aka, all the loans as in view on page load). 

At first I thought it was a timing issue and tried various $nextTick and modifying some code to make sure the carousel isnt loading until after the loans. None of this worked. 

I now believe this could just be an issue with embla and browser rendering. It really struggles to calculate the size of the carousels with the combination of `display:flex` and `width: auto`

This fix is the least obtrusive fix I could make that fixes the issue. 

This might need to get hotfixed -- see ACK-319, since a large campaign went out for `/cc/sage`

See: ACK-319

Note: 
www.kiva.org/cc/sage -- has been changed to default display grid until this was fixed (via contentful)
dev.kiva.org/cc/sage -- has display row and you can see the issue there right now. 

PS - We should deprecate KvCarousel in favor of `~/@kiva/kv-components/vue/KvCarousel`