### PR TITLE
feat: add donate/supportkiva duplicate page

### DIFF
--- a/src/pages/Donate/DonateForm.vue
+++ b/src/pages/Donate/DonateForm.vue
@@ -99,15 +99,6 @@ export default {
 			type: String,
 			default: '',
 		},
-		formSubmitAnalytics: {
-			type: Object,
-			default: () => {
-				return {
-					category: 'Donate Form',
-					action: 'click-donate-support-us-form',
-				};
-			},
-		},
 		id: { // used when you have multiple instances of this form on one page.
 			type: String,
 			default: 'instance1',
@@ -197,11 +188,11 @@ export default {
 					});
 				} else {
 					this.$kvTrackEvent(
-						this.formSubmitAnalytics.category,
-						this.formSubmitAnalytics.action,
-						this.buttonText,
+						'donation',
+						'add-to-basket',
+						'donation-one-time',
+						null,
 						// pass donation amount as whole number
-						numeral(this.selectedAmount).value() * 100,
 						numeral(this.selectedAmount).value() * 100
 					);
 					this.$router.push({

--- a/src/pages/Donate/DonateFromMacroHero.vue
+++ b/src/pages/Donate/DonateFromMacroHero.vue
@@ -24,7 +24,6 @@
 						:button-text="buttonCopy"
 						:data="donationValues"
 						:form-disclaimer="formDisclaimer"
-						:form-submit-analytics="formSubmitAnalytics"
 					/>
 				</div>
 			</div>
@@ -67,10 +66,6 @@ export default {
 	},
 	data() {
 		return {
-			formSubmitAnalytics: {
-				category: '/support-kiva',
-				action: 'Donate from Macro',
-			},
 			sourceSizes: [
 				{
 					width: 1920,

--- a/src/pages/Donate/DonateSupportUs.vue
+++ b/src/pages/Donate/DonateSupportUs.vue
@@ -9,7 +9,6 @@
 					:button-text="buttonText"
 					:data="donationValues"
 					:form-disclaimer="formDisclaimer"
-					:form-submit-analytics="formSubmitAnalytics"
 					:show-disclaimer="false"
 					:activate-monthly-option="true"
 				/>
@@ -37,9 +36,9 @@ import DonateForm from '@/pages/Donate/DonateForm';
 import DonateSupportUsRightRail from '@/pages/Donate/DonateSupportUsRightRail';
 import { documentToHtmlString } from '~/@contentful/rich-text-html-renderer';
 
-const pageQuery = gql`query donateContent {
+const pageQuery = gql`query donateContent($contentKey: String) {
 	contentful {
-		entries (contentType: "page", contentKey: "web-donate-support-us")
+		entries (contentType: "page", contentKey: $contentKey)
 	}
 }`;
 
@@ -71,16 +70,22 @@ export default {
 			defaultSubHeadCopy: '<p>100% of money lent on Kiva goes to funding loans, so we rely on donations to continue this important work. More than two-thirds of our donations come from individual lenders like you.</p>',
 			defaultDonationValues: [20, 35, 50, 100, 200],
 			defaultButtonText: 'Donate',
-			formSubmitAnalytics: {
-				category: '/donate/supportus',
-				action: 'click-donate-support-us-form',
-			},
 		};
 	},
 	inject: ['apollo', 'cookieStore'],
 	apollo: {
 		preFetch: true,
 		query: pageQuery,
+		preFetchVariables({ route }) {
+			return {
+				contentKey: route?.meta?.contentfulPage(route)?.trim(),
+			};
+		},
+		variables() {
+			return {
+				contentKey: this.$route?.meta?.contentfulPage(this.$route)?.trim(),
+			};
+		},
 		result({ data }) {
 			const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
 			this.pageData = pageEntry ? processPageContentFlat(pageEntry) : null;

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -121,6 +121,15 @@ module.exports = [
 		path: '/donate/supportus',
 		component: () => import('@/pages/Donate/DonateSupportUs'),
 		meta: {
+			contentfulPage: () => 'donate/supportus',
+			unbounce: true,
+		},
+	},
+	{
+		path: '/donate/supportkiva',
+		component: () => import('@/pages/Donate/DonateSupportUs'),
+		meta: {
+			contentfulPage: () => 'donate/supportkiva',
 			unbounce: true,
 		},
 	},


### PR DESCRIPTION
* Creates duplicate of donate/supportus at donate/supportkiva
* Clean up donation form analytics success event

ACK-416

This new page will be used to test new content for the donation page, traffic will be routed/experiment will be driven with optimizely. 

Also renamed the contentful key of `donate/supportus` it is currently web-donate-support-us which doesnt really match the convention of the keys in contentful being the url, I will take care of syncing this change in contentful with the release of this to prod. 