### PR TITLE
Vue 1089 add click interaction on kv pager

### DIFF
--- a/src/components/Kv/KvPager.vue
+++ b/src/components/Kv/KvPager.vue
@@ -14,7 +14,7 @@
 					class="tw-cursor-pointer tw-flex"
 					:class="linkClass(0)"
 					aria-label="Previous page"
-					@click="!isCurrent(0) && pageChange(current - 1)"
+					@click="!isCurrent(0) && clickPrevious()"
 				>
 					<kv-icon
 						name="fat-chevron"
@@ -36,7 +36,7 @@
 					class="tw-cursor-pointer"
 					:class="linkClass(n)"
 					:aria-label="`Page ${n + 1}`"
-					@click="!isCurrent(n) && pageChange(n)"
+					@click="!isCurrent(n) && clickPage(n)"
 				>
 					<span v-if="isCurrent(n)" class="tw-sr-only">You're on page</span>
 					{{ n + 1 }}
@@ -47,7 +47,7 @@
 					class="tw-cursor-pointer tw-flex"
 					:class="linkClass(totalPages ? totalPages - 1 : 0)"
 					aria-label="Next page"
-					@click="totalPages && !isCurrent(totalPages - 1) && pageChange(current + 1)"
+					@click="totalPages && !isCurrent(totalPages - 1) && clickNext()"
 				>
 					<kv-icon
 						name="fat-chevron"
@@ -160,6 +160,25 @@ export default {
 			}
 
 			this.$emit('page-changed', { pageOffset: number * this.limit });
+		},
+		clickPage(number) {
+			this.pageChange(number);
+
+			this.$kvTrackEvent?.('Lending', 'click-page-pager', number + 1);
+		},
+		clickPrevious() {
+			const previous = this.current - 1;
+
+			this.pageChange(previous);
+
+			this.$kvTrackEvent?.('Lending', 'click-previous-pager', previous + 1);
+		},
+		clickNext() {
+			const next = this.current + 1;
+
+			this.pageChange(next);
+
+			this.$kvTrackEvent?.('Lending', 'click-next-pager', next + 1);
 		},
 	},
 };

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -228,6 +228,8 @@ export default {
 			const hits = hitIds.join();
 
 			if (hits !== this.trackedHits) {
+				this.$kvSetCustomUrl();
+
 				this.$kvTrackEvent(
 					'Lending',
 					hits ? 'loans-shown' : 'zero-loans-shown',

--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -79,6 +79,11 @@ export default {
 					window.fbq('track', 'PageView');
 				}
 			},
+			setCustomUrl: url => {
+				if (snowplowLoaded) {
+					window.snowplow('setCustomUrl', url);
+				}
+			},
 			trackEvent: (category, action, label, property, value, callback = () => {}) => {
 				const eventLabel = (label !== undefined && label !== null) ? String(label) : undefined;
 				const eventValue = (value !== undefined && value !== null) ? parseInt(value, 10) : undefined;
@@ -429,6 +434,11 @@ export default {
 		// eslint-disable-next-line no-param-reassign
 		Vue.prototype.$fireQueuedEvents = () => {
 			kvActions.fireQueuedEvents();
+		};
+
+		// eslint-disable-next-line no-param-reassign
+		Vue.prototype.$kvSetCustomUrl = (url = window.location.href) => {
+			kvActions.setCustomUrl(url);
 		};
 
 		// eslint-disable-next-line no-param-reassign

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -129,12 +129,14 @@ export function formatSortOptions(standardSorts, flssSorts) {
 			sortSrc: STANDARD_QUERY_TYPE,
 		};
 	});
-	const labeledFlssSorts = flssSorts.map(sort => {
-		return {
-			name: sort.name,
-			sortSrc: FLSS_QUERY_TYPE,
-		};
-	});
+	const labeledFlssSorts = flssSorts.reduce((prev, current) => {
+		// The amountLeft sort is currently returned by the GraphQL enum but isn't fully supported
+		if (current.name !== 'amountLeft') {
+			prev.push({ name: current.name, sortSrc: FLSS_QUERY_TYPE });
+		}
+
+		return prev;
+	}, []);
 	return [...labeledStandardSorts, ...labeledFlssSorts];
 }
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1089
https://kiva.atlassian.net/browse/VUE-1090
https://kiva.atlassian.net/browse/VUE-1092

- Added click analytics to `KvPager`
- Added `$kvSetCustomUrl` to analytics plugin and called before `loans-shown` event -> testing yesterday in dev showed that the URL was not updated like expected after filter changes
- Removed `amountLeft` sort option since FLSS doesn't fully support that option yet