### PR TITLE
fix: accommodate overreserved loans

### DIFF
--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -23,7 +23,7 @@ export function isLoanFundraising(loan) {
 		return false;
 	}
 	// loan amount vs funded + reserved amount
-	if (loanAmount.value() === (fundedAmount.value() + reservedAmount.value())) {
+	if (loanAmount.value() >= (fundedAmount.value() + reservedAmount.value())) {
 		return false;
 	}
 	// all clear

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -23,7 +23,7 @@ export function isLoanFundraising(loan) {
 		return false;
 	}
 	// loan amount vs funded + reserved amount
-	if (loanAmount.value() >= (fundedAmount.value() + reservedAmount.value())) {
+	if (loanAmount.value() <= (fundedAmount.value() + reservedAmount.value())) {
 		return false;
 	}
 	// all clear


### PR DESCRIPTION
update `isLoanFundraising` to return `false` for loans that are overreserved