### PR TITLE
feat: loan count added to tag filter

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -318,7 +318,12 @@ export default {
 	methods: {
 		async fetchFacets(loanSearchState = {}) {
 			// TODO: Prevent this from running on every query (not needed for sorting and paging)
-			const { isoCodes, themes, sectors } = await runFacetsQueries(
+			const {
+				isoCodes,
+				themes,
+				sectors,
+				tags,
+			} = await runFacetsQueries(
 				this.apollo,
 				loanSearchState,
 				FLSS_ORIGIN_LEND_FILTER
@@ -338,7 +343,7 @@ export default {
 				regions: transformIsoCodes(isoCodes, this.allFacets?.countryFacets),
 				sectors: transformSectors(sectors, this.allFacets?.sectorFacets),
 				themes: transformThemes(themes, this.allFacets?.themeFacets),
-				tags: transformTags(this.allFacets?.tagFacets ?? []),
+				tags: transformTags(tags, this.allFacets?.tagFacets),
 				sortOptions: formatSortOptions(this.allFacets?.standardSorts ?? [],
 					this.allFacets?.flssSorts ?? [],
 					this.extendFlssFilters),

--- a/src/graphql/query/flssLoanFacetsQuery.graphql
+++ b/src/graphql/query/flssLoanFacetsQuery.graphql
@@ -2,6 +2,7 @@ query flssLoanFacets(
 	$isoCodeFilters: [FundraisingLoanSearchFilterInput!],
 	$themeFilters: [FundraisingLoanSearchFilterInput!],
 	$sectorFilters: [FundraisingLoanSearchFilterInput!],
+	$tagFilters: [FundraisingLoanSearchFilterInput!],
 	$origin: String) {
 	isoCodes: fundraisingLoans(filters: $isoCodeFilters, origin: $origin) {
 		facets {
@@ -23,6 +24,14 @@ query flssLoanFacets(
 	sectors: fundraisingLoans(filters: $sectorFilters, origin: $origin) {
 		facets {
 			sectorId {
+				key
+				value
+			}
+		}
+  	}
+	tags: fundraisingLoans(filters: $tagFilters, origin: $origin) {
+		facets {
+			tagsIds {
 				key
 				value
 			}

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -48,6 +48,7 @@ export function getFlssFilters(loanSearchState) {
  * @param {Object} isoCodeFilters The filters for the ISO code facets
  * @param {Object} themeFilters The filters for the theme facets
  * @param {Object} sectorFilters The filters for the sector facets
+ * @param {Object} tagFilters The filters for the tag facets
  * @returns {Promise<Array<Object>>} Promise for facets data
  */
 export async function fetchFacets(
@@ -56,6 +57,7 @@ export async function fetchFacets(
 	isoCodeFilters,
 	themeFilters,
 	sectorFilters,
+	tagFilters,
 ) {
 	try {
 		const result = await apollo.query({
@@ -64,7 +66,8 @@ export async function fetchFacets(
 				isoCodeFilters,
 				themeFilters,
 				sectorFilters,
-				origin
+				tagFilters,
+				origin,
 			},
 			fetchPolicy: 'network-only',
 		});

--- a/src/util/loanSearch/dataUtils.js
+++ b/src/util/loanSearch/dataUtils.js
@@ -19,13 +19,15 @@ export async function runFacetsQueries(apollo, loanSearchState = {}, origin = FL
 	const isoCodeFilters = { ...getFlssFilters(loanSearchState), countryIsoCode: undefined };
 	const themeFilters = { ...getFlssFilters(loanSearchState), themeId: undefined };
 	const sectorFilters = { ...getFlssFilters(loanSearchState), sectorId: undefined };
+	const tagFilters = { ...getFlssFilters(loanSearchState), tagId: undefined };
 
-	const facets = await fetchFacets(apollo, origin, isoCodeFilters, themeFilters, sectorFilters);
+	const facets = await fetchFacets(apollo, origin, isoCodeFilters, themeFilters, sectorFilters, tagFilters);
 
 	return {
 		isoCodes: facets?.isoCodes?.facets?.isoCode ?? [],
 		themes: facets?.themes?.facets?.themes ?? [],
 		sectors: facets?.sectors?.facets?.sectorId ?? [],
+		tags: facets?.tags?.facets?.tagsIds ?? [],
 	};
 }
 

--- a/src/util/loanSearch/filterUtils.js
+++ b/src/util/loanSearch/filterUtils.js
@@ -246,18 +246,21 @@ export function transformTagName(name = '') {
 /**
  * Transforms tags into a form usable by the filters
  *
+ * @param {Array<Object>} filteredTags The tag IDs from FLSS
  * @param {Array<Object>} allTags The tags from lend API
  * @returns {Array<Object>} Tags usable by the filters
  */
-export function transformTags(allTags = []) {
-	// TODO: filter options against FLSS loan counts and add numLoansFundraising (VUE-1335)
-
+export function transformTags(filteredTags, allTags = []) {
 	// Public tags have vocabularyId of 2
-	const transformed = allTags.filter(t => t.vocabularyId === 2).map(t => {
-		return {
-			id: t.id,
-			name: transformTagName(t.name),
-		};
+	const publicTags = allTags.filter(t => t.vocabularyId === 2);
+
+	const transformed = [];
+
+	filteredTags.forEach(({ key: id, value: numLoansFundraising }) => {
+		const lookupTag = publicTags.find(t => t.id === +id);
+		if (!lookupTag) return;
+		const tag = { id: lookupTag.id, name: transformTagName(lookupTag.name), numLoansFundraising };
+		transformed.push(tag);
 	});
 
 	return _orderBy(transformed, 'name');

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -71,17 +71,18 @@ describe('flssUtils.js', () => {
 			isoCodeFilters: filters,
 			themeFilters: filters,
 			sectorFilters: filters,
+			tagFilters: filters,
 			origin: 'web:test-context'
 		};
 		const apolloVariables = { query: flssLoanFacetsQuery, variables, fetchPolicy: 'network-only' };
 
 		it('should pass the correct query variables to apollo', async () => {
-			await fetchFacets(apollo, 'web:test-context', filters, filters, filters);
+			await fetchFacets(apollo, 'web:test-context', filters, filters, filters, filters);
 			expect(apollo.query).toHaveBeenCalledWith(apolloVariables);
 		});
 
 		it('should return the fundraising facets data', async () => {
-			const data = await fetchFacets(apollo, 'web:test-context', filters, filters, filters);
+			const data = await fetchFacets(apollo, 'web:test-context', filters, filters, filters, filters);
 			expect(data).toBe(result);
 		});
 	});

--- a/test/unit/specs/util/loanSearch/dataUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/dataUtils.spec.js
@@ -10,9 +10,11 @@ describe('dataUtils.js', () => {
 		const isoCodeFacets = [{ key: 'iso', value: 1 }];
 		const themeFacets = [{ key: 'theme', value: 1 }];
 		const sectorFacets = [{ key: 'sector', value: 1 }];
+		const tagFacets = [{ key: 'tag', value: 1 }];
 		const isoCodes = { facets: { isoCode: isoCodeFacets } };
 		const themes = { facets: { themes: themeFacets } };
 		const sectors = { facets: { sectorId: sectorFacets } };
+		const tags = { facets: { tagsIds: tagFacets } };
 		const origin = FLSS_ORIGIN_NOT_SPECIFIED;
 
 		beforeEach(() => {
@@ -20,7 +22,8 @@ describe('dataUtils.js', () => {
 				.mockImplementation(() => Promise.resolve({
 					isoCodes,
 					themes,
-					sectors
+					sectors,
+					tags,
 				}));
 		});
 
@@ -34,28 +37,65 @@ describe('dataUtils.js', () => {
 				origin,
 				{ countryIsoCode: undefined },
 				{ themeId: undefined },
-				{ sectorId: undefined }
+				{ sectorId: undefined },
+				{ tagId: undefined },
 			);
 			expect(spyFetchFacets).toHaveBeenCalledTimes(1);
-			expect(result).toEqual({ isoCodes: isoCodeFacets, themes: themeFacets, sectors: sectorFacets });
+			expect(result).toEqual({
+				isoCodes: isoCodeFacets,
+				themes: themeFacets,
+				sectors: sectorFacets,
+				tags: tagFacets,
+			});
 		});
 
 		it('should return apply filters', async () => {
 			const apollo = {};
 			const result = await runFacetsQueries(
 				apollo,
-				{ countryIsoCode: ['US'], themeId: [2], sectorId: [1] },
+				{
+					countryIsoCode: ['US'],
+					themeId: [2],
+					sectorId: [1],
+					tagId: [3],
+				},
 				origin
 			);
 			expect(spyFetchFacets).toHaveBeenCalledWith(
 				apollo,
 				origin,
-				{ themeId: { any: [2] }, sectorId: { any: [1] }, countryIsoCode: undefined },
-				{ countryIsoCode: { any: ['US'] }, sectorId: { any: [1] }, themeId: undefined },
-				{ countryIsoCode: { any: ['US'] }, themeId: { any: [2] }, sectorId: undefined }
+				{
+					themeId: { any: [2] },
+					sectorId: { any: [1] },
+					tagId: { any: [3] },
+					countryIsoCode: undefined,
+				},
+				{
+					countryIsoCode: { any: ['US'] },
+					sectorId: { any: [1] },
+					tagId: { any: [3] },
+					themeId: undefined,
+				},
+				{
+					countryIsoCode: { any: ['US'] },
+					themeId: { any: [2] },
+					tagId: { any: [3] },
+					sectorId: undefined,
+				},
+				{
+					countryIsoCode: { any: ['US'] },
+					themeId: { any: [2] },
+					sectorId: { any: [1] },
+					tagId: undefined,
+				},
 			);
 			expect(spyFetchFacets).toHaveBeenCalledTimes(1);
-			expect(result).toEqual({ isoCodes: isoCodeFacets, themes: themeFacets, sectors: sectorFacets });
+			expect(result).toEqual({
+				isoCodes: isoCodeFacets,
+				themes: themeFacets,
+				sectors: sectorFacets,
+				tags: tagFacets,
+			});
 		});
 	});
 

--- a/test/unit/specs/util/loanSearch/filterUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/filterUtils.spec.js
@@ -217,7 +217,7 @@ describe('filterUtils.js', () => {
 			expect(result).toEqual(mockTransformedSectors);
 		});
 
-		it('should filter transform themes with number casting', () => {
+		it('should filter transform sectors with number casting', () => {
 			const mockFilteredSectors = [
 				{
 					key: '2',
@@ -310,28 +310,72 @@ describe('filterUtils.js', () => {
 
 	describe('transformTags', () => {
 		it('should handle empty', () => {
-			expect(transformTags()).toEqual([]);
 			expect(transformTags([])).toEqual([]);
 		});
 
 		it('should transform and sort', () => {
-			const result = transformTags([
+			const flssTags = [
+				{ key: 1, value: 5 },
+				{ key: 2, value: 6 },
+				{ key: 3, value: 7 }
+			];
+
+			const allTags = [
 				{ id: 1, name: 'tag', vocabularyId: 2 },
 				{ id: 2, name: '#tag2', vocabularyId: 2 },
 				{ id: 3, name: 'asd', vocabularyId: 2 }
-			]);
+			];
 
-			expect(result).toEqual([{ id: 3, name: 'asd' }, { id: 1, name: 'tag' }, { id: 2, name: 'tag2' }]);
+			const result = transformTags(flssTags, allTags);
+
+			expect(result).toEqual([
+				{ id: 3, name: 'asd', numLoansFundraising: 7 },
+				{ id: 1, name: 'tag', numLoansFundraising: 5 },
+				{ id: 2, name: 'tag2', numLoansFundraising: 6 }
+			]);
 		});
 
 		it('should only return public tags', () => {
-			const result = transformTags([
+			const flssTags = [
+				{ key: 1, value: 5 },
+				{ key: 2, value: 6 },
+				{ key: 3, value: 7 }
+			];
+
+			const allTags = [
 				{ id: 1, name: 'tag', vocabularyId: 2 },
 				{ id: 2, name: '#tag2', vocabularyId: 1 },
 				{ id: 3, name: 'asd', vocabularyId: 2 }
-			]);
+			];
 
-			expect(result).toEqual([{ id: 3, name: 'asd' }, { id: 1, name: 'tag' }]);
+			const result = transformTags(flssTags, allTags);
+
+			expect(result).toEqual([
+				{ id: 3, name: 'asd', numLoansFundraising: 7 },
+				{ id: 1, name: 'tag', numLoansFundraising: 5 }
+			]);
+		});
+
+		it('should filter transform tags with number casting', () => {
+			const flssTags = [
+				{ key: '1', value: 5 },
+				{ key: '2', value: 6 },
+				{ key: '3', value: 7 }
+			];
+
+			const allTags = [
+				{ id: 1, name: 'tag', vocabularyId: 2 },
+				{ id: 2, name: '#tag2', vocabularyId: 2 },
+				{ id: 3, name: 'asd', vocabularyId: 2 }
+			];
+
+			const result = transformTags(flssTags, allTags);
+
+			expect(result).toEqual([
+				{ id: 3, name: 'asd', numLoansFundraising: 7 },
+				{ id: 1, name: 'tag', numLoansFundraising: 5 },
+				{ id: 2, name: 'tag2', numLoansFundraising: 6 }
+			]);
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1335

- Tag IDs now have loan counts from FLSS
- Loan counts added to tag filter like other filters

![image](https://user-images.githubusercontent.com/16867161/198704700-0c6bb421-bcb0-4b13-a83a-f345c60bc926.png)
