### PR TITLE
fix: better tailwind jit compiling

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 const kvConfig = require('@kiva/kv-components/tailwind.config.cjs');
 
 module.exports = {
+	prefix: 'tw-',
 	presets: [kvConfig],
 	content: [
 		'./node_modules/@kiva/kv-components/**/*.vue',


### PR DESCRIPTION
I know this makes no sense, because we are getting the prefix property from KvConfig, which is getting it from the primitives. But I believe it could be a tailwind bug?

I tried adding this and I got much better results locally. 

Specifically for the use case of adding a class in `ui` repo that is not being used in the `kv-ui-elements` repo and having that class show  up in the compiled code without needing to add it to the purge safelist

I'm curious for others to verify 