### PR TITLE
fix: lighthouse run fails when loan is funded, use newest sort instead

### DIFF
--- a/lighthouserc-prod.js
+++ b/lighthouserc-prod.js
@@ -9,7 +9,7 @@ module.exports = {
 				'https://www.kiva.org/lend/filter',
 				'https://www.kiva.org/lend-by-category',
 				'https://www.kiva.org/lend-by-category/women',
-				'https://www.kiva.org/live-loan/f/sort_popularity/url/1',
+				'https://www.kiva.org/live-loan/f/sort_newest/url/1',
 				'https://www.kiva.org/ui-site-map',
 				'https://www.kiva.org/cc/kiva-universal',
 				'https://www.kiva.org/lp/support-refugees',


### PR DESCRIPTION
Latest lighthouse build failed with a 403 forbidden error that seemed to occur because the loan was funded. Hoping that this resolves that issue for now by looking at newest loans only. A future improvement I am planning is to get the loan id with a separate js function and then go directly to `/lend-beta/<loan id>` or `/lend/<loan id>` instead of going through the live loan redirect.