### PR TITLE
feat: page query param support

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -176,7 +176,7 @@ export default {
 		this.allFacets = await fetchLoanFacets(this.apollo);
 
 		// Initialize the search filters with the query string params
-		await applyQueryParams(this.apollo, this.$route.query, this.allFacets, this.queryType);
+		await applyQueryParams(this.apollo, this.$route.query, this.allFacets, this.queryType, this.loanSearchState);
 
 		// Here we subscribe to the loanSearchState and run the loan query when it updates
 		// TODO: work some guards to prevent duplicate queries and throttling to more carefully control # of queries

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -30,8 +30,8 @@ const mockState = {
 	sectorId: [1],
 	sortBy: 'expiringSoon',
 	theme: ['THEME 1'],
-	pageOffset: 1,
-	pageLimit: 30,
+	pageOffset: 10,
+	pageLimit: 5,
 };
 
 const mockAllFacets = {
@@ -798,18 +798,23 @@ describe('loanSearchUtils.js', () => {
 				variables: {
 					searchParams: {
 						gender: 'female',
-						countryIsoCode: [],
+						countryIsoCode: ['US'],
 						sectorId: [1],
 						sortBy: 'expiringSoon',
 						theme: ['THEME 1'],
-						pageOffset: 0,
-						pageLimit: 15,
+						pageOffset: 5,
+						pageLimit: 5,
 					}
 				}
 			};
-			const query = { ...mockState, sector: mockState.sectorId.toString(), attribute: '1' };
+			const query = {
+				...mockState,
+				sector: mockState.sectorId.toString(),
+				attribute: '1',
+				page: '2',
+			};
 
-			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE);
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -825,6 +830,7 @@ describe('loanSearchUtils.js', () => {
 						sortBy: 'personalized',
 						sectorId: [1],
 						theme: ['THEME 1'],
+						pageOffset: 0,
 					}
 				},
 			};
@@ -851,6 +857,7 @@ describe('loanSearchUtils.js', () => {
 						sortBy: 'personalized',
 						sectorId: [],
 						theme: [],
+						pageOffset: 0,
 					}
 				},
 			};
@@ -872,6 +879,7 @@ describe('loanSearchUtils.js', () => {
 						sortBy: 'popularity',
 						sectorId: [],
 						theme: [],
+						pageOffset: 0,
 					}
 				},
 			};
@@ -882,9 +890,80 @@ describe('loanSearchUtils.js', () => {
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
 
+		it('should support page', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: {
+					searchParams: {
+						...mockState,
+						gender: null,
+						sortBy: null,
+						sectorId: [],
+						theme: [],
+						pageOffset: 15,
+					}
+				},
+			};
+			const query = { page: '4' };
+
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should handle negative page', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: {
+					searchParams: {
+						...mockState,
+						gender: null,
+						sortBy: null,
+						sectorId: [],
+						theme: [],
+						pageOffset: 0,
+					}
+				},
+			};
+			const query = { page: '-1' };
+
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should handle non-number page', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: {
+					searchParams: {
+						...mockState,
+						gender: null,
+						sortBy: null,
+						sectorId: [],
+						theme: [],
+						pageOffset: 0,
+					}
+				},
+			};
+			const query = { page: 'asd' };
+
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
 		it('should not update cache when state unchanged', async () => {
 			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
-			const query = { ...mockState, sector: mockState.sectorId.toString(), attribute: '1' };
+			const query = {
+				...mockState,
+				sector: mockState.sectorId.toString(),
+				attribute: '1',
+				page: '3',
+			};
 
 			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
 
@@ -893,7 +972,7 @@ describe('loanSearchUtils.js', () => {
 	});
 
 	describe('updateQueryParams', () => {
-		it('should preserve UTM params', async () => {
+		it('should preserve UTM params', () => {
 			const state = { gender: 'female' };
 			const router = { currentRoute: { name: 'name', query: { utm_test: 'test' } }, push: jest.fn() };
 
@@ -906,7 +985,7 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should push gender', async () => {
+		it('should push gender', () => {
 			const state = { gender: 'female' };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -915,7 +994,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({ name: 'name', query: state, params: { noScroll: true } });
 		});
 
-		it('should push sector IDs', async () => {
+		it('should push sector IDs', () => {
 			const state = { sectorId: [1, 2] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -928,7 +1007,7 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should not push empty sector ID', async () => {
+		it('should not push empty sector ID', () => {
 			const state = { gender: 'female', sectorId: [] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -941,7 +1020,7 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should push theme IDs', async () => {
+		it('should push theme IDs', () => {
 			const state = { theme: ['THEME 1', 'THEME 2'] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -954,7 +1033,7 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should not push empty theme ID', async () => {
+		it('should not push empty theme ID', () => {
 			const state = { gender: 'female', theme: [] };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -967,7 +1046,7 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should push mapped FLSS sort value', async () => {
+		it('should push mapped FLSS sort value', () => {
 			const state = { sortBy: 'personalized' };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -980,7 +1059,7 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should push standard sort value', async () => {
+		it('should push standard sort value', () => {
 			const state = { sortBy: 'personalized' };
 			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
 
@@ -993,7 +1072,33 @@ describe('loanSearchUtils.js', () => {
 			});
 		});
 
-		it('should not push identical query string', async () => {
+		it('should push page', () => {
+			const state = { pageOffset: 10, pageLimit: 2 };
+			const router = { currentRoute: { name: 'name', query: {} }, push: jest.fn() };
+
+			updateQueryParams(state, router, mockAllFacets, STANDARD_QUERY_TYPE);
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: { page: '6' },
+				params: { noScroll: true }
+			});
+		});
+
+		it('should remove page if first page', () => {
+			const state = { pageOffset: 0, pageLimit: 2 };
+			const router = { currentRoute: { name: 'name', query: { page: '1' } }, push: jest.fn() };
+
+			updateQueryParams(state, router, mockAllFacets, STANDARD_QUERY_TYPE);
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: { },
+				params: { noScroll: true }
+			});
+		});
+
+		it('should not push identical query string', () => {
 			const state = { gender: 'female' };
 			const router = { currentRoute: { name: 'name', query: { gender: 'female' } }, push: jest.fn() };
 

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -1085,7 +1085,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { page: '6' },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 
@@ -1098,7 +1098,7 @@ describe('loanSearchUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { },
-				params: { noScroll: true }
+				params: { noScroll: true, noAnalytics: true }
 			});
 		});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1054
https://kiva.atlassian.net/browse/VUE-1049

- Query params now supports page
- Query param for page not added if page is "1"
- Simple validation added: checks for number above 0 (logged ticket for handling number above available pages)