### PR TITLE
feat: theme controls for SectionWithBackgroundClassic

### DIFF
--- a/src/components/Contentful/CardRow.vue
+++ b/src/components/Contentful/CardRow.vue
@@ -2,6 +2,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template

--- a/src/components/Contentful/CenteredRichText.vue
+++ b/src/components/Contentful/CenteredRichText.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/DynamicHeroClassic.vue
+++ b/src/components/Contentful/DynamicHeroClassic.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/FrequentlyAskedQuestions.vue
+++ b/src/components/Contentful/FrequentlyAskedQuestions.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/HeroWithCarousel.vue
+++ b/src/components/Contentful/HeroWithCarousel.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/HomePage/NewHomeLoansByCategoryGrid.vue
+++ b/src/components/Contentful/HomePage/NewHomeLoansByCategoryGrid.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/LoansByCategoryCarousel.vue
+++ b/src/components/Contentful/LoansByCategoryCarousel.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/MediaItemsCentered.vue
+++ b/src/components/Contentful/MediaItemsCentered.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="sectionBackground"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/RichTextItemsCentered.vue
+++ b/src/components/Contentful/RichTextItemsCentered.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="sectionBackground"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/components/Contentful/SectionWithBackgroundClassic.vue
+++ b/src/components/Contentful/SectionWithBackgroundClassic.vue
@@ -82,7 +82,16 @@ export default {
 			default: () => {},
 		},
 		/**
+		 * Theme name from Contentful settings
 		 *
+		 * Can be one of:
+		 * - 'kivaClassicLight'
+		 * - 'kivaClassicMint'
+		 * - 'kivaClassicGreen'
+		 * - 'kivaClassicDark'
+		 * - 'imageCard'
+		 *
+		 * The default theme 'kivaClassicLight' will be used for any other value.
 		 */
 		themeName: {
 			type: String,
@@ -149,7 +158,7 @@ export default {
 		},
 		themeStyles() {
 			const themeMapper = {
-				kivaCLassicLight: defaultTheme,
+				kivaClassicLight: defaultTheme,
 				kivaClassicMint: mintTheme,
 				kivaClassicGreen: darkGreenTheme,
 				kivaClassicDark: darkTheme,

--- a/src/components/Contentful/SectionWithBackgroundClassic.vue
+++ b/src/components/Contentful/SectionWithBackgroundClassic.vue
@@ -1,5 +1,5 @@
 <template>
-	<section class="tw-relative">
+	<section class="tw-relative" :style="themeStyles">
 		<div
 			class="tw-relative tw-w-full tw-overflow-hidden tw-z-1 tw-top-0"
 			:class="verticalPaddingClasses"
@@ -33,6 +33,13 @@
 </template>
 
 <script>
+import {
+	darkTheme,
+	darkGreenTheme,
+	mintTheme,
+	defaultTheme
+} from '~/@kiva/kv-tokens/configs/kivaColors.cjs';
+
 const KvContentfulImg = () => import('~/@kiva/kv-components/vue/KvContentfulImg');
 
 /**
@@ -73,6 +80,13 @@ export default {
 		verticalPadding: {
 			type: Object,
 			default: () => {},
+		},
+		/**
+		 *
+		 */
+		themeName: {
+			type: String,
+			default: '',
 		}
 	},
 	data() {
@@ -113,6 +127,11 @@ export default {
 					'background-color': this.backgroundContent?.backgroundColor
 				};
 			}
+			if (this.themeStyles) {
+				return {
+					'background-color': 'rgb(var(--bg-primary))'
+				};
+			}
 			return {};
 		},
 		isBackgroundVideo() {
@@ -126,6 +145,21 @@ export default {
 				description: this.backgroundContent?.backgroundMedia?.description ?? '',
 				title: this.backgroundContent?.backgroundMedia?.title ?? '',
 				url: this.backgroundContent?.backgroundMedia?.file?.url ?? ''
+			};
+		},
+		themeStyles() {
+			const themeMapper = {
+				kivaCLassicLight: defaultTheme,
+				kivaClassicMint: mintTheme,
+				kivaClassicGreen: darkGreenTheme,
+				kivaClassicDark: darkTheme,
+				imageCard: darkTheme
+			};
+			const theme = themeMapper[this.themeName] ?? defaultTheme;
+			// No styles needed if using the default theme
+			return theme === defaultTheme ? {} : {
+				...theme,
+				color: 'rgb(var(--text-primary))',
 			};
 		},
 		/**

--- a/src/components/Contentful/StoryCardCarousel.vue
+++ b/src/components/Contentful/StoryCardCarousel.vue
@@ -1,6 +1,7 @@
 <template>
 	<section-with-background-classic
 		:background-content="background"
+		:theme-name="themeName"
 		:vertical-padding="verticalPadding"
 	>
 		<template #content>

--- a/src/plugins/contentful-ui-setting-styles-mixin.js
+++ b/src/plugins/contentful-ui-setting-styles-mixin.js
@@ -44,6 +44,12 @@ export default {
 		swapOrder() {
 			return this.uiSetting?.dataObject?.swapOrder ?? false;
 		},
+		/**
+		 * Depends on themeName property on Contentful dataObject
+		 */
+		themeName() {
+			return this.uiSetting?.dataObject?.themeName ?? '';
+		},
 		uiSetting() {
 			const uiSetting = this.content?.contents?.find(({ contentType }) => {
 				return contentType ? contentType === 'uiSetting' : false;


### PR DESCRIPTION
This allows the theme of any component that uses SectionWithBackgroundClassic to be controlled with a "themeName" string in a UiSetting data block. Part of MARS-245.