### PR TITLE
fix: update query str and tracking on new saved search

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -58,7 +58,7 @@
 			<kv-section-modal-loader :loading="loading" bg-color="secondary" size="large" />
 			<div v-if="initialLoadComplete">
 				<loan-search-saved-search
-					v-if="enableSavedSearch && showSavedSearch"
+					v-if="enableSavedSearch && showSavedSearch && !savedSearchSuccess"
 					:loan-search-state="loanSearchState"
 					:theme-names="themeNames"
 					:show-success-message="showSavedSearchSuccessMessage"
@@ -161,6 +161,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		savedSearchSuccess: {
+			type: Boolean,
+			default: false
+		}
 	},
 	data() {
 		return {

--- a/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
@@ -136,12 +136,14 @@ export default {
 			this.$kvTrackEvent(
 				'Lending',
 				'click-create-saved-search-new-modal',
-				'Create saved search'
+				'Create saved search',
+				this.reformattedSearchState
 			);
 			// We want to exclude sending any utm params
-			const queryString = window.location.search.replace(/(&|\?)utm_[a-zA-Z0-9]*=[a-zA-Z0-9]*/, '');
+			// New lend/filter page doesn't allow for custom keywords ATM - revisit this after exp phase
+			// const queryString = window.location.search.replace(/(&|\?)utm_[a-zA-Z0-9]*=[a-zA-Z0-9]*/, '');
 			createSavedSearch(
-				this.apollo, this.reformattedSearchState, queryString, this.savedSearchName
+				this.apollo, this.reformattedSearchState, '', this.savedSearchName
 			// eslint-disable-next-line no-unused-vars
 			).then(({ data }) => {
 				this.showSuccessMessage(this.savedSearchName);

--- a/src/pages/Lend/LoanSearchPage.vue
+++ b/src/pages/Lend/LoanSearchPage.vue
@@ -47,6 +47,7 @@
 				</div>
 				<loan-search-interface
 					:enable-saved-search="enableSavedSearch"
+					:saved-search-success="savedSearchSuccess"
 					@enable-success-saved-search="enableSuccessSavedSearch"
 				/>
 			</kv-page-container>


### PR DESCRIPTION
- sets the `queryString` param as empty since custom keywords are not yet available on new lend filter page (to revisit after exp), confirmed w/ BE
- additional tracking
- hide saved search notif when creating saved search success message is visible