### PR TITLE
fix: add inviter name to shareLink func

### DIFF
--- a/src/components/Checkout/SocialShareV2.vue
+++ b/src/components/Checkout/SocialShareV2.vue
@@ -129,7 +129,7 @@ export default {
 		shareLink() {
 			const base = `https://${this.$appConfig.host}`;
 			if (this.selectedLoan.id) {
-				return `${base}/lend/${this.selectedLoan.id}?utm_content=${this.utmContent}&scle=${this.shareCardLanguageVersion}`; // eslint-disable-line max-len
+				return `${base}/invitedby/${this.lender.inviterName}/for/${this.selectedLoan.id}?utm_content=${this.utmContent}&scle=${this.shareCardLanguageVersion}`; // eslint-disable-line max-len
 			}
 			return `${base}?utm_content=${this.utmContent}&scle=${this.shareCardLanguageVersion}`;
 		},


### PR DESCRIPTION
This pr changes `shareLink` function inside `SocialShareV2` component to add `inviterName`.