### PR TITLE
fix: pass query origin context on all flss queries

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -311,7 +311,7 @@ export default {
 
 				const [{ loans, totalCount }] = await Promise.all([
 					// Get filtered loans from FLSS
-					await runLoansQuery(this.apollo, this.loanSearchState),
+					await runLoansQuery(this.apollo, this.loanSearchState, 'web:lend-filter'),
 					// Get filtered facet options from FLSS
 					await this.fetchFacets(this.loanSearchState)
 				]);
@@ -367,7 +367,11 @@ export default {
 	methods: {
 		async fetchFacets(loanSearchState = {}) {
 			// TODO: Prevent this from running on every query (not needed for sorting and paging)
-			const { isoCodes, themes, sectors } = await runFacetsQueries(this.apollo, loanSearchState);
+			const { isoCodes, themes, sectors } = await runFacetsQueries(
+				this.apollo,
+				loanSearchState,
+				'web:lend-filter'
+			);
 
 			// Merge all facet options with filtered options
 			this.facets = {

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -127,6 +127,7 @@ import {
 	transformThemes,
 	transformSectors,
 } from '@/util/loanSearch/filterUtils';
+import { FLSS_ORIGIN_LEND_FILTER } from '@/util/flssUtils';
 import { runFacetsQueries, runLoansQuery, fetchLoanFacets } from '@/util/loanSearch/dataUtils';
 import { applyQueryParams, hasExcludedQueryParams, updateQueryParams } from '@/util/loanSearch/queryParamUtils';
 import { updateSearchState } from '@/util/loanSearch/searchStateUtils';
@@ -311,7 +312,7 @@ export default {
 
 				const [{ loans, totalCount }] = await Promise.all([
 					// Get filtered loans from FLSS
-					await runLoansQuery(this.apollo, this.loanSearchState, 'web:lend-filter'),
+					await runLoansQuery(this.apollo, this.loanSearchState, FLSS_ORIGIN_LEND_FILTER),
 					// Get filtered facet options from FLSS
 					await this.fetchFacets(this.loanSearchState)
 				]);
@@ -370,7 +371,7 @@ export default {
 			const { isoCodes, themes, sectors } = await runFacetsQueries(
 				this.apollo,
 				loanSearchState,
-				'web:lend-filter'
+				FLSS_ORIGIN_LEND_FILTER
 			);
 
 			// Merge all facet options with filtered options

--- a/src/components/LoanCollections/KivaClassicSingleCategoryCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicSingleCategoryCarousel.vue
@@ -33,6 +33,7 @@
 import IconClimateChallenge from '@/assets/icons/inline/eco-challenge/globe-leaf.svg';
 import KivaClassicLoanCarousel from '@/components/LoanCollections/KivaClassicLoanCarousel';
 import KvPill from '@/components/Kv/KvPill';
+import { FLSS_ORIGIN_NOT_SPECIFIED } from '@/util/flssUtils';
 
 import {
 	getLoanChannel,
@@ -98,6 +99,10 @@ export default {
 			type: Boolean,
 			default: false
 		},
+		queryContext: {
+			type: String,
+			default: FLSS_ORIGIN_NOT_SPECIFIED,
+		}
 	},
 	data() {
 		return {
@@ -155,13 +160,13 @@ export default {
 				offset: 0,
 				limit: this.loanDisplaySettings?.loanLimit ?? 1,
 				basketId: this.cookieStore.get('kvbskt'),
+				origin: this.queryContext
 			};
 			const channelData = await getLoanChannel(
 				this.apollo,
 				this.loanChannelQueryMap,
 				channelUrl,
 				loanQueryVars,
-				'web:category'
 			);
 			const loanChannelData = channelData?.data?.lend?.loanChannelsById ?? [];
 			this.selectedChannel = loanChannelData?.[0];

--- a/src/components/LoanCollections/KivaClassicSingleCategoryCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicSingleCategoryCarousel.vue
@@ -144,7 +144,8 @@ export default {
 				this.apollo,
 				this.loanChannelQueryMap,
 				channelUrl,
-				loanQueryVars
+				loanQueryVars,
+				'web:category'
 			);
 			const loanChannelData = channelData?.data?.lend?.loanChannelsById ?? [];
 			this.selectedChannel = loanChannelData?.[0];

--- a/src/graphql/query/flssLoanChannel.graphql
+++ b/src/graphql/query/flssLoanChannel.graphql
@@ -9,6 +9,7 @@ query flssLoanChannel(
 	$imgDefaultSize: String = "w480h360"
 	$imgRetinaSize: String = "w960h720"
 	$basketId: String
+	$origin: String
 ) {
 	lend {
 		loanChannelsById(ids: $ids) {
@@ -18,7 +19,7 @@ query flssLoanChannel(
 			url
 		}
 	}
-	fundraisingLoans(filters: $filterObject, sortBy: $sortBy, limit: $pageLimit, pageNumber: $pageNumber) {
+	fundraisingLoans(filters: $filterObject, sortBy: $sortBy, limit: $pageLimit, pageNumber: $pageNumber, origin: $origin) {
 		totalCount
 		values {
 			id

--- a/src/graphql/query/flssLoanFacetsQuery.graphql
+++ b/src/graphql/query/flssLoanFacetsQuery.graphql
@@ -1,8 +1,9 @@
 query flssLoanFacets(
 	$isoCodeFilters: [FundraisingLoanSearchFilterInput!],
 	$themeFilters: [FundraisingLoanSearchFilterInput!],
-	$sectorFilters: [FundraisingLoanSearchFilterInput!]) {
-	isoCodes: fundraisingLoans(filters: $isoCodeFilters) {
+	$sectorFilters: [FundraisingLoanSearchFilterInput!],
+	$origin: String) {
+	isoCodes: fundraisingLoans(filters: $isoCodeFilters, origin: $origin) {
 		facets {
 			isoCode {
 				key
@@ -11,7 +12,7 @@ query flssLoanFacets(
 		}
 
   	}
-	themes: fundraisingLoans(filters: $themeFilters) {
+	themes: fundraisingLoans(filters: $themeFilters, origin: $origin) {
 		facets {
 			themes {
 				key
@@ -19,7 +20,7 @@ query flssLoanFacets(
 			}
 		}
 	}
-	sectors: fundraisingLoans(filters: $sectorFilters) {
+	sectors: fundraisingLoans(filters: $sectorFilters, origin: $origin) {
 		facets {
 			sectorId {
 				key

--- a/src/graphql/query/flssLoansQuery.graphql
+++ b/src/graphql/query/flssLoansQuery.graphql
@@ -7,12 +7,14 @@ query flssLoanData(
 	$pageLimit: Int = 0
 	$imgDefaultSize: String = "w480h360"
 	$imgRetinaSize: String = "w960h720"
+	$origin: String
 ) {
 	fundraisingLoans(
 		filters: $filterObject,
 		limit: $pageLimit,
 		pageNumber: $pageNumber,
-		sortBy: $sortBy
+		sortBy: $sortBy,
+		origin: $origin
 	) {
 		totalCount
 		values {

--- a/src/graphql/query/lendByCategory/categoryServiceLoanChannels.graphql
+++ b/src/graphql/query/lendByCategory/categoryServiceLoanChannels.graphql
@@ -6,6 +6,7 @@ query loanChannelData(
 	$imgDefaultSize: String = "w480h360",
     $imgRetinaSize: String = "w960h720",
 	$excludeIds: [Int!] = [0],
+	$origin: String
 ) {
 	loanCategoriesByLoanChannelIds(
 		loanChannelIds: $ids
@@ -15,7 +16,7 @@ query loanChannelData(
 			loanChannelId
 			name
 			description
-			savedSearch(limit: $numberOfLoans, excludeLoanIds: $excludeIds) {
+			savedSearch(limit: $numberOfLoans, excludeLoanIds: $excludeIds, origin: $origin) {
 				id
 				... on FundraisingLoanSavedSearchPageOutput {
 					filters

--- a/src/graphql/query/lendByCategory/mfiRecommendationsLoans.graphql
+++ b/src/graphql/query/lendByCategory/mfiRecommendationsLoans.graphql
@@ -7,7 +7,8 @@ query getMFIRecommendationsLoans {
 			partnerId: {
 				eq: 59
 			}
-		}
+		},
+		origin: "web:lend-by-category"
 	) {
 		totalCount
 		values {

--- a/src/graphql/query/lendByCategory/personalizedLoans.graphql
+++ b/src/graphql/query/lendByCategory/personalizedLoans.graphql
@@ -1,6 +1,6 @@
 
-query getPersonalizedLoans($limit: Int!, $filters: [FundraisingLoanSearchFilterInput!]) {
-	fundraisingLoans(limit: $limit, sortBy: personalized, filters: $filters) {
+query getPersonalizedLoans($limit: Int!, $filters: [FundraisingLoanSearchFilterInput!], $origin: String) {
+	fundraisingLoans(limit: $limit, sortBy: personalized, filters: $filters, origin: $origin) {
 		totalCount
 		values {
 			id

--- a/src/pages/BorrowerProfile/FundedBorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/FundedBorrowerProfile.vue
@@ -469,7 +469,8 @@ export default {
 							limit: row.limit,
 							filters: [
 								row.filter
-							]
+							],
+							origin: 'web:bp-funded'
 						};
 
 						this.apollo.query({

--- a/src/pages/BorrowerProfile/FundedBorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/FundedBorrowerProfile.vue
@@ -213,6 +213,7 @@ import {
 	getExperimentSettingCached,
 	trackExperimentVersion
 } from '@/util/experimentUtils';
+import { FLSS_ORIGIN_BP_FUNDED } from '@/util/flssUtils';
 import loanUseFilter from '@/plugins/loan-use-filter';
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
@@ -470,7 +471,7 @@ export default {
 							filters: [
 								row.filter
 							],
-							origin: 'web:bp-funded'
+							origin: FLSS_ORIGIN_BP_FUNDED
 						};
 
 						this.apollo.query({

--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -124,6 +124,7 @@ import { addCustomChannelInfo } from '@/util/categoryUtils';
 import logReadQueryError from '@/util/logReadQueryError';
 import { readJSONSetting } from '@/util/settingsUtils';
 import { indexIn } from '@/util/comparators';
+import { FLSS_ORIGIN_LEND_BY_CATEGORY } from '@/util/flssUtils';
 import { isLoanFundraising } from '@/util/loanUtils';
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
 import basketItems from '@/graphql/query/basketItems.graphql';
@@ -399,6 +400,7 @@ export default {
 					excludeIds: ssrLoanIds,
 					imgDefaultSize: this.showHoverLoanCards ? 'w480h300' : 'w480h360',
 					imgRetinaSize: this.showHoverLoanCards ? 'w960h600' : 'w960h720',
+					origin: FLSS_ORIGIN_LEND_BY_CATEGORY
 					// @todo variables for fetching data for custom channels
 				},
 			}).then(({ data }) => {
@@ -417,6 +419,7 @@ export default {
 						ids: this.realCategoryIds,
 						imgDefaultSize: this.showHoverLoanCards ? 'w480h300' : 'w480h360',
 						imgRetinaSize: this.showHoverLoanCards ? 'w960h600' : 'w960h720',
+						origin: FLSS_ORIGIN_LEND_BY_CATEGORY
 					},
 				}).subscribe({
 					next: ({ data }) => {
@@ -499,6 +502,7 @@ export default {
 					ids: recLoanChannels.map(channel => channel.id),
 					imgDefaultSize: this.showHoverLoanCards ? 'w480h300' : 'w480h360',
 					imgRetinaSize: this.showHoverLoanCards ? 'w960h600' : 'w960h720',
+					origin: FLSS_ORIGIN_LEND_BY_CATEGORY
 				};
 
 				return this.apollo.query({
@@ -637,7 +641,8 @@ export default {
 							ids: [category.id],
 							imgDefaultSize: this.showHoverLoanCards ? 'w480h300' : 'w480h360',
 							imgRetinaSize: this.showHoverLoanCards ? 'w960h600' : 'w960h720',
-							excludeIds
+							excludeIds,
+							origin: FLSS_ORIGIN_LEND_BY_CATEGORY
 						};
 						return this.apollo.query({
 							query: recommendedLoansQuery,
@@ -678,7 +683,8 @@ export default {
 								ids: [category.id],
 								imgDefaultSize: this.showHoverLoanCards ? 'w480h300' : 'w480h360',
 								imgRetinaSize: this.showHoverLoanCards ? 'w960h600' : 'w960h720',
-								excludeIds
+								excludeIds,
+								origin: FLSS_ORIGIN_LEND_BY_CATEGORY
 							},
 						}).then(({ data }) => {
 							const fetchedCategory = this.categoryServiceExpActive

--- a/src/pages/Lend/LoanChannelCategoryClimateExperiment.vue
+++ b/src/pages/Lend/LoanChannelCategoryClimateExperiment.vue
@@ -199,7 +199,8 @@ export default {
 				loanChannelQueryMapMixin.data().loanChannelQueryMap,
 				targetedLoanChannelURL,
 				// Build loanQueryVars since SSR doesn't have same context
-				{ ids: [...secondaryEcoLoanChannelIds, targetedLoanChannelID], limit, offset }
+				{ ids: [...secondaryEcoLoanChannelIds, targetedLoanChannelID], limit, offset },
+				'web:category'
 			);
 		}
 	},

--- a/src/pages/Lend/LoanChannelCategoryClimateExperiment.vue
+++ b/src/pages/Lend/LoanChannelCategoryClimateExperiment.vue
@@ -66,6 +66,7 @@
 					:climate-challenge="isEcoChallengeExpShown"
 					:loan-display-settings="loanDisplaySettings"
 					:lend-now-button="true"
+					:query-context="ecoExpQueryContext"
 				/>
 			</div>
 		</kv-page-container>
@@ -80,6 +81,7 @@ import lendFilterExpMixin from '@/plugins/lend-filter-page-exp-mixin';
 import loanChannelQueryMapMixin from '@/plugins/loan-channel-query-map';
 import ViewToggle from '@/components/LoansByCategory/ViewToggle';
 import KivaClassicSingleCategoryCarousel from '@/components/LoanCollections/KivaClassicSingleCategoryCarousel';
+import { FLSS_ORIGIN_CATEGORY } from '@/util/flssUtils';
 import {
 	preFetchChannel,
 	getCachedChannel
@@ -142,6 +144,7 @@ export default {
 			isEcoChallengeExpShown: false,
 			showHowItWorks: true,
 			mdiClose,
+			ecoExpQueryContext: FLSS_ORIGIN_CATEGORY
 		};
 	},
 	computed: {
@@ -197,8 +200,12 @@ export default {
 				loanChannelQueryMapMixin.data().loanChannelQueryMap,
 				targetedLoanChannelURL,
 				// Build loanQueryVars since SSR doesn't have same context
-				{ ids: [...secondaryEcoLoanChannelIds, targetedLoanChannelID], limit, offset },
-				'web:category'
+				{
+					ids: [...secondaryEcoLoanChannelIds, targetedLoanChannelID],
+					limit,
+					offset,
+					origin: FLSS_ORIGIN_CATEGORY
+				},
 			);
 		}
 	},
@@ -217,6 +224,7 @@ export default {
 				limit: 9,
 				offset: 0,
 				basketId: this.cookieStore.get('kvbskt'),
+				origin: FLSS_ORIGIN_CATEGORY
 			}
 		);
 		this.loanChannel = baseData?.lend?.loanChannelsById.find(channel => channel.id === this.targetedLoanChannelID);

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -312,7 +312,8 @@ export default {
 					loanChannelQueryMapMixin.data().loanChannelQueryMap,
 					targetedLoanChannelURL,
 					// Build loanQueryVars since SSR doesn't have same context
-					{ ids: [targetedLoanChannelID], limit, offset }
+					{ ids: [targetedLoanChannelID], limit, offset },
+					'web:category'
 				);
 			});
 		}

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -118,6 +118,7 @@ import {
 	formatSortOptions,
 	transformIsoCodes,
 } from '@/util/loanSearch/filterUtils';
+import { FLSS_ORIGIN_CATEGORY } from '@/util/flssUtils';
 import QuickFilters from '@/components/LoansByCategory/QuickFilters/QuickFilters';
 
 const defaultLoansPerPage = 12;
@@ -237,7 +238,7 @@ export default {
 			return _get(this.loanChannel, 'description') || null;
 		},
 		loans() {
-			return _get(this.loanChannel, 'loans.values') || [];
+			return (this.loanChannel?.loans?.values ?? []).filter(loan => loan !== null);
 		},
 		firstLoan() {
 			// Handle an edge case where a backend error could lead to a null loan
@@ -258,6 +259,7 @@ export default {
 				limit: this.limit,
 				offset: this.offset,
 				basketId: this.cookieStore.get('kvbskt'),
+				origin: FLSS_ORIGIN_CATEGORY
 			};
 		},
 		filterUrl() {
@@ -317,8 +319,12 @@ export default {
 					loanChannelQueryMapMixin.data().loanChannelQueryMap,
 					targetedLoanChannelURL,
 					// Build loanQueryVars since SSR doesn't have same context
-					{ ids: [targetedLoanChannelID], limit, offset },
-					'web:category'
+					{
+						ids: [targetedLoanChannelID],
+						limit,
+						offset,
+						origin: FLSS_ORIGIN_CATEGORY
+					},
 				);
 			});
 		}
@@ -529,7 +535,7 @@ export default {
 		},
 		async fetchFacets(loanSearchState = {}) {
 			// TODO: Prevent this from running on every query (not needed for sorting and paging)
-			const { isoCodes } = await runFacetsQueries(this.apollo, loanSearchState);
+			const { isoCodes } = await runFacetsQueries(this.apollo, loanSearchState, FLSS_ORIGIN_CATEGORY);
 
 			// Merge all facet options with filtered options
 			const facets = {

--- a/src/pages/Thanks/ThanksPageEcoChallenge.vue
+++ b/src/pages/Thanks/ThanksPageEcoChallenge.vue
@@ -191,6 +191,7 @@
 						:loan-channel-id="channelId"
 						:loan-display-settings="loanDisplaySettings"
 						:lend-now-button="true"
+						:query-context="ecoExpQueryContext"
 					/>
 				</div>
 			</kv-page-container>
@@ -206,6 +207,7 @@ import orderBy from 'lodash/orderBy';
 
 import thanksPageQuery from '@/graphql/query/thanksPage.graphql';
 import logReadQueryError from '@/util/logReadQueryError';
+import { FLSS_ORIGIN_THANKS } from '@/util/flssUtils';
 import logFormatter from '@/util/logFormatter';
 import { joinArray } from '@/util/joinArray';
 import { missingMilestones, achievementsQueryFromCache, achievementsQuery } from '@/util/ecoChallengeUtils';
@@ -256,6 +258,7 @@ export default {
 				showViewMoreCard: true,
 				showCheckBackMessage: true
 			},
+			ecoExpQueryContext: FLSS_ORIGIN_THANKS
 		};
 	},
 	apollo: {

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -4,6 +4,17 @@ import flssLoanChannelQuery from '@/graphql/query/flssLoanChannel.graphql';
 import logReadQueryError from '@/util/logReadQueryError';
 
 /**
+ * FLSS Query Context Const lists
+ * Each query that resolves loans from FLSS should provide a descriptive origin formatted as web:##page-context##
+ */
+export const FLSS_ORIGIN_NOT_SPECIFIED = 'web:no-context';
+export const FLSS_ORIGIN_CATEGORY = 'web:category';
+export const FLSS_ORIGIN_LEND_BY_CATEGORY = 'web:lend-by-category';
+export const FLSS_ORIGIN_LEND_FILTER = 'web:lend-filter';
+export const FLSS_ORIGIN_BP_FUNDED = 'web:bp-funded';
+export const FLSS_ORIGIN_THANKS = 'web:thanks';
+
+/**
  * Gets the filters for FLSS
  *
  * @param {Object} loanSearchState The current loan search state from Apollo
@@ -25,13 +36,19 @@ export function getFlssFilters(loanSearchState) {
  * Fetches the facets with number of fundraising loans from FLSS
  *
  * @param {Object} apollo The Apollo client instance
+ * @param {String} origin Origin of query formatted as web:##page-context##
  * @param {Object} isoCodeFilters The filters for the ISO code facets
  * @param {Object} themeFilters The filters for the theme facets
  * @param {Object} sectorFilters The filters for the sector facets
- * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Promise<Array<Object>>} Promise for facets data
  */
-export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters, origin = 'web:no-context') {
+export async function fetchFacets(
+	apollo,
+	origin = FLSS_ORIGIN_NOT_SPECIFIED,
+	isoCodeFilters,
+	themeFilters,
+	sectorFilters,
+) {
 	try {
 		const result = await apollo.query({
 			query: flssLoanFacetsQuery,
@@ -66,7 +83,7 @@ export async function fetchLoans(
 	sortBy = null,
 	pageOffset = 0,
 	pageLimit = 15,
-	origin = 'web:no-context'
+	origin = FLSS_ORIGIN_NOT_SPECIFIED
 ) {
 	try {
 		const result = await apollo.query({
@@ -101,6 +118,7 @@ export function getLoanChannelVariables(queryMapFLSS, loanQueryVars) {
 		pageNumber: loanQueryVars.offset / loanQueryVars.limit,
 		pageLimit: loanQueryVars.limit,
 		basketId: loanQueryVars.basketId,
+		origin: loanQueryVars?.origin ?? FLSS_ORIGIN_NOT_SPECIFIED
 	};
 }
 
@@ -110,14 +128,13 @@ export function getLoanChannelVariables(queryMapFLSS, loanQueryVars) {
  * @param {Object} apollo The Apollo client instance
  * @param {Array} queryMapFLSS The query map entry for the channel
  * @param {Object} loanQueryVars The loan channel query variables
- * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Object} The loan channel data
  */
-export async function fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars, origin = 'web:no-context') {
+export async function fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars) {
 	try {
 		return (await apollo.query({
 			query: flssLoanChannelQuery,
-			variables: { ...getLoanChannelVariables(queryMapFLSS, loanQueryVars), origin }
+			variables: getLoanChannelVariables(queryMapFLSS, loanQueryVars),
 		})).data;
 	} catch (e) {
 		logReadQueryError(e, 'flssUtils fetchLoanChannel flssLoanChannelQuery');

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -28,13 +28,19 @@ export function getFlssFilters(loanSearchState) {
  * @param {Object} isoCodeFilters The filters for the ISO code facets
  * @param {Object} themeFilters The filters for the theme facets
  * @param {Object} sectorFilters The filters for the sector facets
+ * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Promise<Array<Object>>} Promise for facets data
  */
-export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters) {
+export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters, origin = 'web:no-context') {
 	try {
 		const result = await apollo.query({
 			query: flssLoanFacetsQuery,
-			variables: { isoCodeFilters, themeFilters, sectorFilters },
+			variables: {
+				isoCodeFilters,
+				themeFilters,
+				sectorFilters,
+				origin
+			},
 			fetchPolicy: 'network-only',
 		});
 		return result.data;
@@ -51,9 +57,17 @@ export async function fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFi
  * @param {String} sortOrder Sort option for the loan query
  * @param {Int} pageOffset The offset of the page
  * @param {Int} pageLimit The limit/size of the page
+ * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Promise<Array<Object>>} Promise for loan data
  */
-export async function fetchLoans(apollo, filterObject, sortBy = null, pageOffset = 0, pageLimit = 15) {
+export async function fetchLoans(
+	apollo,
+	filterObject,
+	sortBy = null,
+	pageOffset = 0,
+	pageLimit = 15,
+	origin = 'web:no-context'
+) {
 	try {
 		const result = await apollo.query({
 			query: flssLoanQuery,
@@ -62,6 +76,7 @@ export async function fetchLoans(apollo, filterObject, sortBy = null, pageOffset
 				sortBy,
 				pageNumber: pageOffset / pageLimit,
 				pageLimit,
+				origin
 			},
 			fetchPolicy: 'network-only',
 		});
@@ -95,13 +110,14 @@ export function getLoanChannelVariables(queryMapFLSS, loanQueryVars) {
  * @param {Object} apollo The Apollo client instance
  * @param {Array} queryMapFLSS The query map entry for the channel
  * @param {Object} loanQueryVars The loan channel query variables
+ * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Object} The loan channel data
  */
-export async function fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars) {
+export async function fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars, origin = 'web:no-context') {
 	try {
 		return (await apollo.query({
 			query: flssLoanChannelQuery,
-			variables: getLoanChannelVariables(queryMapFLSS, loanQueryVars),
+			variables: { ...getLoanChannelVariables(queryMapFLSS, loanQueryVars), origin }
 		})).data;
 	} catch (e) {
 		logReadQueryError(e, 'flssUtils fetchLoanChannel flssLoanChannelQuery');

--- a/src/util/loanChannelUtils.js
+++ b/src/util/loanChannelUtils.js
@@ -42,9 +42,8 @@ export function transformFLSSData(data) {
  * @param {Array} queryMap The map mixin from loan-channel-query-map.js
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
- * @param {String} origin Origin of query formatted as web:##page-context##
  */
-export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVars, origin) {
+export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVars) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
 
 	if (queryMapFLSS) {
@@ -62,7 +61,7 @@ export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVar
 		}
 
 		if (experimentActive) {
-			return fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars, origin);
+			return fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars);
 		}
 	}
 
@@ -129,16 +128,15 @@ export function getCachedChannel(apollo, queryMap, channelUrl, loanQueryVars) {
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
  * @returns {Object} The loan channel data, transformed if FLSS
- * @param {String} origin Origin of query formatted as web:##page-context##
  */
-export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars, origin) {
+export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
 
 	if (queryMapFLSS) {
 		const experimentActive = checkCachedChannelExperiment(apollo);
 
 		if (experimentActive) {
-			return transformFLSSData(await fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars, origin));
+			return transformFLSSData(await fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars));
 		}
 	}
 

--- a/src/util/loanChannelUtils.js
+++ b/src/util/loanChannelUtils.js
@@ -42,8 +42,9 @@ export function transformFLSSData(data) {
  * @param {Array} queryMap The map mixin from loan-channel-query-map.js
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
+ * @param {String} origin Origin of query formatted as web:##page-context##
  */
-export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVars) {
+export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVars, origin) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
 
 	if (queryMapFLSS) {
@@ -61,7 +62,7 @@ export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVar
 		}
 
 		if (experimentActive) {
-			return fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars);
+			return fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars, origin);
 		}
 	}
 
@@ -128,15 +129,16 @@ export function getCachedChannel(apollo, queryMap, channelUrl, loanQueryVars) {
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
  * @returns {Object} The loan channel data, transformed if FLSS
+ * @param {String} origin Origin of query formatted as web:##page-context##
  */
-export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars) {
+export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars, origin) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
 
 	if (queryMapFLSS) {
 		const experimentActive = checkCachedChannelExperiment(apollo);
 
 		if (experimentActive) {
-			return transformFLSSData(await fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars));
+			return transformFLSSData(await fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars, origin));
 		}
 	}
 

--- a/src/util/loanSearch/dataUtils.js
+++ b/src/util/loanSearch/dataUtils.js
@@ -1,5 +1,10 @@
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
-import { fetchFacets, fetchLoans, getFlssFilters } from '@/util/flssUtils';
+import {
+	fetchFacets,
+	fetchLoans,
+	getFlssFilters,
+	FLSS_ORIGIN_NOT_SPECIFIED,
+} from '@/util/flssUtils';
 import logReadQueryError from '@/util/logReadQueryError';
 
 /**
@@ -10,12 +15,12 @@ import logReadQueryError from '@/util/logReadQueryError';
  * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Object} The filter facets
  */
-export async function runFacetsQueries(apollo, loanSearchState = {}, origin) {
+export async function runFacetsQueries(apollo, loanSearchState = {}, origin = FLSS_ORIGIN_NOT_SPECIFIED) {
 	const isoCodeFilters = { ...getFlssFilters(loanSearchState), countryIsoCode: undefined };
 	const themeFilters = { ...getFlssFilters(loanSearchState), themeId: undefined };
 	const sectorFilters = { ...getFlssFilters(loanSearchState), sectorId: undefined };
 
-	const facets = await fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters, origin);
+	const facets = await fetchFacets(apollo, origin, isoCodeFilters, themeFilters, sectorFilters);
 
 	return {
 		isoCodes: facets?.isoCodes?.facets?.isoCode ?? [],

--- a/src/util/loanSearch/dataUtils.js
+++ b/src/util/loanSearch/dataUtils.js
@@ -7,14 +7,15 @@ import logReadQueryError from '@/util/logReadQueryError';
  *
  * @param {Object} apollo The Apollo client instance
  * @param {Object} loanSearchState The current loan search state from Apollo
+ * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Object} The filter facets
  */
-export async function runFacetsQueries(apollo, loanSearchState = {}) {
+export async function runFacetsQueries(apollo, loanSearchState = {}, origin) {
 	const isoCodeFilters = { ...getFlssFilters(loanSearchState), countryIsoCode: undefined };
 	const themeFilters = { ...getFlssFilters(loanSearchState), themeId: undefined };
 	const sectorFilters = { ...getFlssFilters(loanSearchState), sectorId: undefined };
 
-	const facets = await fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters);
+	const facets = await fetchFacets(apollo, isoCodeFilters, themeFilters, sectorFilters, origin);
 
 	return {
 		isoCodes: facets?.isoCodes?.facets?.isoCode ?? [],
@@ -28,15 +29,17 @@ export async function runFacetsQueries(apollo, loanSearchState = {}) {
  *
  * @param {Object} apollo The Apollo client instance
  * @param {Object} loanSearchState The current loan search state from Apollo
+ * @param {String} origin Origin of query formatted as web:##page-context##
  * @returns {Object} The results of the loan query
  */
-export async function runLoansQuery(apollo, loanSearchState) {
+export async function runLoansQuery(apollo, loanSearchState, origin) {
 	const flssData = await fetchLoans(
 		apollo,
 		getFlssFilters(loanSearchState),
 		loanSearchState?.sortBy,
 		loanSearchState?.pageOffset,
-		loanSearchState?.pageLimit
+		loanSearchState?.pageLimit,
+		origin,
 	);
 
 	return { loans: flssData?.values ?? [], totalCount: flssData?.totalCount ?? 0 };

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -53,16 +53,21 @@ describe('flssUtils.js', () => {
 		const dataObj = { data: result };
 		const apollo = { query: jest.fn(() => Promise.resolve(dataObj)) };
 		const filters = { gender: { any: ['FEMALE'] } };
-		const variables = { isoCodeFilters: filters, themeFilters: filters, sectorFilters: filters };
+		const variables = {
+			isoCodeFilters: filters,
+			themeFilters: filters,
+			sectorFilters: filters,
+			origin: 'web:test-context'
+		};
 		const apolloVariables = { query: flssLoanFacetsQuery, variables, fetchPolicy: 'network-only' };
 
 		it('should pass the correct query variables to apollo', async () => {
-			await fetchFacets(apollo, filters, filters, filters);
+			await fetchFacets(apollo, 'web:test-context', filters, filters, filters);
 			expect(apollo.query).toHaveBeenCalledWith(apolloVariables);
 		});
 
 		it('should return the fundraising facets data', async () => {
-			const data = await fetchFacets(apollo, filters, filters, filters);
+			const data = await fetchFacets(apollo, 'web:test-context', filters, filters, filters);
 			expect(data).toBe(result);
 		});
 	});
@@ -82,6 +87,7 @@ describe('flssUtils.js', () => {
 				sortBy: 'personalized',
 				pageNumber: 3,
 				pageLimit,
+				origin: 'web:no-context'
 			},
 			fetchPolicy: 'network-only',
 		};


### PR DESCRIPTION
Passes the `origin` variable into all `fundraisingLoans` queries.

![Screen Shot 2022-10-05 at 5 56 07 PM](https://user-images.githubusercontent.com/1862756/194193353-df602db9-cd26-45ac-8a81-91354cfa5acd.png)

![Screen Shot 2022-10-05 at 5 55 59 PM](https://user-images.githubusercontent.com/1862756/194193357-1ae2d302-6c59-4cf5-bcb8-877b1dfb3f46.png)
