### PR TITLE
feat: add cookie for redirect to categories-beta page

### DIFF
--- a/src/pages/Categories/CategoriesBeta.vue
+++ b/src/pages/Categories/CategoriesBeta.vue
@@ -171,6 +171,13 @@ export default {
 		}
 	},
 	mounted() {
+		// EXP-ACK-345-Jul2022
+		// This cookie is set during the redirect and signifies the exp is active when landing on this page
+		const expCookieSignifier = this.cookieStore.get('kvcategoriesbeta');
+		if (expCookieSignifier === 'b') {
+			this.$kvTrackEvent('Categories', 'EXP-ACK-345-Jul2022', expCookieSignifier);
+		}
+
 		this.apollo.query({
 			query: gql`
 				query bpHeroBackgroundImage($placeholderKey: String) {


### PR DESCRIPTION
ACK-341

Added tracking for experiment


@galen94 Just FYI -- this is how this will work, user attempts to go to `/categories` which is handled by our legacy php server, that server then assigns that user to an a/b testing variant. And will either render the legacy /categories page or set a cookie and redirect them to `/categories-beta` in either case we fire an analytics event. A cookie is needed here because our vue code doesnt have any concept of the legacy experiment framework. So we can use cookies to share data between the legacy php and the ui vue server. 