### PR TITLE
fix: add missing injections and props for new loans-by-category grid

### DIFF
--- a/src/components/Contentful/HomePage/NewHomeLoansByCategoryGrid.vue
+++ b/src/components/Contentful/HomePage/NewHomeLoansByCategoryGrid.vue
@@ -9,6 +9,7 @@
 					<kiva-multi-category-grid
 						:contentful-loan-channels="contentfulLoanChannels"
 						:loan-display-settings="loanDisplaySettings"
+						:new-home-exp="true"
 					/>
 				</div>
 			</kv-page-container>

--- a/src/components/Homepage/HomeExp/KivaMultiCategoryGrid.vue
+++ b/src/components/Homepage/HomeExp/KivaMultiCategoryGrid.vue
@@ -28,6 +28,7 @@ import LoanCategorySelectorHomeExp from '@/components/LoanCollections/HomeExp/Lo
 
 export default {
 	name: 'KivaMultiCategoryGrid',
+	inject: ['apollo', 'cookieStore'],
 	components: { LoanCategorySelectorHomeExp, KivaClassicLoanCarousel },
 	props: {
 		/**
@@ -61,13 +62,13 @@ export default {
 	},
 	computed: {
 		combinedLoanChannelData() {
-			return this.loanChannelsWithUrgencyExperiment.map(channel => {
+			return this.contentfulLoanChannels.map(channel => {
 				const matchedLoanChannel = this.loanChannelData.find(lc => lc.id === channel.id);
 				return { ...matchedLoanChannel, ...channel };
 			});
 		},
 		loanChannelIds() {
-			return this.loanChannelsWithUrgencyExperiment.map(channelSetting => {
+			return this.contentfulLoanChannels.map(channelSetting => {
 				return channelSetting.id;
 			});
 		},

--- a/src/components/LoanCollections/HomeExp/LoanCategorySelectorHomeExp.vue
+++ b/src/components/LoanCollections/HomeExp/LoanCategorySelectorHomeExp.vue
@@ -3,7 +3,7 @@
 		class="tw-flex tw-justify-start tw-flex-row md:tw-flex-col md:tw-justify-center
 			md:tw-flex-wrap tw-mx-auto tw-overflow-x-auto md:tw-overflow-x-none"
 	>
-		<kv-tabs vertical="true" class="tabs-container">
+		<kv-tabs :vertical="true" class="tabs-container">
 			<template #tabNav>
 				<kv-tab
 					class="md:tw-truncate"


### PR DESCRIPTION
Ran into a couple issues trying this out in a Contentful page.