### PR TITLE
feat: use flss for lbc page for eco game categories

### DIFF
--- a/src/components/LoanCollections/KivaClassicSingleCategoryCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicSingleCategoryCarousel.vue
@@ -35,7 +35,7 @@ import KivaClassicLoanCarousel from '@/components/LoanCollections/KivaClassicLoa
 import KvPill from '@/components/Kv/KvPill';
 
 import {
-	preFetchChannel,
+	getLoanChannel,
 } from '@/util/loanChannelUtils';
 import loanChannelQueryMapMixin from '@/plugins/loan-channel-query-map';
 
@@ -140,7 +140,7 @@ export default {
 				limit: this.loanDisplaySettings?.loanLimit ?? 1,
 				basketId: this.cookieStore.get('kvbskt'),
 			};
-			const channelData = await preFetchChannel(
+			const channelData = await getLoanChannel(
 				this.apollo,
 				this.loanChannelQueryMap,
 				channelUrl,

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -402,22 +402,37 @@ export default {
 				{
 					id: 116,
 					url: 'solar-energy',
-					queryParams: 'queryString=solar&tag=9&sortBy=popularity'
+					queryParams: 'queryString=solar',
+					flssLoanSearch: {
+						description: 'solar'
+					},
 				},
 				{
 					id: 117,
 					url: 'sustainable-agriculture',
-					queryParams: 'sector=1&tag=8&sortBy=amountLeft'
+					queryParams: 'sector=1&tag=8&sortBy=amountLeft',
+					flssLoanSearch: {
+						sectorId: [1],
+						tagId: [8]
+					},
 				},
 				{
 					id: 118,
 					url: 'recycle-and-re-use',
-					queryParams: 'queryString=used clothing&distributionModel=field_partner&sortBy=popularity',
+					queryParams: 'queryString=used clothing',
+					flssLoanSearch: {
+						description: 'clothing',
+						tagId: [9],
+					},
 				},
 				{
 					id: 119,
 					url: 'other-eco-friendly-loans',
-					queryParams: 'tag=9,8&distributionModel=field_partner&sortBy=expiringSoon',
+					queryParams: 'tag=9,8&distributionModel=field_partner',
+					flssLoanSearch: {
+						tagId: [8, 9],
+						distributionModel: 'FIELDPARTNER'
+					},
 				},
 
 				// IWD 2020 Loan Channels

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -16,6 +16,8 @@ export function getFlssFilters(loanSearchState) {
 		...(loanSearchState?.themeId?.length && { themeId: { any: loanSearchState.themeId } }),
 		...(loanSearchState?.sectorId?.length && { sectorId: { any: loanSearchState.sectorId } }),
 		...(loanSearchState?.distributionModel && { distributionModel: { eq: loanSearchState.distributionModel } }),
+		...(loanSearchState?.tagId?.length && { tagId: { any: loanSearchState.tagId } }),
+		...(loanSearchState?.description && { description: { eq: loanSearchState.description } }),
 	};
 }
 

--- a/src/util/loanChannelUtils.js
+++ b/src/util/loanChannelUtils.js
@@ -121,6 +121,33 @@ export function getCachedChannel(apollo, queryMap, channelUrl, loanQueryVars) {
 }
 
 /**
+ * Gets the loan channel data from the API
+ *
+ * @param {Object} apollo The Apollo client instance
+ * @param {Array} queryMap The map mixin from loan-channel-query-map.js
+ * @param {string} channelUrl The URL of the loan channel
+ * @param {Object} loanQueryVars The loan channel query variables
+ * @returns {Object} The loan channel data, transformed if FLSS
+ */
+export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars) {
+	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
+
+	if (queryMapFLSS) {
+		const experimentActive = checkCachedChannelExperiment(apollo);
+
+		if (experimentActive) {
+			return transformFLSSData(await fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars));
+		}
+	}
+
+	try {
+		return apollo.query({ query: loanChannelQuery, variables: loanQueryVars });
+	} catch (e) {
+		logReadQueryError(e, 'loanChannelUtils getLoanChannel loanChannelQuery');
+	}
+}
+
+/**
  * Watches the loan channel query and returns the observer
  *
  * @param {Object} apollo The Apollo client instance

--- a/src/util/loanSearch/queryParamUtils.js
+++ b/src/util/loanSearch/queryParamUtils.js
@@ -35,9 +35,9 @@ export function hasExcludedQueryParams(query) {
 		'partner',
 		'riskRating',
 		'state',
-		'queryString',
+		'queryString', // can be mapped to description
 		'loanLimit',
-		'tag',
+		'tag', // can be mapped to tagId
 	];
 	// Check route.query for excluded params
 	const queryContainsExcludedParams = Object.keys(query).filter(key => {


### PR DESCRIPTION
Use FLSS for the lend-by-category/"category" pages and the eco friendly game page with sub categories for the categories that are in the eco game. The "filter" link will still default to the legacy page, since the new one does not have support for keywords.

Since the subcategory carousels on the eco page are not set to prefetch, and we only have `getCachedChannel` `preFetchChannel` and `watch` in `loanChannelUtils.js ` I added one more function which is just a regular fetch. Not super elegant since it's basically the same as getCachedChannel....