### PR TITLE
Vue 1324 add individual group filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.312.0",
+	"version": "2.341.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.312.0",
+			"version": "2.341.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.18.2",

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -13,6 +13,8 @@ export const getDefaultLoanSearchState = () => ({
 	pageOffset: 0, // Expects a number
 	pageLimit: 15, // Expects a number
 	distributionModel: null, // Expects DIRECT or FIELDPARTNER
+	isIndividual: null, // Expects a boolean
+	lenderRepaymentTerm: null, // Expects a MinMaxRange
 });
 
 // export queries, resolvers and defaults for LoanSearchState

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -85,6 +85,8 @@ type LoanSearchState {
 	pageOffset: [Int]
 	pageLimit: [Int]
 	distributionModel: String
+	isIndividual: Boolean
+	lenderRepaymentTerm: MinMaxRange
 }
 
 type TipMessage {

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -16,6 +16,17 @@
 			all-option-title="All genders"
 			@updated="handleUpdatedFilters"
 		/>
+		<template v-if="extendFlssFilters">
+			<hr class="tw-border-tertiary tw-my-1">
+			<loan-search-radio-group-filter
+				:options="facets.isIndividualOptions"
+				:selected="loanSearchState.isIndividual"
+				filter-key="isIndividual"
+				event-action="click-isIndividual-filter"
+				:value-map="isIndividualValueMap"
+				@updated="handleUpdatedFilters"
+			/>
+		</template>
 		<hr class="tw-border-tertiary tw-my-1">
 		<kv-accordion-item id="acc-sort-by" :open="false">
 			<template #header>
@@ -72,21 +83,32 @@
 				event-action="click-theme-filter"
 			/>
 		</kv-accordion-item>
-		<kv-accordion-item v-if="extendFlssFilters" id="acc-tags" :open="false">
-			<template #header>
-				<h2 class="tw-text-h4">
-					Tags
-				</h2>
-			</template>
-			<loan-search-checkbox-list-filter
-				:options="facets.tags"
-				:ids="loanSearchState.tagId"
-				@updated="handleUpdatedFilters"
-				filter-key="tagId"
-				event-action="click-tag-filter"
-			/>
-		</kv-accordion-item>
 		<template v-if="extendFlssFilters">
+			<kv-accordion-item id="acc-tags" :open="false">
+				<template #header>
+					<h2 class="tw-text-h4">
+						Tags
+					</h2>
+				</template>
+				<loan-search-checkbox-list-filter
+					:options="facets.tags"
+					:ids="loanSearchState.tagId"
+					@updated="handleUpdatedFilters"
+					filter-key="tagId"
+					event-action="click-tag-filter"
+				/>
+			</kv-accordion-item>
+			<h2 class="tw-text-h4 tw-pt-2">
+				Loan length
+			</h2>
+			<loan-search-radio-group-filter
+				:options="facets.lenderRepaymentTerms"
+				:selected="loanSearchState.lenderRepaymentTerm"
+				filter-key="lenderRepaymentTerm"
+				event-action="click-lenderRepaymentTerm-filter"
+				:value-map="lenderRepaymentTermValueMap"
+				@updated="handleUpdatedFilters"
+			/>
 			<h2 class="tw-text-h4 tw-pt-2">
 				Loan distribution
 			</h2>
@@ -129,7 +151,7 @@ import { mdiClose, mdiArrowRight } from '@mdi/js';
 import LoanSearchLocationFilter from '@/components/Lend/LoanSearch/LoanSearchLocationFilter';
 import LoanSearchCheckboxListFilter from '@/components/Lend/LoanSearch/LoanSearchCheckboxListFilter';
 import LoanSearchSortBy from '@/components/Lend/LoanSearch/LoanSearchSortBy';
-import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
+import { FLSS_QUERY_TYPE, isIndividualValueMap, lenderRepaymentTermValueMap } from '@/util/loanSearch/filterUtils';
 import KvSectionModalLoader from '@/components/Kv/KvSectionModalLoader';
 import LoanSearchRadioGroupFilter from '@/components/Lend/LoanSearch/LoanSearchRadioGroupFilter';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
@@ -176,6 +198,8 @@ export default {
 		return {
 			mdiClose,
 			mdiArrowRight,
+			isIndividualValueMap,
+			lenderRepaymentTermValueMap,
 		};
 	},
 	methods: {

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -109,6 +109,7 @@
 				:value-map="lenderRepaymentTermValueMap"
 				@updated="handleUpdatedFilters"
 			/>
+			<hr class="tw-border-tertiary tw-my-1">
 			<h2 class="tw-text-h4 tw-pt-2">
 				Loan distribution
 			</h2>

--- a/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
@@ -28,8 +28,22 @@
 <script>
 import _throttle from 'lodash/throttle';
 import KvChipClassic from '@/components/Kv/KvChipClassic';
-import { transformTagName, genderDisplayMap, distributionModelDisplayMap } from '@/util/loanSearch/filterUtils';
+import {
+	transformTagName,
+	genderDisplayMap,
+	distributionModelDisplayMap,
+	isIndividualDisplayMap,
+	isIndividualValueMap,
+	lenderRepaymentTermDisplayMap,
+	lenderRepaymentTermValueMap,
+	getFilterKeyFromValue,
+} from '@/util/loanSearch/filterUtils';
 import KvTextLink from '~/@kiva/kv-components/vue/KvTextLink';
+
+const GENDER_TYPE = 'Gender';
+const DISTRIBUTION_MODEL_TYPE = 'DistributionModel';
+const IS_INDIVIDUAL_TYPE = 'IsIndividual';
+const LENDER_REPAYMENT_TERM_TYPE = 'LenderRepaymentTerm';
 
 export default {
 	name: 'LoanSearchFilterChips',
@@ -76,7 +90,7 @@ export default {
 	methods: {
 		formatRemovedFacet(facetType, facet) {
 			switch (facetType) {
-				case 'Gender':
+				case GENDER_TYPE:
 					return { gender: null };
 				case 'Sector':
 					return { sectorId: [...this.loanSearchState.sectorId?.filter(id => facet.id !== id)] };
@@ -90,8 +104,12 @@ export default {
 					return { themeId: [...this.loanSearchState.themeId?.filter(id => facet.id !== id)] };
 				case 'Tag':
 					return { tagId: [...this.loanSearchState.tagId?.filter(id => facet.id !== id)] };
-				case 'DistributionModel':
+				case DISTRIBUTION_MODEL_TYPE:
 					return { distributionModel: null };
+				case IS_INDIVIDUAL_TYPE:
+					return { isIndividual: null };
+				case LENDER_REPAYMENT_TERM_TYPE:
+					return { lenderRepaymentTerm: null };
 				default:
 					return {};
 			}
@@ -102,7 +120,7 @@ export default {
 				const genderFacet = allFacets.genderFacets?.find(f => f.name === loanSearchState.gender);
 				itemList.push({
 					name: genderDisplayMap[genderFacet?.name.toUpperCase()],
-					__typename: 'Gender'
+					__typename: GENDER_TYPE
 				});
 			}
 			if (loanSearchState.countryIsoCode?.length) {
@@ -143,7 +161,25 @@ export default {
 					?.find(f => f.name === loanSearchState.distributionModel);
 				itemList.push({
 					name: distributionModelDisplayMap[distributionModelFacet?.name.toUpperCase()],
-					__typename: 'DistributionModel'
+					__typename: DISTRIBUTION_MODEL_TYPE
+				});
+			}
+			if (loanSearchState.isIndividual !== null) {
+				itemList.push({
+					name: isIndividualDisplayMap[getFilterKeyFromValue(
+						loanSearchState.isIndividual,
+						isIndividualValueMap
+					)],
+					__typename: IS_INDIVIDUAL_TYPE
+				});
+			}
+			if (loanSearchState.lenderRepaymentTerm) {
+				itemList.push({
+					name: lenderRepaymentTermDisplayMap[getFilterKeyFromValue(
+						loanSearchState.lenderRepaymentTerm,
+						lenderRepaymentTermValueMap
+					)],
+					__typename: LENDER_REPAYMENT_TERM_TYPE
 				});
 			}
 			return itemList;

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -129,6 +129,8 @@ import {
 	transformTags,
 	transformGenderOptions,
 	transformDistributionModelOptions,
+	transformIsIndividualOptions,
+	transformLenderRepaymentTermOptions,
 } from '@/util/loanSearch/filterUtils';
 import { FLSS_ORIGIN_LEND_FILTER } from '@/util/flssUtils';
 import { runFacetsQueries, runLoansQuery, fetchLoanFacets } from '@/util/loanSearch/dataUtils';
@@ -297,19 +299,14 @@ export default {
 			return isNumber(storedPageLimit) ? +storedPageLimit : this.loanSearchState.pageLimit;
 		},
 		showSavedSearch() {
-			// implement more global solution when out of exp phase
-			const countryFilterApplied = this.loanSearchState.countryIsoCode.length > 0;
-			const genderFilterApplied = !!this.loanSearchState.gender;
-			const sectorFilterApplied = this.loanSearchState.sectorId.length > 0;
-			const themeFilterApplied = this.loanSearchState.themeId.length > 0;
-			const tagFilterApplied = this.loanSearchState.tagId.length > 0;
-			const distributionModelFilterApplied = !!this.loanSearchState.distributionModel;
-			return countryFilterApplied
-				|| genderFilterApplied
-				|| sectorFilterApplied
-				|| themeFilterApplied
-				|| tagFilterApplied
-				|| distributionModelFilterApplied;
+			return this.loanSearchState.countryIsoCode.length > 0
+				|| !!this.loanSearchState.gender
+				|| this.loanSearchState.sectorId.length > 0
+				|| this.loanSearchState.themeId.length > 0
+				|| this.loanSearchState.tagId.length > 0
+				|| !!this.loanSearchState.distributionModel
+				|| this.loanSearchState.isIndividual !== null
+				|| !!this.loanSearchState.lenderRepaymentTerm;
 		},
 		themeNames() {
 			return this.allFacets?.themeNames ?? [];
@@ -333,6 +330,8 @@ export default {
 				tags: transformTags(this.allFacets?.tagFacets ?? []),
 				sortOptions: formatSortOptions(this.allFacets?.standardSorts ?? [], this.allFacets?.flssSorts ?? []),
 				distributionModels: transformDistributionModelOptions(this.allFacets?.distributionModelFacets),
+				isIndividualOptions: transformIsIndividualOptions(),
+				lenderRepaymentTerms: transformLenderRepaymentTermOptions(),
 			};
 		},
 		trackLoans() {

--- a/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
@@ -130,6 +130,14 @@ export default {
 				theme: this.loanSearchState?.themeId.map(themeId => this.themeNames[themeId]),
 				loanTags: this.loanSearchState?.tagId,
 				distributionModel: distributionModelEnumMap[this.loanSearchState?.distributionModel?.toUpperCase()],
+				// Reverse "isIndividual" to match legacy "isGroup" query param
+				isGroup: this.loanSearchState?.isIndividual !== null ? !this.loanSearchState.isIndividual : null,
+				// Create new simple object that can be saved to legacy "MinMaxRangeInput" type
+				lenderTerm: this.loanSearchState?.lenderRepaymentTerm
+					? {
+						min: this.loanSearchState.lenderRepaymentTerm.min,
+						max: this.loanSearchState.lenderRepaymentTerm.max
+					} : null,
 			};
 		},
 		loginUrl() {

--- a/src/graphql/mutation/updateLoanSearchState.graphql
+++ b/src/graphql/mutation/updateLoanSearchState.graphql
@@ -10,5 +10,10 @@ mutation updateLoanSearch($searchParams: JSONObject) {
 		pageOffset
 		pageLimit
 		distributionModel
+		isIndividual
+		lenderRepaymentTerm {
+			min
+			max
+		}
 	}
 }

--- a/src/graphql/query/loanSearchState.graphql
+++ b/src/graphql/query/loanSearchState.graphql
@@ -10,5 +10,10 @@ query loanSearchStateQuery {
 		pageOffset
 		pageLimit
 		distributionModel
+		isIndividual
+		lenderRepaymentTerm {
+			min
+			max
+		}
 	}
 }

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -1,4 +1,5 @@
 /* eslint-disable max-len */
+import { createMinMaxRange } from '@/util/loanSearch/minMaxRange';
 
 export default {
 	data() {
@@ -139,7 +140,10 @@ export default {
 					id: 11,
 					url: 'short-term-loans',
 					queryParams: 'status=fundRaising&lenderTerm=0,16',
-					algoliaParams: 'repayment=%3A16'
+					algoliaParams: 'repayment=%3A16',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16)
+					},
 				},
 				{
 					id: 6,
@@ -208,7 +212,10 @@ export default {
 					id: 14,
 					url: 'groups',
 					queryParams: 'status=fundRaising&isGroup=1',
-					algoliaParams: '' // not support show exit link
+					algoliaParams: '', // not support show exit link
+					flssLoanSearch: {
+						isIndividual: false
+					},
 				},
 				{
 					id: 1,
@@ -410,6 +417,9 @@ export default {
 					id: 79,
 					url: 'group-loans',
 					queryParams: 'status=fundRaising&isGroup=1&distributionModel=both',
+					flssLoanSearch: {
+						isIndividual: false
+					},
 				},
 
 				// Lend By Category Carousel Layout Sub Channels
@@ -712,31 +722,55 @@ export default {
 					id: 144,
 					url: 'short-term-loans-almost-funded',
 					queryParams: 'lenderTerm=0,16&sortBy=amountLeft',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16),
+						sortBy: 'amountLeft'
+					},
 				},
 				{
 					id: 145,
 					url: 'africa-short-term-loans',
 					queryParams: 'status=fundRaising&lenderTerm=0,16&country=MZ,UG,TZ,SN,RW,KE,CD,LR,SL,BF,CM,GH,NG,TG,MG,MW,ZM,ML,EG,LS,ZA,BI,SS,ZW,NA&distributionModel=both',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16),
+						countryIsoCode: ['MZ', 'UG', 'TZ', 'SN', 'RW', 'KE', 'CD', 'LR', 'SL', 'BF', 'CM', 'GH', 'NG', 'TG', 'MG', 'MW', 'ZM', 'ML', 'EG', 'LS', 'ZA', 'BI', 'SS', 'ZW', 'NA'],
+					},
 				},
 				{
 					id: 146,
 					url: 'asia-short-term-loans',
 					queryParams: 'status=fundRaising&lenderTerm=0,16&country=KH,NP,TJ,TH,VN,PH,KG,IN,ID,PK,MM,LA,BT,BD&distributionModel=both',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16),
+						countryIsoCode: ['KH', 'NP', 'TJ', 'TH', 'VN', 'PH', 'KG', 'IN', 'ID', 'PK', 'MM', 'LA', 'BT', 'BD'],
+					},
 				},
 				{
 					id: 148,
 					url: 'eastern-europe-short-term-loans',
 					queryParams: 'status=fundRaising&lenderTerm=0,16&country=GE,AL,XK,MD&distributionModel=both',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16),
+						countryIsoCode: ['GE', 'AL', 'XK', 'MD'],
+					},
 				},
 				{
 					id: 149,
 					url: 'middle-east-short-term-loans',
 					queryParams: 'status=fundRaising&lenderTerm=0,16&country=JO,PS,IL,TR&distributionModel=both',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16),
+						countryIsoCode: ['JO', 'PS', 'IL', 'TR'],
+					},
 				},
 				{
 					id: 150,
 					url: 'oceania-short-term-loans',
 					queryParams: 'status=fundRaising&lenderTerm=0,16&country=WS,TL,SB,TO,FJ,PG,VU,GU&distributionModel=both',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 16),
+						countryIsoCode: ['WS', 'TL', 'SB', 'TO', 'FJ', 'PG', 'VU', 'GU'],
+					},
 				},
 				{
 					id: 151,

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -2,6 +2,7 @@ import flssLoanQuery from '@/graphql/query/flssLoansQuery.graphql';
 import flssLoanFacetsQuery from '@/graphql/query/flssLoanFacetsQuery.graphql';
 import flssLoanChannelQuery from '@/graphql/query/flssLoanChannel.graphql';
 import logReadQueryError from '@/util/logReadQueryError';
+import { getMinMaxRangeFilter } from '@/util/loanSearch/minMaxRange';
 
 /**
  * FLSS Query Context Const lists
@@ -29,6 +30,12 @@ export function getFlssFilters(loanSearchState) {
 		...(loanSearchState?.distributionModel && { distributionModel: { eq: loanSearchState.distributionModel } }),
 		...(loanSearchState?.tagId?.length && { tagId: { any: loanSearchState.tagId } }),
 		...(loanSearchState?.description && { description: { eq: loanSearchState.description } }),
+		...(typeof loanSearchState?.isIndividual !== 'undefined' && loanSearchState.isIndividual !== null && {
+			isIndividual: { eq: loanSearchState.isIndividual }
+		}),
+		...(loanSearchState?.lenderRepaymentTerm && {
+			lenderRepaymentTerm: { range: getMinMaxRangeFilter(loanSearchState.lenderRepaymentTerm) }
+		}),
 	};
 }
 

--- a/src/util/loanSearch/filterUtils.js
+++ b/src/util/loanSearch/filterUtils.js
@@ -1,5 +1,6 @@
 import _orderBy from 'lodash/orderBy';
 import { sortRegions } from '@/util/loanSearch/countryUtils';
+import { createMinMaxRange } from '@/util/loanSearch/minMaxRange';
 
 /**
  * Used to map the sort value to display value
@@ -43,40 +44,74 @@ export const FLSS_QUERY_TYPE = 'flss';
  */
 export const STANDARD_QUERY_TYPE = 'standard';
 
-/**
- * Key for configuring expected female enum value
- */
+// Gender enum keys
 export const FEMALE_KEY = 'FEMALE';
-
-/**
- * Key for configuring expected male enum value
- */
 export const MALE_KEY = 'MALE';
 
-/**
- * Key for configuring expected field partner enum value
- */
+// Distribution model enum keys
 export const FIELDPARTNER_KEY = 'FIELDPARTNER';
-
-/**
- * Key for configuring expected direct enum value
- */
 export const DIRECT_KEY = 'DIRECT';
+
+// Is individual option keys
+export const INDIVIDUAL_KEY = 'INDIVIDUAL';
+export const GROUP_KEY = 'GROUP';
+
+// Lender repayment term option keys
+export const EIGHT_MONTHS_KEY = 'EIGHT_MONTHS';
+export const SIXTEEN_MONTHS_KEY = 'SIXTEEN_MONTHS';
+export const TWO_YEARS_KEY = 'TWO_YEARS';
+export const MORE_THAN_TWO_YEARS_KEY = 'MORE_THAN_TWO_YEARS_KEY';
 
 /**
  * Maps the gender enum names to display names
  */
 export const genderDisplayMap = {
 	[FEMALE_KEY]: 'Women',
-	[MALE_KEY]: 'Men',
+	[MALE_KEY]: 'Men'
 };
 
 /**
- * Maps the distributor enum names to display names
+ * Maps the distribution model enum names to display names
  */
 export const distributionModelDisplayMap = {
 	[FIELDPARTNER_KEY]: 'Partner',
 	[DIRECT_KEY]: 'Direct',
+};
+
+/**
+ * Maps the is individual keys to display names
+ */
+export const isIndividualDisplayMap = {
+	[INDIVIDUAL_KEY]: 'Individual',
+	[GROUP_KEY]: 'Group',
+};
+
+/**
+ * Maps the is individual keys to values
+ */
+export const isIndividualValueMap = {
+	[INDIVIDUAL_KEY]: true,
+	[GROUP_KEY]: false,
+};
+
+/**
+ * Maps the lender repayment term keys to display names
+ */
+export const lenderRepaymentTermDisplayMap = {
+	[EIGHT_MONTHS_KEY]: '8 mths or less',
+	[SIXTEEN_MONTHS_KEY]: '16 mths or less',
+	[TWO_YEARS_KEY]: '2 yrs or less',
+	[MORE_THAN_TWO_YEARS_KEY]: '2 yrs or more'
+};
+
+/**
+ * Maps the lender repayment term keys to values
+ */
+export const lenderRepaymentTermValueMap = {
+	[EIGHT_MONTHS_KEY]: createMinMaxRange(0, 8),
+	[SIXTEEN_MONTHS_KEY]: createMinMaxRange(0, 16),
+	[TWO_YEARS_KEY]: createMinMaxRange(0, 24),
+	[MORE_THAN_TWO_YEARS_KEY]: createMinMaxRange(24, 400),
 };
 
 /**
@@ -218,16 +253,20 @@ export function transformTags(allTags = []) {
  *
  * @param {Array<Object>} options The options to transform
  * @param {Array<string>} order The order of the options (name property)
- * @param {Object} map Display name map
+ * @param {Object} displayMap The map for name to display title
+ * @param {Object} valueMap The map for name to value
  * @returns {Array<Object>} The transformed radio group options
  */
-export function transformRadioGroupOptions(options, order, map) {
+export function transformRadioGroupOptions(options, order, displayMap, valueMap = {}) {
 	const capitalizedOrder = order.map(o => o.toUpperCase());
 
 	const transformed = options.filter(o => capitalizedOrder.includes(o.name.toUpperCase())).map(o => {
+		const key = o.name.toUpperCase();
+
 		return {
 			name: o.name,
-			title: map[o.name.toUpperCase()] ?? o
+			title: displayMap[key] ?? o,
+			value: valueMap[key] ?? o.name,
 		};
 	}).sort((a, b) => capitalizedOrder.indexOf(a.name.toUpperCase()) - capitalizedOrder.indexOf(b.name.toUpperCase()));
 
@@ -252,6 +291,55 @@ export function transformGenderOptions(genders) {
  */
 export function transformDistributionModelOptions(distributionModels) {
 	return transformRadioGroupOptions(distributionModels, [FIELDPARTNER_KEY, DIRECT_KEY], distributionModelDisplayMap);
+}
+
+/**
+ * Prepares the is individual options to be used by a radio group
+ *
+ * @returns The transformed radio group options
+ */
+export function transformIsIndividualOptions() {
+	const options = [{ name: INDIVIDUAL_KEY }, { name: GROUP_KEY }];
+	const order = [INDIVIDUAL_KEY, GROUP_KEY];
+	return transformRadioGroupOptions(options, order, isIndividualDisplayMap, isIndividualValueMap);
+}
+
+/**
+ * Prepares the lender repayment term options to be used by a radio group
+ *
+ * @returns The transformed radio group options
+ */
+export function transformLenderRepaymentTermOptions() {
+	const options = [
+		{ name: EIGHT_MONTHS_KEY },
+		{ name: SIXTEEN_MONTHS_KEY },
+		{ name: TWO_YEARS_KEY },
+		{ name: MORE_THAN_TWO_YEARS_KEY }
+	];
+	const order = [EIGHT_MONTHS_KEY, SIXTEEN_MONTHS_KEY, TWO_YEARS_KEY, MORE_THAN_TWO_YEARS_KEY];
+	return transformRadioGroupOptions(options, order, lenderRepaymentTermDisplayMap, lenderRepaymentTermValueMap);
+}
+
+/**
+ * Gets the filter key based on the value
+ * @param {(Object|boolean|string)} value The filter value
+ * @param {Object} valueMap The filter key to value map
+ * @returns The key of the filter
+ */
+export function getFilterKeyFromValue(value, valueMap) {
+	const isMinMax = typeof value === 'object'
+		&& typeof value?.min !== 'undefined'
+		&& typeof value?.max !== 'undefined';
+
+	return Object.keys(valueMap).find(k => {
+		const mapValue = valueMap[k];
+
+		if (isMinMax) {
+			return mapValue.min === value.min && mapValue.max === value.max;
+		}
+
+		return mapValue === value;
+	});
 }
 
 /**

--- a/src/util/loanSearch/minMaxRange.js
+++ b/src/util/loanSearch/minMaxRange.js
@@ -10,7 +10,7 @@ import { isNumber } from '@/util/numberUtils';
 export function createMinMaxRange(min, max) {
 	if (!isNumber(min) || !isNumber(max)) return;
 
-	return { min, max };
+	return { min, max, __typename: 'MinMaxRange' };
 }
 
 /**

--- a/src/util/loanSearch/minMaxRange.js
+++ b/src/util/loanSearch/minMaxRange.js
@@ -1,0 +1,43 @@
+import { isNumber } from '@/util/numberUtils';
+
+/**
+ * Creates the min max range object
+ *
+ * @param {number} min The min of the range
+ * @param {number} max The max of the range
+ * @returns The new min max range object
+ */
+export function createMinMaxRange(min, max) {
+	if (!isNumber(min) || !isNumber(max)) return;
+
+	return { min, max };
+}
+
+/**
+ * Gets the FLSS filter object from the min max range object
+ *
+ * @param {number} param0.min The min of the range
+ * @param {number} param0.max The max of the range
+ * @returns The FLSS filter object
+ */
+export function getMinMaxRangeFilter({ min, max }) {
+	if (!isNumber(min) && !isNumber(max)) return null;
+
+	return {
+		...(typeof min !== 'undefined' && { gte: min }),
+		...(typeof max !== 'undefined' && { lte: max })
+	};
+}
+
+/**
+ * Gets the query param string based on the min max range object
+ *
+ * @param {number} param0.min The min of the range
+ * @param {number} param0.max The max of the range
+ * @returns The query param string
+ */
+export function getMinMaxRangeQueryParam({ min, max }) {
+	if (!isNumber(min) || !isNumber(max)) return null;
+
+	return [min, max].join();
+}

--- a/src/util/loanSearch/queryParamUtils.js
+++ b/src/util/loanSearch/queryParamUtils.js
@@ -1,6 +1,7 @@
 import { isNumber } from '@/util/numberUtils';
 import { updateSearchState } from '@/util/loanSearch/searchStateUtils';
 import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
+import { createMinMaxRange, getMinMaxRangeQueryParam } from '@/util/loanSearch/minMaxRange';
 import VueRouter from 'vue-router';
 
 /**
@@ -26,12 +27,6 @@ export function hasExcludedQueryParams(query) {
 		'activity',
 		'city_state',
 		'defaultRate',
-		// We don't yet officially support this query param, but will soon
-		// Dropping it doesn't have any ill affect on the most popular categories
-		// If problems are reported we can uncomment this one to redirect to legacy
-		// 'distributionModel',
-		'isGroup',
-		'lenderTerm',
 		'loanTags',
 		'partner',
 		'riskRating',
@@ -57,6 +52,48 @@ export function getEnumNameFromQueryParam(param, facets) {
 	if (param) {
 		return facets.find(f => f.name.toUpperCase() === param.toUpperCase())?.name;
 	}
+}
+
+/**
+ * Gets boolean value based on string query param
+ *
+ * @param {string} param The query param to parse
+ * @returns The boolean value
+ */
+export function getBooleanValueFromQueryParam(param) {
+	const lowerParam = param?.toLowerCase();
+
+	// eslint-disable-next-line no-nested-ternary
+	return lowerParam === 'true' ? true : (lowerParam === 'false' ? false : null);
+}
+
+/**
+ * Gets the min max range object based on string query param
+ *
+ * @param {string} param The query param to parse
+ * @returns The min max range object
+ */
+export function getMinMaxRangeFromQueryParam(param) {
+	if (!param) return;
+
+	const minMaxSplit = param?.split(',');
+
+	if (minMaxSplit.length === 2 && isNumber(minMaxSplit[0]) && isNumber(minMaxSplit[1])) {
+		return createMinMaxRange(+minMaxSplit[0], +minMaxSplit[1]);
+	}
+}
+
+/**
+ * Gets the is individual filter value based on the query param
+ *
+ * @param {string} param The query param to parse
+ * @returns The is individual filter value
+ */
+export function getIsIndividualFromQueryParam(param) {
+	const value = getBooleanValueFromQueryParam(param);
+
+	// Reverse the "isGroup" param that is used to match legacy filters
+	return typeof value === 'boolean' ? !value : null;
 }
 
 /**
@@ -163,6 +200,8 @@ export async function applyQueryParams(apollo, query, allFacets, queryType, page
 		),
 		tagId: getIdsFromQueryParam(query.tag || query.tags, allFacets.tagNames, allFacets.tagFacets),
 		distributionModel: getEnumNameFromQueryParam(query.distributionModel, allFacets.distributionModelFacets),
+		isIndividual: getIsIndividualFromQueryParam(query.isGroup),
+		lenderRepaymentTerm: getMinMaxRangeFromQueryParam(query.lenderTerm),
 		pageOffset: page * pageLimit,
 		pageLimit,
 	};
@@ -206,6 +245,13 @@ export function updateQueryParams(loanSearchState, router, queryType) {
 		...(loanSearchState.themeId?.length && { attribute: loanSearchState.themeId.join() }),
 		...(loanSearchState.tagId?.length && { tag: loanSearchState.tagId.join() }),
 		...(loanSearchState.distributionModel && { distributionModel: loanSearchState.distributionModel }),
+		// Reverse "isIndividual" to match legacy "isGroup" query param
+		...(typeof loanSearchState.isIndividual === 'boolean' && {
+			isGroup: (!loanSearchState.isIndividual).toString()
+		}),
+		...(loanSearchState.lenderRepaymentTerm && {
+			lenderTerm: getMinMaxRangeQueryParam(loanSearchState.lenderRepaymentTerm)
+		}),
 		...(queryParamSortBy && { sortBy: queryParamSortBy }),
 		...(page > 1 && { page: page.toString() }),
 		...utmParams,

--- a/src/util/loanSearch/searchStateUtils.js
+++ b/src/util/loanSearch/searchStateUtils.js
@@ -2,7 +2,11 @@ import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.g
 import createSavedSearchMutation from '@/graphql/mutation/createSavedSearch.graphql';
 import { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
 import { isNumber } from '@/util/numberUtils';
-import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
+import {
+	FLSS_QUERY_TYPE,
+	getFilterKeyFromValue,
+	lenderRepaymentTermValueMap,
+} from '@/util/loanSearch/filterUtils';
 
 /**
  * Returns loan search state that has been validated against the available facets
@@ -44,6 +48,17 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		? loanSearchState.distributionModel
 		: null;
 
+	const validatedIsIndividual = typeof loanSearchState?.isIndividual === 'boolean'
+		? loanSearchState?.isIndividual
+		: null;
+
+	const validatedLenderRepaymentTerm = getFilterKeyFromValue(
+		loanSearchState?.lenderRepaymentTerm,
+		lenderRepaymentTermValueMap
+	)
+		? { ...loanSearchState.lenderRepaymentTerm, __typename: 'MinMaxRange' }
+		: null;
+
 	return {
 		gender: validatedGender,
 		countryIsoCode: validatedIsoCodes,
@@ -54,6 +69,8 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		pageOffset: validatedPageOffset,
 		pageLimit: validatedPageLimit,
 		distributionModel: validatedDistributionModel,
+		isIndividual: validatedIsIndividual,
+		lenderRepaymentTerm: validatedLenderRepaymentTerm,
 	};
 }
 

--- a/src/util/loanSearch/searchStateUtils.js
+++ b/src/util/loanSearch/searchStateUtils.js
@@ -56,7 +56,7 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		loanSearchState?.lenderRepaymentTerm,
 		lenderRepaymentTermValueMap
 	)
-		? { ...loanSearchState.lenderRepaymentTerm, __typename: 'MinMaxRange' }
+		? { ...loanSearchState.lenderRepaymentTerm }
 		: null;
 
 	return {

--- a/src/util/numberUtils.js
+++ b/src/util/numberUtils.js
@@ -8,7 +8,7 @@
  * @returns Whether the value is a number
  */
 export function isNumber(value) {
-	if (['object', 'boolean'].includes(typeof value)) return false;
+	if (value === '' || ['object', 'boolean'].includes(typeof value)) return false;
 
 	return !Number.isNaN(Number(value));
 }

--- a/test/unit/fixtures/mockLoanSearchData.js
+++ b/test/unit/fixtures/mockLoanSearchData.js
@@ -6,6 +6,8 @@ export const mockState = {
 	themeId: [1],
 	tagId: [1],
 	distributionModel: 'DIRECT',
+	isIndividual: false,
+	lenderRepaymentTerm: { min: 0, max: 8, __typename: 'MinMaxRange' },
 	pageOffset: 10,
 	pageLimit: 5,
 };

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
@@ -140,6 +140,36 @@ describe('LoanSearchFilterChips', () => {
 		expect(emitted().updated[0]).toEqual([{ distributionModel: null }]);
 	});
 
+	it('should handle is individual chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('Group'));
+
+		expect(emitted().updated[0]).toEqual([{ isIndividual: null }]);
+	});
+
+	it('should handle lender repayment term chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText('8 mths or less'));
+
+		expect(emitted().updated[0]).toEqual([{ lenderRepaymentTerm: null }]);
+	});
+
 	it('should track event', async () => {
 		const user = userEvent.setup();
 

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchRadioGroupFilter.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchRadioGroupFilter.spec.js
@@ -2,7 +2,15 @@ import { render } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import LoanSearchRadioGroupFilter, { ALL_LOANS_TITLE } from '@/components/Lend/LoanSearch/LoanSearchRadioGroupFilter';
 
-const getOptions = () => [...Array(4)].map((_c, i) => ({ title: `Option ${i}`, name: i.toString() }));
+const getOptions = (isObject = false, isBoolean = false) => [...Array(4)].map((_c, i) => ({
+	title: `Option ${i}`,
+	name: i.toString(),
+	// eslint-disable-next-line no-nested-ternary
+	value: isObject ? { asd: `${i + 1}` } : (isBoolean ? false : `${i + 1}`),
+}));
+
+// eslint-disable-next-line no-param-reassign
+const getValueMap = options => options.reduce((map, option) => { map[option.name] = option.value; return map; }, {});
 
 describe('LoanSearchRadioGroupFilter', () => {
 	it('should default to all', () => {
@@ -76,5 +84,105 @@ describe('LoanSearchRadioGroupFilter', () => {
 
 		const radio = getByLabelText(allOptionTitle);
 		expect(radio.checked).toBeTruthy();
+	});
+
+	it('should emit updated', async () => {
+		const options = getOptions();
+
+		const user = userEvent.setup();
+
+		const { getByLabelText, emitted } = render(LoanSearchRadioGroupFilter, {
+			props: { options, filterKey: 'option', eventAction: 'action' }
+		});
+
+		let radio = getByLabelText(ALL_LOANS_TITLE);
+		expect(radio.checked).toBeTruthy();
+
+		radio = getByLabelText('Option 1');
+		await user.click(radio);
+		expect(radio.checked).toBeTruthy();
+
+		expect(emitted().updated[0]).toEqual([{ option: options[1].value }]);
+	});
+
+	it('should use value map', async () => {
+		const user = userEvent.setup();
+
+		const options = getOptions();
+		const map = getValueMap(options);
+
+		const { getByLabelText, updateProps, emitted } = render(LoanSearchRadioGroupFilter, {
+			props: {
+				options, selected: '2', filterKey: 'option', eventAction: 'action', valueMap: map
+			}
+		});
+
+		let radio = getByLabelText(ALL_LOANS_TITLE);
+		expect(radio.checked).toBeFalsy();
+
+		radio = getByLabelText('Option 1');
+		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ selected: options[0].value });
+		radio = getByLabelText('Option 0');
+		expect(radio.checked).toBeTruthy();
+
+		radio = getByLabelText('Option 1');
+		await user.click(radio);
+		expect(radio.checked).toBeTruthy();
+
+		expect(emitted().updated[0]).toEqual([{ option: options[1].value }]);
+	});
+
+	it('should handle boolean', async () => {
+		const user = userEvent.setup();
+
+		const options = getOptions(false, true);
+		const map = getValueMap(options);
+
+		const { getByLabelText, updateProps, emitted } = render(LoanSearchRadioGroupFilter, {
+			props: {
+				options, filterKey: 'option', eventAction: 'action', valueMap: map
+			}
+		});
+
+		let radio = getByLabelText(ALL_LOANS_TITLE);
+		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ selected: options[0].value });
+		radio = getByLabelText('Option 0');
+		expect(radio.checked).toBeTruthy();
+
+		radio = getByLabelText('Option 1');
+		await user.click(radio);
+		expect(radio.checked).toBeTruthy();
+
+		expect(emitted().updated[0]).toEqual([{ option: options[1].value }]);
+	});
+
+	it('should handle object', async () => {
+		const user = userEvent.setup();
+
+		const options = getOptions(true);
+		const map = getValueMap(options);
+
+		const { getByLabelText, updateProps, emitted } = render(LoanSearchRadioGroupFilter, {
+			props: {
+				options, filterKey: 'option', selected: false, eventAction: 'action', valueMap: map
+			}
+		});
+
+		let radio = getByLabelText(ALL_LOANS_TITLE);
+		expect(radio.checked).toBeTruthy();
+
+		await updateProps({ selected: options[0].value });
+		radio = getByLabelText('Option 0');
+		expect(radio.checked).toBeTruthy();
+
+		radio = getByLabelText('Option 1');
+		await user.click(radio);
+		expect(radio.checked).toBeTruthy();
+
+		expect(emitted().updated[0]).toEqual([{ option: options[1].value }]);
 	});
 });

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -25,6 +25,7 @@ describe('flssUtils.js', () => {
 				tagId: [],
 				sectorId: [],
 				distributionModel: null,
+				isIndividual: null,
 				description: null,
 			};
 
@@ -39,6 +40,8 @@ describe('flssUtils.js', () => {
 				tagId: [1],
 				sectorId: [1],
 				distributionModel: 'DIRECT',
+				isIndividual: false,
+				lenderRepaymentTerm: { min: 0, max: 8, __typename: 'MinMaxRange' },
 				description: 'desc',
 			};
 
@@ -49,6 +52,8 @@ describe('flssUtils.js', () => {
 				tagId: { any: [1] },
 				sectorId: { any: [1] },
 				distributionModel: { eq: 'DIRECT' },
+				isIndividual: { eq: false },
+				lenderRepaymentTerm: { range: { gte: 0, lte: 8 } },
 				description: { eq: 'desc' },
 			});
 		});

--- a/test/unit/specs/util/loanSearch/filterUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/filterUtils.spec.js
@@ -21,6 +21,18 @@ import {
 	DIRECT_KEY,
 	genderDisplayMap,
 	distributionModelDisplayMap,
+	transformIsIndividualOptions,
+	transformLenderRepaymentTermOptions,
+	getFilterKeyFromValue,
+	INDIVIDUAL_KEY,
+	GROUP_KEY,
+	isIndividualDisplayMap,
+	EIGHT_MONTHS_KEY,
+	SIXTEEN_MONTHS_KEY,
+	TWO_YEARS_KEY,
+	MORE_THAN_TWO_YEARS_KEY,
+	lenderRepaymentTermDisplayMap,
+	lenderRepaymentTermValueMap,
 } from '@/util/loanSearch/filterUtils';
 import _orderBy from 'lodash/orderBy';
 import {
@@ -335,9 +347,9 @@ describe('filterUtils.js', () => {
 			const result = transformRadioGroupOptions(options, order, map);
 
 			expect(result).toEqual([
-				{ name: 'a', title: 'AA' },
-				{ name: 'b', title: 'BB' },
-				{ name: 'c', title: 'CC' }
+				{ name: 'a', title: 'AA', value: 'a' },
+				{ name: 'b', title: 'BB', value: 'b' },
+				{ name: 'c', title: 'CC', value: 'c' }
 			]);
 		});
 	});
@@ -353,8 +365,8 @@ describe('filterUtils.js', () => {
 			const result = transformGenderOptions(genders);
 
 			expect(result).toEqual([
-				{ name: FEMALE_KEY, title: genderDisplayMap[FEMALE_KEY] },
-				{ name: MALE_KEY, title: genderDisplayMap[MALE_KEY] },
+				{ name: FEMALE_KEY, title: genderDisplayMap[FEMALE_KEY], value: FEMALE_KEY },
+				{ name: MALE_KEY, title: genderDisplayMap[MALE_KEY], value: MALE_KEY },
 			]);
 		});
 	});
@@ -370,9 +382,76 @@ describe('filterUtils.js', () => {
 			const result = transformDistributionModelOptions(distributionModels);
 
 			expect(result).toEqual([
-				{ name: FIELDPARTNER_KEY, title: distributionModelDisplayMap[FIELDPARTNER_KEY] },
-				{ name: DIRECT_KEY, title: distributionModelDisplayMap[DIRECT_KEY] },
+				{
+					name: FIELDPARTNER_KEY,
+					title: distributionModelDisplayMap[FIELDPARTNER_KEY],
+					value: FIELDPARTNER_KEY
+				},
+				{ name: DIRECT_KEY, title: distributionModelDisplayMap[DIRECT_KEY], value: DIRECT_KEY },
 			]);
+		});
+	});
+
+	describe('transformIsIndividualOptions', () => {
+		it('should transform and sort', () => {
+			const result = transformIsIndividualOptions();
+
+			expect(result).toEqual([
+				{ name: INDIVIDUAL_KEY, title: isIndividualDisplayMap[INDIVIDUAL_KEY], value: true },
+				{ name: GROUP_KEY, title: isIndividualDisplayMap[GROUP_KEY], value: false },
+			]);
+		});
+	});
+
+	describe('transformLenderRepaymentTermOptions', () => {
+		it('should transform and sort', () => {
+			const result = transformLenderRepaymentTermOptions();
+
+			expect(result).toEqual([
+				{
+					name: EIGHT_MONTHS_KEY,
+					title: lenderRepaymentTermDisplayMap[EIGHT_MONTHS_KEY],
+					value: lenderRepaymentTermValueMap[EIGHT_MONTHS_KEY]
+				},
+				{
+					name: SIXTEEN_MONTHS_KEY,
+					title: lenderRepaymentTermDisplayMap[SIXTEEN_MONTHS_KEY],
+					value: lenderRepaymentTermValueMap[SIXTEEN_MONTHS_KEY]
+				},
+				{
+					name: TWO_YEARS_KEY,
+					title: lenderRepaymentTermDisplayMap[TWO_YEARS_KEY],
+					value: lenderRepaymentTermValueMap[TWO_YEARS_KEY]
+				},
+				{
+					name: MORE_THAN_TWO_YEARS_KEY,
+					title: lenderRepaymentTermDisplayMap[MORE_THAN_TWO_YEARS_KEY],
+					value: lenderRepaymentTermValueMap[MORE_THAN_TWO_YEARS_KEY]
+				},
+			]);
+		});
+	});
+
+	describe('getFilterKeyFromValue', () => {
+		it('should return undefined when not found', () => {
+			const result = getFilterKeyFromValue('asd', lenderRepaymentTermValueMap);
+
+			expect(result).toEqual(undefined);
+		});
+
+		it('should get filter key', () => {
+			const result = getFilterKeyFromValue(1, { test: 1 });
+
+			expect(result).toEqual('test');
+		});
+
+		it('should get filter key from min max range', () => {
+			const result = getFilterKeyFromValue(
+				lenderRepaymentTermValueMap[EIGHT_MONTHS_KEY],
+				lenderRepaymentTermValueMap
+			);
+
+			expect(result).toEqual(EIGHT_MONTHS_KEY);
 		});
 	});
 

--- a/test/unit/specs/util/loanSearch/minMaxRange.spec.js
+++ b/test/unit/specs/util/loanSearch/minMaxRange.spec.js
@@ -11,7 +11,7 @@ describe('minMaxRange.js', () => {
 		});
 
 		it('should create min max range', () => {
-			expect(createMinMaxRange(1, 100)).toEqual({ min: 1, max: 100 });
+			expect(createMinMaxRange(1, 100)).toEqual({ min: 1, max: 100, __typename: 'MinMaxRange' });
 		});
 	});
 

--- a/test/unit/specs/util/loanSearch/minMaxRange.spec.js
+++ b/test/unit/specs/util/loanSearch/minMaxRange.spec.js
@@ -1,0 +1,41 @@
+import { createMinMaxRange, getMinMaxRangeFilter, getMinMaxRangeQueryParam } from '@/util/loanSearch/minMaxRange';
+
+describe('minMaxRange.js', () => {
+	describe('createMinMaxRange', () => {
+		it('should check numbers', () => {
+			expect(createMinMaxRange()).toBe(undefined);
+			expect(createMinMaxRange(1)).toBe(undefined);
+			expect(createMinMaxRange(undefined, 1)).toBe(undefined);
+			expect(createMinMaxRange('asd', 1)).toBe(undefined);
+			expect(createMinMaxRange(1, 'asd')).toBe(undefined);
+		});
+
+		it('should create min max range', () => {
+			expect(createMinMaxRange(1, 100)).toEqual({ min: 1, max: 100 });
+		});
+	});
+
+	describe('getMinMaxRangeFilter', () => {
+		it('should handle bad numbers', () => {
+			expect(getMinMaxRangeFilter({})).toEqual(null);
+		});
+
+		it('should create min max range', () => {
+			expect(getMinMaxRangeFilter({ min: 1, max: 100 })).toEqual({ gte: 1, lte: 100 });
+			expect(getMinMaxRangeFilter({ min: 1 })).toEqual({ gte: 1 });
+			expect(getMinMaxRangeFilter({ max: 100 })).toEqual({ lte: 100 });
+		});
+	});
+
+	describe('getMinMaxRangeQueryParam', () => {
+		it('should handle bad numbers', () => {
+			expect(getMinMaxRangeQueryParam({})).toBe(null);
+			expect(getMinMaxRangeQueryParam({ min: 1 })).toBe(null);
+			expect(getMinMaxRangeQueryParam({ max: 100 })).toBe(null);
+		});
+
+		it('should return query param', () => {
+			expect(getMinMaxRangeQueryParam({ min: 1, max: 100 })).toBe('1,100');
+		});
+	});
+});

--- a/test/unit/specs/util/loanSearch/searchStateUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/searchStateUtils.spec.js
@@ -91,6 +91,31 @@ describe('searchStateUtils.js', () => {
 
 			expect(result).toEqual({ ...mockState, distributionModel: null });
 		});
+
+		it('should validate is individual', () => {
+			const state = { ...mockState, isIndividual: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, isIndividual: null });
+		});
+
+		it('should validate lender repayment term', () => {
+			const state = { ...mockState, lenderRepaymentTerm: 'asd' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({ ...mockState, lenderRepaymentTerm: null });
+		});
+
+		it('should add lender repayment term typename', () => {
+			const result = getValidatedSearchState(mockState, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({
+				...mockState,
+				lenderRepaymentTerm: { ...mockState.lenderRepaymentTerm, __typename: 'MinMaxRange' }
+			});
+		});
 	});
 
 	describe('updateSearchState', () => {

--- a/test/unit/specs/util/numberUtils.spec.js
+++ b/test/unit/specs/util/numberUtils.spec.js
@@ -25,6 +25,7 @@ describe('numberUtils.js', () => {
 			expect(isNumber(undefined)).toBe(false);
 			expect(isNumber(true)).toBe(false);
 			expect(isNumber(false)).toBe(false);
+			expect(isNumber('')).toBe(false);
 			expect(isNumber('.')).toBe(false);
 			expect(isNumber('1asd')).toBe(false);
 			expect(isNumber('1.asd')).toBe(false);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1324
https://kiva.atlassian.net/browse/VUE-1341

- Added `isIndividual` and 'lenderRepaymentTerm` filters to the new filter page
- Uses legacy query params: `isGroup` and `lenderTerm`
- Created pattern (similar to old pattern) for min max range filters
- Created pattern for boolean filters
- Updated and verified channel mappings with new filters

![image](https://user-images.githubusercontent.com/16867161/196292307-832d51cd-7de7-4e5a-abbe-d48c166f6d48.png)
