### PR TITLE
NewHomeLoansByCategoryGrid prefetch MARS-274

### DIFF
--- a/src/components/LoanCollections/HomeExp/KivaLoanCardCategory.vue
+++ b/src/components/LoanCollections/HomeExp/KivaLoanCardCategory.vue
@@ -1,16 +1,8 @@
 <template>
 	<div class="tw-pt-4">
-		<transition name="kvfade">
-			<div
-				v-if="isLoading"
-				class="spinner tw-text-center"
-			>
-				<kv-loading-spinner />
-			</div>
-		</transition>
 		<kv-carousel
 			id="loan-category-carousel"
-			v-if="augmentedLoanIds.length > 0 && isVisible"
+			v-if="augmentedLoanIds.length > 0"
 			:class="['tw-w-full tw-overflow-visible md:tw-overflow-hidden', { 'md:tw-hidden' : newHomeExp }]"
 			:embla-options="{
 				loop: false,
@@ -26,7 +18,7 @@
 				<!-- TODO Re-implement card position analytics -->
 				<new-home-page-loan-card
 					:item-index="index"
-					:key="`loan-${loanId}`"
+					:key="`loan-${loanId||index}`"
 					:loan-id="loanId"
 				/>
 			</template>
@@ -55,14 +47,14 @@
 				</div>
 			</div>
 		</kv-carousel>
-		<template v-if="newHomeExp && !isLoading">
+		<template v-if="newHomeExp">
 			<div class="tw-hidden md:tw-grid md:tw-grid-cols-2 md:tw-gap-4 lg:tw-grid-cols-3">
 				<template v-for="(loanId, index) in augmentedLoanIds">
 					<!-- show loan card -->
 					<!-- TODO Re-implement card position analytics -->
 					<new-home-page-loan-card
 						:item-index="index"
-						:key="`loan-${loanId}`"
+						:key="`loan-${loanId||index}`"
 						:loan-id="loanId"
 					/>
 				</template>
@@ -90,7 +82,6 @@
 <script>
 import { getCategoryName } from '@/util/categoryUtils';
 import NewHomePageLoanCard from '@/components/LoanCards/NewHomePageLoanCard';
-import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 import KvCarousel from '~/@kiva/kv-components/vue/KvCarousel';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
@@ -98,15 +89,10 @@ export default {
 	name: 'KivaLoanCardCategory',
 	components: {
 		KvCarousel,
-		KvLoadingSpinner,
 		NewHomePageLoanCard,
 		KvButton
 	},
 	props: {
-		isVisible: {
-			type: Boolean,
-			default: false
-		},
 		loanIds: {
 			type: Array,
 			default: () => [],
@@ -139,9 +125,6 @@ export default {
 		};
 	},
 	computed: {
-		isLoading() {
-			return this.augmentedLoanIds.length === 0 && !this.isVisible;
-		},
 		augmentedLoanIds() {
 			const clonedLoanIds = [...this.loanIds];
 			return clonedLoanIds;

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -162,7 +162,7 @@ export function readLoanFragment({
 	apollo, loanId, fragment
 }) {
 	let partnerFragment;
-	let	directFragment;
+	let directFragment;
 	try {
 		// Attempt to read the loan card fragment for LoanPartner from the cache
 		// If cache is missing fragment fields, this will throw an invariant error

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -157,3 +157,31 @@ export function watchLoanCardData({
 	// Return the observer to allow modification of variables
 	return queryObserver;
 }
+
+export function readLoanFragment({
+	apollo, loanId, fragment
+}) {
+	let partnerFragment;
+	let	directFragment;
+	try {
+		// Attempt to read the loan card fragment for LoanPartner from the cache
+		// If cache is missing fragment fields, this will throw an invariant error
+		partnerFragment = apollo.readFragment({
+			id: `LoanPartner:${loanId}`,
+			fragment,
+		}) || null;
+	} catch (e) {
+		// no-op
+	}
+	try {
+		// Attempt to read the loan card fragment for LoanDirect from the cache
+		// If cache is missing fragment fields, this will throw an invariant error
+		directFragment = apollo.readFragment({
+			id: `LoanDirect:${loanId}`,
+			fragment,
+		}) || null;
+	} catch (e) {
+		// no-op
+	}
+	return partnerFragment || directFragment;
+}


### PR DESCRIPTION
Loads the first loan in the first category during prefetch so that it is server-rendered. Remaining loan ids in the category are loaded on mounted. Other categories are only loaded when selected. Placeholder loan cards in a loading state are created by using loan id 0, which returns `null` from the api.

This required modifying the ContentfulPage prefetch so that it passed the ContentGroup content to each group as it was prefetched. 

https://user-images.githubusercontent.com/4149025/197258380-c0e7a62d-745d-460f-91fb-49f7f16b9d26.mov

