### PR TITLE
fix: load head scripts before anything else

### DIFF
--- a/server/index.template.html
+++ b/server/index.template.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 <html data-vue-meta-server-rendered lang="en">
 	<head>
+		{{{ renderedConfig }}}
+		{{{ renderedExternals }}}
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
 		{{{ meta.inject().meta.text() }}}
 		{{{ meta.inject().link.text() }}}
 		{{{ meta.inject().title.text() }}}
 		{{{ renderStyles() }}}
-		{{{ renderedConfig }}}
 		{{{ meta.inject().style.text() }}}
 		{{{ meta.inject().script.text() }}}
-		{{{ renderedExternals }}}
 	</head>
 	<body>
 		{{{ renderedNoscript }}}


### PR DESCRIPTION
The goal of this is to improve the Optimizely loading time to hopefully minimize or avoid the FOUC caused for pages with Optimizely experiments. By moving the renderedExternals to the very first line in the `<head>`, that should get the browser to load and execute OneTrust (and then hopefully Optimizely) before loading anything else like fonts, styles, or the body of the page. This has the potential to break things and to harm the overall loading performance scores, so I'll be keeping a close eye on it and I'll revert this if necessary.