### PR TITLE
fix: kvdropdown menu showing up under borrower profile lend cta

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -29,6 +29,7 @@
 					},
 					'lg:tw-rounded-t',
 					'lg:tw-px-4',
+					'lg:tw-gap-1'
 				]"
 			>
 				<div
@@ -211,16 +212,10 @@
 						All shares reserved
 					</p>
 					<hr
-						class="tw-hidden md:tw-block tw-border-tertiary tw-w-full"
-						:class="[
-							{
-								'md:tw-mt-1': !socialExpEnabled,
-								'tw-my-2 lg:tw-mb-3': socialExpEnabled,
-							}
-						]"
+						class="tw-hidden md:tw-block tw-border-tertiary tw-w-full tw-my-2"
 					>
 					<div
-						class="tw-flex lg:tw-justify-center tw-w-full tw-items-center"
+						class="tw-flex lg:tw-justify-center tw-w-full"
 						:class="isLoggedIn ? 'tw-justify-between' : 'tw-justify-end'"
 					>
 						<loan-bookmark
@@ -231,9 +226,9 @@
 						/>
 						<jump-links
 							:class="[
-								'tw-hidden md:tw-block',
+								'tw-hidden md:tw-block lg:tw-mb-1.5',
 								{
-									'tw-my-3': !socialExpEnabled
+									'md:tw-mb-3': isSticky || !socialExpEnabled,
 								}
 							]"
 							data-testid="bp-lend-cta-jump-links"

--- a/src/components/BorrowerProfile/LoanBookmark.vue
+++ b/src/components/BorrowerProfile/LoanBookmark.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<button
-			class="tw-text-action tw-inline-flex tw-p-1 tw-cursor-pointer tw-whitespace-nowrap tw-font-medium"
+			class="tw-text-action tw-inline-flex tw-cursor-pointer tw-whitespace-nowrap tw-font-medium"
 			@click="toggleBookmark()"
 		>
 			<kv-material-icon

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -91,7 +91,7 @@
 			<loan-bookmark
 				v-if="isLoggedIn"
 				:loan-id="loanId"
-				class="md:tw-hidden"
+				class="md:tw-hidden tw-mt-1"
 				data-testid="bp-mobile-summary-bookmark"
 			/>
 

--- a/src/components/Kv/KvDropdown.vue
+++ b/src/components/Kv/KvDropdown.vue
@@ -174,8 +174,14 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 @import 'settings';
 @import 'foundation';
 @include foundation-dropdown;
+</style>
+
+<style lang="postcss" scoped>
+.dropdown-pane {
+	@apply !tw-z-overlay;
+}
 </style>


### PR DESCRIPTION
I introduced this bug, on the non PFP pages, the about menu and user menu show up under the lend cta. This is because unlike the lend menu they use the kv-dropdown component which has a different z-index. 😭 

I'll hotfix this out

The rest are more minor spacing changes. 

The borrower profile is starting to feel a little bit hacky with all the state dependent styling and the 3 different states and all their permutations (share button on/off, logged in/out, social exp on/off). Maybe some refactoring and more thinking of these styles with style guide in mind.  Personally I prefer the approach with the share button of using slots from the borrower profile to slot the button in the summary card/lend cta. It at least keeps the component in one place vs having an instance nested in the lend cta and another in the summary card (like the jump links)....