### PR TITLE
fix: computed property warning on checkout page

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -562,7 +562,6 @@ export default {
 			const isMatchedLoan = loan.loan?.matchingText;
 			return hasCredits && isMatchedLoan;
 		});
-		this.showMatchedLoanKivaCredit = matchedLoansWithCredit.length > 0;
 		this.matchedText = matchedLoansWithCredit[0]?.loan?.matchingText ?? '';
 	},
 	mounted() {


### PR DESCRIPTION
`showMatchedLoanKivaCredit` is a computed property on line 619, and we should not assign it a value