### PR TITLE
fix: update developer tools readme

### DIFF
--- a/Developer_Tools.md
+++ b/Developer_Tools.md
@@ -36,7 +36,7 @@ Command Shift P - to install extensions manually
 - [ESlint - dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for Javascript linting.
 - [Stylelint - stylelint.vscode-stylelint](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) for scss linting.
 - [Vue VSCode Snippets - sdras.vue-vscode-snippets](https://marketplace.visualstudio.com/items?itemName=sdras.vue-vscode-snippets) VueJS code snippets
-- [GraphQL - prisma.vscode-graphql](https://marketplace.visualstudio.com/items?itemName=Prisma.vscode-graphql) GraphQL Syntax support.
+- [GraphQL - graphql.vscode-graphql](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) GraphQL Syntax support.
 - [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) Quickly find Tailwind class options
 
 > Search the name (ex. octref.vetur or shinn.stylelint) into the Extensions area to install within VSCode
@@ -46,7 +46,7 @@ Install all extensions via the command line
 > First requires that VSCode is in your PATH variable. From VSCode Command Palette (⇧⌘P) execute command "Shell Command: Install 'code' command in PATH"
 
 ```bash
-code --install-extension octref.vetur && code --install-extension EditorConfig.EditorConfig && code --install-extension dbaeumer.vscode-eslint && code --install-extension stylelint.vscode-stylelint && code --install-extension sdras.vue-vscode-snippets && code --install-extension prisma.vscode-graphql
+code --install-extension octref.vetur && code --install-extension EditorConfig.EditorConfig && code --install-extension dbaeumer.vscode-eslint && code --install-extension stylelint.vscode-stylelint && code --install-extension sdras.vue-vscode-snippets && code --install-extension GraphQL.vscode-graphql
 ```
 
 ### VSCode Setup for Eslint
@@ -67,12 +67,12 @@ ESLint auto fix
 {
     /* Other workspace settings...  */
     "editor.formatOnSave": false,
-	"editor.codeActionsOnSave": {
-		"source.fixAll": true,
-		"source.fixAll.eslint": true,
-		"source.fixAll.tslint": true,
-		"source.fixAll.stylelint": true,
-	},
+ "editor.codeActionsOnSave": {
+  "source.fixAll": true,
+  "source.fixAll.eslint": true,
+  "source.fixAll.tslint": true,
+  "source.fixAll.stylelint": true,
+ },
 }
 ```
 


### PR DESCRIPTION
The GraphQL vscode extension has been taken over by VSCode and is not maintained by prisma anymore, updated links