### PR TITLE
feat: increase number of allowed webpack chunks

### DIFF
--- a/build/webpack.client.base.conf.js
+++ b/build/webpack.client.base.conf.js
@@ -15,7 +15,11 @@ module.exports = merge(baseWebpackConfig, {
 	optimization: {
 		splitChunks: {
 			chunks: 'all',
-			maxAsyncRequests: 8, // default is 6
+			maxAsyncRequests: Infinity, // default is 6
+			cacheGroups: {
+				default: false,
+				vendors: false
+			}
 		}
 	},
 	plugins: [


### PR DESCRIPTION
This pr changes `webpack.client.base.conf.js` configuration file to ensure that modules are only loaded when they are actually used by the page.