### PR TITLE
feat: results per page component

### DIFF
--- a/.storybook/stories/KvResultsPerPage.stories.js
+++ b/.storybook/stories/KvResultsPerPage.stories.js
@@ -1,0 +1,22 @@
+import KvResultsPerPage from '@/components/Kv/KvResultsPerPage';
+
+export default {
+	title: 'Kv/KvResultsPerPage',
+	component: KvResultsPerPage,
+};
+
+const story = (args) => {
+	const template = (_args, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { KvResultsPerPage },
+		template: `<kv-results-per-page :options="options" :selected="selected" />`,
+	})
+	template.args = args;
+	return template;
+};
+
+export const Default = story();
+
+export const Options = story({ options: [1, 2, 3] });
+
+export const Selected = story({ options: [1, 2, 3], selected: 2 });

--- a/src/components/Kv/KvResultsPerPage.vue
+++ b/src/components/Kv/KvResultsPerPage.vue
@@ -1,0 +1,65 @@
+<template>
+	<fieldset class="tw-flex tw-items-center tw-justify-center tw-my-3" aria-label="Results per page">
+		<label class="tw-text-secondary tw-whitespace-nowrap tw-mr-2">
+			Loans per page
+		</label>
+		<kv-select id="results-per-page" v-model="selectedOption" @change="handleChanged">
+			<option v-for="(option, i) in options" :key="i" :value="option" :aria-label="`${option} per page`">
+				{{ option }}
+			</option>
+		</kv-select>
+	</fieldset>
+</template>
+
+<script>
+import KvSelect from '~/@kiva/kv-components/vue/KvSelect';
+
+export const defaultOptions = [15, 25, 50];
+
+export default {
+	name: 'KvResultsPerPage',
+	components: {
+		KvSelect,
+	},
+	props: {
+		options: {
+			type: Array,
+			default: () => defaultOptions,
+			validator: value => value.length > 0,
+		},
+		selected: {
+			type: Number,
+			default: undefined
+		},
+		scrollToTop: {
+			type: Boolean,
+			default: true,
+		},
+	},
+	data() {
+		return {
+			selectedOption: this.selected || this.options?.[0],
+		};
+	},
+	methods: {
+		handleChanged(pageLimit) {
+			if (this.scrollToTop && window.scrollTo) {
+				window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+			}
+
+			this.$emit('updated', { pageLimit: +pageLimit });
+		}
+	},
+	watch: {
+		selected(next) {
+			// Ensure the value is a valid option
+			const nextSelected = this.options.includes(next) ? next : this.options?.[0];
+
+			if (nextSelected !== this.selectedOption) {
+				// Don't emit when value is changed via the component prop
+				this.selectedOption = nextSelected;
+			}
+		},
+	},
+};
+</script>

--- a/src/components/Kv/KvResultsPerPage.vue
+++ b/src/components/Kv/KvResultsPerPage.vue
@@ -48,6 +48,8 @@ export default {
 			}
 
 			this.$emit('updated', { pageLimit: +pageLimit });
+
+			this.$kvTrackEvent?.('Lending', 'click-results-per-page', pageLimit);
 		}
 	},
 	watch: {

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -59,6 +59,11 @@
 				:offset="loanSearchState.pageOffset"
 				@page-changed="handleUpdatedFilters"
 			/>
+			<kv-results-per-page
+				v-if="initialLoadComplete"
+				:selected="loanSearchState.pageLimit"
+				@updated="handleResultsPerPage"
+			/>
 		</div>
 	</div>
 </template>
@@ -82,10 +87,14 @@ import {
 } from '@/util/loanSearchUtils';
 import KvSectionModalLoader from '@/components/Kv/KvSectionModalLoader';
 import KvPager from '@/components/Kv/KvPager';
+import KvResultsPerPage from '@/components/Kv/KvResultsPerPage';
 import { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
+import { isNumber } from '@/util//numberUtils';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
+
+const COOKIE_KEY = 'kv-search-result-count';
 
 export default {
 	name: 'LoanSearchInterface',
@@ -98,6 +107,7 @@ export default {
 		KvLightbox,
 		KvSectionModalLoader,
 		KvPager,
+		KvResultsPerPage,
 	},
 	data() {
 		return {
@@ -176,7 +186,7 @@ export default {
 		this.allFacets = await fetchLoanFacets(this.apollo);
 
 		// Initialize the search filters with the query string params
-		await applyQueryParams(this.apollo, this.$route.query, this.allFacets, this.queryType, this.loanSearchState);
+		await applyQueryParams(this.apollo, this.$route.query, this.allFacets, this.queryType, this.defaultPageLimit);
 
 		// Here we subscribe to the loanSearchState and run the loan query when it updates
 		// TODO: work some guards to prevent duplicate queries and throttling to more carefully control # of queries
@@ -222,6 +232,13 @@ export default {
 			}
 		});
 	},
+	computed: {
+		defaultPageLimit() {
+			const storedPageLimit = this.cookieStore.get(COOKIE_KEY);
+
+			return isNumber(storedPageLimit) ? +storedPageLimit : this.loanSearchState.pageLimit;
+		},
+	},
 	methods: {
 		trackLoans() {
 			const hitIds = this.loans.map(l => l.id);
@@ -251,11 +268,28 @@ export default {
 		handleResetFilters() {
 			this.updateState();
 		},
+		handleResultsPerPage(payload) {
+			// Reset to first page when page limit changes
+			this.updateState({ ...this.loanSearchState, ...payload, pageOffset: 0 });
+
+			// Set cookie with 2 year expiration
+			const expires = new Date();
+			expires.setFullYear(expires.getFullYear() + 2);
+
+			this.cookieStore.set(COOKIE_KEY, payload.pageLimit, { expires });
+		},
 	},
 	watch: {
 		$route(to) {
 			// Update the loan search state when the user clicks back/forward in the browser
-			applyQueryParams(this.apollo, to.query, this.allFacets, this.queryType, this.loanSearchState);
+			applyQueryParams(
+				this.apollo,
+				to.query,
+				this.allFacets,
+				this.queryType,
+				this.loanSearchState.pageLimit,
+				this.loanSearchState
+			);
 		}
 	}
 };

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -41,6 +41,15 @@
 			<div v-if="initialLoadComplete" class="tw-hidden md:tw-block tw-h-4 tw-mb-2 md:tw-mb-3 lg:tw-mb-3.5">
 				<p>{{ totalCount }} Loans</p>
 			</div>
+			<template v-if="initialLoadComplete && totalCount === 0">
+				<p class="tw-text-center">
+					All borrowers matching this search have been funded.
+				</p>
+				<p class="tw-text-center tw-mt-2">
+					Please adjust your criteria or
+					<a class="tw-cursor-pointer" @click="handleResetFilters">start a new search.</a>
+				</p>
+			</template>
 			<kv-grid class="tw-grid-rows-4">
 				<loan-card-controller
 					v-for="loan in loans"
@@ -52,18 +61,18 @@
 					:rounded-corners="true"
 				/>
 			</kv-grid>
-			<kv-pager
-				v-if="totalCount > 0"
-				:limit="loanSearchState.pageLimit"
-				:total="totalCount"
-				:offset="loanSearchState.pageOffset"
-				@page-changed="handleUpdatedFilters"
-			/>
-			<kv-results-per-page
-				v-if="initialLoadComplete"
-				:selected="loanSearchState.pageLimit"
-				@updated="handleResultsPerPage"
-			/>
+			<template v-if="initialLoadComplete && totalCount > 0">
+				<kv-pager
+					:limit="loanSearchState.pageLimit"
+					:total="totalCount"
+					:offset="loanSearchState.pageOffset"
+					@page-changed="handleUpdatedFilters"
+				/>
+				<kv-results-per-page
+					:selected="loanSearchState.pageLimit"
+					@updated="handleResultsPerPage"
+				/>
+			</template>
 		</div>
 	</div>
 </template>

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -510,19 +510,21 @@ export function getThemeNamesQueryParam(param, facets) {
  * @param {Object} query The Vue Router query object (this.$route.query)
  * @param {Object} allFacets All available facets from the APIs
  * @param {string} queryType The current query type (lend vs FLSS)
+ * @param {number} pageLimit The limit/size of the page
  * @param {Object} previousState The previous search state
  */
-export async function applyQueryParams(apollo, query, allFacets, queryType, previousState) {
-	// Convert query param 1-based page to pager 0-based page
-	const page = isNumber(query.page) && query.page > 0 ? query.page - 1 : 0;
+export async function applyQueryParams(apollo, query, allFacets, queryType, pageLimit, previousState = {}) {
+	// Convert query param 1-based page to pager 0-based page and ensure page is an integer
+	const page = isNumber(query.page) && query.page >= 1 ? Math.floor(query.page) - 1 : 0;
 
 	const filters = {
-		...previousState, // The countryIsoCode and pageLimit are not currently in the query params
 		gender: query.gender,
-		sortBy: queryType === FLSS_QUERY_TYPE ? lendToFlssSort.get(query.sortBy) : query.sortBy,
+		countryIsoCode: previousState.countryIsoCode,
 		sectorId: getSectorIdsFromQueryParam(query.sector, allFacets.sectorNames, allFacets.sectorFacets, true),
+		sortBy: queryType === FLSS_QUERY_TYPE ? lendToFlssSort.get(query.sortBy) : query.sortBy,
 		theme: getThemeNamesQueryParam(query.attribute, allFacets.themeFacets),
-		pageOffset: page * previousState.pageLimit,
+		pageOffset: page * pageLimit,
+		pageLimit,
 	};
 
 	await updateSearchState(apollo, filters, allFacets, queryType, previousState);

--- a/test/unit/specs/components/Kv/KvResultsPerPage.spec.js
+++ b/test/unit/specs/components/Kv/KvResultsPerPage.spec.js
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import KvResultsPerPage, { defaultOptions } from '@/components/Kv/KvResultsPerPage';
+
+global.scrollTo = jest.fn();
+
+describe('KvResultsPerPage', () => {
+	afterEach(jest.clearAllMocks);
+
+	it('should render default options', () => {
+		const { getByLabelText } = render(KvResultsPerPage);
+
+		defaultOptions.forEach(option => {
+			getByLabelText(`${option} per page`);
+		});
+	});
+
+	it('should render all options', () => {
+		const options = [1, 2, 3];
+
+		const { getByLabelText } = render(KvResultsPerPage, { props: { options } });
+
+		options.forEach(option => {
+			getByLabelText(`${option} per page`);
+		});
+	});
+
+	it('should select prop by default', () => {
+		const options = [1, 2, 3];
+
+		const { getByRole } = render(KvResultsPerPage, { props: { options, selected: 2 } });
+
+		expect(getByRole('combobox').value).toBe('2');
+	});
+
+	it('should emit updated', async () => {
+		const user = userEvent.setup();
+
+		const options = [1, 2, 3];
+
+		const { getByRole, emitted } = render(KvResultsPerPage, { props: { options } });
+
+		await user.selectOptions(getByRole('combobox'), '1');
+
+		expect(global.scrollTo).toHaveBeenCalledTimes(1);
+		expect(emitted().updated).toEqual([[{ pageLimit: 1 }]]);
+	});
+
+	it('should not emit updated with prop change', async () => {
+		const options = [1, 2, 3];
+
+		const { updateProps, getByRole, emitted } = render(KvResultsPerPage, { props: { options } });
+
+		await updateProps({ selected: 2 });
+
+		expect(getByRole('combobox').value).toBe('2');
+		expect(emitted().updated).toBe(undefined);
+	});
+
+	it('should not set invalid option', async () => {
+		const options = [1, 2, 3];
+
+		const { updateProps, getByRole } = render(KvResultsPerPage, { props: { options, selected: 2 } });
+
+		expect(getByRole('combobox').value).toBe('2');
+
+		await updateProps({ selected: 4 });
+
+		expect(getByRole('combobox').value).toBe('1');
+	});
+});

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -814,7 +814,7 @@ describe('loanSearchUtils.js', () => {
 				page: '2',
 			};
 
-			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -841,7 +841,7 @@ describe('loanSearchUtils.js', () => {
 				attribute: '1'
 			};
 
-			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -863,7 +863,7 @@ describe('loanSearchUtils.js', () => {
 			};
 			const query = { sortBy: 'popularity' };
 
-			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -885,7 +885,7 @@ describe('loanSearchUtils.js', () => {
 			};
 			const query = { sortBy: 'popularity' };
 
-			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -907,7 +907,7 @@ describe('loanSearchUtils.js', () => {
 			};
 			const query = { page: '4' };
 
-			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -929,7 +929,29 @@ describe('loanSearchUtils.js', () => {
 			};
 			const query = { page: '-1' };
 
-			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState.pageLimit, mockState);
+
+			expect(apollo.mutate).toHaveBeenCalledWith(params);
+		});
+
+		it('should handle decimal page', async () => {
+			const apollo = { mutate: jest.fn(() => Promise.resolve()) };
+			const params = {
+				mutation: updateLoanSearchMutation,
+				variables: {
+					searchParams: {
+						...mockState,
+						gender: null,
+						sortBy: null,
+						sectorId: [],
+						theme: [],
+						pageOffset: 5,
+					}
+				},
+			};
+			const query = { page: '2.5' };
+
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -951,7 +973,7 @@ describe('loanSearchUtils.js', () => {
 			};
 			const query = { page: 'asd' };
 
-			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, STANDARD_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledWith(params);
 		});
@@ -965,7 +987,7 @@ describe('loanSearchUtils.js', () => {
 				page: '3',
 			};
 
-			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState);
+			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState.pageLimit, mockState);
 
 			expect(apollo.mutate).toHaveBeenCalledTimes(0);
 		});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1053
https://kiva.atlassian.net/browse/VUE-1093
https://kiva.atlassian.net/browse/VUE-1094

- Created new `KvResultsPerPage` component modeled after the existing Algolia component
- Couldn't use the old component because it was a wrapped Algolia component
- Resets to the first page when results per page changed, like existing component
- Added behavior of scrolling back to the top of the page when results per page changed
- We can remove the scroll behavior, but I thought the UX made sense, since the pager also scrolls
- Fixed potential edge case in pager
- Added 0 loan state

![image](https://user-images.githubusercontent.com/16867161/174112488-209a6189-3eb9-40c1-8822-ae5e19f44a10.png)

![image](https://user-images.githubusercontent.com/16867161/174154765-98ae4bf4-fc84-4990-b059-e23b4592ddd7.png)
