### PR TITLE
fix: clear up warning from github around lighthouse action, there may…

### DIFF
--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -32,7 +32,7 @@ jobs:
           lhci upload --target=filesystem --outputDir=./lhci
           node format-lh-for-s3.js
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: ${{ secrets.LHCI_S3_REGION }}
           role-to-assume: ${{ secrets.LHCI_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
… be more...

ref. https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning

I'm guessing that dependabot and maybe our storybook deploy will need updates that are within those actions as well. I just noticed this one when inspecting the lighthouse action.