### PR TITLE
fix: require loan purchase to display focused share ask on thanks page MARS-218

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -2,7 +2,7 @@
 	<www-page
 		:gray-background="true"
 	>
-		<div class="row page-content" v-if="receipt && isGuest">
+		<div class="row page-content" v-if="receipt && !showFocusedShareAsk">
 			<div class="small-12 columns thanks">
 				<div class="thanks__header hide-for-print">
 					<template v-if="receipt">
@@ -96,7 +96,7 @@
 			</thanks-layout-v2>
 		</div>
 		<thanks-page-share
-			v-if="receipt && !isGuest"
+			v-if="receipt && showFocusedShareAsk"
 			:receipt="receipt"
 			:lender="lender"
 			:loan="selectedLoan"
@@ -233,6 +233,10 @@ export default {
 				return true;
 			}
 			return false;
+		},
+		showFocusedShareAsk() {
+			// Only show focused share ask for non-guest loan purchases
+			return !this.isGuest && this.selectedLoan.id;
 		}
 	},
 	created() {
@@ -318,7 +322,7 @@ export default {
 			}
 		}
 
-		if (!this.isGuest) {
+		if (this.showFocusedShareAsk) {
 			const shareCardLanguage = this.apollo.readFragment({
 				id: 'Experiment:share_card_language',
 				fragment: experimentVersionFragment,


### PR DESCRIPTION
Fixes production issue that causes thanks page to 502 for non-lending checkouts (donations, kiva card purchases)