### PR TITLE
fix: temporarily remove /cc/kiva-universal from lighthouse as it is f…

### DIFF
--- a/lighthouserc-prod.js
+++ b/lighthouserc-prod.js
@@ -14,7 +14,7 @@ module.exports = {
 				'https://www.kiva.org/lend-by-category/women',
 				// 'https://www.kiva.org/live-loan/f/sort_newest/url/1',
 				'https://www.kiva.org/ui-site-map',
-				'https://www.kiva.org/cc/kiva-universal',
+				// 'https://www.kiva.org/cc/kiva-universal',
 				'https://www.kiva.org/lp/support-refugees',
 				'https://www.kiva.org/design',
 				'https://www.kiva.org/cps/home'


### PR DESCRIPTION
…ailing on most mobile loads

Lighthouse tends to use a mobile device for its runs, this path has caused failures for the past few days so we need to remove it for now until we can optimize the page to load properly on throttled devices.