### PR TITLE
fix: always set user attribute

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -654,14 +654,12 @@ export default {
 			}
 		}
 		// MARS-246 Hotjar user attributes
-		if (this.userId) {
-			setHotJarUserAttributes({
-				userId: this.userId,
-				hasEverLoggedIn: this.hasEverLoggedIn,
-				hasLentBefore: Boolean(hasLentBefore),
-				hasDepositBefore: Boolean(hasDepositBefore),
-			});
-		}
+		setHotJarUserAttributes({
+			userId: this.userId,
+			hasEverLoggedIn: this.hasEverLoggedIn,
+			hasLentBefore: Boolean(hasLentBefore),
+			hasDepositBefore: Boolean(hasDepositBefore),
+		});
 	},
 	methods: {
 		toggleLendMenu(immediate = false) {


### PR DESCRIPTION
Removing the condition in order to run surveys for people that has not logged in before. (Default `user_id` value on user attributes is `null` based on [hotjar documentation](https://help.hotjar.com/hc/en-us/articles/360038394053))