### PR TITLE
fix: update cps temporary homepage route

### DIFF
--- a/src/pages/Homepage/Homepage.vue
+++ b/src/pages/Homepage/Homepage.vue
@@ -99,7 +99,7 @@ export default {
 				const expVersion = result?.data?.experiment?.version;
 
 				if (expVersion === 'c') {
-					return Promise.reject({	path: '/cps/home' });
+					return Promise.reject({	path: '/pgtmp/home' });
 				}
 
 				const component = await ContentfulPage();


### PR DESCRIPTION
CPS routes have been updated, so we need to update the redirect route. Just want to verify this in Dev before I prep the hotfix updates.

I'm organizing additional PRs to update lighthoust-prod.js config and routes in puppet as well.