### PR TITLE
fix: mg landing header on wide displays styling fix

### DIFF
--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -3,6 +3,7 @@
 		<template v-if="!isOptionalChoiceExperiment">
 			<kv-hero
 				v-if="!isImpactVisibilityExperiment"
+				class="tw-text-center"
 				style="margin-bottom: 0;"
 			>
 				<template #images>
@@ -17,7 +18,10 @@
 				</template>
 				<template #overlayContent>
 					<div class="row">
-						<div class="tw-max-w-sm tw-bg-white tw-rounded tw-hidden md:tw-block tw-ml-2 tw-p-2">
+						<div
+							class="tw-max-w-sm tw-bg-white tw-rounded tw-hidden
+						md:tw-block tw-ml-2 tw-p-2 tw-text-left"
+						>
 							<h1
 								class="tw-text-primary
 							tw-text-h2" v-html="heroHeadline"
@@ -84,7 +88,7 @@
 							:src="heroImage" alt=""
 						>
 					</div>
-					<div class="tw-pt-16 md:tw-pt-11 lg:tw-max-w-5xl lg:tw-mx-auto tw-px-2">
+					<div class="tw-pt-16 md:tw-pt-11 lg:tw-max-w-5xl lg:tw-mx-auto tw-px-2 tw-text-left">
 						<h2 class="md:tw-text-center tw-text-subhead">
 							With these settings, you’ll support borrowers like this.
 						</h2>


### PR DESCRIPTION
Ran into this small bug: 

Before: 
![Screen Shot 2022-07-18 at 1 10 15 PM](https://user-images.githubusercontent.com/4371888/179600212-e7964d27-8f5b-4344-a0a9-9297ce9b61cf.png)

After:
![Screen Shot 2022-07-18 at 1 12 49 PM](https://user-images.githubusercontent.com/4371888/179600334-91affb65-9286-4feb-8c7b-f1aa0d63f3ef.png)

No changes for smaller screens
