### PR TITLE
fix: hasOptOut should be false when kvgdpr cookie does not exist

### DIFF
--- a/src/head/script.js
+++ b/src/head/script.js
@@ -3,7 +3,7 @@ export default (config, globalOneTrustEvent) => {
 	const cookies = typeof document !== 'undefined' ? document.cookie.split(';') : [];
 	let optout = false;
 	for (let i = 0; i < cookies.length; i++) { // eslint-disable-line
-		if (cookies[i].indexOf('kvgdpr') !== -1 && cookies[i].indexOf('opted_out=true') !== -1) {
+		if (cookies[i].indexOf('kvgdpr') > -1 && cookies[i].indexOf('opted_out=true') > -1) {
 			optout = true;
 		}
 	}

--- a/src/pages/LandingPages/Unbounce/IFrameEmbed.vue
+++ b/src/pages/LandingPages/Unbounce/IFrameEmbed.vue
@@ -73,7 +73,7 @@ export default {
 			const cookies = typeof document !== 'undefined' ? document.cookie.split(';') : [];
 			let optout = false;
 			for (let i = 0; i < cookies.length; i++) { // eslint-disable-line
-				if (cookies[i].indexOf('kvgdpr') !== -1 && cookies[i].indexOf('opted_out=true') !== -1) {
+				if (cookies[i].indexOf('kvgdpr') > -1 && cookies[i].indexOf('opted_out=true') > -1) {
 					optout = true;
 				}
 			}

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -44,7 +44,7 @@ function addRenderedHtml(context, config) {
 			renderedExternals += `<script type="text/javascript" data-domain-script="${key}" src="${src}"></script>`;
 		}
 		// setup Optimizely script if not opted-out of 3rd party scripts
-		const hasOptOut = context?.cookies?.kvgdpr?.indexOf('opted_out=true') !== -1;
+		const hasOptOut = context?.cookies?.kvgdpr?.indexOf('opted_out=true') > -1;
 		if (!hasOptOut && config?.enableOptimizely && config?.optimizelyProjectId) {
 			// eslint-disable-next-line max-len
 			renderedExternals += '<script type="text/javascript">window["optimizely"]=window["optimizely"]||[];window["optimizely"].push({"type":"holdEvents"});</script>';

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -22,6 +22,7 @@ const isDev = process.env.NODE_ENV !== 'production';
 let renderedConfig = '';
 let renderedNoscript = '';
 let renderedExternals = '';
+let renderedExternalsOptIn = '';
 
 // This adds non-vue-rendered html strings to the request context.
 // These strings are added to the final html response using server/index.template.html
@@ -43,25 +44,32 @@ function addRenderedHtml(context, config) {
 			// eslint-disable-next-line max-len
 			renderedExternals += `<script type="text/javascript" data-domain-script="${key}" src="${src}"></script>`;
 		}
-		// setup Optimizely script if not opted-out of 3rd party scripts
-		const hasOptOut = context?.cookies?.kvgdpr?.indexOf('opted_out=true') > -1;
-		if (!hasOptOut && config?.enableOptimizely && config?.optimizelyProjectId) {
-			// eslint-disable-next-line max-len
-			renderedExternals += '<script type="text/javascript">window["optimizely"]=window["optimizely"]||[];window["optimizely"].push({"type":"holdEvents"});</script>';
-			const optimizelySrc = `https://cdn.optimizely.com/js/${config?.optimizelyProjectId}.js`;
-			renderedExternals += `<script type="text/javascript" src="${optimizelySrc}"></script>`;
-		}
 		// add primary head script
 		const renderedHeadScript = serialize(headScript);
 		const renderedOneTrustEvent = serialize(oneTrustEvent);
 		// eslint-disable-next-line max-len
 		renderedExternals += `<script>(${renderedHeadScript})(window.__KV_CONFIG__, ${renderedOneTrustEvent});</script>`;
 	}
+	// render externals for users that are not opted out of 3rd party cookies
+	if (!renderedExternalsOptIn) {
+		// setup Optimizely loader
+		if (config?.enableOptimizely && config?.optimizelyProjectId) {
+			// eslint-disable-next-line max-len
+			renderedExternalsOptIn += '<script type="text/javascript">window["optimizely"]=window["optimizely"]||[];window["optimizely"].push({"type":"holdEvents"});</script>';
+			const optimizelySrc = `https://cdn.optimizely.com/js/${config?.optimizelyProjectId}.js`;
+			renderedExternalsOptIn += `<script type="text/javascript" src="${optimizelySrc}"></script>`;
+		}
+		// append regular externals
+		renderedExternalsOptIn += renderedExternals;
+	}
+
+	// check for 3rd party script opt-out
+	const hasOptOut = context?.cookies?.kvgdpr?.indexOf('opted_out=true') > -1;
 
 	// add rendered strings to request render context
 	context.renderedConfig = renderedConfig;
 	context.renderedNoscript = renderedNoscript;
-	context.renderedExternals = renderedExternals;
+	context.renderedExternals = hasOptOut ? renderedExternals : renderedExternalsOptIn;
 }
 
 // This exported function will be called by `bundleRenderer`.


### PR DESCRIPTION
Optimizely isn't loading at all for new users. Tracked down the issue to the `hasOptOut` definition in server-entry, which was returning `true` when the kvgpdr cookie didn't exist. I don't think script.js and IFrameEmbed have this issue because they aren't using optional chaining, but I changed the comparisons in those files as well just to be safe.

```js
const a = {};
a?.b?.c?.indexOf('string') !== -1; // true
a?.b?.c?.indexOf('string') > -1; // false
```

I also found that because the renderedExternals string is cached, all users were getting the same script tags, regardless of having the opt-out cookie or not. I addressed that by making separate strings for opted in and opted out users.