### PR TITLE
fix: don't add background as a question in faqs

### DIFF
--- a/src/components/Contentful/FrequentlyAskedQuestions.vue
+++ b/src/components/Contentful/FrequentlyAskedQuestions.vue
@@ -43,7 +43,9 @@ export default {
 			return this.content?.title ?? null;
 		},
 		frequentlyAskedQuestions() {
-			return this.content?.contents ?? null;
+			return this.content?.contents?.filter(({ contentType }) => {
+				return contentType ? contentType === 'richTextContent' : false;
+			});
 		},
 		background() {
 			return this.content?.contents?.find(({ contentType }) => {


### PR DESCRIPTION
Fixes issue where background colors is added as a question, see Kyle's conversation in Slack. Seems to **not** be an issue in: https://github.com/kiva/cms-page-server/blob/main/components/contentful/FrequentlyAskedQuestions.vue

