### PR TITLE
fix: fetch more lenders to avoid small filtered list

### DIFF
--- a/src/components/BorrowerProfile/LendersList.vue
+++ b/src/components/BorrowerProfile/LendersList.vue
@@ -121,7 +121,7 @@ export default {
 			return this.numLenders > 3 ? 2 : 1;
 		},
 		filteredLenders() {
-			return this.lenders.filter(lender => lender?.name?.toLowerCase() !== 'anonymous');
+			return this.lenders.filter(lender => lender?.name?.toLowerCase() !== 'anonymous').slice(0, 3);
 		},
 		sortedLenders() {
 			const inviterName = this.$route.query.utm_content ?? '';

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -164,7 +164,7 @@ const pageQuery = gql`
 					hash
 				}
 				plannedExpirationDate
-				lenders(limit: 3) {
+				lenders(limit: 10) {
 					values {
 						id
 						name


### PR DESCRIPTION
## Description
As there isn't a fast way of filtering lenders collection in loan type to avoid fetching anonymous lenders.

The idea behind this pr is to fetch more lenders (10) in order to have more options and always show the required amount of lenders (3 lenders in desktop and 2 in mobile).

Problem: Fetching 3 lenders and filtering one because was an anonymous lender. This image should show 3 people.
<img width="454" alt="image" src="https://user-images.githubusercontent.com/56947778/180040114-fcc370e1-4a3e-4309-a685-0bdb8430e7d9.png">
