### PR TITLE
Vue 1307 add keyword search field

### DIFF
--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -15,6 +15,7 @@ export const getDefaultLoanSearchState = () => ({
 	distributionModel: null, // Expects DIRECT or FIELDPARTNER
 	isIndividual: null, // Expects a boolean
 	lenderRepaymentTerm: null, // Expects a MinMaxRange
+	keywordSearch: null, // Expects a string
 });
 
 // export queries, resolvers and defaults for LoanSearchState

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -87,6 +87,7 @@ type LoanSearchState {
 	distributionModel: String
 	isIndividual: Boolean
 	lenderRepaymentTerm: MinMaxRange
+	keywordSearch: String
 }
 
 type TipMessage {

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -26,6 +26,18 @@
 				:value-map="isIndividualValueMap"
 				@updated="handleUpdatedFilters"
 			/>
+			<hr class="tw-border-tertiary tw-my-1">
+			<h2 class="tw-text-h4 tw-pt-1">
+				Keywords
+			</h2>
+			<kv-text-input
+				id="keywords-text-input"
+				placeholder="Search borrower story"
+				:can-clear="true"
+				v-model="keywordSearch"
+				@input="value => debouncedHandleUpdatedFilters({ keywordSearch: value.trim() })"
+				class="tw-w-full tw-py-1.5"
+			/>
 		</template>
 		<hr class="tw-border-tertiary tw-my-1">
 		<kv-accordion-item id="acc-sort-by" :open="false">
@@ -110,7 +122,7 @@
 				@updated="handleUpdatedFilters"
 			/>
 			<hr class="tw-border-tertiary tw-my-1">
-			<h2 class="tw-text-h4 tw-pt-2">
+			<h2 class="tw-text-h4 tw-pt-1">
 				Loan distribution
 			</h2>
 			<loan-search-radio-group-filter
@@ -155,7 +167,9 @@ import LoanSearchSortBy from '@/components/Lend/LoanSearch/LoanSearchSortBy';
 import { FLSS_QUERY_TYPE, isIndividualValueMap, lenderRepaymentTermValueMap } from '@/util/loanSearch/filterUtils';
 import KvSectionModalLoader from '@/components/Kv/KvSectionModalLoader';
 import LoanSearchRadioGroupFilter from '@/components/Lend/LoanSearch/LoanSearchRadioGroupFilter';
+import _debounce from 'lodash/debounce';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
+import KvTextInput from '~/@kiva/kv-components/vue/KvTextInput';
 
 export default {
 	name: 'LoanSearchFilter',
@@ -163,6 +177,7 @@ export default {
 	components: {
 		KvAccordionItem,
 		KvMaterialIcon,
+		KvTextInput,
 		LoanSearchRadioGroupFilter,
 		LoanSearchLocationFilter,
 		LoanSearchCheckboxListFilter,
@@ -201,6 +216,8 @@ export default {
 			mdiArrowRight,
 			isIndividualValueMap,
 			lenderRepaymentTermValueMap,
+			keywordSearch: '',
+			debouncedHandleUpdatedFilters: _debounce(this.handleUpdatedFilters, 750),
 		};
 	},
 	methods: {
@@ -216,7 +233,12 @@ export default {
 		},
 		handleUpdatedFilters(payload) {
 			this.$emit('updated', payload);
-		}
+		},
+	},
+	watch: {
+		loanSearchState(state) {
+			this.keywordSearch = state.keywordSearch ?? '';
+		},
 	},
 };
 </script>

--- a/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
@@ -44,6 +44,7 @@ const GENDER_TYPE = 'Gender';
 const DISTRIBUTION_MODEL_TYPE = 'DistributionModel';
 const IS_INDIVIDUAL_TYPE = 'IsIndividual';
 const LENDER_REPAYMENT_TERM_TYPE = 'LenderRepaymentTerm';
+const KEYWORD_SEARCH_TYPE = 'KeywordSearch';
 
 export default {
 	name: 'LoanSearchFilterChips',
@@ -110,6 +111,8 @@ export default {
 					return { isIndividual: null };
 				case LENDER_REPAYMENT_TERM_TYPE:
 					return { lenderRepaymentTerm: null };
+				case KEYWORD_SEARCH_TYPE:
+					return { keywordSearch: null };
 				default:
 					return {};
 			}
@@ -181,6 +184,9 @@ export default {
 					)],
 					__typename: LENDER_REPAYMENT_TERM_TYPE
 				});
+			}
+			if (loanSearchState.keywordSearch) {
+				itemList.push({ name: loanSearchState.keywordSearch, __typename: KEYWORD_SEARCH_TYPE });
 			}
 			return itemList;
 		},

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -306,7 +306,8 @@ export default {
 				|| this.loanSearchState.tagId.length > 0
 				|| !!this.loanSearchState.distributionModel
 				|| this.loanSearchState.isIndividual !== null
-				|| !!this.loanSearchState.lenderRepaymentTerm;
+				|| !!this.loanSearchState.lenderRepaymentTerm
+				|| !!this.loanSearchState.keywordSearch;
 		},
 		themeNames() {
 			return this.allFacets?.themeNames ?? [];

--- a/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
@@ -180,11 +180,12 @@ export default {
 			);
 			// We want to exclude sending any utm params
 			// New lend/filter page doesn't allow for custom keywords ATM - revisit this after exp phase
-			// const queryString = window.location.search.replace(/(&|\?)utm_[a-zA-Z0-9]*=[a-zA-Z0-9]*/, '');
 			createSavedSearch(
-				this.apollo, this.reformattedSearchState, '', this.savedSearchName
-			// eslint-disable-next-line no-unused-vars
-			).then(({ data }) => {
+				this.apollo,
+				this.reformattedSearchState,
+				this.loanSearchState?.keywordSearch ?? '',
+				this.savedSearchName
+			).then(() => {
 				this.showSuccessMessage(this.savedSearchName);
 			}).catch(errorResponse => {
 				logFormatter(errorResponse, 'error');

--- a/src/graphql/mutation/updateLoanSearchState.graphql
+++ b/src/graphql/mutation/updateLoanSearchState.graphql
@@ -15,5 +15,6 @@ mutation updateLoanSearch($searchParams: JSONObject) {
 			min
 			max
 		}
+		keywordSearch
 	}
 }

--- a/src/graphql/query/loanSearchState.graphql
+++ b/src/graphql/query/loanSearchState.graphql
@@ -15,5 +15,6 @@ query loanSearchStateQuery {
 			min
 			max
 		}
+		keywordSearch
 	}
 }

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -429,7 +429,7 @@ export default {
 					url: 'solar-energy',
 					queryParams: 'queryString=solar',
 					flssLoanSearch: {
-						description: 'solar'
+						keywordSearch: 'solar'
 					},
 				},
 				{
@@ -446,7 +446,7 @@ export default {
 					url: 'recycle-and-re-use',
 					queryParams: 'queryString=used clothing',
 					flssLoanSearch: {
-						description: 'clothing',
+						keywordSearch: 'clothing',
 						tagId: [9],
 					},
 				},

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -29,7 +29,7 @@ export function getFlssFilters(loanSearchState) {
 		...(loanSearchState?.sectorId?.length && { sectorId: { any: loanSearchState.sectorId } }),
 		...(loanSearchState?.distributionModel && { distributionModel: { eq: loanSearchState.distributionModel } }),
 		...(loanSearchState?.tagId?.length && { tagId: { any: loanSearchState.tagId } }),
-		...(loanSearchState?.description && { description: { eq: loanSearchState.description } }),
+		...(loanSearchState?.keywordSearch && { description: { eq: loanSearchState.keywordSearch } }),
 		...(typeof loanSearchState?.isIndividual !== 'undefined' && loanSearchState.isIndividual !== null && {
 			isIndividual: { eq: loanSearchState.isIndividual }
 		}),

--- a/src/util/loanSearch/queryParamUtils.js
+++ b/src/util/loanSearch/queryParamUtils.js
@@ -33,7 +33,6 @@ export function hasExcludedQueryParams(query) {
 		'partner',
 		'riskRating',
 		'state',
-		'queryString', // can be mapped to description
 		'loanLimit',
 	];
 	// Check route.query for excluded params
@@ -204,6 +203,7 @@ export async function applyQueryParams(apollo, query, allFacets, queryType, page
 		distributionModel: getEnumNameFromQueryParam(query.distributionModel, allFacets.distributionModelFacets),
 		isIndividual: getIsIndividualFromQueryParam(query.isGroup),
 		lenderRepaymentTerm: getMinMaxRangeFromQueryParam(query.lenderTerm),
+		keywordSearch: query.queryString,
 		pageOffset: page * pageLimit,
 		pageLimit,
 	};
@@ -254,6 +254,7 @@ export function updateQueryParams(loanSearchState, router, queryType) {
 		...(loanSearchState.lenderRepaymentTerm && {
 			lenderTerm: getMinMaxRangeQueryParam(loanSearchState.lenderRepaymentTerm)
 		}),
+		...(loanSearchState.keywordSearch && { queryString: loanSearchState.keywordSearch }),
 		...(queryParamSortBy && { sortBy: queryParamSortBy }),
 		...(page > 1 && { page: page.toString() }),
 		...utmParams,

--- a/src/util/loanSearch/searchStateUtils.js
+++ b/src/util/loanSearch/searchStateUtils.js
@@ -59,6 +59,8 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		? { ...loanSearchState.lenderRepaymentTerm }
 		: null;
 
+	const validatedKeywordSearch = loanSearchState?.keywordSearch?.trim() || null;
+
 	return {
 		gender: validatedGender,
 		countryIsoCode: validatedIsoCodes,
@@ -71,6 +73,7 @@ export function getValidatedSearchState(loanSearchState, allFacets, queryType) {
 		distributionModel: validatedDistributionModel,
 		isIndividual: validatedIsIndividual,
 		lenderRepaymentTerm: validatedLenderRepaymentTerm,
+		keywordSearch: validatedKeywordSearch,
 	};
 }
 

--- a/test/unit/fixtures/mockLoanSearchData.js
+++ b/test/unit/fixtures/mockLoanSearchData.js
@@ -10,6 +10,7 @@ export const mockState = {
 	lenderRepaymentTerm: { min: 0, max: 8, __typename: 'MinMaxRange' },
 	pageOffset: 10,
 	pageLimit: 5,
+	keywordSearch: 'search',
 };
 
 export const savedSearchParams = {

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
@@ -170,6 +170,21 @@ describe('LoanSearchFilterChips', () => {
 		expect(emitted().updated[0]).toEqual([{ lenderRepaymentTerm: null }]);
 	});
 
+	it('should handle keyword search chip click', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(LoanSearchFilterChips, {
+			props: {
+				loanSearchState: mockState,
+				allFacets: mockAllFacets
+			}
+		});
+
+		await user.click(getByText(mockState.keywordSearch));
+
+		expect(emitted().updated[0]).toEqual([{ keywordSearch: null }]);
+	});
+
 	it('should track event', async () => {
 		const user = userEvent.setup();
 

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -26,7 +26,7 @@ describe('flssUtils.js', () => {
 				sectorId: [],
 				distributionModel: null,
 				isIndividual: null,
-				description: null,
+				keywordSearch: null,
 			};
 
 			expect(getFlssFilters(state)).toEqual({});
@@ -42,7 +42,7 @@ describe('flssUtils.js', () => {
 				distributionModel: 'DIRECT',
 				isIndividual: false,
 				lenderRepaymentTerm: { min: 0, max: 8, __typename: 'MinMaxRange' },
-				description: 'desc',
+				keywordSearch: 'search',
 			};
 
 			expect(getFlssFilters(state)).toEqual({
@@ -54,7 +54,7 @@ describe('flssUtils.js', () => {
 				distributionModel: { eq: 'DIRECT' },
 				isIndividual: { eq: false },
 				lenderRepaymentTerm: { range: { gte: 0, lte: 8 } },
-				description: { eq: 'desc' },
+				description: { eq: 'search' },
 			});
 		});
 	});

--- a/test/unit/specs/util/loanSearch/queryParamUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/queryParamUtils.spec.js
@@ -26,7 +26,6 @@ describe('queryParamUtils.js', () => {
 			expect(hasExcludedQueryParams({ partner: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ riskRating: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ state: [] })).toBe(true);
-			expect(hasExcludedQueryParams({ queryString: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ loanLimit: [] })).toBe(true);
 		});
 
@@ -345,6 +344,7 @@ describe('queryParamUtils.js', () => {
 							...lenderRepaymentTermValueMap[SIXTEEN_MONTHS_KEY],
 							__typename: 'MinMaxRange'
 						},
+						keywordSearch: 'search',
 					}
 				}
 			};
@@ -358,7 +358,8 @@ describe('queryParamUtils.js', () => {
 				page: '2',
 				distributionModel: 'DIRECT',
 				isGroup: 'true',
-				lenderTerm: '0,16'
+				lenderTerm: '0,16',
+				queryString: 'search',
 			};
 
 			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState.pageLimit, mockState);
@@ -383,6 +384,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: null,
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				},
 			};
@@ -410,6 +412,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: null,
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				},
 			};
@@ -437,6 +440,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: null,
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				},
 			};
@@ -464,6 +468,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: null,
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				},
 			};
@@ -491,6 +496,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: null,
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				},
 			};
@@ -518,6 +524,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: null,
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				},
 			};
@@ -541,6 +548,7 @@ describe('queryParamUtils.js', () => {
 				distributionModel: 'DIRECT',
 				isGroup: 'true',
 				lenderTerm: '0,8',
+				queryString: 'search',
 			};
 
 			await applyQueryParams(apollo, query, mockAllFacets, FLSS_QUERY_TYPE, mockState.pageLimit, mockState);
@@ -565,6 +573,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: 'DIRECT',
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				}
 			};
@@ -601,6 +610,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: 'DIRECT',
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				}
 			};
@@ -637,6 +647,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: 'DIRECT',
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				}
 			};
@@ -673,6 +684,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: 'DIRECT',
 						isIndividual: null,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				}
 			};
@@ -709,6 +721,7 @@ describe('queryParamUtils.js', () => {
 						distributionModel: 'DIRECT',
 						isIndividual: false,
 						lenderRepaymentTerm: null,
+						keywordSearch: null,
 					}
 				}
 			};
@@ -949,6 +962,19 @@ describe('queryParamUtils.js', () => {
 			expect(router.push).toHaveBeenCalledWith({
 				name: 'name',
 				query: { lenderTerm: '0,8' },
+				params: { noScroll: true, noAnalytics: true }
+			});
+		});
+
+		it('should push queryString', () => {
+			const state = { keywordSearch: 'search' };
+			const router = getRouter();
+
+			updateQueryParams(state, router, FLSS_QUERY_TYPE);
+
+			expect(router.push).toHaveBeenCalledWith({
+				name: 'name',
+				query: { queryString: 'search' },
 				params: { noScroll: true, noAnalytics: true }
 			});
 		});

--- a/test/unit/specs/util/loanSearch/searchStateUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/searchStateUtils.spec.js
@@ -116,6 +116,39 @@ describe('searchStateUtils.js', () => {
 				lenderRepaymentTerm: { ...mockState.lenderRepaymentTerm, __typename: 'MinMaxRange' }
 			});
 		});
+
+		it('should validate keyword search and trim', () => {
+			const state = { ...mockState, keywordSearch: 'test ' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({
+				...mockState,
+				keywordSearch: 'test',
+			});
+		});
+
+		it('should validate keyword search empty string', () => {
+			const state = { ...mockState, keywordSearch: ' ' };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({
+				...mockState,
+				keywordSearch: null,
+			});
+		});
+
+		it('should validate keyword search undefined', () => {
+			const state = { ...mockState, keywordSearch: undefined };
+
+			const result = getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+			expect(result).toEqual({
+				...mockState,
+				keywordSearch: null,
+			});
+		});
 	});
 
 	describe('updateSearchState', () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1307

- Implemented keyword search filter/input
- Brought over placeholder from legacy, "Search borrower story"
- I know we're moving away from lodash, but using `debounce` from lodash is quite convenient... And we want debounce on a text input that changes filters...
- Used the same query param as legacy, `queryString`

![image](https://user-images.githubusercontent.com/16867161/197037666-54ea8374-1d16-4932-a0a3-d40371045ae5.png)
