### PR TITLE
fix: use optimized default make-fetch-happen agent instead of custom agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.220.3",
+	"version": "2.221.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.220.3",
+			"version": "2.221.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.18.2",
@@ -15,15 +15,9 @@
 				"@chenfengyuan/vue-countdown": "^1.1.5",
 				"@contentful/rich-text-html-renderer": "^14.1.1",
 				"@contentful/rich-text-types": "^14.1.2",
-<<<<<<< HEAD
-				"@godaddy/terminus": "^4.4.1",
+				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.12.1",
-=======
-				"@godaddy/terminus": "^4.11.0",
-				"@graphql-tools/load": "^6.2.4",
-				"@graphql-tools/url-loader": "^6.3.0",
->>>>>>> origin/main
 				"@kiva/kv-components": "^3.0.6",
 				"@kiva/kv-tokens": "^2.1.0",
 				"@mdi/js": "^5.9.55",
@@ -67,7 +61,6 @@
 				"graphql-tag": "^2.12.6",
 				"gsap": "^3.5.1",
 				"helmet": "^4.6.0",
-				"https": "^1.0.0",
 				"instantsearch.js": "^3.6.0",
 				"js-cookie": "^2.2.1",
 				"jsonwebtoken": "^8.5.1",
@@ -20941,11 +20934,6 @@
 				"node": ">=0.8",
 				"npm": ">=1.3.7"
 			}
-		},
-		"node_modules/https": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-			"integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
 		},
 		"node_modules/https-browserify": {
 			"version": "1.0.0",
@@ -57210,11 +57198,6 @@
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
 			}
-		},
-		"https": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
-			"integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
 		},
 		"https-browserify": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,6 @@
 		"graphql-tag": "^2.12.6",
 		"gsap": "^3.5.1",
 		"helmet": "^4.6.0",
-		"https": "^1.0.0",
 		"instantsearch.js": "^3.6.0",
 		"js-cookie": "^2.2.1",
 		"jsonwebtoken": "^8.5.1",

--- a/server/util/fetch.js
+++ b/server/util/fetch.js
@@ -1,12 +1,10 @@
 const minipassFetch = require('make-fetch-happen');
-const https = require('https');
 
 module.exports = function fetch(url, options) {
+	const onVm = url.indexOf('vm') > -1;
 	return minipassFetch(url, {
+		// fix request blocked b/c of self-signed certificate on dev-vm.
+		strictSSL: !onVm,
 		...options,
-		agent: new https.Agent({
-			// fix request blocked b/c of self-signed certificate on dev-vm. TODO: maybe do a prod check?
-			rejectUnauthorized: false
-		}),
 	});
 };

--- a/src/api/HttpLink.js
+++ b/src/api/HttpLink.js
@@ -1,30 +1,18 @@
 import * as Sentry from '@sentry/vue';
 import { BatchHttpLink } from 'apollo-link-batch-http';
-// http is a nodejs dep only used during development mode (there is no http npm package as of July 2020)
-import { Agent as HttpAgent } from 'http'; // eslint-disable-line import/no-extraneous-dependencies
-import { Agent as SslAgent } from 'https';
 
 export default ({ kvAuth0, uri = '', fetch }) => {
 	const onVm = uri.indexOf('vm') > -1;
-	const usingLocal = uri.indexOf('localhost') > -1;
-	const secure = uri.indexOf('https') === 0;
-	let agent;
-
-	if (usingLocal && !secure) {
-		agent = new HttpAgent();
-	} else {
-		agent = new SslAgent({
-			// fix request blocked b/c of self-signed certificate on dev-vm.
-			rejectUnauthorized: !onVm
-		});
-	}
 
 	const options = {
 		uri,
 		fetch,
 		headers: {},
 		credentials: 'same-origin',
-		fetchOptions: { agent }
+		fetchOptions: {
+			// fix request blocked b/c of self-signed certificate on dev-vm.
+			strictSSL: !onVm,
+		}
 	};
 
 	// Add Fake Authentication info to the server URI if it is provided and allowed.


### PR DESCRIPTION
Because we were providing a custom agent we weren't getting any of the optimized configurations (specifically keepAlive). We only needed the custom agent for allowing invalid VM certificates via `rejectUnauthorized`, and that can be controlled using [the `strictSSL` option](https://github.com/npm/make-fetch-happen#--optsca-optscert-optskey-optsstrictssl) instead.