### PR TITLE
fix: remove cookie based exp redirect to lend-classic

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -372,7 +372,7 @@
 											</li>
 											<li>
 												<router-link
-													:to="`/lend/${loanId}#loanComments`"
+													:to="`/lend-classic/${loanId}#loanComments`"
 													v-kv-track-event="['TopNav','click-Portfolio-My Conversations']"
 												>
 													My conversations

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -438,15 +438,6 @@ export default {
 					},
 				})
 				.then(({ data }) => {
-					const expCookieSignifier = cookieStore.get('kvlendborrowerbeta');
-					if (expCookieSignifier === 'a' || expCookieSignifier === 'c') {
-						const { query } = route;
-						return Promise.reject({
-							path: `/lend-classic/${route.params.id}`,
-							query,
-						});
-					}
-
 					const loan = data?.lend?.loan;
 					if (loan === null || loan === 'undefined') {
 						// redirect to legacy borrower profile


### PR DESCRIPTION
This cookie will no longer be set. Suppose we can leave this code in for a while longer if we want though...