### PR TITLE
fix: remove jump of content when toggling FAQs

### DIFF
--- a/src/components/Kv/KvExpandableQuestion.vue
+++ b/src/components/Kv/KvExpandableQuestion.vue
@@ -14,11 +14,12 @@
 			/>
 		</button>
 		<kv-expandable easing="ease-in-out">
-			<div
-				v-show="open"
-				class="tw-prose tw-pb-4 tw-pt-2"
-				v-html="content"
-			>
+			<div v-show="open">
+				<div
+					class="tw-prose tw-pb-4 tw-pt-2"
+					v-html="content"
+				>
+				</div>
 			</div>
 		</kv-expandable>
 	</div>


### PR DESCRIPTION
## Before

![ezgif com-gif-maker](https://user-images.githubusercontent.com/4149025/190732198-ddcf16db-b71c-44b2-9b0b-7088e80d5185.gif)

## After

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/4149025/190732353-6669febc-3d55-4765-9b22-1ab665637c71.gif)
