### PR TITLE
fix: only show expected FLSS sort options

### DIFF
--- a/src/util/loanSearch/filterUtils.js
+++ b/src/util/loanSearch/filterUtils.js
@@ -21,6 +21,8 @@ export const sortByNameToDisplay = {
 	personalized: 'Recommended'
 };
 
+export const visibleFLSSSortOptions = ['expiringSoon', 'amountHighToLow', 'amountLowToHigh', 'personalized'];
+
 /**
  * The themes/attributes that are always visible in the filter UI
  */
@@ -51,8 +53,7 @@ export function formatSortOptions(standardSorts, flssSorts) {
 		};
 	}) ?? [];
 	const labeledFlssSorts = flssSorts?.reduce((prev, current) => {
-		// The amountLeft sort is currently returned by the GraphQL enum but isn't fully supported
-		if (current.name !== 'amountLeft') {
+		if (visibleFLSSSortOptions.includes(current.name)) {
 			prev.push({ name: current.name, sortSrc: FLSS_QUERY_TYPE });
 		}
 

--- a/test/unit/specs/util/loanSearch/filterUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/filterUtils.spec.js
@@ -9,6 +9,7 @@ import {
 	formatSortOptions,
 	FLSS_QUERY_TYPE,
 	STANDARD_QUERY_TYPE,
+	visibleFLSSSortOptions,
 } from '@/util/loanSearch/filterUtils';
 import _orderBy from 'lodash/orderBy';
 import {
@@ -32,7 +33,7 @@ const mockBTheme = (numLoansFundraising = 4) => ({ id: 3, name: 'b', numLoansFun
 describe('filterUtils.js', () => {
 	describe('formatSortOptions', () => {
 		const mockStandardSorts = [{ name: 'a' }, { name: 'b' }];
-		const mockFLSSSorts = [{ name: 'c' }, { name: 'd' }];
+		const mockFLSSSorts = visibleFLSSSortOptions.map(f => ({ name: f, sortSrc: FLSS_QUERY_TYPE }));
 
 		it('should handle empty', () => {
 			expect(formatSortOptions()).toEqual([]);
@@ -44,18 +45,21 @@ describe('filterUtils.js', () => {
 			expect(formatSortOptions(mockStandardSorts, mockFLSSSorts)).toEqual([
 				{ name: 'a', sortSrc: STANDARD_QUERY_TYPE },
 				{ name: 'b', sortSrc: STANDARD_QUERY_TYPE },
-				{ name: 'c', sortSrc: FLSS_QUERY_TYPE },
-				{ name: 'd', sortSrc: FLSS_QUERY_TYPE }
+				...mockFLSSSorts
 			]);
 		});
 
-		it('should exclude amountLeft', () => {
-			expect(formatSortOptions(mockStandardSorts, [...mockFLSSSorts, { name: 'amountLeft' }])).toEqual([
-				{ name: 'a', sortSrc: STANDARD_QUERY_TYPE },
-				{ name: 'b', sortSrc: STANDARD_QUERY_TYPE },
-				{ name: 'c', sortSrc: FLSS_QUERY_TYPE },
-				{ name: 'd', sortSrc: FLSS_QUERY_TYPE }
-			]);
+		it('should exclude non-visible sort options', () => {
+			expect(formatSortOptions(mockStandardSorts, [
+				...mockFLSSSorts,
+				{ name: 'amountLeft' },
+				{ name: 'researchScore' }
+			]))
+				.toEqual([
+					{ name: 'a', sortSrc: STANDARD_QUERY_TYPE },
+					{ name: 'b', sortSrc: STANDARD_QUERY_TYPE },
+					...mockFLSSSorts
+				]);
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1180

- Instead of explicitly excluding, sort options are now explicitly included
- This will prevent this bug from happening the next time a sort option is released