### PR TITLE
fix: corporate campaign logo in footer distortion

### DIFF
--- a/src/components/CorporateCampaign/CampaignLogoGroup.vue
+++ b/src/components/CorporateCampaign/CampaignLogoGroup.vue
@@ -8,7 +8,7 @@
 		>+</span>
 		<kv-contentful-img
 			v-if="corporateLogoUrl"
-			class="tw-h-full campaign-logo-group__corporate"
+			class="campaign-logo-group__corporate"
 			:contentful-src="corporateLogoUrl"
 			:height="28"
 			alt=""


### PR DESCRIPTION
This makes all the corporate landing pages look better. The bottom logo was always getting distorted. 

Fix for MRKT-597, see slack