### PR TITLE
refactor: remove inactive experiments

### DIFF
--- a/src/components/Homepage/HomepageVerticalCTA.vue
+++ b/src/components/Homepage/HomepageVerticalCTA.vue
@@ -28,29 +28,9 @@
 </template>
 
 <script>
-import _get from 'lodash/get';
-import gql from 'graphql-tag';
-
-import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
-import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import SectionWithBackground from '@/components/Contentful/SectionWithBackground';
 import KvContentfulImg from '~/@kiva/kv-components/vue/KvContentfulImg';
 import { documentToHtmlString } from '~/@contentful/rich-text-html-renderer';
-
-const pageQuery = gql`
-  query homepageVerticalCTA {
-    general {
-      homepage_verticalcta_active: uiConfigSetting(key: "homepage_verticalcta_active") {
-        key
-        value
-      }
-      homepage_verticalcta_exp: uiExperimentSetting(key: "homepage_verticalcta") {
-        key
-        value
-      }
-    }
-  }
-`;
 
 export default {
 	name: 'HomepageVerticalCTA',
@@ -65,38 +45,9 @@ export default {
 		},
 	},
 	inject: ['apollo', 'cookieStore'],
-	apollo: {
-		query: pageQuery,
-		preFetch(config, client) {
-			return client.query({
-				query: pageQuery
-			}).then(() => {
-				return client.query({ query: experimentAssignmentQuery, variables: { id: 'homepage_verticalcta' } });
-			});
-		},
-		result({ data }) {
-			// EXP-GROW-612 is only targed for homepage
-			// Always show the comopnent unless we're on the homepage
-			if (this.$route.path !== '/') {
-				this.showVerticalCTA = true;
-			} else {
-				// eslint-disable-next-line max-len
-				const verticalCTAExpActive = _get(data, 'general.homepage_verticalcta_active.value') === 'true' || false;
-				if (verticalCTAExpActive) {
-					const verticalCTAExp = this.apollo.readFragment({
-						id: 'Experiment:homepage_verticalcta',
-						fragment: experimentVersionFragment,
-					}) || {};
-					const { version } = verticalCTAExp;
-					this.showVerticalCTA = version === 'shown';
-					this.$kvTrackEvent('Home', 'EXP-GROW-612-May2021', this.showVerticalCTA ? 'b' : 'a');
-				}
-			}
-		}
-	},
 	data() {
 		return {
-			showVerticalCTA: false
+			showVerticalCTA: true
 		};
 	},
 	computed: {

--- a/src/pages/LandingPages/MGCovid19/CovidLandingForm.vue
+++ b/src/pages/LandingPages/MGCovid19/CovidLandingForm.vue
@@ -2,7 +2,7 @@
 	<form @submit.prevent.stop="submit" novalidate>
 		<div class="row">
 			<div class="small-12 columns input-wrapper recurring-amounts">
-				<fieldset v-if="!oneTimeOnly && expRecurringOnly !== 'shown'">
+				<fieldset v-if="!oneTimeOnly">
 					<legend class="visually-hidden">
 						Choose how often to contribute
 					</legend>
@@ -17,9 +17,6 @@
 				<fieldset>
 					<legend v-if="oneTimeOnly">
 						Choose a one-time amount to contribute
-					</legend>
-					<legend v-else-if="expRecurringOnly === 'shown'">
-						Contribute monthly:
 					</legend>
 					<legend v-else class="visually-hidden">
 						Choose an amount to contribute
@@ -75,10 +72,6 @@ import KvButton from '~/@kiva/kv-components/vue/KvButton';
 const pageQuery = gql`query covidLandingPage {
 	general {
 		covDefaultAmountExp: uiExperimentSetting(key: "covid19response_default_amount") {
-			key
-			value
-		}
-		mgRecurringOnlyExp: uiExperimentSetting(key: "mg_recurring_only") {
 			key
 			value
 		}
@@ -195,7 +188,6 @@ export default {
 			minOnetimeAmount: 25,
 			maxDepositAmount: 10000,
 			expDefaultAmount: null,
-			expRecurringOnly: null,
 		};
 	},
 	inject: ['apollo', 'cookieStore'],
@@ -207,7 +199,6 @@ export default {
 			}).then(() => {
 				return Promise.all([
 					client.query({ query: experimentQuery, variables: { id: 'covid19response_default_amount' } }),
-					client.query({ query: experimentQuery, variables: { id: 'mg_recurring_only' } })
 				]);
 			});
 		},
@@ -222,15 +213,6 @@ export default {
 				this.recurringCustomAmount = 25;
 				this.recurringAmount = 25;
 			}
-
-			const mgRecurringOnlyExp = this.apollo.readFragment({
-				id: 'Experiment:mg_recurring_only',
-				fragment: experimentVersionFragment,
-			}) || {};
-			this.expRecurringOnly = mgRecurringOnlyExp.version;
-			if (this.expRecurringOnly === 'shown') {
-				this.isRecurring = true;
-			}
 		},
 	},
 	mounted() {
@@ -240,14 +222,6 @@ export default {
 				'Monthly Good',
 				'EXP-GROW-96-May2020',
 				this.expDefaultAmount === 'shown' ? 'b' : 'a'
-			);
-		}
-
-		if (this.expRecurringOnly && this.expRecurringOnly !== 'unassigned') {
-			this.$kvTrackEvent(
-				'MonthlyGood',
-				'EXP-GROW-104-May2020',
-				this.expRecurringOnly === 'shown' ? 'b' : 'a'
 			);
 		}
 

--- a/src/util/experimentPreFetch.js
+++ b/src/util/experimentPreFetch.js
@@ -12,7 +12,6 @@ import updateExperimentVersion from '@/graphql/mutation/updateExperimentVersion.
 // TODO: Centralize this in Settings Manager or elsewhere, then Fetch it First
 let activeExperiments = [
 	'lend_filter_v2',
-	'expandable_loan_cards',
 	'checkout_login_cta',
 	'guest_checkout_cta',
 	'mg_highlight_in_nav',


### PR DESCRIPTION
Removed the experiments: 
"homepage_verticalcta_active"
"homepage_verticalcta"
"mg_recurring_only"
"expandable_loan_cards"

from UI

also deleted from settings manager.  
Updated in excel doc. 

All of these were disabled and/or out of date range. Tried to do minimal cleanup, I'm not sure some of these components are even used anymore... 
