### PR TITLE
fix: bugs related to FLSS loan channel

### DIFF
--- a/src/graphql/query/flssLoanChannel.graphql
+++ b/src/graphql/query/flssLoanChannel.graphql
@@ -3,6 +3,7 @@
 query flssLoanChannel(
 	$ids: [Int],
 	$filterObject: [FundraisingLoanSearchFilterInput!]
+	$sortBy: SortEnum = personalized
 	$pageNumber: Int = 0
 	$pageLimit: Int = 0
 	$imgDefaultSize: String = "w480h360"
@@ -17,7 +18,7 @@ query flssLoanChannel(
 			url
 		}
 	}
-	fundraisingLoans(filters: $filterObject, limit: $pageLimit, pageNumber: $pageNumber) {
+	fundraisingLoans(filters: $filterObject, sortBy: $sortBy, limit: $pageLimit, pageNumber: $pageNumber) {
 		totalCount
 		values {
 			id

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -20,7 +20,7 @@
 				<p v-else>
 					We couldn't find any loans for this search.
 					<router-link to="/lend-by-category">
-						Browse these loans
+						<span>Browse these loans</span>
 					</router-link>.
 				</p>
 			</div>

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -297,7 +297,7 @@ export default {
 					url: 'united-states-loans',
 					queryParams: 'country=us&distributionModel=field_partner&gender=female&riskRating=0,5&status=fundRaising&sortBy=popularity',
 					algoliaParams: 'gender=female&countries=North%20America%20>%20United%20States&sortBy=popularity',
-					flssLoanSearch: { countryIsoCode: ['US'], gender: 'female', distributionModel: 'FIELDPARTNER' },
+					flssLoanSearch: { countryIsoCode: ['US'], gender: 'female' },
 				},
 				{
 					id: 87,

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -84,6 +84,7 @@ export function getLoanChannelVariables(queryMapFLSS, loanQueryVars) {
 	return {
 		ids: [...loanQueryVars.ids],
 		filterObject: getFlssFilters(queryMapFLSS),
+		sortBy: queryMapFLSS.sortBy,
 		pageNumber: loanQueryVars.offset / loanQueryVars.limit,
 		pageLimit: loanQueryVars.limit,
 		basketId: loanQueryVars.basketId,

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -99,7 +99,7 @@ describe('flssUtils.js', () => {
 
 	describe('getLoanChannelVariables', () => {
 		it('should return variables', () => {
-			const queryMap = { sector: [1, 2, 3] };
+			const queryMap = { sector: [1, 2, 3], sortBy: 'expiringSoon' };
 			const loanQueryVars = {
 				ids: [3],
 				offset: 10,
@@ -111,6 +111,7 @@ describe('flssUtils.js', () => {
 
 			expect(result.ids).toEqual(loanQueryVars.ids);
 			expect(result.filterObject).toEqual(getFlssFilters(queryMap));
+			expect(result.sortBy).toEqual(queryMap.sortBy);
 			expect(result.pageNumber).toBe(loanQueryVars.offset / loanQueryVars.limit);
 			expect(result.pageLimit).toBe(loanQueryVars.limit);
 			expect(result.basketId).toBe(loanQueryVars.basketId);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1113

- After functionally testing all of the FLSS-supported channels, a couple issues were encountered
- Sort order was not being applied to channels
- If there were no loans, there was a trailing whitespace after "Browse these loans" and before the "."
- The US channel had no results since all US loans are currently direct in the database