### PR TITLE
feat: update placement of user attributes

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -653,12 +653,14 @@ export default {
 				logReadQueryError(e, 'User Data For Optimizely Metrics');
 			}
 		}
+	},
+	mounted() {
 		// MARS-246 Hotjar user attributes
 		setHotJarUserAttributes({
 			userId: this.userId,
 			hasEverLoggedIn: this.hasEverLoggedIn,
-			hasLentBefore: Boolean(hasLentBefore),
-			hasDepositBefore: Boolean(hasDepositBefore),
+			hasLentBefore: Boolean(this.cookieStore.get(hasLentBeforeCookie)),
+			hasDepositBefore: Boolean(this.cookieStore.get(hasDepositBeforeCookie)),
 		});
 	},
 	methods: {


### PR DESCRIPTION
Polls based on user attributes are not triggering, but when sending a user attribute manually in the console, the poll appears immediately. We believe this is happening because user attributes were sent on the `created` hook when the DOM is not yet loaded.

If the behavior remains the same on `dev` the change will be reverted.