### PR TITLE
fix: additional preconnect for anonymous crossorigin requests

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -144,13 +144,24 @@ export default {
 					rel: 'canonical',
 					href: `https://${this.$appConfig.host}${this.$route.path}`
 				}
-			].concat([
-				(/^[a-z]+:\/\//i.test(this.$appConfig?.publicPath) ? {
+			].concat(/^[a-z]+:\/\//i.test(this.$appConfig?.publicPath) ? [
+				{
+					vmid: 'dns-prefetch',
+					rel: 'dns-prefetch',
+					href: `https://${new URL(this.$appConfig.publicPath).hostname}`
+				},
+				{
 					vmid: 'preconnect',
 					rel: 'preconnect',
 					href: `https://${new URL(this.$appConfig.publicPath).hostname}`
-				} :	{})
-			]).concat([
+				},
+				{
+					vmid: 'preconnect-crossorigin',
+					rel: 'preconnect',
+					crossorigin: '',
+					href: `https://${new URL(this.$appConfig.publicPath).hostname}`
+				},
+			] : []).concat([
 				// Standard Favicons + Android favicons
 				{
 					rel: 'icon',


### PR DESCRIPTION
Found this warning in lighthouse reports:
<img width="913" alt="Screen Shot 2022-07-13 at 2 50 20 PM" src="https://user-images.githubusercontent.com/4149025/178850333-96b72252-821f-4cd5-a6f0-3b43d1434dbd.png">

Followed this guide to add this preconnect https://crenshaw.dev/preconnect-resource-hint-crossorigin-attribute/