### PR TITLE
fix: inject cookieStore in whatIsKiva component

### DIFF
--- a/src/components/BorrowerProfile/WhatIsKivaModal.vue
+++ b/src/components/BorrowerProfile/WhatIsKivaModal.vue
@@ -92,6 +92,7 @@ import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 export default {
 	name: 'WhatIsKivaModal',
+	inject: ['cookieStore'],
 	components: {
 		KvLightbox,
 		KvButton,


### PR DESCRIPTION
Injecting  `cookieStore` in component to fix undefined error when setting the cookie