### PR TITLE
feat: changed Braintree dropin error content to include support email

### DIFF
--- a/src/plugins/braintree-dropin-error-mixin.js
+++ b/src/plugins/braintree-dropin-error-mixin.js
@@ -3,11 +3,9 @@ export default {
 		processBraintreeDropInError(trackCategory, kivaBraintreeResponse) {
 			const errorCode = kivaBraintreeResponse.errors?.[0]?.extensions?.code;
 			const errorMessage = kivaBraintreeResponse.errors?.[0]?.message;
-			const standardErrorCode = `(Braintree error: ${errorCode})`;
 			// eslint-disable-next-line max-len
-			const standardError = `There was an error processing your payment. Please try again. ${standardErrorCode}`;
+			const standardError = 'There was an error processing your payment. Please confirm your payment details and try again or contact our support team at <a href="mailto:contactus@kiva.org">contactus@kiva.org</a>.';
 
-			// Potential error message: 'Transaction failed. Please select a different payment method.';
 			this.$showTipMsg(standardError, 'error');
 
 			// Fire specific exception to Snowplow


### PR DESCRIPTION
https://kiva.atlassian.net/browse/FIN-693

Seemed simple enough not to trouble you with it! But I would appreciate anything that's off here. Via linting I needed to use the `'` style quote here.