### PR TITLE
feat: reset page offset when filtering, fixed analytics URL

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -82,7 +82,7 @@
 					:limit="loanSearchState.pageLimit"
 					:total="totalCount"
 					:offset="loanSearchState.pageOffset"
-					@page-changed="handleUpdatedFilters"
+					@page-changed="handlePageChange"
 				/>
 				<kv-results-per-page
 					:selected="loanSearchState.pageLimit"
@@ -266,12 +266,12 @@ export default {
 	},
 	methods: {
 		trackLoans() {
+			this.$kvSetCustomUrl();
+
 			const hitIds = this.loans.map(l => l.id);
 			const hits = hitIds.join();
 
 			if (hits !== this.trackedHits) {
-				this.$kvSetCustomUrl();
-
 				this.$kvTrackEvent?.(
 					'Lending',
 					hits ? 'loans-shown' : 'zero-loans-shown',
@@ -290,10 +290,14 @@ export default {
 			updateSearchState(this.apollo, filters, this.allFacets, this.queryType, this.loanSearchState);
 		},
 		handleUpdatedFilters(filters) {
-			this.updateState({ ...this.loanSearchState, ...filters });
+			this.updateState({ ...this.loanSearchState, ...filters, pageOffset: 0 });
 		},
 		handleResetFilters() {
 			this.updateState();
+		},
+		handlePageChange(payload) {
+			// Handle pager separately so that filters can reset the page offset
+			this.updateState({ ...this.loanSearchState, ...payload });
 		},
 		handleResultsPerPage(payload) {
 			// Reset to first page when page limit changes


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1092
https://kiva.atlassian.net/browse/VUE-1096

- Fixed issue where analytics URL wasn't updated when visible results matched previous search
- Fixed issue where changing a filter to reduce results would result in empty page if user was on page beyond new results
- Updated behavior to reset to first page when a new filter gets changed, like lend page