### PR TITLE
Vue 1033 implement loan pager component

### DIFF
--- a/.storybook/stories/KvPager.stories.js
+++ b/.storybook/stories/KvPager.stories.js
@@ -1,0 +1,43 @@
+import KvPager from '@/components/Kv/KvPager';
+
+export default {
+	title: 'Kv/KvPager',
+	component: KvPager,
+};
+
+const story = (args) => {
+	const template = (_args, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { KvPager },
+		template: `<kv-pager
+			:page-size="pageSize"
+			:total="total"
+			:current="current"
+			:extra-pages="extraPages"
+			:scroll-to-top="scrollToTop" />`,
+	})
+	template.args = args;
+	return template;
+};
+
+export const Default = story({ pageSize: 10, total: 0 });
+
+export const FewerPages = story({ pageSize: 10, total: 30 });
+
+export const MorePages = story({ pageSize: 10, total: 1000 });
+
+export const SecondSelected = story({ pageSize: 10, total: 1000, current: 1 });
+
+export const ThirdSelected = story({ pageSize: 10, total: 1000, current: 2 });
+
+export const FourthSelected = story({ pageSize: 10, total: 1000, current: 3 });
+
+export const LastSelected = story({ pageSize: 10, total: 1000, current: 99 });
+
+export const SecondToLastSelected = story({ pageSize: 10, total: 1000, current: 98 });
+
+export const ThirdToLastSelected = story({ pageSize: 10, total: 1000, current: 97 });
+
+export const FourthToLastSelected = story({ pageSize: 10, total: 1000, current: 96 });
+
+export const MoreExtraPages = story({ pageSize: 10, total: 1000, extraPages: 6 });

--- a/.storybook/stories/KvPager.stories.js
+++ b/.storybook/stories/KvPager.stories.js
@@ -10,9 +10,9 @@ const story = (args) => {
 		props: Object.keys(argTypes),
 		components: { KvPager },
 		template: `<kv-pager
-			:page-size="pageSize"
+			:limit="limit"
 			:total="total"
-			:current="current"
+			:offset="offset"
 			:extra-pages="extraPages"
 			:scroll-to-top="scrollToTop" />`,
 	})
@@ -20,24 +20,24 @@ const story = (args) => {
 	return template;
 };
 
-export const Default = story({ pageSize: 10, total: 0 });
+export const Default = story({ limit: 10, total: 0 });
 
-export const FewerPages = story({ pageSize: 10, total: 30 });
+export const FewerPages = story({ limit: 10, total: 30 });
 
-export const MorePages = story({ pageSize: 10, total: 1000 });
+export const MorePages = story({ limit: 10, total: 1000 });
 
-export const SecondSelected = story({ pageSize: 10, total: 1000, current: 1 });
+export const SecondSelected = story({ limit: 10, total: 1000, offset: 10 });
 
-export const ThirdSelected = story({ pageSize: 10, total: 1000, current: 2 });
+export const ThirdSelected = story({ limit: 10, total: 1000, offset: 20 });
 
-export const FourthSelected = story({ pageSize: 10, total: 1000, current: 3 });
+export const FourthSelected = story({ limit: 10, total: 1000, offset: 30 });
 
-export const LastSelected = story({ pageSize: 10, total: 1000, current: 99 });
+export const LastSelected = story({ limit: 10, total: 1000, offset: 990 });
 
-export const SecondToLastSelected = story({ pageSize: 10, total: 1000, current: 98 });
+export const SecondToLastSelected = story({ limit: 10, total: 1000, offset: 980 });
 
-export const ThirdToLastSelected = story({ pageSize: 10, total: 1000, current: 97 });
+export const ThirdToLastSelected = story({ limit: 10, total: 1000, offset: 970 });
 
-export const FourthToLastSelected = story({ pageSize: 10, total: 1000, current: 96 });
+export const FourthToLastSelected = story({ limit: 10, total: 1000, offset: 960 });
 
-export const MoreExtraPages = story({ pageSize: 10, total: 1000, extraPages: 6 });
+export const MoreExtraPages = story({ limit: 10, total: 1000, extraPages: 6 });

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -20,8 +20,8 @@ export const getDefaultLoanSearchState = () => ({
 	sectorId: [], // Expects an array of ints
 	sortBy: null, // Expects a string that matches the SortEnum
 	theme: [], // Expects an array of strings
-	pageNumber: 0, // Expects a number
-	pageSize: 15, // Expects a number
+	pageOffset: 0, // Expects a number
+	pageLimit: 15, // Expects a number
 });
 
 // export queries, resolvers and defaults for LoanSearchState

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -14,18 +14,24 @@ const __typename = 'LoanSearchState';
 // 	}
 // `;
 
+export const getDefaultLoanSearchState = () => ({
+	gender: null, // Expects a string
+	countryIsoCode: [], // Expects an array of strings
+	sectorId: [], // Expects an array of ints
+	sortBy: null, // Expects a string that matches the SortEnum
+	theme: [], // Expects an array of strings
+	pageNumber: 0, // Expects a number
+	pageSize: 15, // Expects a number
+});
+
 // export queries, resolvers and defaults for LoanSearchState
 export default () => {
 	return {
 		defaults: {
 			loanSearchState: {
-				id: 'SearchData', // using a hard-coded id for now to enable cache
-				gender: '', // expects a string
-				countryIsoCode: [], // expects an array of strings
-				sectorId: [], // expects an array of ints
-				sortBy: null, // expects a string that matches the SortEnum
-				theme: [], // expects an array of strings
+				id: 'SearchData', // Using a hard-coded id for now to enable cache
 				__typename,
+				...getDefaultLoanSearchState(),
 			},
 		},
 		resolvers: {

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -81,8 +81,8 @@ type LoanSearchState {
 	sectorId: [Int]
 	sortBy: String
 	theme: [String]
-	pageNumber: [Int]
-	pageSize: [Int]
+	pageOffset: [Int]
+	pageLimit: [Int]
 }
 
 type TipMessage {

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -81,6 +81,8 @@ type LoanSearchState {
 	sectorId: [Int]
 	sortBy: String
 	theme: [String]
+	pageNumber: [Int]
+	pageSize: [Int]
 }
 
 type TipMessage {

--- a/src/components/Kv/KvPager.vue
+++ b/src/components/Kv/KvPager.vue
@@ -1,0 +1,163 @@
+<template>
+	<nav aria-label="Pagination">
+		<ul :class="`
+			tw-text-center
+			tw-mx-auto
+			tw-my-[.75rem]
+			tw-flex
+			tw-justify-between
+			tw-items-center
+			tw-max-w-[17rem]`"
+		>
+			<li class="pagination-previous">
+				<a
+					class="tw-cursor-pointer tw-flex"
+					:class="linkClass(0)"
+					aria-label="Previous page"
+					@click="!isCurrent(0) && pageChange(selectedCurrent - 1)"
+				>
+					<kv-icon
+						name="fat-chevron"
+						:from-sprite="true"
+						class="tw-h-2 tw-w-2 tw-fill-current tw-rotate-90"
+					/>
+					<span class="tw-sr-only">Previous page</span>
+				</a>
+			</li>
+			<li v-for="(n, i) in numbers"
+				:key="i"
+				:aria-hidden="isEllipsis(n)"
+			>
+				<template v-if="isEllipsis(n)">
+					...
+				</template>
+				<a
+					v-else
+					class="tw-cursor-pointer"
+					:class="linkClass(n)"
+					:aria-label="`Page ${n + 1}`"
+					@click="!isCurrent(n) && pageChange(n)"
+				>
+					<span v-if="isCurrent(n)" class="tw-sr-only">You're on page</span>
+					{{ n + 1 }}
+				</a>
+			</li>
+			<li class="pagination-next">
+				<a
+					class="tw-cursor-pointer tw-flex"
+					:class="linkClass(totalPages ? totalPages - 1 : 0)"
+					aria-label="Next page"
+					@click="totalPages && !isCurrent(totalPages - 1) && pageChange(selectedCurrent + 1)"
+				>
+					<kv-icon
+						name="fat-chevron"
+						:from-sprite="true"
+						class="tw-h-2 tw-w-2 tw-fill-current tw--rotate-90"
+					/>
+					<span class="tw-sr-only">Next page</span>
+				</a>
+			</li>
+		</ul>
+	</nav>
+</template>
+
+<script>
+import KvIcon from './KvIcon';
+
+export default {
+	name: 'KvPager',
+	components: {
+		KvIcon,
+	},
+	props: {
+		pageSize: {
+			type: Number,
+			required: true,
+			validator: value => value > 0,
+		},
+		total: {
+			type: Number,
+			required: true,
+			validator: value => value >= 0,
+		},
+		current: {
+			type: Number,
+			default: 0,
+			validator: value => value >= 0,
+		},
+		extraPages: {
+			type: Number,
+			default: 3,
+			validator: value => value > 0
+		},
+		scrollToTop: {
+			type: Boolean,
+			default: true,
+		}
+	},
+	computed: {
+		selectedCurrent() {
+			return this.current < this.totalPages ? this.current : 0;
+		},
+		totalPages() {
+			return Math.ceil(this.total / this.pageSize);
+		},
+		numbers() {
+			// If less than the max, there will be no ellipsis, so just return the numbers
+			if (this.totalPages < (this.extraPages + 2)) {
+				return this.range(0, this.totalPages - 1);
+			}
+
+			const numbers = [];
+
+			// Add the 'middle' block of numbers based upon the current page
+			if ([0, 1, 2].includes(this.selectedCurrent)) {
+				numbers.push(...this.range(1, this.extraPages));
+			} else if ([this.totalPages - 3, this.totalPages - 2, this.totalPages - 1].includes(this.selectedCurrent)) {
+				numbers.push(...this.range(this.totalPages - this.extraPages - 1, this.totalPages - 2));
+			} else {
+				const delta = Math.floor(this.extraPages / 2);
+				numbers.push(...this.range(this.selectedCurrent - delta, this.selectedCurrent + delta));
+			}
+
+			// Add a placeholder for first ellipsis
+			if (numbers[1] !== 2) {
+				numbers.splice(0, 0, -1);
+			}
+
+			// Add a placeholder for second ellipsis
+			const totalNumbers = numbers.length;
+			if (numbers[totalNumbers - 1] !== this.totalPages - 2) {
+				numbers.splice(totalNumbers, 0, -1);
+			}
+
+			// Add first and last pages
+			numbers.unshift(0);
+			numbers.push(this.totalPages - 1);
+
+			return numbers;
+		},
+	},
+	methods: {
+		range(start, end) {
+			return [...Array(end - start + 1)].map((_, n) => n + start);
+		},
+		isCurrent(number) {
+			return number === this.selectedCurrent;
+		},
+		isEllipsis(number) {
+			return number === -1;
+		},
+		linkClass(number) {
+			return { 'tw-text-tertiary': this.isCurrent(number), 'tw-pointer-events-none': this.isCurrent(number) };
+		},
+		pageChange(number) {
+			if (this.scrollToTop && window.scrollTo) {
+				window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+			}
+
+			this.$emit('page-changed', { pageNumber: number });
+		},
+	},
+};
+</script>

--- a/src/components/Kv/KvPager.vue
+++ b/src/components/Kv/KvPager.vue
@@ -14,7 +14,7 @@
 					class="tw-cursor-pointer tw-flex"
 					:class="linkClass(0)"
 					aria-label="Previous page"
-					@click="!isCurrent(0) && pageChange(selectedCurrent - 1)"
+					@click="!isCurrent(0) && pageChange(current - 1)"
 				>
 					<kv-icon
 						name="fat-chevron"
@@ -47,7 +47,7 @@
 					class="tw-cursor-pointer tw-flex"
 					:class="linkClass(totalPages ? totalPages - 1 : 0)"
 					aria-label="Next page"
-					@click="totalPages && !isCurrent(totalPages - 1) && pageChange(selectedCurrent + 1)"
+					@click="totalPages && !isCurrent(totalPages - 1) && pageChange(current + 1)"
 				>
 					<kv-icon
 						name="fat-chevron"
@@ -70,7 +70,7 @@ export default {
 		KvIcon,
 	},
 	props: {
-		pageSize: {
+		limit: {
 			type: Number,
 			required: true,
 			validator: value => value > 0,
@@ -80,7 +80,7 @@ export default {
 			required: true,
 			validator: value => value >= 0,
 		},
-		current: {
+		offset: {
 			type: Number,
 			default: 0,
 			validator: value => value >= 0,
@@ -96,11 +96,14 @@ export default {
 		}
 	},
 	computed: {
-		selectedCurrent() {
-			return this.current < this.totalPages ? this.current : 0;
+		current() {
+			const page = this.offset / this.limit;
+
+			// This component uses a 0-based page index
+			return page < this.totalPages ? page : 0;
 		},
 		totalPages() {
-			return Math.ceil(this.total / this.pageSize);
+			return Math.ceil(this.total / this.limit);
 		},
 		numbers() {
 			// If less than the max, there will be no ellipsis, so just return the numbers
@@ -111,13 +114,13 @@ export default {
 			const numbers = [];
 
 			// Add the 'middle' block of numbers based upon the current page
-			if ([0, 1, 2].includes(this.selectedCurrent)) {
+			if ([0, 1, 2].includes(this.current)) {
 				numbers.push(...this.range(1, this.extraPages));
-			} else if ([this.totalPages - 3, this.totalPages - 2, this.totalPages - 1].includes(this.selectedCurrent)) {
+			} else if ([this.totalPages - 3, this.totalPages - 2, this.totalPages - 1].includes(this.current)) {
 				numbers.push(...this.range(this.totalPages - this.extraPages - 1, this.totalPages - 2));
 			} else {
 				const delta = Math.floor(this.extraPages / 2);
-				numbers.push(...this.range(this.selectedCurrent - delta, this.selectedCurrent + delta));
+				numbers.push(...this.range(this.current - delta, this.current + delta));
 			}
 
 			// Add a placeholder for first ellipsis
@@ -143,7 +146,7 @@ export default {
 			return [...Array(end - start + 1)].map((_, n) => n + start);
 		},
 		isCurrent(number) {
-			return number === this.selectedCurrent;
+			return number === this.current;
 		},
 		isEllipsis(number) {
 			return number === -1;
@@ -156,7 +159,7 @@ export default {
 				window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
 			}
 
-			this.$emit('page-changed', { pageNumber: number });
+			this.$emit('page-changed', { pageOffset: number * this.limit });
 		},
 	},
 };

--- a/src/components/Lend/LoanSearch/LoanSearchGenderFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchGenderFilter.vue
@@ -34,7 +34,7 @@ export default {
 	},
 	data() {
 		return {
-			selectedGender: this.gender,
+			selectedGender: this.gender || '',
 			genderOptions: [
 				{
 					title: BOTH_TITLE,

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -52,6 +52,13 @@
 					:rounded-corners="true"
 				/>
 			</kv-grid>
+			<kv-pager
+				v-if="totalCount > 0"
+				:page-size="loanSearchState.pageSize"
+				:total="totalCount"
+				:current="loanSearchState.pageNumber"
+				@page-changed="handleUpdatedFilters"
+			/>
 		</div>
 	</div>
 </template>
@@ -74,6 +81,8 @@ import {
 	transformSectors,
 } from '@/util/loanSearchUtils';
 import KvSectionModalLoader from '@/components/Kv/KvSectionModalLoader';
+import KvPager from '@/components/Kv/KvPager';
+import { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
@@ -88,6 +97,7 @@ export default {
 		LoanSearchFilter,
 		KvLightbox,
 		KvSectionModalLoader,
+		KvPager,
 	},
 	data() {
 		return {
@@ -155,7 +165,7 @@ export default {
 			loans: [],
 			totalCount: 0,
 			isLightboxVisible: false,
-			loanSearchState: {},
+			loanSearchState: getDefaultLoanSearchState(),
 			queryType: FLSS_QUERY_TYPE
 		};
 	},

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -54,9 +54,9 @@
 			</kv-grid>
 			<kv-pager
 				v-if="totalCount > 0"
-				:page-size="loanSearchState.pageSize"
+				:limit="loanSearchState.pageLimit"
 				:total="totalCount"
-				:current="loanSearchState.pageNumber"
+				:offset="loanSearchState.pageOffset"
 				@page-changed="handleUpdatedFilters"
 			/>
 		</div>

--- a/src/graphql/mutation/updateLoanSearchState.graphql
+++ b/src/graphql/mutation/updateLoanSearchState.graphql
@@ -6,5 +6,7 @@ mutation updateLoanSearch($searchParams: JSONObject) {
 		sectorId
 		sortBy
 		theme
+		pageNumber
+		pageSize
 	}
 }

--- a/src/graphql/mutation/updateLoanSearchState.graphql
+++ b/src/graphql/mutation/updateLoanSearchState.graphql
@@ -6,7 +6,7 @@ mutation updateLoanSearch($searchParams: JSONObject) {
 		sectorId
 		sortBy
 		theme
-		pageNumber
-		pageSize
+		pageOffset
+		pageLimit
 	}
 }

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -4,13 +4,13 @@ query flssLoanData(
 	$filterObject: [FundraisingLoanSearchFilterInput!]
 	$sortBy: SortEnum = personalized
 	$pageNumber: Int = 0
-	$pageSize: Int = 0
+	$pageLimit: Int = 0
 	$imgDefaultSize: String = "w480h360"
 	$imgRetinaSize: String = "w960h720"
 ) {
 	fundraisingLoans(
 		filters: $filterObject,
-		limit: $pageSize,
+		limit: $pageLimit,
 		pageNumber: $pageNumber,
 		sortBy: $sortBy
 	) {

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -2,16 +2,16 @@
 
 query flssLoanData(
 	$filterObject: [FundraisingLoanSearchFilterInput!]
+	$sortBy: SortEnum = personalized
+	$pageNumber: Int = 0
+	$pageSize: Int = 0
 	$imgDefaultSize: String = "w480h360"
 	$imgRetinaSize: String = "w960h720"
-	$limit: Int = 0
-	$offset: Int = 0
-	$sortBy: SortEnum = personalized
 ) {
 	fundraisingLoans(
 		filters: $filterObject,
-		limit: $limit,
-		pageNumber: $offset
+		limit: $pageSize,
+		pageNumber: $pageNumber,
 		sortBy: $sortBy
 	) {
 		totalCount

--- a/src/graphql/query/loanSearchState.graphql
+++ b/src/graphql/query/loanSearchState.graphql
@@ -4,7 +4,9 @@ query loanSearchStateQuery {
 		gender
 		sectorId
 		countryIsoCode
-		theme
 		sortBy
+		theme
+		pageNumber
+		pageSize
 	}
 }

--- a/src/graphql/query/loanSearchState.graphql
+++ b/src/graphql/query/loanSearchState.graphql
@@ -6,7 +6,7 @@ query loanSearchStateQuery {
 		countryIsoCode
 		sortBy
 		theme
-		pageNumber
-		pageSize
+		pageOffset
+		pageLimit
 	}
 }

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -27,20 +27,20 @@ export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFi
  * Fetches the loan data from FLSS
  *
  * @param {Object} apollo The apollo client instance
- * @param {Object} loanQueryFilters The filters for the loan query
+ * @param {Object} filterObject The filters for the loan query
  * @param {String} sortOrder Sort option for the loan query
  * @param {String} pageOffset PageNumber or Offset (FLSS uses a page number, Lend Loans uses a count offset)
  * @returns {Promise<Array<Object>>} Promise for loan data
  */
-export async function fetchLoans(apollo, loanQueryFilters, sortBy = null, pageOffset = 0) {
+export async function fetchLoans(apollo, filterObject, sortBy = null, pageNumber = 0, pageSize = 15) {
 	try {
 		const result = await apollo.query({
 			query: flssLoanQuery,
 			variables: {
-				filterObject: loanQueryFilters,
+				filterObject,
 				sortBy,
-				pageNumber: pageOffset,
-				limit: 20
+				pageNumber,
+				pageSize,
 			},
 			fetchPolicy: 'network-only',
 		});

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -29,18 +29,19 @@ export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFi
  * @param {Object} apollo The apollo client instance
  * @param {Object} filterObject The filters for the loan query
  * @param {String} sortOrder Sort option for the loan query
- * @param {String} pageOffset PageNumber or Offset (FLSS uses a page number, Lend Loans uses a count offset)
+ * @param {Int} pageOffset The offset of the page
+ * @param {Int} pageLimit The limit/size of the page
  * @returns {Promise<Array<Object>>} Promise for loan data
  */
-export async function fetchLoans(apollo, filterObject, sortBy = null, pageNumber = 0, pageSize = 15) {
+export async function fetchLoans(apollo, filterObject, sortBy = null, pageOffset = 0, pageLimit = 15) {
 	try {
 		const result = await apollo.query({
 			query: flssLoanQuery,
 			variables: {
 				filterObject,
 				sortBy,
-				pageNumber,
-				pageSize,
+				pageNumber: pageOffset / pageLimit,
+				pageLimit,
 			},
 			fetchPolicy: 'network-only',
 		});

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -514,7 +514,7 @@ export function getThemeNamesQueryParam(param, facets) {
  */
 export async function applyQueryParams(apollo, query, allFacets, queryType, previousState = {}) {
 	const filters = {
-		...previousState, // Country ISO code, page number, and page size are not currently in the query params
+		...previousState, // Country ISO code, page offset, and page size are not currently in the query params
 		gender: query.gender,
 		sortBy: queryType === FLSS_QUERY_TYPE ? lendToFlssSort.get(query.sortBy) : query.sortBy,
 		sectorId: getSectorIdsFromQueryParam(query.sector, allFacets.sectorNames, allFacets.sectorFacets, true),

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -69,13 +69,13 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		// Handle casing differences between FLSS and lend API theme values. FLSS does case insensitive fuzzy matching.
 		.map(t => t.toUpperCase());
 
-	const validatedPageNumber = isNumber(loanSearchState?.pageNumber)
-		? loanSearchState.pageNumber
-		: defaultLoanSearchState.pageNumber;
+	const validatedPageOffset = isNumber(loanSearchState?.pageOffset)
+		? loanSearchState.pageOffset
+		: defaultLoanSearchState.pageOffset;
 
-	const validatedPageSize = isNumber(loanSearchState?.pageSize)
-		? loanSearchState.pageSize
-		: defaultLoanSearchState.pageSize;
+	const validatedPageLimit = isNumber(loanSearchState?.pageLimit)
+		? loanSearchState.pageLimit
+		: defaultLoanSearchState.pageLimit;
 
 	return {
 		gender: validatedGender,
@@ -83,8 +83,8 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		sectorId: validatedSectorIds,
 		sortBy: validatedSortBy,
 		theme: validatedThemes,
-		pageNumber: validatedPageNumber,
-		pageSize: validatedPageSize,
+		pageOffset: validatedPageOffset,
+		pageLimit: validatedPageLimit,
 	};
 }
 
@@ -393,8 +393,8 @@ export async function runLoansQuery(apollo, loanSearchState) {
 		apollo,
 		getFlssFilters(loanSearchState),
 		loanSearchState?.sortBy,
-		loanSearchState?.pageNumber,
-		loanSearchState?.pageSize
+		loanSearchState?.pageOffset,
+		loanSearchState?.pageLimit
 	);
 
 	return { loans: flssData?.values ?? [], totalCount: flssData?.totalCount ?? 0 };

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -2,6 +2,8 @@ import orderBy from 'lodash/orderBy';
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
 import { fetchFacets, fetchLoans } from '@/util/flssUtils';
+import { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
+import { isNumber } from '@/util/numberUtils';
 
 /**
  * API query types, FLSS and lend (standard)
@@ -50,23 +52,39 @@ export const sortByNameToDisplay = {
 export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 	const validSorts = queryType === FLSS_QUERY_TYPE ? allFacets.flssSorts : allFacets.standardSorts;
 
+	const defaultLoanSearchState = getDefaultLoanSearchState();
+
 	const validatedGender = allFacets.genders.includes(loanSearchState?.gender?.toUpperCase())
 		? loanSearchState.gender : null;
+
 	const validatedIsoCodes = loanSearchState?.countryIsoCode
 		?.filter(c => allFacets.countryIsoCodes.includes(c.toUpperCase())) ?? [];
+
 	const validatedSectorIds = loanSearchState?.sectorId?.filter(s => allFacets.sectorIds.includes(s)) ?? [];
+
 	const validatedSortBy = validSorts.some(s => s.name === loanSearchState.sortBy) ? loanSearchState.sortBy : null;
+
 	// TODO: change to theme IDs when theme ID filter is on prod
 	const validatedThemes = (loanSearchState?.theme?.filter(t => allFacets.themeNames.includes(t.toUpperCase())) ?? [])
 		// Handle casing differences between FLSS and lend API theme values. FLSS does case insensitive fuzzy matching.
 		.map(t => t.toUpperCase());
+
+	const validatedPageNumber = isNumber(loanSearchState?.pageNumber)
+		? loanSearchState.pageNumber
+		: defaultLoanSearchState.pageNumber;
+
+	const validatedPageSize = isNumber(loanSearchState?.pageSize)
+		? loanSearchState.pageSize
+		: defaultLoanSearchState.pageSize;
 
 	return {
 		gender: validatedGender,
 		countryIsoCode: validatedIsoCodes,
 		sectorId: validatedSectorIds,
 		sortBy: validatedSortBy,
-		theme: validatedThemes
+		theme: validatedThemes,
+		pageNumber: validatedPageNumber,
+		pageSize: validatedPageSize,
 	};
 }
 
@@ -349,7 +367,7 @@ export function getFlssFilters(loanSearchState) {
  * @param {Object} loanSearchState The current loan search state from Apollo
  * @returns {Object} The filter facets
  */
-export async function runFacetsQueries(apollo, loanSearchState = {}) {
+export async function runFacetsQueries(apollo, loanSearchState) {
 	const isoCodeFilters = { ...getFlssFilters(loanSearchState), countryIsoCode: undefined };
 	const themeFilters = { ...getFlssFilters(loanSearchState), theme: undefined };
 	const sectorFilters = { ...getFlssFilters(loanSearchState), sectorId: undefined };
@@ -370,14 +388,16 @@ export async function runFacetsQueries(apollo, loanSearchState = {}) {
  * @param {Object} loanSearchState The current loan search state from Apollo
  * @returns {Object} The results of the loan query
  */
-export async function runLoansQuery(apollo, loanSearchState = {}) {
+export async function runLoansQuery(apollo, loanSearchState) {
 	const flssData = await fetchLoans(
 		apollo,
 		getFlssFilters(loanSearchState),
-		loanSearchState?.sortBy ?? null
+		loanSearchState?.sortBy,
+		loanSearchState?.pageNumber,
+		loanSearchState?.pageSize
 	);
 
-	return { loans: flssData?.values || [], totalCount: flssData?.totalCount || 0 };
+	return { loans: flssData?.values ?? [], totalCount: flssData?.totalCount ?? 0 };
 }
 
 /**
@@ -434,7 +454,7 @@ export function getSectorIdsFromQueryParam(sector, allFacets) {
 	if (!sector) return;
 
 	// Handles FLSS and legacy query params, such as "1" and "1,2"
-	if (sector.includes(',') || !Number.isNaN(Number(sector))) {
+	if (sector.includes(',') || isNumber(sector)) {
 		return sector.split(',').filter(s => s !== '').map(s => +s);
 	}
 
@@ -463,7 +483,7 @@ export function getThemeNamesQueryParam(param, facets) {
 	if (!param) return;
 
 	// Handles FLSS and legacy query params, such as "1" and "1,2"
-	if (param.includes(',') || !Number.isNaN(Number(param))) {
+	if (param.includes(',') || isNumber(param)) {
 		return param.split(',').filter(s => s !== '').reduce((prev, current) => {
 			const facet = facets.find(s => s.id === +current);
 			if (facet) {
@@ -494,12 +514,11 @@ export function getThemeNamesQueryParam(param, facets) {
  */
 export async function applyQueryParams(apollo, query, allFacets, queryType, previousState = {}) {
 	const filters = {
+		...previousState, // Country ISO code, page number, and page size are not currently in the query params
 		gender: query.gender,
 		sortBy: queryType === FLSS_QUERY_TYPE ? lendToFlssSort.get(query.sortBy) : query.sortBy,
 		sectorId: getSectorIdsFromQueryParam(query.sector, allFacets.sectorNames, allFacets.sectorFacets, true),
 		theme: getThemeNamesQueryParam(query.attribute, allFacets.themeFacets),
-		// TODO: replace previous state usage as query param support expands
-		...(previousState && { countryIsoCode: previousState.countryIsoCode })
 	};
 
 	await updateSearchState(apollo, filters, allFacets, queryType, previousState);

--- a/src/util/numberUtils.js
+++ b/src/util/numberUtils.js
@@ -8,7 +8,7 @@
  * @returns Whether the value is a number
  */
 export function isNumber(value) {
-	if (value === null || ['object', 'boolean'].includes(typeof value)) return false;
+	if (['object', 'boolean'].includes(typeof value)) return false;
 
 	return !Number.isNaN(Number(value));
 }

--- a/src/util/numberUtils.js
+++ b/src/util/numberUtils.js
@@ -1,0 +1,14 @@
+// TODO: remove eslint-disable when more exports are added
+/* eslint-disable import/prefer-default-export */
+
+/**
+ * Returns whether the provided value is a number
+ *
+ * @param {*} value The value to check
+ * @returns Whether the value is a number
+ */
+export function isNumber(value) {
+	if (value === null || ['object', 'boolean'].includes(typeof value)) return false;
+
+	return !Number.isNaN(Number(value));
+}

--- a/test/unit/specs/api/localResolvers/loanSearch.spec.js
+++ b/test/unit/specs/api/localResolvers/loanSearch.spec.js
@@ -1,16 +1,6 @@
-import loanSearchFactory from '@/api/localResolvers/loanSearch';
+import loanSearchFactory, { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
 
-const defaultLoanSearchState = {
-	loanSearchState: {
-		id: 'SearchData',
-		gender: '',
-		countryIsoCode: [],
-		sectorId: [],
-		sortBy: '',
-		theme: [],
-		__typename: 'LoanSearchState',
-	}
-};
+const defaultLoanSearchState = getDefaultLoanSearchState();
 
 describe('loanSearch.js', () => {
 	describe('Query.loanSearchState', () => {

--- a/test/unit/specs/components/Kv/KvPager.spec.js
+++ b/test/unit/specs/components/Kv/KvPager.spec.js
@@ -10,7 +10,7 @@ describe('KvPager', () => {
 	it('should render arrows disabled by default', async () => {
 		const user = userEvent.setup();
 
-		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 0 } });
+		const { getByLabelText, emitted } = render(KvPager, { props: { limit: 10, total: 0 } });
 
 		await user.click(getByLabelText('Previous page'));
 		await user.click(getByLabelText('Next page'));
@@ -19,13 +19,13 @@ describe('KvPager', () => {
 	});
 
 	it('should render aria current page label', () => {
-		const { getByText } = render(KvPager, { props: { pageSize: 10, total: 30 } });
+		const { getByText } = render(KvPager, { props: { limit: 10, total: 30 } });
 
 		getByText("You're on page");
 	});
 
 	it('should render fewer pages', () => {
-		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 30 } });
+		const { getByLabelText } = render(KvPager, { props: { limit: 10, total: 30 } });
 
 		getByLabelText('Page 1');
 		getByLabelText('Page 2');
@@ -33,7 +33,7 @@ describe('KvPager', () => {
 	});
 
 	it('should render more pages', () => {
-		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000 } });
+		const { getByLabelText } = render(KvPager, { props: { limit: 10, total: 1000 } });
 
 		getByLabelText('Page 1');
 		getByLabelText('Page 2');
@@ -43,7 +43,7 @@ describe('KvPager', () => {
 	});
 
 	it('should render fourth selected', () => {
-		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 3 } });
+		const { getByLabelText } = render(KvPager, { props: { limit: 10, total: 1000, offset: 30 } });
 
 		getByLabelText('Page 1');
 		getByLabelText('Page 3');
@@ -53,7 +53,7 @@ describe('KvPager', () => {
 	});
 
 	it('should render last selected', () => {
-		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 99 } });
+		const { getByLabelText } = render(KvPager, { props: { limit: 10, total: 1000, offset: 990 } });
 
 		getByLabelText('Page 1');
 		getByLabelText('Page 97');
@@ -63,7 +63,7 @@ describe('KvPager', () => {
 	});
 
 	it('should render fourth to last last selected', () => {
-		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 96 } });
+		const { getByLabelText } = render(KvPager, { props: { limit: 10, total: 1000, offset: 960 } });
 
 		getByLabelText('Page 1');
 		getByLabelText('Page 96');
@@ -73,7 +73,7 @@ describe('KvPager', () => {
 	});
 
 	it('should render more extra pages', () => {
-		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, extraPages: 6 } });
+		const { getByLabelText } = render(KvPager, { props: { limit: 10, total: 1000, extraPages: 6 } });
 
 		getByLabelText('Page 1');
 		getByLabelText('Page 2');
@@ -88,18 +88,18 @@ describe('KvPager', () => {
 	it('should emit page click', async () => {
 		const user = userEvent.setup();
 
-		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000 } });
+		const { getByLabelText, emitted } = render(KvPager, { props: { limit: 10, total: 1000 } });
 
 		await user.click(getByLabelText('Page 2'));
 
 		expect(global.scrollTo).toHaveBeenCalledTimes(1);
-		expect(emitted()['page-changed']).toEqual([[{ pageNumber: 1 }]]);
+		expect(emitted()['page-changed']).toEqual([[{ pageOffset: 10 }]]);
 	});
 
 	it('should not emit current page click', async () => {
 		const user = userEvent.setup();
 
-		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000 } });
+		const { getByLabelText, emitted } = render(KvPager, { props: { limit: 10, total: 1000 } });
 
 		await user.click(getByLabelText('Page 1'));
 
@@ -109,22 +109,22 @@ describe('KvPager', () => {
 	it('should emit previous click', async () => {
 		const user = userEvent.setup();
 
-		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 1 } });
+		const { getByLabelText, emitted } = render(KvPager, { props: { limit: 10, total: 1000, offset: 10 } });
 
 		await user.click(getByLabelText('Previous page'));
 
 		expect(global.scrollTo).toHaveBeenCalledTimes(1);
-		expect(emitted()['page-changed']).toEqual([[{ pageNumber: 0 }]]);
+		expect(emitted()['page-changed']).toEqual([[{ pageOffset: 0 }]]);
 	});
 
 	it('should emit next click', async () => {
 		const user = userEvent.setup();
 
-		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 0 } });
+		const { getByLabelText, emitted } = render(KvPager, { props: { limit: 10, total: 1000 } });
 
 		await user.click(getByLabelText('Next page'));
 
 		expect(global.scrollTo).toHaveBeenCalledTimes(1);
-		expect(emitted()['page-changed']).toEqual([[{ pageNumber: 1 }]]);
+		expect(emitted()['page-changed']).toEqual([[{ pageOffset: 10 }]]);
 	});
 });

--- a/test/unit/specs/components/Kv/KvPager.spec.js
+++ b/test/unit/specs/components/Kv/KvPager.spec.js
@@ -1,0 +1,130 @@
+import { render } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import KvPager from '@/components/Kv/KvPager';
+
+global.scrollTo = jest.fn();
+
+describe('KvPager', () => {
+	afterEach(jest.clearAllMocks);
+
+	it('should render arrows disabled by default', async () => {
+		const user = userEvent.setup();
+
+		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 0 } });
+
+		await user.click(getByLabelText('Previous page'));
+		await user.click(getByLabelText('Next page'));
+
+		expect(emitted()['page-changed']).toBe(undefined);
+	});
+
+	it('should render aria current page label', () => {
+		const { getByText } = render(KvPager, { props: { pageSize: 10, total: 30 } });
+
+		getByText("You're on page");
+	});
+
+	it('should render fewer pages', () => {
+		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 30 } });
+
+		getByLabelText('Page 1');
+		getByLabelText('Page 2');
+		getByLabelText('Page 3');
+	});
+
+	it('should render more pages', () => {
+		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000 } });
+
+		getByLabelText('Page 1');
+		getByLabelText('Page 2');
+		getByLabelText('Page 3');
+		getByLabelText('Page 4');
+		getByLabelText('Page 100');
+	});
+
+	it('should render fourth selected', () => {
+		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 3 } });
+
+		getByLabelText('Page 1');
+		getByLabelText('Page 3');
+		getByLabelText('Page 4');
+		getByLabelText('Page 5');
+		getByLabelText('Page 100');
+	});
+
+	it('should render last selected', () => {
+		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 99 } });
+
+		getByLabelText('Page 1');
+		getByLabelText('Page 97');
+		getByLabelText('Page 98');
+		getByLabelText('Page 99');
+		getByLabelText('Page 100');
+	});
+
+	it('should render fourth to last last selected', () => {
+		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 96 } });
+
+		getByLabelText('Page 1');
+		getByLabelText('Page 96');
+		getByLabelText('Page 97');
+		getByLabelText('Page 98');
+		getByLabelText('Page 100');
+	});
+
+	it('should render more extra pages', () => {
+		const { getByLabelText } = render(KvPager, { props: { pageSize: 10, total: 1000, extraPages: 6 } });
+
+		getByLabelText('Page 1');
+		getByLabelText('Page 2');
+		getByLabelText('Page 3');
+		getByLabelText('Page 4');
+		getByLabelText('Page 5');
+		getByLabelText('Page 6');
+		getByLabelText('Page 7');
+		getByLabelText('Page 100');
+	});
+
+	it('should emit page click', async () => {
+		const user = userEvent.setup();
+
+		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000 } });
+
+		await user.click(getByLabelText('Page 2'));
+
+		expect(global.scrollTo).toHaveBeenCalledTimes(1);
+		expect(emitted()['page-changed']).toEqual([[{ pageNumber: 1 }]]);
+	});
+
+	it('should not emit current page click', async () => {
+		const user = userEvent.setup();
+
+		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000 } });
+
+		await user.click(getByLabelText('Page 1'));
+
+		expect(emitted()['page-changed']).toBe(undefined);
+	});
+
+	it('should emit previous click', async () => {
+		const user = userEvent.setup();
+
+		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 1 } });
+
+		await user.click(getByLabelText('Previous page'));
+
+		expect(global.scrollTo).toHaveBeenCalledTimes(1);
+		expect(emitted()['page-changed']).toEqual([[{ pageNumber: 0 }]]);
+	});
+
+	it('should emit next click', async () => {
+		const user = userEvent.setup();
+
+		const { getByLabelText, emitted } = render(KvPager, { props: { pageSize: 10, total: 1000, current: 0 } });
+
+		await user.click(getByLabelText('Next page'));
+
+		expect(global.scrollTo).toHaveBeenCalledTimes(1);
+		expect(emitted()['page-changed']).toEqual([[{ pageNumber: 1 }]]);
+	});
+});

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -33,9 +33,9 @@ describe('flssUtils.js', () => {
 			query: flssLoanQuery,
 			variables: {
 				filterObject: loanQueryFilters,
-				limit: 20,
 				sortBy: 'personalized',
 				pageNumber: 0,
+				pageSize: 15,
 			},
 			fetchPolicy: 'network-only',
 		};

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -28,25 +28,26 @@ describe('flssUtils.js', () => {
 		const apollo = { query: jest.fn(() => Promise.resolve(dataObj)) };
 		const loanQueryFilters = { any: ['US'] };
 		const sortBy = 'personalized';
-		const pageOffset = 0;
+		const pageOffset = 15;
+		const pageLimit = 5;
 		const apolloVariables = {
 			query: flssLoanQuery,
 			variables: {
 				filterObject: loanQueryFilters,
 				sortBy: 'personalized',
-				pageNumber: 0,
-				pageSize: 15,
+				pageNumber: 3,
+				pageLimit,
 			},
 			fetchPolicy: 'network-only',
 		};
 
 		it('should pass the correct query variables to apollo', async () => {
-			await fetchLoans(apollo, loanQueryFilters, sortBy, pageOffset);
+			await fetchLoans(apollo, loanQueryFilters, sortBy, pageOffset, pageLimit);
 			expect(apollo.query).toHaveBeenCalledWith(apolloVariables);
 		});
 
 		it('should return the fundraising loans data', async () => {
-			const data = await fetchLoans(apollo, loanQueryFilters, sortBy, pageOffset);
+			const data = await fetchLoans(apollo, loanQueryFilters, sortBy, pageOffset, pageLimit);
 			expect(data).toBe(result);
 		});
 	});

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -30,8 +30,8 @@ const mockState = {
 	sectorId: [1],
 	sortBy: 'expiringSoon',
 	theme: ['THEME 1'],
-	pageNumber: 1,
-	pageSize: 30,
+	pageOffset: 1,
+	pageLimit: 30,
 };
 
 const mockAllFacets = {
@@ -154,20 +154,20 @@ describe('loanSearchUtils.js', () => {
 			expect(result).toEqual({ ...mockState, theme: [] });
 		});
 
-		it('should validate pageNumber', () => {
-			const state = { ...mockState, pageNumber: 'asd' };
+		it('should validate pageOffset', () => {
+			const state = { ...mockState, pageOffset: 'asd' };
 
 			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
 
-			expect(result).toEqual({ ...mockState, pageNumber: 0 });
+			expect(result).toEqual({ ...mockState, pageOffset: 0 });
 		});
 
-		it('should validate pageSize', () => {
-			const state = { ...mockState, pageSize: 'asd' };
+		it('should validate pageLimit', () => {
+			const state = { ...mockState, pageLimit: 'asd' };
 
 			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
 
-			expect(result).toEqual({ ...mockState, pageSize: 15 });
+			expect(result).toEqual({ ...mockState, pageLimit: 15 });
 		});
 	});
 
@@ -595,8 +595,8 @@ describe('loanSearchUtils.js', () => {
 				apollo,
 				getFlssFilters(mockState),
 				mockState.sortBy,
-				mockState.pageNumber,
-				mockState.pageSize
+				mockState.pageOffset,
+				mockState.pageLimit
 			);
 			expect(result).toEqual({ loans, totalCount });
 		});
@@ -802,8 +802,8 @@ describe('loanSearchUtils.js', () => {
 						sectorId: [1],
 						sortBy: 'expiringSoon',
 						theme: ['THEME 1'],
-						pageNumber: 0,
-						pageSize: 15,
+						pageOffset: 0,
+						pageLimit: 15,
 					}
 				}
 			};

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -29,7 +29,9 @@ const mockState = {
 	countryIsoCode: ['US'],
 	sectorId: [1],
 	sortBy: 'expiringSoon',
-	theme: ['THEME 1']
+	theme: ['THEME 1'],
+	pageNumber: 1,
+	pageSize: 30,
 };
 
 const mockAllFacets = {
@@ -150,6 +152,22 @@ describe('loanSearchUtils.js', () => {
 			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
 
 			expect(result).toEqual({ ...mockState, theme: [] });
+		});
+
+		it('should validate pageNumber', () => {
+			const state = { ...mockState, pageNumber: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, pageNumber: 0 });
+		});
+
+		it('should validate pageSize', () => {
+			const state = { ...mockState, pageSize: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, STANDARD_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, pageSize: 15 });
 		});
 	});
 
@@ -572,8 +590,14 @@ describe('loanSearchUtils.js', () => {
 		afterEach(jest.restoreAllMocks);
 
 		it('should return loans', async () => {
-			const result = await runLoansQuery(apollo);
-			expect(spyFetchLoans).toHaveBeenCalledWith(apollo, {}, null);
+			const result = await runLoansQuery(apollo, mockState);
+			expect(spyFetchLoans).toHaveBeenCalledWith(
+				apollo,
+				getFlssFilters(mockState),
+				mockState.sortBy,
+				mockState.pageNumber,
+				mockState.pageSize
+			);
 			expect(result).toEqual({ loans, totalCount });
 		});
 	});
@@ -777,7 +801,9 @@ describe('loanSearchUtils.js', () => {
 						countryIsoCode: [],
 						sectorId: [1],
 						sortBy: 'expiringSoon',
-						theme: ['THEME 1']
+						theme: ['THEME 1'],
+						pageNumber: 0,
+						pageSize: 15,
 					}
 				}
 			};

--- a/test/unit/specs/util/numberUtils.spec.js
+++ b/test/unit/specs/util/numberUtils.spec.js
@@ -1,0 +1,33 @@
+import { isNumber } from '@/util/numberUtils';
+
+describe('numberUtils.js', () => {
+	describe('isNumber', () => {
+		it('should validate number', () => {
+			expect(isNumber(-1)).toBe(true);
+			expect(isNumber(0)).toBe(true);
+			expect(isNumber(1)).toBe(true);
+			expect(isNumber(1.5)).toBe(true);
+			expect(isNumber(5.321456)).toBe(true);
+			expect(isNumber(500)).toBe(true);
+			expect(isNumber('-1')).toBe(true);
+			expect(isNumber('0')).toBe(true);
+			expect(isNumber('1')).toBe(true);
+			expect(isNumber('1.5')).toBe(true);
+			expect(isNumber('5.321456')).toBe(true);
+			expect(isNumber('500')).toBe(true);
+		});
+
+		it('should validate non-number', () => {
+			expect(isNumber({})).toBe(false);
+			expect(isNumber([])).toBe(false);
+			expect(isNumber(NaN)).toBe(false);
+			expect(isNumber(null)).toBe(false);
+			expect(isNumber(undefined)).toBe(false);
+			expect(isNumber(true)).toBe(false);
+			expect(isNumber(false)).toBe(false);
+			expect(isNumber('.')).toBe(false);
+			expect(isNumber('1asd')).toBe(false);
+			expect(isNumber('1.asd')).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1033
https://kiva.atlassian.net/browse/VUE-1059

- Implemented new `KvPager` component
- The existing `KvPagination` used the Vue router directly, both accessing the query params and pushing routes, so I created a new component without that dependency
- The new pager component is entirely tailwind and has the new arrow icons, but it retains the existing behavior (I fixed one edge case as well from the existing component)
- Added `pageOffset` and `pageLimit` to `loanSearchState`
- There are some conversions between offset and page number in the areas that need page numbers (FLSS + pager), but the state holds the more generic offset and limit values
- Created `numberUtils`, since I kept needing a simple method to check if a value is a number

![image](https://user-images.githubusercontent.com/16867161/173461720-fbb16dd0-784e-4fa0-b1c0-446c0708c523.png)

![image](https://user-images.githubusercontent.com/16867161/173461691-914d2fd2-8fac-40c2-9cd6-6b4c947496c2.png)