### PR TITLE
fix: revert module type for routes file, pass expFragment to prevent …

### DIFF
--- a/src/pages/ContentfulPage.vue
+++ b/src/pages/ContentfulPage.vue
@@ -45,6 +45,7 @@ import {
 	trackExperimentVersion
 } from '@/util/experimentUtils';
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
+import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 
 // MARS-124 experiment
 const manualLendingLPExpKey = 'manual_lending_lp';
@@ -268,13 +269,15 @@ export default {
 		preFetchVariables({ route, client }) {
 			return {
 				contentType: 'page',
-				contentKey: route?.meta?.contentfulPage(route, client)?.trim(),
+				contentKey: route?.meta?.contentfulPage(route, client, experimentVersionFragment)?.trim(),
 			};
 		},
 		variables() {
 			return {
 				contentType: 'page',
-				contentKey: this.$route?.meta?.contentfulPage(this.$route, this.apollo)?.trim(),
+				contentKey: this.$route?.meta?.contentfulPage(
+					this.$route, this.apollo, experimentVersionFragment
+				)?.trim(),
 			};
 		},
 		async preFetch(config, client, args) {
@@ -305,7 +308,9 @@ export default {
 				query: contentfulEntries,
 				variables: {
 					contentType: 'page',
-					contentKey: args?.route?.meta?.contentfulPage(args?.route, client)?.trim(),
+					contentKey: args?.route?.meta?.contentfulPage(
+						args?.route, client, experimentVersionFragment
+					)?.trim(),
 				}
 			}).then(({ data }) => {
 				// Get Contentful page data

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,12 +1,10 @@
-import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
-
-const routes = [
+module.exports = [
 	{
 		path: '/',
 		name: 'homepage',
 		component: () => import('@/pages/Homepage/Homepage'),
 		meta: {
-			contentfulPage: (route, apollo) => {
+			contentfulPage: (route, apollo, experimentVersionFragment) => {
 				const exp = apollo?.readFragment({
 					id: 'Experiment:new_home_layout',
 					fragment: experimentVersionFragment,
@@ -586,5 +584,3 @@ const routes = [
 		}
 	},
 ];
-
-export default routes;


### PR DESCRIPTION
…importing into routes.js

This prevents the mixing of esm + common js modules and allows our `/sitemaps/ui.xml` route to resolve properly. Currently it fails with a 500 error.