### PR TITLE
fix: remove cc/kiva-universal from dev lighthouse

### DIFF
--- a/lighthouserc-dev.js
+++ b/lighthouserc-dev.js
@@ -12,8 +12,8 @@ module.exports = {
 				'http://localhost:8888/lend/filter',
 				'http://localhost:8888/lend-by-category/women',
 				'http://localhost:8888/ui-site-map',
-				'http://localhost:8888/cc/kiva-universal',
-				'http://localhost:8888/lp/support-refugees'
+				// 'http://localhost:8888/cc/kiva-universal',
+				'http://localhost:8888/lp/how-kiva-works'
 			],
 			numberOfRuns: 5,
 		},


### PR DESCRIPTION
To be clear this is not a long term fix, it will just let us get through a full test run to get the latest ui code in QA. We need to get this page back in shape...

Some of the recent changes merged in this sprint and maybe the lighthouse updates from the week prior.