### PR TITLE
fix: canonical loop issue

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -159,16 +159,8 @@ export default {
 		WwwPage,
 	},
 	metaInfo() {
-		const canonicalUrl = `https://${this.$appConfig.host}${this.$route.path}`.replace('-beta', '');
 		return {
 			title: this.pageTitle,
-			link: [
-				{
-					vmid: 'canonical',
-					rel: 'canonical',
-					href: canonicalUrl
-				}
-			],
 			meta: [
 				{ property: 'og:title', vmid: 'og:title', content: `Lend as little as $25 to ${this.name}` },
 				{ property: 'og:type', vmid: 'og:type', content: 'kivadotorg:loan' },

--- a/src/pages/BorrowerProfile/FundedBorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/FundedBorrowerProfile.vue
@@ -220,18 +220,6 @@ const newFundedBorrowerPageExpKey = 'new_funded_borrower_page';
 
 export default {
 	name: 'FundedBorrowerProfile',
-	metaInfo() {
-		const canonicalUrl = `https://${this.$appConfig.host}${this.$route.path}`.replace('funded', 'lend');
-		return {
-			link: [
-				{
-					vmid: 'canonical',
-					rel: 'canonical',
-					href: canonicalUrl
-				}
-			]
-		};
-	},
 	components: {
 		WwwPage,
 		LoanCardImage,


### PR DESCRIPTION
This pr fixes a canonical loop within the Funded Borrower Profile and Borrower Profile pages this was cause for the customized canonical url in both pages. So the recommended solution was to remove these `canonicalUrl` 