### PR TITLE
fix: combine loan channel pages to avoid issues with max limit 100 in…

### DIFF
--- a/src/graphql/query/loanChannelPage.graphql
+++ b/src/graphql/query/loanChannelPage.graphql
@@ -1,3 +1,5 @@
+# In production our loanChannels are limited to a max limit of 100 channels
+# These 2 aliased calls in effect fetch the first 200 channels in production
 query loanChannelPage {
 	my {
 		userAccount {
@@ -5,8 +7,13 @@ query loanChannelPage {
 		}
 	}
 	lend {
-		loanChannels(offset:0, limit:1000) {
-			totalCount
+		firstLoanChannels: loanChannels(offset:0, limit:100) {
+			values {
+				id
+				url
+			}
+		}
+		secondLoanChannels: loanChannels(offset:100, limit:100) {
 			values {
 				id
 				url

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -350,6 +350,18 @@ export default {
 			return client.query({
 				query: loanChannelPageQuery
 			}).then(({ data }) => {
+				// combine both 'pages' of loan channels
+				const pageQueryData = {
+					...data,
+					lend: {
+						loanChannels: {
+							values: [
+								...(data?.lend?.firstLoanChannels?.values ?? []),
+								...(data?.lend?.secondLoanChannels?.values ?? [])
+							]
+						}
+					}
+				};
 				const { route } = args;
 				const { query, params, path } = route;
 
@@ -357,7 +369,7 @@ export default {
 				const targetedLoanChannelURL = params.category;
 
 				// Isolate targeted loan channel id
-				const targetedLoanChannelID = getTargetedChannel(targetedLoanChannelURL, data);
+				const targetedLoanChannelID = getTargetedChannel(targetedLoanChannelURL, pageQueryData);
 
 				// Get page limit and offset
 				const currentRoute = path.replace('/lend-by-category/', '');
@@ -391,14 +403,27 @@ export default {
 			logReadQueryError(e, 'LoanChannelCategoryControl created loanChannelPageQuery');
 		}
 
+		// combine both 'pages' of loan channels
+		const pageQueryData = {
+			...allChannelsData,
+			lend: {
+				loanChannels: {
+					values: [
+						...(allChannelsData?.lend?.firstLoanChannels?.values ?? []),
+						...(allChannelsData?.lend?.secondLoanChannels?.values ?? [])
+					]
+				}
+			}
+		};
+
 		// Set user status
-		this.isVisitor = !_get(allChannelsData, 'my.userAccount.id');
+		this.isVisitor = !_get(pageQueryData, 'my.userAccount.id');
 
 		// Filter routes on param.category to get current path
 		this.targetedLoanChannelURL = _get(this.$route, 'params.category');
 
 		// Isolate targeted loan channel id
-		this.targetedLoanChannelID = getTargetedChannel(this.targetedLoanChannelURL, allChannelsData);
+		this.targetedLoanChannelID = getTargetedChannel(this.targetedLoanChannelURL, pageQueryData);
 
 		// Extract query
 		this.pageQuery = _get(this.$route, 'query');

--- a/src/pages/Lend/LoanChannelCategoryRecommendedByLenders.vue
+++ b/src/pages/Lend/LoanChannelCategoryRecommendedByLenders.vue
@@ -269,10 +269,23 @@ export default {
 			return client.query({
 				query: loanChannelPageQuery
 			}).then(({ data }) => {
+				// combine both 'pages' of loan channels
+				const pageQueryData = {
+					...data,
+					lend: {
+						loanChannels: {
+							values: [
+								...(data?.lend?.firstLoanChannels?.values ?? []),
+								...(data?.lend?.secondLoanChannels?.values ?? [])
+							]
+						}
+					}
+				};
+
 				// filter routes on route.param.category to get current path
 				const targetedLoanChannelURL = routePath;
 				// isolate targeted loan channel id
-				const targetedLoanChannelID = getTargetedChannel(targetedLoanChannelURL, data);
+				const targetedLoanChannelID = getTargetedChannel(targetedLoanChannelURL, pageQueryData);
 				// extract query
 				const pageQuery = _get(args, 'route.query');
 
@@ -301,13 +314,25 @@ export default {
 		} catch (e) {
 			logReadQueryError(e, 'LoanChannelCategoryPage loanChannelPageQuery');
 		}
+		// combine both 'pages' of loan channels
+		const pageQueryData = {
+			...allChannelsData,
+			lend: {
+				loanChannels: {
+					values: [
+						...(allChannelsData?.lend?.firstLoanChannels?.values ?? []),
+						...(allChannelsData?.lend?.secondLoanChannels?.values ?? [])
+					]
+				}
+			}
+		};
 
 		// set user status
-		this.isVisitor = !_get(allChannelsData, 'my.userAccount.id');
+		this.isVisitor = !_get(pageQueryData, 'my.userAccount.id');
 		// filter routes on param.category to get current path
 		const targetedLoanChannelURL = routePath;
 		// isolate targeted loan channel id
-		this.targetedLoanChannelID = getTargetedChannel(targetedLoanChannelURL, allChannelsData);
+		this.targetedLoanChannelID = getTargetedChannel(targetedLoanChannelURL, pageQueryData);
 		// extract query
 		this.pageQuery = _get(this.$route, 'query');
 


### PR DESCRIPTION
… prod

These are the only use cases of this `.graphql` query file. 

The only other uses of these type of query is in the LoanSpotlight component (which will never fail since it has a backup category) and the CategoryAdminControls (which is commented out, and not in use atm)