### PR TITLE
Vue 1086 adjust pageview loans shown events for filters

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -159,8 +159,11 @@ router.onReady(() => {
 	router.afterEach((to, from) => {
 		// finish loading
 		app.$Progress.finish();
-		// fire pageview
-		app.$fireAsyncPageView(to, from);
+
+		if (!to?.params?.noAnalytics) {
+			// fire pageview
+			app.$fireAsyncPageView(to, from);
+		}
 	});
 
 	router.onError(() => app.$Progress.fail());

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -214,14 +214,16 @@ export default {
 	},
 	methods: {
 		trackLoans() {
-			const hits = this.loans.map(l => l.id).join();
+			const hitIds = this.loans.map(l => l.id);
+			const hits = hitIds.join();
 
 			if (hits !== this.trackedHits) {
 				this.$kvTrackEvent(
 					'Lending',
 					hits ? 'loans-shown' : 'zero-loans-shown',
 					hits ? 'loan-ids' : undefined,
-					hits || undefined
+					hits || undefined,
+					hitIds.length ? hitIds.length : 0,
 				);
 
 				this.trackedHits = hits;

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -579,6 +579,6 @@ export function updateQueryParams(loanSearchState, router, allFacets, queryType)
 
 	// Vue throws duplicate navigation exception when identical paths are pushed to the router
 	if (!doParamsMatch) {
-		router.push({ ...router.currentRoute, query: newParams, params: { noScroll: true } });
+		router.push({ ...router.currentRoute, query: newParams, params: { noScroll: true, noAnalytics: true } });
 	}
 }

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -902,7 +902,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { ...state, utm_test: 'test' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -912,7 +912,11 @@ describe('loanSearchUtils.js', () => {
 
 			updateQueryParams(state, router, mockAllFacets, FLSS_QUERY_TYPE);
 
-			expect(router.push).toHaveBeenCalledWith({ name: 'name', query: state, params: { noScroll: true } });
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: state,
+				params: { noScroll: true, noAnalytics: true }
+			});
 		});
 
 		it('should push sector IDs', async () => {
@@ -924,7 +928,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { sector: '1,2' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -937,7 +941,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { gender: 'female' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -950,7 +954,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { attribute: '1,2' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -963,7 +967,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { gender: 'female' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -976,7 +980,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { sortBy: 'popularity' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -989,7 +993,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { sortBy: 'personalized' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1086

- Added optional route param support (`noAnalytics`) to allowing skipping page view analytics
- Added hit counts to `loans-shown` event