### PR TITLE
chore(deps): bump @kiva/kv-components from 3.5.1 to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.282.0",
+	"version": "2.289.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.282.0",
+			"version": "2.289.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.18.2",
@@ -4092,9 +4092,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.5.1.tgz",
-			"integrity": "sha512-e4s5UGlGLDlNb2Oz4d21gMH2nMYdBh5Y3lNI/MjbPZM6WhhNX3f2jT0PuHkXW+jD/WNI0jPu/92dWcs5xXjwcQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.6.0.tgz",
+			"integrity": "sha512-OW04tihyjuRQZEFXvt6PJoEBlhLvIDlXHoOssEZl8+P0bezem/SFs52KWV4wgxXR93Qb3Wy6bG5S7zKtyemvGw==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^2.2.0",
 				"@mdi/js": "^5.9.55",
@@ -43227,9 +43227,9 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.5.1.tgz",
-			"integrity": "sha512-e4s5UGlGLDlNb2Oz4d21gMH2nMYdBh5Y3lNI/MjbPZM6WhhNX3f2jT0PuHkXW+jD/WNI0jPu/92dWcs5xXjwcQ==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.6.0.tgz",
+			"integrity": "sha512-OW04tihyjuRQZEFXvt6PJoEBlhLvIDlXHoOssEZl8+P0bezem/SFs52KWV4wgxXR93Qb3Wy6bG5S7zKtyemvGw==",
 			"requires": {
 				"@kiva/kv-tokens": "^2.2.0",
 				"@mdi/js": "^5.9.55",


### PR DESCRIPTION
Brings in carousel fix and Contentful image captions.