### PR TITLE
feat: loan filter chips tests and stories

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -24,6 +24,9 @@ import config from '../config/local';
 // initialize vue-meta
 Vue.use(Meta);
 
+// Mock the analytics Vue plugin
+Vue.use({ install: Vue => { Vue.prototype.$kvTrackEvent = () => {}; }});
+
 // provide global application config
 Vue.prototype.$appConfig = config.app;
 

--- a/.storybook/stories/LoanSearchFilterChips.stories.js
+++ b/.storybook/stories/LoanSearchFilterChips.stories.js
@@ -1,0 +1,61 @@
+import LoanSearchFilterChips from '@/components/Lend/LoanSearch/LoanSearchFilterChips';
+
+export default {
+	title: 'Loan Search/Loan Search Filter Chips',
+	component: LoanSearchFilterChips,
+};
+
+const loanSearchState = {
+	gender: 'female',
+	countryIsoCode: ['US'],
+	sectorId: [1],
+	theme: ['THEME 1'],
+};
+
+const allFacets = {
+	countryFacets: [
+		{
+			country: {
+				isoCode: 'US',
+				name: 'United States',
+				region: 'North America',
+				__typename: 'Country'
+			}
+		},
+		{
+			country: {
+				isoCode: 'CA',
+				name: 'Canada',
+				region: 'North America',
+				__typename: 'Country'
+			}
+		}
+	],
+	countryIsoCodes: ['US', 'CA'],
+	countryNames: ['UNITED STATES', 'CANADA'],
+	sectorFacets: [
+		{ id: 1, name: 'Sector 1', __typename: 'Sector' },
+		{ id: 2, name: 'Sector 2', __typename: 'Sector' }
+	],
+	sectorIds: [1],
+	sectorNames: ['SECTOR 1', 'SECTOR 2'],
+	themeFacets: [
+		{ id: 1, name: 'Theme 1', __typename: 'LoanThemeFilter' },
+		{ id: 2, name: 'Theme 2', __typename: 'LoanThemeFilter' }
+	],
+	themeNames: ['THEME 1', 'THEME 2'],
+	genderFacets: [{ name: 'female', __typename: 'Gender' }, { name: 'male', __typename: 'Gender' }],
+	genders: ['FEMALE', 'MALE'],
+};
+
+const story = (args = {}) => {
+	const template = (_, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { LoanSearchFilterChips },
+		template: '<loan-search-filter-chips :loan-search-state="loanSearchState" :all-facets="allFacets" />',
+	})
+	template.args = args;
+	return template;
+};
+
+export const Chips = story({ loanSearchState, allFacets });

--- a/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
@@ -110,7 +110,7 @@ export default {
 			const formattedFacet = this.formatRemovedFacet(facetType, facet);
 			this.$emit('updated', formattedFacet);
 
-			this.$kvTrackEvent?.('Lending', 'click-remove-filter-chip', `${facetType}-${facet.name}`);
+			this.$kvTrackEvent('Lending', 'click-remove-filter-chip', `${facetType}-${facet.name}`);
 		}
 	},
 };

--- a/test/unit/jest.conf.js
+++ b/test/unit/jest.conf.js
@@ -37,5 +37,6 @@ module.exports = {
 		'<rootDir>/node_modules/'
 	],
 	testURL: 'http://localhost',
-	testEnvironment: 'jsdom'
+	testEnvironment: 'jsdom',
+	setupFiles: ['<rootDir>/test/unit/setupJestMocks.js']
 };

--- a/test/unit/setupJestMocks.js
+++ b/test/unit/setupJestMocks.js
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+
+// Mock the analytics Vue plugin
+Vue.use({
+	// eslint-disable-next-line no-shadow
+	install: Vue => {
+		// eslint-disable-next-line no-param-reassign
+		Vue.prototype.$kvTrackEvent = () => {};
+	}
+});

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
@@ -1,0 +1,170 @@
+import Vue from 'vue';
+import { render } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import LoanSearchFilterChips from '@/components/Lend/LoanSearch/LoanSearchFilterChips';
+
+const mockState = {
+	gender: 'female',
+	countryIsoCode: ['US'],
+	sectorId: [1],
+	theme: ['THEME 1'],
+};
+
+const mockAllFacets = {
+	countryFacets: [
+		{
+			country: {
+				isoCode: 'US',
+				name: 'United States',
+				region: 'North America',
+				__typename: 'Country'
+			}
+		},
+		{
+			country: {
+				isoCode: 'CA',
+				name: 'Canada',
+				region: 'North America',
+				__typename: 'Country'
+			}
+		}
+	],
+	countryIsoCodes: ['US', 'CA'],
+	countryNames: ['UNITED STATES', 'CANADA'],
+	sectorFacets: [
+		{ id: 1, name: 'Sector 1', __typename: 'Sector' },
+		{ id: 2, name: 'Sector 2', __typename: 'Sector' }
+	],
+	sectorIds: [1],
+	sectorNames: ['SECTOR 1', 'SECTOR 2'],
+	themeFacets: [
+		{ id: 1, name: 'Theme 1', __typename: 'LoanThemeFilter' },
+		{ id: 2, name: 'Theme 2', __typename: 'LoanThemeFilter' }
+	],
+	themeNames: ['THEME 1', 'THEME 2'],
+	genderFacets: [{ name: 'female', __typename: 'Gender' }, { name: 'male', __typename: 'Gender' }],
+	genders: ['FEMALE', 'MALE'],
+};
+
+describe('LoanSearchFilterChips', () => {
+	let spyTrackEvent;
+
+	beforeEach(() => {
+		spyTrackEvent = jest.spyOn(Vue.prototype, '$kvTrackEvent');
+	});
+
+	afterEach(jest.restoreAllMocks);
+
+	it('should handle missing props', () => {
+		render(LoanSearchFilterChips);
+		render(LoanSearchFilterChips, { props: { allFacets: mockAllFacets } });
+	});
+
+	it('should handle render state with missing state', () => {
+		render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: {},
+				allFacets: mockAllFacets
+			}
+		});
+	});
+
+	it('should handle render state', () => {
+		const { getByText } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		getByText('United States');
+		getByText('Sector 1');
+		getByText('Theme 1');
+		getByText('Women');
+	});
+
+	it('should handle render state with missing state', () => {
+		render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: {},
+				allFacets: mockAllFacets
+			}
+		});
+	});
+
+	it('should handle country chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('United States'));
+
+		expect(emitted().updated[0]).toEqual([{ countryIsoCode: [] }]);
+	});
+
+	it('should handle sector chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('Sector 1'));
+
+		expect(emitted().updated[0]).toEqual([{ sectorId: [] }]);
+	});
+
+	it('should handle theme chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('Theme 1'));
+
+		expect(emitted().updated[0]).toEqual([{ theme: [] }]);
+	});
+
+	it('should handle gender chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('Women'));
+
+		expect(emitted().updated[0]).toEqual([{ gender: null }]);
+	});
+
+	it('should track event', async () => {
+		const user = userEvent.setup();
+
+		const { getByText } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('Women'));
+
+		expect(spyTrackEvent).toHaveBeenCalledTimes(1);
+		expect(spyTrackEvent).toHaveBeenCalledWith('Lending', 'click-remove-filter-chip', 'Gender-Women');
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1100

- Added `LoanSearchFilterChips` unit tests and stories
- Added global `$kvTrackEvent` mocking for both tests and stories
- With this mocking, we can now spy on `$kvTrackEvent` (like in this PR) or usages will simply not break tests/stories