### PR TITLE
fix: do not show reserved loans for upsells on checkout

### DIFF
--- a/src/graphql/query/checkout/upsellLoans.graphql
+++ b/src/graphql/query/checkout/upsellLoans.graphql
@@ -1,7 +1,7 @@
 
 query upsellLoans {
 	lend {
-		loans (sortBy: amountLeft, limit: 1) {
+		loans (sortBy: amountLeft, limit: 20) {
           values {
             id
             name

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -276,6 +276,7 @@ import UpsellModule from '@/components/Checkout/UpsellModule';
 import updateLoanReservation from '@/graphql/mutation/updateLoanReservation.graphql';
 import * as Sentry from '@sentry/vue';
 import _forEach from 'lodash/forEach';
+import { isLoanFundraising } from '@/util/loanUtils';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
@@ -793,21 +794,8 @@ export default {
 				fetchPolicy: 'network-only',
 			}).then(({ data }) => {
 				const loans = data?.lend?.loans?.values;
-				// eslint-disable-next-line no-plusplus
-				for (let i = 0; i < loans.length; i++) {
-					const fundedAmt = Number(loans[i].loanFundraisingInfo?.fundedAmount);
-					const reservedAmt = Number(loans[i].loanFundraisingInfo?.reservedAmount);
-					const loanAmt = Number(loans[i].loanAmount);
-					// temp solution so we don't show reserved loans on upsell
-					if (fundedAmt + reservedAmt < loanAmt) {
-						this.upsellLoan = loans[i];
-						break;
-					}
-				}
-				// fallback behavior
-				if (this.upsellLoan === {}) {
-					this.upsellLoan = data?.lend?.loans?.values[0];
-				}
+				// Temp solution so we don't show reserved loans on upsell
+				this.upsellLoan = loans.filter(loan => isLoanFundraising(loan))[0] || data?.lend?.loans?.values[0];
 			});
 		},
 		verificationComplete() {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -34,7 +34,11 @@
 							@updating-totals="setUpdatingTotals"
 						/>
 						<upsell-module
-							v-if="!upsellCookieActive && showUpsellModule && isUpsellsExperimentEnabled "
+							v-if="!upsellCookieActive &&
+								showUpsellModule &&
+								isUpsellsExperimentEnabled
+								&& upsellLoan.name
+							"
 							:loan="upsellLoan"
 							:close-upsell-module="closeUpsellModule"
 							:add-to-basket="addToBasket"
@@ -793,9 +797,9 @@ export default {
 				query: upsellQuery,
 				fetchPolicy: 'network-only',
 			}).then(({ data }) => {
-				const loans = data?.lend?.loans?.values;
+				const loans = data?.lend?.loans?.values || [];
 				// Temp solution so we don't show reserved loans on upsell
-				this.upsellLoan = loans.filter(loan => isLoanFundraising(loan))[0] || data?.lend?.loans?.values[0];
+				this.upsellLoan = loans.filter(loan => isLoanFundraising(loan))[0] || {};
 			});
 		},
 		verificationComplete() {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -792,7 +792,22 @@ export default {
 				query: upsellQuery,
 				fetchPolicy: 'network-only',
 			}).then(({ data }) => {
-				this.upsellLoan = data?.lend?.loans?.values[0];
+				const loans = data?.lend?.loans?.values;
+				// eslint-disable-next-line no-plusplus
+				for (let i = 0; i < loans.length; i++) {
+					const fundedAmt = Number(loans[i].loanFundraisingInfo?.fundedAmount);
+					const reservedAmt = Number(loans[i].loanFundraisingInfo?.reservedAmount);
+					const loanAmt = Number(loans[i].loanAmount);
+					// temp solution so we don't show reserved loans on upsell
+					if (fundedAmt + reservedAmt < loanAmt) {
+						this.upsellLoan = loans[i];
+						break;
+					}
+				}
+				// fallback behavior
+				if (this.upsellLoan === {}) {
+					this.upsellLoan = data?.lend?.loans?.values[0];
+				}
 			});
 		},
 		verificationComplete() {


### PR DESCRIPTION
this PR updates the upsells module experiment to ensure we do not show reserved loans to users. if user A reserves the upsell module loan, other users will see a different loan instead. 

per: https://kivahq.slack.com/archives/C02TDSFQ551/p1655394514010749