### PR TITLE
chore(deps-dev): update browsers list db

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.221.4",
+	"version": "2.225.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.221.4",
+			"version": "2.225.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.18.2",
@@ -12064,13 +12064,19 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001304",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
-			"integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/browserslist"
-			}
+			"version": "1.0.30001365",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001365.tgz",
+			"integrity": "sha512-VDQZ8OtpuIPMBA4YYvZXECtXbddMCUFJk1qu8Mqxfm/SZJNSr1cy4IuLCOL7RJ/YASrvJcYg1Zh+UEUQ5m6z8Q==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/browserslist"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				}
+			]
 		},
 		"node_modules/canvas": {
 			"version": "2.7.0",
@@ -49199,9 +49205,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001304",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001304.tgz",
-			"integrity": "sha512-bdsfZd6K6ap87AGqSHJP/s1V+U6Z5lyrcbBu3ovbCCf8cSYpwTtGrCBObMpJqwxfTbLW6YTIdbb1jEeTelcpYQ=="
+			"version": "1.0.30001365",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001365.tgz",
+			"integrity": "sha512-VDQZ8OtpuIPMBA4YYvZXECtXbddMCUFJk1qu8Mqxfm/SZJNSr1cy4IuLCOL7RJ/YASrvJcYg1Zh+UEUQ5m6z8Q=="
 		},
 		"canvas": {
 			"version": "2.7.0",


### PR DESCRIPTION
Ran `npx browserslist@latest --update-db`:

```
Latest version:     1.0.30001365
Installed version:  1.0.30001304
Removing old caniuse-lite from lock file
Installing new caniuse-lite version
$ npm install caniuse-lite
Cleaning package.json dependencies from caniuse-lite
$ npm uninstall caniuse-lite
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 97
+ and_chr 103
- and_ff 95
+ and_ff 101
- android 97
+ android 103
- chrome 97
- chrome 96
+ chrome 103
+ chrome 102
+ chrome 101
- edge 97
- edge 96
+ edge 103
+ edge 102
- firefox 96
- firefox 95
+ firefox 102
+ firefox 101
- ios_saf 15.2-15.3
- ios_saf 15.0-15.1
+ ios_saf 15.5
+ ios_saf 15.4
- opera 82
- opera 81
+ opera 86
+ opera 85
- safari 15.2-15.3
- safari 15.1
- safari 14.1
+ safari 15.5
+ safari 15.4
- samsung 15.0
+ samsung 17.0
```