### PR TITLE
feat: dynamic upsell when no loans under $50

### DIFF
--- a/src/components/Checkout/UpsellModule.vue
+++ b/src/components/Checkout/UpsellModule.vue
@@ -20,10 +20,15 @@
 				</h4>
 				<h3 v-if="enableExperimentCopy" class="tw-text-h3 tw-mb-2">
 					<!-- eslint-disable-next-line max-len -->
-					{{ loan.name }} is missing just {{ amountLeft | numeral('$0,0[.]00') }}! Be the person to complete their loan.
+					{{ loan.name }} is missing just {{ amountToAdd | numeral('$0,0[.]00') }}! Be the person to complete their loan.
+				</h3>
+				<h3 v-if="useDynamicUpsell" class="tw-text-h3 tw-mb-2">
+					{{ loan.name }}'s loan is close to expiring.
+					Can you chip in {{ amountToAdd | numeral('$0,0[.]00') }}
+					to help {{ pronouns[0] }} reach {{ pronouns[1] }} goal?
 				</h3>
 				<h3 v-else class="tw-text-h3 tw-mb-2">
-					Complete {{ loan.name }}'s loan for just {{ amountLeft | numeral('$0,0[.]00') }}
+					Complete {{ loan.name }}'s loan for just {{ amountToAdd | numeral('$0,0[.]00') }}
 				</h3>
 				<div>
 					<fundraising-status-meter
@@ -43,7 +48,7 @@
 					<kv-button
 						variant="link"
 						class="tw-w-full md:tw-w-44 tw-mt-2 md:tw-mt-7"
-						@click="addToBasket(loanId, amountLeft)"
+						@click="addToBasket(loanId, amountToAdd)"
 					>
 						Add loan to basket
 					</kv-button>
@@ -84,6 +89,10 @@ export default {
 		enableExperimentCopy: {
 			type: Boolean,
 			default: false,
+		},
+		useDynamicUpsell: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {
@@ -97,7 +106,7 @@ export default {
 			'view-checkout-upsell',
 			'View',
 			this.loan?.id,
-			this.amountLeft
+			this.amountToAdd
 		);
 	},
 	computed: {
@@ -116,6 +125,18 @@ export default {
 		percentRaised() {
 			return (this.loan?.loanAmount - this.amountLeft) / this.loan?.loanAmount;
 		},
+		pronouns() {
+			if (this.loan?.gender === 'male') return ['him', 'his'];
+			if (this.loan?.gender === 'female') return ['her', 'her'];
+			return ['them', 'their'];
+		},
+		amountToAdd() {
+			if (this.useDynamicUpsell) {
+				const basketValues = [5, 10, 15, 20, 25];
+				return basketValues[Math.floor(Math.random() * 5)];
+			}
+			return this.amountLeft;
+		}
 	},
 };
 </script>

--- a/src/graphql/query/checkout/upsellLoansExpiringSoon.graphql
+++ b/src/graphql/query/checkout/upsellLoansExpiringSoon.graphql
@@ -1,0 +1,23 @@
+
+query upsellLoansExpiringSoon {
+	lend {
+		loans (sortBy: expiringSoon, limit: 20) {
+          values {
+            id
+            name
+			gender
+            loanAmount
+			status
+      	    loanFundraisingInfo {
+        	 fundedAmount
+			 reservedAmount
+      	    }
+			image {
+				url
+				id
+				hash
+        	}
+          }
+		}
+	}
+}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -937,10 +937,10 @@ export default {
 				const amountLeft = upsellLoan?.loanAmount
 					- upsellLoan?.loanFundraisingInfo?.fundedAmount
 					- upsellLoan?.loanFundraisingInfo?.reservedAmount;
-				if (amountLeft <= 50) {
-					this.upsellLoan = upsellLoan;
-				} else {
+				if (amountLeft > 50 && this.enableDynamicUpsells) {
 					this.getDynamicUpsellModuleData();
+				} else {
+					this.upsellLoan = upsellLoan;
 				}
 			});
 		},


### PR DESCRIPTION
an experiment we are running where if there are no loans available with <=$50 left to lend, we will show loans that are expiring soonest first instead. we will determine a random amount for the user to lend (5/10/15/20/25) on the client side.

![Screen Shot 2022-09-21 at 2 49 54 PM](https://user-images.githubusercontent.com/15318176/191587354-f066da77-a6fd-496b-84f1-fb0d8348ab2a.png)
![Screen Shot 2022-09-21 at 2 50 01 PM](https://user-images.githubusercontent.com/15318176/191587357-941fcb95-7ae5-4874-816a-157b39862d56.png)
