### PR TITLE
fix: also check name url param for inviter public id MARS-206

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -142,6 +142,7 @@ import {
 import loanUseFilter from '@/plugins/loan-use-filter';
 
 const socialElementsExpKey = 'social_elements';
+const getPublicId = route => route?.query?.utm_content ?? route?.query?.name ?? '';
 const pageQuery = gql`
 	query borrowerProfileMeta($loanId: Int!, $publicId: String!, $getInviter: Boolean!) {
 		general {
@@ -361,13 +362,14 @@ export default {
 	apollo: {
 		query: pageQuery,
 		preFetch(config, client, { route }) {
+			const publicId = getPublicId(route);
 			return client
 				.query({
 					query: pageQuery,
 					variables: {
 						loanId: Number(route.params?.id ?? 0),
-						publicId: route.query?.utm_content ?? '',
-						getInviter: !!route.query?.utm_content
+						publicId,
+						getInviter: !!publicId
 					},
 				})
 				.then(({ data }) => {
@@ -388,17 +390,19 @@ export default {
 				});
 		},
 		preFetchVariables({ route }) {
+			const publicId = getPublicId(route);
 			return {
 				loanId: Number(route?.params?.id ?? 0),
-				publicId: route.query?.utm_content ?? '',
-				getInviter: !!route.query?.utm_content,
+				publicId,
+				getInviter: !!publicId,
 			};
 		},
 		variables() {
+			const publicId = getPublicId(this.$route);
 			return {
 				loanId: Number(this.$route?.params?.id ?? 0),
-				publicId: this.$route?.query?.utm_content ?? '',
-				getInviter: !!this.$route?.query?.utm_content,
+				publicId,
+				getInviter: !!publicId,
 			};
 		},
 		result(result) {


### PR DESCRIPTION
It turns out that in the case of using the /invitedby/{lender_id}/for/{loan_id} url it sets the inviter id in the `name` parameter instead of `utm_content`. We should change that so it uses utm_content instead, but until we can get that released in the monolith this will deal with the issue.