### PR TITLE
fix: hide empty categories on the eco experiment layout

### DIFF
--- a/src/pages/Lend/LoanChannelCategoryClimateExperiment.vue
+++ b/src/pages/Lend/LoanChannelCategoryClimateExperiment.vue
@@ -184,6 +184,10 @@ export default {
 		this.secondaryEcoLoanChannelsResponse = baseData?.lend?.loanChannelsById
 			.filter(channel => channel.id !== this.targetedLoanChannelID) ?? [];
 
+		// filter out any secondary channels that do not have loans
+		this.secondaryEcoLoanChannelsResponse = this.secondaryEcoLoanChannelsResponse
+			.filter(channel => channel.loans.totalCount > 0);
+
 		/*
 		 * Experiment Initializations
 		*/


### PR DESCRIPTION
ACK-393

If a category has no loans, then hide it from the exp carousel layout