### PR TITLE
feat: use loanCardFields fragment for kiva classic basic loan card

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -472,19 +472,32 @@ export default {
 		this.destroyViewportObserver();
 	},
 	created() {
+		let partnerFragment;
+		let	directFragment;
 		try {
 			// Attempt to read the loan card fragment from the cache
-			// If cache is missing fragment fields, this will throw and invariant error
-			const loanCardFieldFragment = this.apollo.readFragment({
+			// If cache is missing fragment fields, this will throw an invariant error
+			partnerFragment = this.apollo.readFragment({
 				id: `LoanPartner:${this.loanId}`,
 				fragment: loanCardFieldsFragment,
 			}) || null;
-			if (loanCardFieldFragment) {
-				this.loan = loanCardFieldFragment;
-				this.isLoading = false;
-			}
 		} catch (e) {
 			// no-op
+		}
+		try {
+			// Attempt to read the loan card fragment from the cache
+			// If cache is missing fragment fields, this will throw an invariant error
+			directFragment = this.apollo.readFragment({
+				id: `LoanDirect:${this.loanId}`,
+				fragment: loanCardFieldsFragment,
+			}) || null;
+		} catch (e) {
+			// no-op
+		}
+		const loanCardFieldFragment = partnerFragment || directFragment;
+		if (loanCardFieldFragment) {
+			this.loan = loanCardFieldFragment;
+			this.isLoading = false;
 		}
 	},
 	watch: {

--- a/src/graphql/fragments/loanCardFields.graphql
+++ b/src/graphql/fragments/loanCardFields.graphql
@@ -1,5 +1,6 @@
 fragment loanCardFields on LoanBasic {
 	id
+	distributionModel
 	status
 	name
 	borrowerCount
@@ -35,10 +36,17 @@ fragment loanCardFields on LoanBasic {
 	plannedExpirationDate
 	matchingText
 	matchRatio
+	isMatchable
 	userProperties {
 		favorited
 		lentTo
 	}
+
+	image {
+		id
+		hash
+	}
+
 	# lenders added for DetailedLoanCard Query Cache
 	lenders(limit: 0) {
 		totalCount


### PR DESCRIPTION
Added fields to commonly used fragment (used in both flss and legacy lend by category queries) then kiva classic loan card can just load these fields if they are present. 

This makes it so the eco-challenge page loads all the cards almost instantly since we have already queried for them when getting the categories on `src/pages/Lend/LoanChannelCategoryClimateExperiment.vue`