### PR TITLE
feat: eco challenge thanks page

### DIFF
--- a/src/graphql/query/achievementMilestones.graphql
+++ b/src/graphql/query/achievementMilestones.graphql
@@ -1,0 +1,12 @@
+query achievementMilestonesForCheckout($loanIds: [String!]!) {
+	achievementMilestonesForCheckout(loanIds: $loanIds){
+		checkoutMilestoneProgresses {
+			achievement
+			milestoneName
+			postCheckoutProgress
+			progress
+			status
+			target
+		}
+	}
+}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -271,6 +271,8 @@ import numeral from 'numeral';
 import { preFetchAll } from '@/util/apolloPreFetch';
 import syncDate from '@/util/syncDate';
 import { myFTDQuery, formatTransactionData } from '@/util/checkoutUtils';
+import { achievementsQuery, hasMadeAchievementsProgression } from '@/util/ecoChallengeUtils';
+
 import { getPromoFromBasket } from '@/util/campaignUtils';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import checkoutSettings from '@/graphql/query/checkout/checkoutSettings.graphql';
@@ -302,8 +304,14 @@ import * as Sentry from '@sentry/vue';
 import _forEach from 'lodash/forEach';
 import { isLoanFundraising } from '@/util/loanUtils';
 import MatchedLoansLightbox from '@/components/Checkout/MatchedLoansLightbox';
+import {
+	getExperimentSettingCached,
+	trackExperimentVersion
+} from '@/util/experimentUtils';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
+
+const ecoChallengeExpKey = 'eco_challenge';
 
 // Query to gather user Teams
 const myTeamsQuery = gql`query myTeamsQuery {
@@ -388,6 +396,7 @@ export default {
 			teamJoinStatus: null,
 			enableUpsellsCopy: false,
 			myTeams: [],
+			isEcoChallengeExpShown: false,
 		};
 	},
 	apollo: {
@@ -565,6 +574,20 @@ export default {
 		this.handleToast();
 		this.getPromoInformationFromBasket();
 		this.getUpsellModuleData();
+
+		const ecoChallengeExpData = getExperimentSettingCached(this.apollo, ecoChallengeExpKey);
+		if (ecoChallengeExpData?.enabled) {
+			const { version } = trackExperimentVersion(
+				this.apollo,
+				this.$kvTrackEvent,
+				'Lending',
+				ecoChallengeExpKey,
+				'EXP-ACK-392-Sep2022'
+			);
+			if (version === 'b') {
+				this.isEcoChallengeExpShown = true;
+			}
+		}
 	},
 	computed: {
 		isUpsellUnder100() {
@@ -682,6 +705,9 @@ export default {
 		},
 		promoAmount() {
 			return this.promoData?.promoFund?.promoPrice ?? null;
+		},
+		loanIdsInBasket() {
+			return this.loans.map(loan => loan.id);
 		}
 	},
 	methods: {
@@ -793,7 +819,7 @@ export default {
 				this.setUpdatingTotals(false);
 			});
 		},
-		completeTransaction(transactionId) {
+		async completeTransaction(transactionId) {
 			// compile transaction data
 			const transactionData = formatTransactionData(
 				numeral(transactionId).value(),
@@ -806,6 +832,22 @@ export default {
 			// Fetch FTD Status
 			const myFTDQueryUtil = myFTDQuery(this.apollo);
 
+			// Fetch Eco Challenge Game Status
+			// If user is in eco challenge and a loan in basket makes progress towards
+			// eco challenge, set extraQueryParam
+			let extraQueryParam = '';
+			if (this.isEcoChallengeExpShown) {
+				const myAchievements = await achievementsQuery(this.apollo, this.loanIdsInBasket);
+				// eslint-disable-next-line max-len
+				const checkoutMilestoneProgresses = myAchievements?.data?.achievementMilestonesForCheckout?.checkoutMilestoneProgresses;
+				const showEcoThanksPage = hasMadeAchievementsProgression(
+					checkoutMilestoneProgresses,
+					'climate-challenge'
+				);
+				extraQueryParam = showEcoThanksPage ? '&ecoChallenge=true' : '';
+			}
+			// end game code
+
 			myFTDQueryUtil.then(({ data }) => {
 				// determine ftd status
 				const isFTD = data?.my?.userAccount?.isFirstTimeDepositor;
@@ -817,7 +859,7 @@ export default {
 				// redirect to thanks
 				window.setTimeout(
 					() => {
-						this.redirectToThanks(transactionId);
+						this.redirectToThanks(transactionId, extraQueryParam);
 					},
 					800
 				);

--- a/src/pages/Checkout/PostPurchase.vue
+++ b/src/pages/Checkout/PostPurchase.vue
@@ -35,9 +35,13 @@ export default {
 						// get tracking data from snowplow cookie
 						const { snowplowUserId, snowplowSessionId } = parseSPCookie(cookieStore);
 
+						// If eco challenge is true send to eco thanks page
+						const successPath = route.query.ecoChallenge === 'true'
+							? '/checkout/eco-challenge/thanks' : '/thanks';
+
 						// build route for thanks page redirect
 						const successRoute = {
-							path: '/thanks',
+							path: successPath,
 							query: { kiva_transaction_id: transactionId },
 						};
 

--- a/src/pages/Thanks/ThanksPageEcoChallenge.vue
+++ b/src/pages/Thanks/ThanksPageEcoChallenge.vue
@@ -12,10 +12,7 @@
 					:icon="mdiCheckAll"
 				/>
 				<div v-if="receipt">
-					<p v-if="isGuest">
-						Success, we've emailed your receipt to you.
-					</p>
-					<p v-else>
+					<p>
 						Success, your receipt has been sent to <strong class="fs-mask">{{ lender.email }}</strong>
 					</p>
 				</div>
@@ -85,7 +82,7 @@
 					<h2>Way to go!</h2>
 					<p class="tw-text-subhead tw-mt-1">
 						<!-- eslint-disable-next-line max-len -->
-						By supporting this eco-friendly loan for solar panels you're helping to building climate resiliency in underserved regions that need it most.
+						By supporting this eco-friendly loan you're helping to building climate resiliency in underserved regions that need it most.
 					</p>
 					<div
 						class="tw-bg-black tw-rounded tw-flex tw-items-center
@@ -160,7 +157,7 @@
 					class="tw-flex tw-w-full tw-justify-between"
 				>
 					<h2 class="tw-mr-1.5">
-						X more loans to complete this challenge
+						{{ loansRemainingInChallenge }} more loans to complete this challenge
 					</h2>
 					<div
 						class="tw-flex"
@@ -177,14 +174,15 @@
 								:value="66"
 							/>
 							<p class="tw-text-h4 tw-text-right tw-font-medium tw-mt-1">
-								1 loan to go
+								<!-- eslint-disable-next-line max-len -->
+								{{ loansRemainingInChallenge }} {{ loansRemainingInChallenge == 1 ? 'loan' : 'loans' }} to go
 							</p>
 						</div>
 					</div>
 				</div>
 				<p class="tw-text-subhead">
 					<!-- eslint-disable-next-line max-len -->
-					On Kiva a little goes a long way in offsetting your carbon footprint. Make a {categories missing} to go greener.
+					On Kiva a little goes a long way in offsetting your carbon footprint. Make a {{ categoriesMissingString }} loan to go greener.
 				</p>
 			</kv-page-container>
 		</div>
@@ -201,6 +199,7 @@ import thanksPageQuery from '@/graphql/query/thanksPage.graphql';
 import logReadQueryError from '@/util/logReadQueryError';
 import logFormatter from '@/util/logFormatter';
 import { joinArray } from '@/util/joinArray';
+import { missingMilestones, achievementsQueryFromCache, achievementsQuery } from '@/util/ecoChallengeUtils';
 import BorrowerImage from '@/components/BorrowerProfile/BorrowerImage';
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import KvSocialShareButton from '@/components/Kv/KvSocialShareButton';
@@ -238,10 +237,9 @@ export default {
 		return {
 			lender: {},
 			loans: [],
-			receipt: null,
-			isGuest: false,
 			mdiCheckAll,
-			loansRemainingInChallenge: 0,
+			missingMilestones: [],
+			receipt: null,
 		};
 	},
 	apollo: {
@@ -256,6 +254,14 @@ export default {
 					checkoutId: transactionId,
 					visitorId: cookieStore.get('uiv') || null,
 				}
+			}).then(({ data }) => {
+				const loansResponse = data?.shop?.receipt?.items?.values ?? [];
+				const loans = loansResponse
+					.filter(item => item.basketItemType === 'loan_reservation')
+					.map(item => item.loan);
+
+				const loanIdsInTransaction = loans.map(loan => loan.id);
+				return achievementsQuery(client, loanIdsInTransaction);
 			}).catch(errorResponse => {
 				logFormatter(
 					`Thanks eco challenge page preFetch failed: (transaction_id: ${transactionId})`,
@@ -266,20 +272,51 @@ export default {
 		}
 	},
 	computed: {
+		categoriesMissingString() {
+			const milestoneNames = this.missingMilestones.map(milestone => milestone.milestoneName);
+			return joinArray(milestoneNames).replaceAll('-', ' ');
+		},
+		loansRemainingInChallenge() {
+			let loansRemaining = 0;
+			this.missingMilestones.forEach(milestone => {
+				loansRemaining += milestone.target - milestone.progress;
+			});
+			return loansRemaining;
+		},
 		climateFact() {
 			// eslint-disable-next-line max-len
 			return 'Did you know that a biodigester is a system that transforms livestock waste (💩) into organic fertilizer for crops, as well as biogas that can be used for household energy?';
 		},
+		// Return the first "eco friendly" loan we find in the loans that are part of this transaction.
+		// If none are found, return the first loan.
+		// Hacky implementation for game test, it should be improved upon.
 		loan() {
 			const orderedLoans = orderBy(this.loans, ['unreservedAmount'], ['desc']);
-			return orderedLoans[0] || {};
-		},
-		borrowerSupport() {
-			const loanNames = this.loans.map(loan => loan.name);
-			if (loanNames.length > 3) {
-				return `these ${loanNames.length} borrowers`;
-			}
-			return joinArray(loanNames, 'and');
+
+			// terms used in solar loans, or reuse loans or sustainable agriculture loans
+			// if this term is in a loan we can assume it was the eco challenge loan that
+			// was part of the checkout
+			const arrayOfTerms = [
+				'solar',
+				'biodigester',
+				'fertilizer',
+				'manure',
+				'livestock',
+				'clothes',
+				'fabric',
+				'shirts',
+				'trousers',
+				'garments'
+			];
+			const ecoLoan = orderedLoans.find(loan => {
+				return arrayOfTerms.some(element => {
+					if (loan.use.includes(element)) {
+						return true;
+					}
+					return false;
+				});
+			});
+			return ecoLoan || orderedLoans[0];
 		},
 	},
 	created() {
@@ -308,14 +345,19 @@ export default {
 		// receipt from rendering in the rare cases this query fails.
 		// But it will not throw a server error.
 		this.receipt = data?.shop?.receipt ?? null;
-		this.isGuest = this.receipt && !data?.my?.userAccount;
 
 		const loansResponse = this.receipt?.items?.values ?? [];
 		this.loans = loansResponse
 			.filter(item => item.basketItemType === 'loan_reservation')
 			.map(item => item.loan);
+		const loanIdsInTransaction = this.loans.map(loan => loan.id);
+		const myAchievements = achievementsQueryFromCache(this.apollo, loanIdsInTransaction);
 
-		if (!this.isGuest && !data?.my?.userAccount) {
+		// eslint-disable-next-line max-len
+		const checkoutMilestoneProgresses = myAchievements?.achievementMilestonesForCheckout?.checkoutMilestoneProgresses;
+		this.missingMilestones = missingMilestones(checkoutMilestoneProgresses, 'climate-challenge');
+
+		if (!data?.my?.userAccount) {
 			logFormatter(
 				`Failed to get lender for transaction id: ${transactionId}`,
 				'info',
@@ -345,22 +387,4 @@ export default {
 		}
 	},
 };
-
-// sample api response
-// "data": {
-//     "achievementMilestonesForCheckout": {
-//       "checkoutMilestoneProgresses": [
-//         {
-//           "achievement": "climate-challenge",
-//           "milestoneName": "solar-and-used-clothes",
-//           "postCheckoutProgress": 2,
-//           "progress": 0,
-//           "status": "COMPLETABLE",
-//           "target": 2
-//         }
-//       ],
-//       "userId": "3480555"
-//     }
-//   }
-// }
 </script>

--- a/src/plugins/checkout-utils-mixin.js
+++ b/src/plugins/checkout-utils-mixin.js
@@ -171,12 +171,12 @@ export default {
 		/* Redirect to the thanks
 		 * @param transactionId
 		 */
-		redirectToThanks(transactionId) {
+		redirectToThanks(transactionId, additionalQueryParams) {
 			checkInjections(this, injections);
-
 			if (transactionId) {
 				this.cookieStore.remove('kvbskt', { path: '/', secure: true });
-				window.location = `/checkout/post-purchase?kiva_transaction_id=${transactionId}`;
+				// eslint-disable-next-line max-len
+				window.location = `/checkout/post-purchase?kiva_transaction_id=${transactionId}${additionalQueryParams}`;
 			}
 		}
 	}

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -91,6 +91,13 @@ module.exports = [
 		}
 	},
 	{
+		path: '/checkout/eco-challenge/thanks',
+		component: () => import('@/pages/Thanks/ThanksPageEcoChallenge'),
+		meta: {
+			excludeFromStaticSitemap: true,
+		}
+	},
+	{
 		path: '/confirm-instant-donation/:token/:amount',
 		component: () => import('@/pages/InstantActions/ConfirmInstantDonation'),
 		meta: {

--- a/src/util/ecoChallengeUtils.js
+++ b/src/util/ecoChallengeUtils.js
@@ -1,0 +1,85 @@
+import achievementMilestonesQuery from '@/graphql/query/achievementMilestones.graphql';
+
+/**
+ * achievementsQuery query
+ * Checks for Eco Challenge Achievement status
+ *
+ * @param {Object} apollo Apollo Client instance
+ * @param {Object} loanIdsArray Array of loan ids as ints
+ *
+ * @returns {Promise}
+ */
+export function achievementsQuery(apollo, loanIdsArray) {
+	// Convert array of loan ids to array of strings
+	const loanIds = loanIdsArray.map(loanId => loanId.toString());
+	// Fetch FTD Status
+	return apollo.query({
+		query: achievementMilestonesQuery,
+		variables: {
+			loanIds
+		}
+	});
+}
+
+/**
+ * achievementsQueryFromCache query
+ * Checks for Eco Challenge Achievement status
+ *
+ * @param {Object} apollo Apollo Client instance
+ * @param {Object} loanIdsArray Array of loan ids as ints
+ *
+ * @returns {Promise}
+ */
+export function achievementsQueryFromCache(apollo, loanIdsArray) {
+	// Convert array of loan ids to array of strings
+	const loanIds = loanIdsArray.map(loanId => loanId.toString());
+	// Fetch FTD Status
+	return apollo.readQuery({
+		query: achievementMilestonesQuery,
+		variables: {
+			loanIds
+		}
+	});
+}
+
+/**
+ * hasMadeAchievementsProgression
+ * Checks for Eco Challenge Achievement status
+ *
+ * @param {Array} achievementsQueryResult The array of milestones from the request result from the achievementsQuery
+ * @param {Object} achievementName String of achievement name as stored in the achievement service
+ *
+ * @returns {Boolean} Does this query result represent progress towards this achievement?
+ */
+export function hasMadeAchievementsProgression(achievementsQueryResult = [], achievementName = '') {
+	// filter out all achievements by achievementName
+	const achievementMilestones = achievementsQueryResult
+		.filter(milestone => milestone.achievement === achievementName);
+
+	// If any of the achievementMilestones have the status
+	// "COMPLETABLE", or "NEW_PROGRESS" then we have progress
+	// towards this achievement
+	return achievementMilestones
+		.some(milestone => milestone.status === 'COMPLETABLE' || milestone.status === 'NEW_PROGRESS');
+}
+
+/**
+ * missingMilestones
+ * Returns what a user needs to complete the achievement
+ *
+ * @param {Array} achievementsQueryResult The array of milestones from the request result from the achievementsQuery
+ * @param {Object} achievementName String of achievement name as stored in the achievement service
+ *
+ * @returns {array} Array of milestones still needed
+ */
+export function missingMilestones(achievementsQueryResult = [], achievementName = '') {
+	// filter out all achievements by achievementName
+	const achievementMilestones = achievementsQueryResult
+		.filter(milestone => milestone.achievement === achievementName);
+
+	// filter out all milestones that have been completed in the past or will be complete after this checkout
+	const missingMilestonesArray = achievementMilestones
+		.filter(milestone => milestone.status !== 'COMPLETABLE' && milestone.status !== 'ALREADY_COMPLETE');
+
+	return missingMilestonesArray;
+}

--- a/test/unit/specs/util/ecoChallengeUtils.spec.js
+++ b/test/unit/specs/util/ecoChallengeUtils.spec.js
@@ -1,0 +1,108 @@
+import {
+	hasMadeAchievementsProgression, missingMilestones
+} from '@/util/ecoChallengeUtils';
+
+const sampleAPIMilestoneProgress = [
+	{
+		achievement: 'climate-challenge',
+		milestoneName: 'solar',
+		postCheckoutProgress: 1,
+		progress: 0,
+		status: 'COMPLETABLE',
+		target: 1
+	},
+	{
+		achievement: 'climate-challenge',
+		milestoneName: 'recycle-reuse',
+		postCheckoutProgress: 0,
+		progress: 0,
+		status: 'NO_NEW_PROGRESS',
+		target: 1
+	},
+	{
+		achievement: 'climate-challenge',
+		milestoneName: 'sustainable-agriculture',
+		postCheckoutProgress: 0,
+		progress: 0,
+		status: 'NO_NEW_PROGRESS',
+		target: 1
+	},
+	{
+		achievement: 'another-challenge',
+		milestoneName: 'recycle-reuse',
+		postCheckoutProgress: 2,
+		progress: 2,
+		status: 'NEW_PROGRESS',
+		target: 3
+	},
+	{
+		achievement: 'another-challenge',
+		milestoneName: 'sustainable-agriculture',
+		postCheckoutProgress: 2,
+		progress: 0,
+		status: 'NO_NEW_PROGRESS',
+		target: 3
+	},
+	{
+		achievement: 'another-challenge',
+		milestoneName: 'solar',
+		postCheckoutProgress: 4,
+		progress: 4,
+		status: 'ALREADY_COMPLETE',
+		target: 4
+	},
+	{
+		achievement: 'another-challenge',
+		milestoneName: 'solar-roofs',
+		postCheckoutProgress: 2,
+		progress: 1,
+		status: 'COMPLETABLE',
+		target: 2
+	}
+
+];
+describe('ecoChallengeUtils.js hasMadeAchievementsProgression', () => {
+	test('Should return true for achievement with 1 milestone in completeable status', () => {
+		expect(hasMadeAchievementsProgression(sampleAPIMilestoneProgress, 'climate-challenge')).toBe(true);
+	});
+
+	test('Should return false for missing achievement', () => {
+		expect(hasMadeAchievementsProgression(sampleAPIMilestoneProgress, 'test-challenge')).toBe(false);
+	});
+
+	test('Should return false if either param is missing or undefined', () => {
+		expect(hasMadeAchievementsProgression(sampleAPIMilestoneProgress, undefined)).toBe(false);
+		expect(hasMadeAchievementsProgression(sampleAPIMilestoneProgress, '')).toBe(false);
+		expect(hasMadeAchievementsProgression(undefined, 'climate-challenge')).toBe(false);
+		expect(hasMadeAchievementsProgression([], 'climate-challenge')).toBe(false);
+	});
+
+	test('Should return true for achievement with 1 milestone in new_progress status', () => {
+		const newProgress = sampleAPIMilestoneProgress;
+		newProgress[0].status = 'NEW_PROGRESS';
+		expect(hasMadeAchievementsProgression(newProgress, 'climate-challenge')).toBe(true);
+	});
+});
+
+describe('ecoChallengeUtils.js missingMilestones', () => {
+	test('Should return achievements yet to be completed', () => {
+		expect(missingMilestones(sampleAPIMilestoneProgress, 'another-challenge')).toEqual([
+			{
+				achievement: 'another-challenge',
+				milestoneName: 'recycle-reuse',
+				postCheckoutProgress: 2,
+				progress: 2,
+				status: 'NEW_PROGRESS',
+				target: 3
+			},
+			{
+				achievement: 'another-challenge',
+				milestoneName: 'sustainable-agriculture',
+				postCheckoutProgress: 2,
+				progress: 0,
+				status: 'NO_NEW_PROGRESS',
+				target: 3
+			},
+		]);
+	});
+});


### PR DESCRIPTION
* Adds routing to eco thanks page and reading achievement information from service

On checkout, if user is part of the eco_challenge experiment, fetch the achievements milestones (which is passed loan ids in basket) if these loans would progress the users challenge progress, add a query param, the goes through post purchase route and directs them to the thank you page. 

Added some computed properties to the thank you page to parse achievement response. This thank you page is based on the mars exp, so it only shows 1 loan in the hero area. Ideally we would want this loan to be one of the loans in the checkout that contributed to the challenge progress, this proved to be a little difficult, so for the test, I am generalizing the message displayed next to the loan, and then just searching for any of a list of eco terms in the loan uses of the transaction to try to find the eco loan. I expect in some cases, with checking out multiple loans, this could miss and a non eco loan will be shown up top in the header area.... 

![Screen Shot 2022-09-19 at 3 38 06 PM](https://user-images.githubusercontent.com/4371888/191128212-2b6ae305-1dce-4a90-b763-7c664cdc9d0a.png)
![Screen Shot 2022-09-19 at 2 57 17 PM](https://user-images.githubusercontent.com/4371888/191128213-2164f7c7-c0c8-4569-bcfe-eb5c5a9d2764.png)
