### PR TITLE
feat: apply location to query params filtering and shared state

### DIFF
--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -177,7 +177,9 @@ export function isoToCountryName(isoCode, countryList = []) {
  * @returns {Object}
  */
 export function mapIsoCodesToCountryNames(isoCodes, regions) {
-	const mappedIsos = regions?.reduce((regionObject, region) => {
+	if (!isoCodes || !regions) return {};
+
+	const mappedIsos = regions.reduce((regionObject, region) => {
 		const countryNames = isoCodes.filter(
 			iso => region?.countries?.find(country => country.isoCode === iso)
 		).map(iso => {
@@ -185,6 +187,7 @@ export function mapIsoCodesToCountryNames(isoCodes, regions) {
 		});
 		return countryNames.length ? { ...regionObject, [region.region]: countryNames } : { ...regionObject };
 	}, {});
+
 	return mappedIsos;
 }
 
@@ -440,6 +443,7 @@ export async function fetchLoanFacets(apollo) {
 		return {
 			countryFacets,
 			countryIsoCodes: countryFacets.map(c => c.country.isoCode.toUpperCase()),
+			countryNames: countryFacets.map(c => c.country.name.toUpperCase()),
 			sectorFacets,
 			sectorIds: sectorFacets.map(s => s.id),
 			sectorNames: sectorFacets.map(s => s.name.toUpperCase()),
@@ -463,6 +467,40 @@ export async function fetchLoanFacets(apollo) {
  */
 export function getCheckboxLabel(item) {
 	return `${item.name || item.region} (${item.numLoansFundraising})`;
+}
+
+/**
+ * Returns the country ISO codes based on the query param. Handles FLSS/legacy and Algolia formats.
+ *
+ * @param {string} param The query param
+ * @param {Object} allFacets All available facets from the APIs
+ * @returns {Array} Valid sector IDs based on the query param
+ */
+export function getCountryIsoCodesFromQueryParam(param, allFacets) {
+	if (!param) return;
+
+	const decoded = decodeURI(param).toUpperCase();
+
+	// Handles FLSS and legacy query params, such as "do,ht"
+	if (decoded.includes(',') || allFacets.countryIsoCodes.includes(decoded)) {
+		return decoded.split(',').filter(s => s !== '');
+	}
+
+	// Handles Algolia query params, such as "Africa%20>%20Burkina%20Faso~Africa%20>%20Congo%20%28DRC%29"
+	return decoded.split('~').reduce((prev, current) => {
+		const [region, country] = current.toUpperCase().split('>').map(s => s.trim());
+
+		if (allFacets.countryNames.includes(country)) {
+			const facet = allFacets.countryFacets.find(({ country: c }) => (
+				c.region.toUpperCase() === region && c.name.toUpperCase() === country
+			));
+
+			if (facet) {
+				prev.push(facet.country.isoCode);
+			}
+		}
+		return prev;
+	}, []);
 }
 
 /**
@@ -541,7 +579,7 @@ export async function applyQueryParams(apollo, query, allFacets, queryType, page
 
 	const filters = {
 		gender: query.gender,
-		countryIsoCode: previousState.countryIsoCode,
+		countryIsoCode: getCountryIsoCodesFromQueryParam(query.country || query.countries, allFacets),
 		sectorId: getSectorIdsFromQueryParam(query.sector, allFacets.sectorNames, allFacets.sectorFacets, true),
 		sortBy: queryType === FLSS_QUERY_TYPE ? lendToFlssSort.get(query.sortBy) : query.sortBy,
 		theme: getThemeNamesQueryParam(query.attribute, allFacets.themeFacets),
@@ -595,11 +633,11 @@ export function updateQueryParams(loanSearchState, router, allFacets, queryType)
 	// Create new query params object
 	const newParams = {
 		...(loanSearchState.gender && { gender: loanSearchState.gender }),
-		...(loanSearchState.sectorId?.length && { sector: loanSearchState.sectorId.join(',') }),
-		...(loanSearchState.theme?.length && { attribute: themeIds.join(',') }),
+		...(loanSearchState.countryIsoCode?.length && { country: loanSearchState.countryIsoCode.join() }),
+		...(loanSearchState.sectorId?.length && { sector: loanSearchState.sectorId.join() }),
+		...(loanSearchState.theme?.length && { attribute: themeIds.join() }),
 		...(queryParamSortBy && { sortBy: queryParamSortBy }),
 		...(page > 1 && { page: page.toString() }),
-		// TODO: add params as query param support expands
 		...utmParams,
 	};
 

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchLocationFilter.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchLocationFilter.spec.js
@@ -48,6 +48,47 @@ describe('LoanSearchLocationFilter', () => {
 		expect(countries.length).toBe(0);
 	});
 
+	it('should pre-select', async () => {
+		const user = userEvent.setup();
+
+		const regions = getRegions();
+
+		const { getByText, getByLabelText } = render(LoanSearchLocationFilter, {
+			props: { activeIsoCodes: [regions[0].countries[0].isoCode], regions }
+		});
+
+		// Open first region
+		const region = getByText(getCheckboxLabel(regions[0]));
+		await user.click(region);
+
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[0])).checked).toBeTruthy();
+	});
+
+	it('should select based on prop', async () => {
+		const user = userEvent.setup();
+
+		const regions = getRegions();
+
+		const { getByText, getByLabelText, updateProps } = render(LoanSearchLocationFilter, { props: { regions } });
+
+		// Open first region
+		const region = getByText(getCheckboxLabel(regions[0]));
+		await user.click(region);
+
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[0])).checked).toBeFalsy();
+
+		await updateProps({ activeIsoCodes: [regions[0].countries[0].isoCode] });
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[0])).checked).toBeTruthy();
+
+		await updateProps({ activeIsoCodes: [regions[0].countries[0].isoCode, regions[0].countries[1].isoCode] });
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[0])).checked).toBeTruthy();
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[1])).checked).toBeTruthy();
+
+		await updateProps({ activeIsoCodes: [] });
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[0])).checked).toBeFalsy();
+		expect(getByLabelText(getCheckboxLabel(regions[0].countries[1])).checked).toBeFalsy();
+	});
+
 	it('should emit updated', async () => {
 		const user = userEvent.setup();
 		const regions = getRegions();


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1103
https://kiva.atlassian.net/browse/VUE-1043

- Location (country) query param now active when filters change or page initialized
- Location selection shared between desktop and mobile views through query param

![image](https://user-images.githubusercontent.com/16867161/176974214-ffce8629-a08e-4251-9d64-71d69f788586.png)
