### PR TITLE
feat: display achievement service badge on lending stats page

### DIFF
--- a/src/graphql/query/myLendingStats.graphql
+++ b/src/graphql/query/myLendingStats.graphql
@@ -1,5 +1,8 @@
 query myLendingStats {
 	my {
+		userAccount {
+			id
+		}
 		lendingStats {
 			id
 			countriesLentTo {

--- a/src/graphql/query/userAchievementsProgress.graphql
+++ b/src/graphql/query/userAchievementsProgress.graphql
@@ -1,0 +1,11 @@
+
+query userAchievementProgress(
+	$userId: String!
+) {
+	userAchievementProgress(userId: $userId) {
+		achievementProgress {
+			achievementId
+			status
+		}
+	}
+}

--- a/src/pages/LendingStats/BadgesSection.vue
+++ b/src/pages/LendingStats/BadgesSection.vue
@@ -1,0 +1,45 @@
+<template>
+	<section data-testid="lend-stat-badges" class="stats-section">
+		<h2 class="tw-flex tw-gap-2 tw-mb-4">
+			<span>My Badges</span>
+			<span class="lent-count tw-text-base tw-bg-brand tw-text-white tw-py-0.5 tw-px-1 tw-self-center">
+				{{ badgesObtained }}/{{ totalBadges }}
+			</span>
+		</h2>
+		<div class="tw-flex" v-if="achievementId === 'climate-challenge'">
+			<eco-challenge-badge class="tw-h-10 tw-w-10 tw-mr-2 tw-flex-none tw-mx-auto" />
+			<div class="tw-w-full">
+				<span class="tw-font-medium">Eco-friendly October Challenge</span>
+				<p class="tw-text-secondary tw-text-small">
+					October 2022
+				</p>
+			</div>
+		</div>
+	</section>
+</template>
+
+<script>
+import EcoChallengeBadge from '@/assets/icons/inline/eco-challenge/badge.svg';
+
+export default {
+	name: 'BadgesSection',
+	props: {
+		badgesObtained: {
+			type: Number,
+			default: 0
+		},
+		totalBadges: {
+			type: Number,
+			default: 0
+		},
+		// TODO: refactor for multiple badges
+		achievementId: {
+			type: String,
+			default: ''
+		}
+	},
+	components: {
+		EcoChallengeBadge,
+	},
+};
+</script>


### PR DESCRIPTION
<img width="991" alt="Screen Shot 2022-10-24 at 9 58 25 AM" src="https://user-images.githubusercontent.com/4371888/197572312-cd12ac0b-44dd-48e1-acd9-a58d08508ccf.png">

I just added this new query to the created hook, I suppose the page could be refactored to add this in prefetch, but it will need a sequence of requests since the achievements api request depends on the userId. 

Users without badges should not be shown anything, for now. 