### PR TITLE
Web vitals & PageSpeed Insights tracking MARS-169

### DIFF
--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -5,6 +5,10 @@ on:
     # run nightly at midnight
     - cron:  '0 0 * * *'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   lhci:
     name: Lighthouse
@@ -12,30 +16,25 @@ jobs:
     env:
       LHCI_GITHUB_APP_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LHCI_PROD_BUILD_TOKEN: ${{ secrets.LHCI_PROD_BUILD_TOKEN }}
+      PSI_API_KEY: ${{ secrets.LHCI_PSI_API_KEY }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 15.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
         with:
-          node-version: 15.x
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dependencies
-        with:
-          path: |
-            ~/.cache
-            ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: npm install, build
+          node-version: 16
+      - name: Run Lighthouse CI
         run: |
-          npm ci --prefer-offline
-          npm run build
-      - name: run Lighthouse CI
-        run: |
-          npm install -g @lhci/cli@0.7.x
+          npm install -g @lhci/cli@0.9.x
           lhci autorun --config=./lighthouserc-prod.js
+          lhci upload --target=filesystem --outputDir=./lhci
+          node format-lh-for-s3.js
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.LHCI_S3_REGION }}
+          role-to-assume: ${{ secrets.LHCI_AWS_ROLE_TO_ASSUME }}
+          role-session-name: LighthouseGithubAction
+      - name: Upload to S3
+        run: |
+          aws s3 sync lhci/final/ s3://${{ secrets.LHCI_S3_BUCKET }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ test/e2e/results
 server/available-routes.json
 build/schema.graphql
 .nyc_output/
+.lighthouseci/
+lhci/
 
 # Editor directories and files
 .idea

--- a/format-lh-for-s3.js
+++ b/format-lh-for-s3.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+const manifest = require('./lhci/manifest.json');
+
+const FINAL_DIR = './lhci/final';
+
+// create directory for final reports if it does not exist
+if (!fs.existsSync(FINAL_DIR)) {
+	fs.mkdirSync(FINAL_DIR);
+}
+
+manifest.forEach(report => {
+	fs.readFile(report.jsonPath, (readErr, data) => {
+		if (readErr) throw readErr;
+
+		// Get relevant data from report
+		const body = JSON.parse(data);
+		const relevantData = JSON.stringify({
+			url: report?.url,
+			fetchTime: body?.fetchTime,
+			performanceScore: report?.summary?.performance,
+			accessibilityScore: report?.summary?.accessibility,
+			bestPracticesScore: report?.summary?.['best-practices'],
+			seoScore: report?.summary?.seo,
+			pwaScore: report?.summary?.pwa,
+			runDuration: body?.timing?.total,
+			runIsMedianResult: report?.isRepresentativeRun,
+			lighthouseVersion: body?.lighthouseVersion,
+			userAgent: body?.userAgent,
+			formFactor: body?.configSettings?.formFactor,
+			locale: body?.configSettings?.locale,
+		});
+
+		// Write final file
+		const filename = path.basename(report.jsonPath);
+		fs.writeFile(`${FINAL_DIR}/${filename}`, relevantData, writeErr => {
+			if (writeErr) throw writeErr;
+		});
+	});
+});

--- a/lighthouserc-prod.js
+++ b/lighthouserc-prod.js
@@ -1,6 +1,8 @@
 module.exports = {
 	ci: {
 		collect: {
+			method: 'psi',
+			psiApiKey: process.env.PSI_API_KEY,
 			settings: {
 				onlyCategories: ['accessibility', 'best-practices', 'performance', 'seo'],
 				maxWaitForLoad: 90000,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.255.0",
+	"version": "2.259.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.255.0",
+			"version": "2.259.2",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.18.2",
@@ -97,6 +97,7 @@
 				"vue2-touch-events": "^2.3.2",
 				"vuedraggable": "^2.23.0",
 				"vuelidate": "^0.7.6",
+				"web-vitals": "^2.1.4",
 				"webpack-merge": "^5.8.0",
 				"whatwg-fetch": "^3.6.2",
 				"winston": "^3.3.3"
@@ -38287,6 +38288,11 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/web-vitals": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
+			"integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+		},
 		"node_modules/webidl-conversions": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -69948,6 +69954,11 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
 			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+		},
+		"web-vitals": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
+			"integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
 		},
 		"webidl-conversions": {
 			"version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
 		"vue2-touch-events": "^2.3.2",
 		"vuedraggable": "^2.23.0",
 		"vuelidate": "^0.7.6",
+		"web-vitals": "^2.1.4",
 		"webpack-merge": "^5.8.0",
 		"whatwg-fetch": "^3.6.2",
 		"winston": "^3.3.3"

--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -13,6 +13,7 @@ import showTipMessage from '@/graphql/mutation/tipMessage/showTipMessage.graphql
 import { preFetchAll } from '@/util/apolloPreFetch';
 import { authenticationGuard } from '@/util/authenticationGuard';
 import { contentfulPreviewCookie } from '@/util/contentfulPreviewCookie';
+import collectWebVitals from '@/util/webVitals';
 
 import createApp from '@/main';
 import '@/assets/iconLoader';
@@ -107,11 +108,12 @@ try {
 	// do nothing (leave user id as null)
 }
 
-// setup global analytics configuratino + data
+// setup global analytics configuration + data
 app.$setKvAnalyticsData(userId).then(() => {
 	// fire server rendered pageview
 	app.$fireServerPageView();
 	app.$fireQueuedEvents();
+	collectWebVitals(app.$kvTrackEvent);
 });
 
 // Setup adding touch info to the state

--- a/src/util/webVitals.js
+++ b/src/util/webVitals.js
@@ -1,0 +1,37 @@
+import {
+	getCLS,
+	getFCP,
+	getFID,
+	getLCP,
+	getTTFB,
+} from 'web-vitals';
+
+const trackingCategory = 'web vitals';
+const trackingAction = 'report';
+
+export default function collectWebVitals(trackEvent) {
+	const handleReport = ({ name, id, delta }) => {
+		// The name of the metric in acronym form ('CLS', 'FCP', 'FID', 'LCP', 'TTFB').
+		const label = name;
+
+		// A unique ID representing this particular metric that's specific to the
+		// current page load. This ID can be used by an analytics tool to dedupe
+		// multiple values sent for the same metric, or to group multiple deltas
+		// together and calculate a total.
+		const property = id;
+
+		// The delta between the current value and the last-reported value.
+		// On the first report, `delta` and `value` will always be the same.
+		// Snowplow requires that se_value is an integer, so the value is rounded.
+		// For CLS the value is first multiplied by 1000 for greater precision.
+		const value = Math.round(name === 'CLS' ? delta * 1000 : delta);
+
+		// Send metric value as an event
+		trackEvent(trackingCategory, trackingAction, label, property, value);
+	};
+	getCLS(handleReport);
+	getFCP(handleReport);
+	getFID(handleReport);
+	getLCP(handleReport);
+	getTTFB(handleReport);
+}


### PR DESCRIPTION
A couple things in this PR:

- Switching the nightly production Lighthouse test to use the PageSpeed Insights API, to improve consistency of the results and automatically keep the Lighthouse version used for the test up-to-date.
- Adding a step to the Lighthouse test that uploads trimmed-down versions of the reports to S3 where they can be consumed by our data warehouse.
- Tracking [web vitals](https://github.com/GoogleChrome/web-vitals) (CLS, FCP, FID, LCP, TTFB) for real-user page loads via Snowplow.