### PR TITLE
feat: new select box component for lend filter partner ID

### DIFF
--- a/.storybook/stories/KvSelectBox.stories.js
+++ b/.storybook/stories/KvSelectBox.stories.js
@@ -1,0 +1,30 @@
+import KvSelectBox from '@/components/Kv/KvSelectBox';
+
+export default {
+	title: 'Kv/Form Elements/KvSelectBox',
+	component: KvSelectBox,
+};
+
+const items = [...Array(20)].map((_, i) => ({ id: i, name: `Item ${i + 1}` }));
+[...Array(5)].forEach((_, i) => items.splice([i * 5], 0, { isHeader: true, name: `Header ${i + 1}` }));
+
+const story = (args) => {
+	const template = (_args, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { KvSelectBox },
+		data: () => ({
+			myCoolModel: '',
+		}),
+		template: `<kv-select-box id="select-box" :items="items">
+			<option value="test">Test</option>
+			<option value="test2">Test2</option>
+			<option value="test3">Test3</option>
+		</kv-select-box>`,
+	})
+	template.args = args;
+	return template;
+};
+
+export const Empty = story();
+
+export const Items = story({ items });

--- a/src/components/Kv/KvSelectBox.vue
+++ b/src/components/Kv/KvSelectBox.vue
@@ -1,0 +1,124 @@
+<template>
+	<div>
+		<kv-text-input ref="input" :id="id" v-model="search" :can-clear="true" autocomplete="off" @focus="open" />
+		<div
+			ref="dropdown"
+			:class="{ 'tw-hidden': !this.show }"
+			class="
+				tw-border
+				tw-border-tertiary
+				tw-py-0.5
+				tw-rounded-sm
+				tw-bg-white
+				tw-overflow-auto"
+			:style="{ 'max-height': '200px' }"
+		>
+			<ul>
+				<li
+					v-for="(item, i) in filteredItems"
+					:key="i"
+					class="tw-py-0.5 tw-px-1.5"
+					:class="{
+						'tw-pb-1': item.isHeader,
+						'tw-cursor-pointer hover:tw-bg-action-highlight hover:tw-text-white': !item.isHeader
+					}"
+					@click="clickItem(item)"
+				>
+					<span :class="{ 'tw-border-b tw-pb-0.5': item.isHeader }">
+						{{ item.name }}
+					</span>
+				</li>
+				<li v-if="filteredItems.length === 0" class="tw-py-0.5 tw-px-1.5">
+					{{ NO_RESULTS }}
+				</li>
+			</ul>
+		</div>
+	</div>
+</template>
+
+<script>
+import KvTextInput from '~/@kiva/kv-components/vue/KvTextInput';
+
+export const NO_RESULTS = 'No results found';
+
+export default {
+	name: 'KvSelectBox',
+	components: {
+		KvTextInput,
+	},
+	props: {
+		id: {
+			type: String,
+			required: true
+		},
+		items: {
+			type: Array,
+			default: () => ([])
+		}
+	},
+	data() {
+		return {
+			NO_RESULTS,
+			popper: null,
+			show: false,
+			search: '',
+		};
+	},
+	mounted() {
+		document.addEventListener('click', this.clickDocument);
+	},
+	beforeDestroy() {
+		document.removeEventListener('click', this.clickDocument);
+
+		if (this.popper) {
+			this.popper.destroy();
+		}
+	},
+	computed: {
+		filteredItems() {
+			// Lower case search non-header items
+			const filtered = this.items
+				.filter(i => i.isHeader || i.name.toLowerCase().includes(this.search.toLowerCase().trim()));
+
+			// eslint-disable-next-line no-plusplus
+			for (let i = 0; i < filtered.length; ++i) {
+				// Remove headers that have no filtered items
+				if (filtered[i].isHeader && (i + 1 === filtered.length || filtered?.[i + 1]?.isHeader)) {
+					// eslint-disable-next-line no-plusplus
+					filtered.splice(i--, 1);
+				}
+			}
+
+			return filtered;
+		},
+	},
+	methods: {
+		async open() {
+			await this.initPopper();
+
+			this.show = true;
+		},
+		close() {
+			this.show = false;
+		},
+		async initPopper() {
+			if (this.popper) return;
+
+			const { default: Popper } = await import('popper.js');
+
+			// In case popper was initialized in another callback while importing
+			if (this.popper) return;
+
+			this.popper = new Popper(this.$refs.input.$el, this.$refs.dropdown, { placement: 'bottom-start' });
+		},
+		clickDocument(e) {
+			if (!this.$refs.input.$el.contains(e.target) && !this.$refs.dropdown.contains(e.target)) {
+				this.close();
+			}
+		},
+		clickItem({ id }) {
+			this.$emit('selected', { id });
+		},
+	},
+};
+</script>

--- a/test/unit/specs/components/Kv/KvSelectBox.spec.js
+++ b/test/unit/specs/components/Kv/KvSelectBox.spec.js
@@ -1,0 +1,66 @@
+import { render } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
+import KvSelectBox, { NO_RESULTS } from '@/components/Kv/KvSelectBox';
+
+const items = [...Array(20)].map((_, i) => ({ id: i, name: `Item ${i + 1}` }));
+[...Array(5)].forEach((_, i) => items.splice([i * 5], 0, { isHeader: true, name: `Header ${i + 1}` }));
+
+describe('KvSelectBox', () => {
+	it('should render no results found', () => {
+		const { getByText } = render(KvSelectBox, { props: { id: 'id' } });
+
+		getByText(NO_RESULTS);
+	});
+
+	it('should render all headers and items', () => {
+		const { getByText } = render(KvSelectBox, { props: { id: 'id', items } });
+
+		items.forEach(item => {
+			getByText(item.name);
+		});
+	});
+
+	it('should render hidden', () => {
+		const { getByText } = render(KvSelectBox, { props: { id: 'id' } });
+
+		expect(getByText(NO_RESULTS).parentNode.parentNode.classList.contains('tw-hidden')).toBe(true);
+	});
+
+	it('should display when clicked', async () => {
+		const user = userEvent.setup();
+
+		const { getByRole, getByText } = render(KvSelectBox, { props: { id: 'id' } });
+
+		await user.click(getByRole('textbox'));
+
+		expect(getByText(NO_RESULTS).parentNode.parentNode.classList.contains('tw-hidden')).toBe(false);
+	});
+
+	it('should hide when document clicked', async () => {
+		const user = userEvent.setup();
+
+		const { getByRole, getByText } = render(KvSelectBox, { props: { id: 'id' } });
+
+		await user.click(getByRole('textbox'));
+
+		const popper = getByText(NO_RESULTS).parentNode.parentNode;
+
+		expect(popper.classList.contains('tw-hidden')).toBe(false);
+
+		await user.click(popper.parentNode);
+
+		expect(popper.classList.contains('tw-hidden')).toBe(true);
+	});
+
+	it('should emit selected', async () => {
+		const user = userEvent.setup();
+
+		const { getByText, emitted } = render(KvSelectBox, { props: { id: 'id', items } });
+
+		await user.click(getByText(items[1].name).parentNode);
+
+		const payload = emitted().selected[0][0];
+
+		expect(payload).toEqual({ id: 0 });
+	});
+});


### PR DESCRIPTION
- Partner ID needed a new component for rendering a list of selectable items w/ headers
- Here's the first pass, and I'm sure it'll be adjusted as it's used in the filters
- Utilized popper to save time, and we were already using it in this repo
- Works fine so far in desktop + mobile
- Creating separate PR in the spirit of small regular PRs

Empty/no-results:
![image](https://user-images.githubusercontent.com/16867161/197583781-3617321b-b30c-40cc-98b1-6b102f5f3444.png)

Results w/ no filtering:
![image](https://user-images.githubusercontent.com/16867161/197583873-a5b16c29-edf3-4cd8-b9f3-d75c7fc2d1fb.png)

Results w/ filtering:
![image](https://user-images.githubusercontent.com/16867161/197583954-421f4b74-cb3e-4506-a28b-b59a68b94e40.png)
