### PR TITLE
Add range slider functionality

### DIFF
--- a/.storybook/stories/KvRangeMinMaxSlider.stories.js
+++ b/.storybook/stories/KvRangeMinMaxSlider.stories.js
@@ -16,6 +16,8 @@ const story = (args) => {
 				:step="step"
 				:min="min"
 				:max="max"
+				:is-percentage="isPercentage"
+				:displayed-unit="displayedUnit"
 			/>
 		`,
 	});
@@ -30,3 +32,7 @@ export const SmallerRange = story({ rangeMin: 0, rangeMax: 5 });
 export const LargerStep = story({ step: 10 });
 
 export const Selected = story({ min: 30, max: 50 });
+
+export const Percentage = story({ rangeMin: 0, rangeMax: 1, step: 0.001, isPercentage: true, displayedUnit: '%' });
+
+export const Unit = story({ displayedUnit: '°' });

--- a/src/components/Kv/KvRangeMinMaxSlider.vue
+++ b/src/components/Kv/KvRangeMinMaxSlider.vue
@@ -362,11 +362,13 @@ input[type=range]:hover::-ms-thumb {
 	transform: scale(1.15);
 }
 
-#range-min-tooltip, #range-max-tooltip {
+#range-min-tooltip,
+#range-max-tooltip {
 	@apply tw-absolute tw-text-center tw-text-small;
+
 	top: 26px;
 	height: 24px;
-    width: 50px;
+	width: 50px;
 }
 
 #range-min-tooltip {

--- a/src/components/Kv/KvSectionModalLoader.vue
+++ b/src/components/Kv/KvSectionModalLoader.vue
@@ -2,7 +2,7 @@
 	<div
 		v-if="loading"
 		:aria-label="LOADING_LABEL"
-		class="tw-absolute tw-w-full tw-h-full tw-bg-opacity-[65%] tw-z-1 tw-top-0 tw-left-0"
+		class="tw-absolute tw-w-full tw-h-full tw-bg-opacity-[65%] tw-z-2 tw-top-0 tw-left-0"
 		:class="[`tw-bg-${bgColor}`, {'tw-rounded': rounded }]"
 	>
 		<div class="tw-absolute tw-top-5 tw-left-1/2 tw--translate-x-1/2">

--- a/src/components/Kv/KvSelectBox.vue
+++ b/src/components/Kv/KvSelectBox.vue
@@ -20,7 +20,7 @@
 				tw-rounded-sm
 				tw-bg-white
 				tw-overflow-auto
-				tw-z-1"
+				tw-z-2"
 			:style="{ 'max-height': '200px' }"
 		>
 			<ul>

--- a/src/util/loanSearch/filterUtils.js
+++ b/src/util/loanSearch/filterUtils.js
@@ -121,3 +121,35 @@ export function getCheckboxLabel(item) {
 
 	return `${item.name || item.region}${countLabel}`;
 }
+
+/**
+ * Gets the adjusted number ready for display
+ *
+ * @param {number} value The value of the number
+ * @param {boolean} isPercentage Whether the number is a decimal-representation of a percentage
+ * @param {string} unit The unit to display after the number
+ * @param {number} step The step associated with selecting the number
+ * @returns The number to be used for display
+ */
+export function getDisplayedNumber(value, isPercentage = false, unit = undefined, step = undefined) {
+	const stepWithFallback = step ?? 1;
+
+	// Get visual step based on whether the number is a decimal percentage
+	const precision = isPercentage ? stepWithFallback * 100 : stepWithFallback;
+
+	// Use string splitting to count decimals
+	const numberOfDecimals = Math.floor(precision) === precision ? 0 : precision.toString().split('.')[1].length || 0;
+
+	// Adjust for decimal percentage
+	let adjustedValue = isPercentage ? value * 100 : value;
+
+	if (step) {
+		// Set fixed decimals if the number isn't a whole number
+		adjustedValue = Math.floor(adjustedValue) !== adjustedValue
+			? adjustedValue.toFixed(numberOfDecimals)
+			: adjustedValue;
+	}
+
+	// Return with displayed unit
+	return `${adjustedValue}${unit ?? ''}`;
+}

--- a/test/unit/specs/components/Kv/KvRangeMinMaxSlider.spec.js
+++ b/test/unit/specs/components/Kv/KvRangeMinMaxSlider.spec.js
@@ -247,4 +247,112 @@ describe('KvRangeMinMaxSlider', () => {
 
 		expect(emitted().change[1][0]).toEqual({ min: 5, max: 10 });
 	});
+
+	it('should handle decimal step', async () => {
+		const { getAllByRole, updateProps } = render(KvRangeMinMaxSlider, { props: { step: 0.5 } });
+
+		const rangeInputs = getAllByRole('slider');
+
+		expect(rangeInputs[0].min).toBe('0');
+		expect(rangeInputs[0].max).toBe('100');
+		expect(rangeInputs[0].value).toBe('0');
+		expect(rangeInputs[0].step).toBe('0.5');
+		expect(rangeInputs[1].min).toBe('0');
+		expect(rangeInputs[1].max).toBe('100');
+		expect(rangeInputs[1].value).toBe('100');
+		expect(rangeInputs[1].step).toBe('0.5');
+
+		await updateProps({ min: 0.5, max: 8.5 });
+
+		expect(rangeInputs[0].min).toBe('0');
+		expect(rangeInputs[0].max).toBe('100');
+		expect(rangeInputs[0].value).toBe('0.5');
+		expect(rangeInputs[0].step).toBe('0.5');
+		expect(rangeInputs[1].min).toBe('0');
+		expect(rangeInputs[1].max).toBe('100');
+		expect(rangeInputs[1].value).toBe('8.5');
+		expect(rangeInputs[1].step).toBe('0.5');
+	});
+
+	it('should handle max of 0', async () => {
+		const { getAllByRole, updateProps } = render(KvRangeMinMaxSlider);
+
+		const rangeInputs = getAllByRole('slider');
+
+		expect(rangeInputs[0].min).toBe('0');
+		expect(rangeInputs[0].max).toBe('100');
+		expect(rangeInputs[0].value).toBe('0');
+		expect(rangeInputs[0].step).toBe('1');
+		expect(rangeInputs[1].min).toBe('0');
+		expect(rangeInputs[1].max).toBe('100');
+		expect(rangeInputs[1].value).toBe('100');
+		expect(rangeInputs[1].step).toBe('1');
+
+		await updateProps({ min: 0, max: 0 });
+
+		expect(rangeInputs[0].min).toBe('0');
+		expect(rangeInputs[0].max).toBe('100');
+		expect(rangeInputs[0].value).toBe('0');
+		expect(rangeInputs[0].step).toBe('1');
+		expect(rangeInputs[1].min).toBe('0');
+		expect(rangeInputs[1].max).toBe('100');
+		expect(rangeInputs[1].value).toBe('0');
+		expect(rangeInputs[1].step).toBe('1');
+	});
+
+	it('should display tooltips', () => {
+		const { getByText } = render(KvRangeMinMaxSlider);
+
+		getByText('0');
+		getByText('100');
+	});
+
+	it('should display decimals as percentages', () => {
+		const { getByText } = render(KvRangeMinMaxSlider, {
+			props: {
+				rangeMax: 1,
+				max: 0.9,
+				isPercentage: true,
+			}
+		});
+
+		getByText('0');
+		getByText('90');
+	});
+
+	it('should display display tooltips with decimals', () => {
+		const { getByText } = render(KvRangeMinMaxSlider, {
+			props: {
+				rangeMax: 10,
+				step: 0.1,
+				min: 4.1,
+				max: 9,
+			}
+		});
+
+		getByText('4.1');
+		getByText('9');
+	});
+
+	it('should display display tooltips with percentages as decimals', () => {
+		const { getByText } = render(KvRangeMinMaxSlider, {
+			props: {
+				rangeMax: 1,
+				step: 0.001,
+				min: 0.001,
+				max: 1,
+				isPercentage: true,
+			}
+		});
+
+		getByText('0.1');
+		getByText('100');
+	});
+
+	it('should display tooltip units', () => {
+		const { getByText } = render(KvRangeMinMaxSlider, { props: { displayedUnit: '%' } });
+
+		getByText('0%');
+		getByText('100%');
+	});
 });

--- a/test/unit/specs/util/loanSearch/filterUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/filterUtils.spec.js
@@ -3,6 +3,7 @@ import {
 	getCheckboxLabel,
 	transformRadioGroupOptions,
 	getFilterKeyFromValue,
+	getDisplayedNumber,
 } from '@/util/loanSearch/filterUtils';
 import { lenderRepaymentTermValueMap, EIGHT_MONTHS_KEY } from '@/util/loanSearch/filters/lenderRepaymentTerms';
 
@@ -111,6 +112,33 @@ describe('filterUtils.js', () => {
 
 		it('should handle missing numLoansFundraising', () => {
 			expect(getCheckboxLabel({ name: 'test' })).toBe('test');
+		});
+	});
+
+	describe('getDisplayedNumber', () => {
+		it('should return value', () => {
+			expect(getDisplayedNumber(4)).toBe('4');
+			expect(getDisplayedNumber(4.5)).toBe('4.5');
+			expect(getDisplayedNumber(4.55)).toBe('4.55');
+		});
+
+		it('should return percentage', () => {
+			expect(getDisplayedNumber(4, true)).toBe('400');
+		});
+
+		it('should return unit', () => {
+			expect(getDisplayedNumber(4, false, '%')).toBe('4%');
+		});
+
+		it('should return percentage and unit', () => {
+			expect(getDisplayedNumber(4, true, '%')).toBe('400%');
+		});
+
+		it('should return value with precision based on step', () => {
+			expect(getDisplayedNumber(4, false, undefined, 0.001)).toBe('4');
+			expect(getDisplayedNumber(4.001, false, undefined, '.001')).toBe('4.001');
+			expect(getDisplayedNumber(4.0011, false, undefined, '.001')).toBe('4.001');
+			expect(getDisplayedNumber(4.0016, false, undefined, '.001')).toBe('4.002');
 		});
 	});
 });


### PR DESCRIPTION
The following changes were needed for the new filters w/ range sliders. General behavior matches legacy.

- Handles now have tooltips that show values that track with the handles as they move
- A unit can be displayed in the tooltip
- A range slider can be a percentage, which assumes the number needs to be multiplied by 100 when displayed
- The number of decimals shown is based on the step provided
- Adjusted the z index on a couple other components to ensure everything layers correctly

Tooltips:
![image](https://user-images.githubusercontent.com/16867161/199848342-fc77d6a6-de17-45b1-9894-c7ebf9e9822e.png)

Unit:
![image](https://user-images.githubusercontent.com/16867161/199848138-e867cd7a-4a06-4636-9e3b-1b00afac8a4a.png)

Percentage w/ unit:
![image](https://user-images.githubusercontent.com/16867161/199847963-2713c5fe-1a47-4034-998e-165c6ad0acec.png)