### PR TITLE
feat: track lend-by-category and borrower profile page performance

### DIFF
--- a/lighthouserc-prod.js
+++ b/lighthouserc-prod.js
@@ -7,8 +7,9 @@ module.exports = {
 			url: [
 				'https://www.kiva.org/',
 				'https://www.kiva.org/lend/filter',
-				// 'https://www.kiva.org/lend-by-category',
+				'https://www.kiva.org/lend-by-category',
 				'https://www.kiva.org/lend-by-category/women',
+				'https://www.kiva.org/live-loan/f/sort_popularity/url/1',
 				'https://www.kiva.org/ui-site-map',
 				'https://www.kiva.org/cc/kiva-universal',
 				'https://www.kiva.org/lp/support-refugees',


### PR DESCRIPTION
This uses the live-loan redirect url add the fundraising borrower profile to the lighthouse monitoring