### PR TITLE
fix: remove commented out code in this config

### DIFF
--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -21,8 +21,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 30
-      # - name: Fetch base_ref HEAD to use it as Ancestor hash in LHCI
-      #   run: git fetch --depth=1 origin +refs/heads/${{github.base_ref}}:refs/remotes/origin/${{github.base_ref}}
       - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
minor clean. Our run this evening should be fine with the fetch depth addition. Let's see if it solves the ancestor warning...