### PR TITLE
fix: initial load has all facets regardless of query params

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -265,6 +265,9 @@ export default {
 		// Fetch the facet options from the lend and FLSS APIs
 		this.allFacets = await fetchLoanFacets(this.apollo);
 
+		// Load all available facets without loan search state applied
+		await this.fetchFacets();
+
 		// Initialize the search filters with the query string params
 		await applyQueryParams(this.apollo, this.$route.query, this.allFacets, this.queryType, this.defaultPageLimit);
 
@@ -281,21 +284,12 @@ export default {
 				// Update the query string with the latest loan search state
 				updateQueryParams(this.loanSearchState, this.$router, this.queryType);
 
-				const [{ isoCodes, themes, sectors }, { loans, totalCount }] = await Promise.all([
-					// Get filtered facet options from FLSS
-					// TODO: Prevent this from running on every query (not needed for sorting and paging)
-					await runFacetsQueries(this.apollo, this.loanSearchState),
+				const [{ loans, totalCount }] = await Promise.all([
 					// Get filtered loans from FLSS
-					await runLoansQuery(this.apollo, this.loanSearchState)
+					await runLoansQuery(this.apollo, this.loanSearchState),
+					// Get filtered facet options from FLSS
+					await this.fetchFacets(this.loanSearchState)
 				]);
-
-				// Merge all facet options with filtered options
-				this.facets = {
-					regions: transformIsoCodes(isoCodes, this.allFacets?.countryFacets),
-					sectors: transformSectors(sectors, this.allFacets?.sectorFacets),
-					themes: transformThemes(themes, this.allFacets?.themeFacets),
-					sortOptions: formatSortOptions(this.allFacets?.standardSorts ?? [], this.allFacets?.flssSorts ?? [])
-				};
 
 				// Store loan data in component
 				this.loans = loans;
@@ -320,6 +314,18 @@ export default {
 		},
 	},
 	methods: {
+		async fetchFacets(loanSearchState = {}) {
+			// TODO: Prevent this from running on every query (not needed for sorting and paging)
+			const { isoCodes, themes, sectors } = await runFacetsQueries(this.apollo, loanSearchState);
+
+			// Merge all facet options with filtered options
+			this.facets = {
+				regions: transformIsoCodes(isoCodes, this.allFacets?.countryFacets),
+				sectors: transformSectors(sectors, this.allFacets?.sectorFacets),
+				themes: transformThemes(themes, this.allFacets?.themeFacets),
+				sortOptions: formatSortOptions(this.allFacets?.standardSorts ?? [], this.allFacets?.flssSorts ?? [])
+			};
+		},
 		trackLoans() {
 			this.$kvSetCustomUrl();
 

--- a/src/util/loanSearchUtils.js
+++ b/src/util/loanSearchUtils.js
@@ -389,7 +389,7 @@ export function getIsoCodes(regions, selectedCountries) {
  * @param {Object} loanSearchState The current loan search state from Apollo
  * @returns {Object} The filter facets
  */
-export async function runFacetsQueries(apollo, loanSearchState) {
+export async function runFacetsQueries(apollo, loanSearchState = {}) {
 	const isoCodeFilters = { ...getFlssFilters(loanSearchState), countryIsoCode: undefined };
 	const themeFilters = { ...getFlssFilters(loanSearchState), themeId: undefined };
 	const sectorFilters = { ...getFlssFilters(loanSearchState), sectorId: undefined };

--- a/test/unit/specs/util/loanSearchUtils.spec.js
+++ b/test/unit/specs/util/loanSearchUtils.spec.js
@@ -563,6 +563,19 @@ describe('loanSearchUtils.js', () => {
 			expect(spyFetchFacets).toHaveBeenCalledTimes(1);
 			expect(result).toEqual({ isoCodes: isoCodeFacets, themes: themeFacets, sectors: sectorFacets });
 		});
+
+		it('should return apply filters', async () => {
+			const apollo = {};
+			const result = await runFacetsQueries(apollo, { countryIsoCode: ['US'], themeId: [2], sectorId: [1] });
+			expect(spyFetchFacets).toHaveBeenCalledWith(
+				apollo,
+				{ themeId: { any: [2] }, sectorId: { any: [1] }, countryIsoCode: undefined },
+				{ countryIsoCode: { any: ['US'] }, sectorId: { any: [1] }, themeId: undefined },
+				{ countryIsoCode: { any: ['US'] }, themeId: { any: [2] }, sectorId: undefined }
+			);
+			expect(spyFetchFacets).toHaveBeenCalledTimes(1);
+			expect(result).toEqual({ isoCodes: isoCodeFacets, themes: themeFacets, sectors: sectorFacets });
+		});
 	});
 
 	describe('runLoansQuery', () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1136

- Added extra query for all facets on mount
- It does lead to an extra render of the filters and an extra async call on mount, but otherwise we won't get the full list of available filters from FLSS for display
- Added a missing test case for `runFacetsQueries`

![image](https://user-images.githubusercontent.com/16867161/177878367-9f78d044-19f4-4083-b42d-4aafbc73b84e.png)