### PR TITLE
fix: error getting cache for viewtoggle component

### DIFF
--- a/src/components/LoansByCategory/ViewToggle.vue
+++ b/src/components/LoansByCategory/ViewToggle.vue
@@ -32,10 +32,11 @@
 <script>
 import KvIcon from '@/components/Kv/KvIcon';
 import getCacheKey from '@/util/getCacheKey';
+import { hashCode } from '@/util/settingsUtils';
 
 export default {
 	name: 'ViewToggle',
-	serverCacheKey: props => getCacheKey(`${props.browseUrl}-${props.filterUrl}`),
+	serverCacheKey: props => getCacheKey(hashCode(`${props.browseUrl}-${props.filterUrl}`)),
 	components: {
 		KvIcon,
 	},


### PR DESCRIPTION
This pr fixes an error getting cache for `ViewToggle` component probably caused by the formatting of the url.