### PR TITLE
fix: update lighthouse checkout step to gain visibility to ancestor hash

### DIFF
--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -19,6 +19,10 @@ jobs:
       PSI_API_KEY: ${{ secrets.LHCI_PSI_API_KEY }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 40
+      - name: Fetch base_ref HEAD to use it as Ancestor hash in LHCI
+        run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Force github checkout action to look deeper into the commit history.

ref. https://github.com/GoogleChrome/lighthouse-ci/blob/main/docs/troubleshooting.md#running-lhci-in-github-actions-i-constantly-get-ancestor-hash-not-determinable