### PR TITLE
fix: hide lend button when all shared are reserved

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -150,7 +150,7 @@
 		<!-- Lend button -->
 		<kv-ui-button
 			key="lendButton"
-			v-if="!isLoading && inBorrowerProfilePage && !isAdding"
+			v-if="!allSharesReserved && !isLoading && inBorrowerProfilePage && !isAdding"
 			class="tw-inline-flex tw-flex-1"
 			data-testid="bp-lend-cta-lend-button"
 			type="submit"


### PR DESCRIPTION
`KivaClassicBasicLoanCard` component shows the `Lend` button when shares are reserved and it’s not possible to lend. This change hides the lend button when `allSharesReserved` variable is `true`.

<img width="361" alt="image" src="https://user-images.githubusercontent.com/56947778/173697693-ce5d2f4d-7c35-44e6-a3eb-a72e909baae4.png">
