### PR TITLE
fix: only import braintree dropin on initialization in the client

### DIFF
--- a/src/components/Payment/BraintreeDropInInterface.vue
+++ b/src/components/Payment/BraintreeDropInInterface.vue
@@ -9,7 +9,6 @@
 import _get from 'lodash/get';
 import numeral from 'numeral';
 import * as Sentry from '@sentry/vue';
-import Dropin from 'braintree-web-drop-in';
 import getClientToken from '@/graphql/query/checkout/getClientToken.graphql';
 import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 
@@ -147,8 +146,6 @@ export default {
 					} else {
 						this.clientToken = _get(response, 'data.shop.getClientToken');
 						this.initializeDropIn(this.clientToken);
-						// Replace our loader with the dropIn loader after a small delay
-						setTimeout(() => this.setUpdatingPaymentWrapper(false), 500);
 					}
 				}).catch(error => {
 					console.error(error);
@@ -159,7 +156,10 @@ export default {
 				this.initializeDropIn(this.$appConfig.btTokenKey);
 			}
 		},
-		initializeDropIn(authToken) {
+		async initializeDropIn(authToken) {
+			const { default: Dropin } = await import('braintree-web-drop-in');
+			// Replace our loader with the dropIn loader after a small delay
+			setTimeout(() => this.setUpdatingPaymentWrapper(false), 500);
 			Dropin.create({
 				authorization: authToken,
 				container: '#dropin-container',


### PR DESCRIPTION
This addresses a 500 error caused by importing a module on the server that tries to use `window`:
```
uncaughtException: window is not defined
ReferenceError: window is not defined
    at Object.<anonymous> (/ui/node_modules/braintree-web/lib/vendor/polyfill.js:3:51)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at Module.require (/ui/node_modules/require-in-the-middle/index.js:43:24)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/ui/node_modules/braintree-web/lib/create-authorization-data.js:3:12)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
```