### PR TITLE
fix: error handling for upsell loans

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -839,16 +839,31 @@ export default {
 				if (errors) {
 					// Handle errors from adding to basket
 					_forEach(errors, error => {
-						this.$showTipMsg(error.message, 'error');
-						try {
+						// Case if upsell loan gets reserved while user is in basket
+						if (error.extensions?.code === 'no_shares_added_regular_xb') {
 							this.$kvTrackEvent(
-								'Lending',
-								'Add-to-Basket',
-								`Failed: ${error.message.substring(0, 40)}...`
+								'Basket',
+								'click-checkout-upsell',
+								'Add loan to basket',
+								loanId,
+								amountLeft
 							);
-							Sentry.captureMessage(`Add to Basket: ${error.message}`);
-						} catch (e) {
+							// eslint-disable-next-line max-len
+							this.$showTipMsg('Looks like that loan was reserved by someone else! Try this one instead.', 'info');
+							this.getUpsellModuleData();
+							this.refreshTotals();
+						} else {
+							this.$showTipMsg(error.message, 'error');
+							try {
+								this.$kvTrackEvent(
+									'Lending',
+									'Add-to-Basket',
+									`Failed: ${error.message.substring(0, 40)}...`
+								);
+								Sentry.captureMessage(`Add to Basket: ${error.message}`);
+							} catch (e) {
 							// no-op
+							}
 						}
 					});
 				} else {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -843,10 +843,9 @@ export default {
 						if (error.extensions?.code === 'no_shares_added_regular_xb') {
 							this.$kvTrackEvent(
 								'Basket',
-								'click-checkout-upsell',
-								'Add loan to basket',
-								loanId,
-								amountLeft
+								'click-checkout-upsell-reserved',
+								'ATC reserved loan attempted',
+								loanId
 							);
 							// eslint-disable-next-line max-len
 							this.$showTipMsg('Looks like that loan was reserved by someone else! Try this one instead.', 'info');


### PR DESCRIPTION
fixes an issue on upsell loans where if a user tries to add a reserved loan, it will pull a new non-reserved loan for them as the upsell loan in their cart

![Screen Shot 2022-06-22 at 1 41 25 PM](https://user-images.githubusercontent.com/15318176/175126394-1407ae7a-c246-4208-a32f-dd062d38edbb.png)
