### PR TITLE
fix: remove bottom margin in mobile view

### DIFF
--- a/src/components/BorrowerProfile/LendersList.vue
+++ b/src/components/BorrowerProfile/LendersList.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="tw-mb-3 lg:tw-mb-4">
+	<div class="lg:tw-mb-4">
 		<div class="tw-w-full tw-relative">
 			<span
 				class="tw-block tw-text-center tw-mb-2"


### PR DESCRIPTION
Small design fix. There was an extra margin in the bottom of the lenders list in the mobile view that was hiding a portion of the borrower's story image.