### PR TITLE
fix: add other file extensions so @vueuse modules can be found

### DIFF
--- a/test/unit/jest.conf.js
+++ b/test/unit/jest.conf.js
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
 	rootDir: path.resolve(__dirname, '../../'),
 	testMatch: ['**/unit/specs/**/*.spec.js'],
-	moduleFileExtensions: ['js', 'json', 'vue'],
+	moduleFileExtensions: ['js', 'cjs', 'mjs', 'json', 'vue'],
 	moduleNameMapper: {
 		'^~/(.*)$': '<rootDir>/node_modules/$1',
 		'^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
We found that the vueuse components had cjs/mjs extensions so jest couldn't find them... maybe we need to add this elsewhere too???