### PR TITLE
feat: new partner filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.371.1",
+	"version": "2.375.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.371.1",
+			"version": "2.375.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@babel/eslint-parser": "^7.18.2",

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -17,6 +17,9 @@ export const getDefaultLoanSearchState = () => ({
 	lenderRepaymentTerm: null, // Expects a MinMaxRange
 	keywordSearch: null, // Expects a string
 	partnerId: [], // Expects an array of ints
+	partnerRiskRating: null, // Expects a MinMaxRange
+	partnerDefaultRate: null, // Expects a MinMaxRange
+	partnerAvgProfitability: null, // Expects a MinMaxRange
 });
 
 // export queries, resolvers and defaults for LoanSearchState

--- a/src/api/localSchema.graphql
+++ b/src/api/localSchema.graphql
@@ -89,6 +89,9 @@ type LoanSearchState {
 	lenderRepaymentTerm: MinMaxRange
 	keywordSearch: String
 	partnerId: [Int]
+	partnerRiskRating: MinMaxRange
+	partnerDefaultRate: MinMaxRange
+	partnerAvgProfitability: MinMaxRange
 }
 
 type TipMessage {

--- a/src/graphql/mutation/updateLoanSearchState.graphql
+++ b/src/graphql/mutation/updateLoanSearchState.graphql
@@ -17,5 +17,17 @@ mutation updateLoanSearch($searchParams: JSONObject) {
 		}
 		keywordSearch
 		partnerId
+		partnerRiskRating {
+			min
+			max
+		}
+		partnerDefaultRate {
+			min
+			max
+		}
+		partnerAvgProfitability {
+			min
+			max
+		}
 	}
 }

--- a/src/graphql/query/loanSearchState.graphql
+++ b/src/graphql/query/loanSearchState.graphql
@@ -17,5 +17,17 @@ query loanSearchStateQuery {
 		}
 		keywordSearch
 		partnerId
+		partnerRiskRating {
+			min
+			max
+		}
+		partnerDefaultRate {
+			min
+			max
+		}
+		partnerAvgProfitability {
+			min
+			max
+		}
 	}
 }

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -364,6 +364,9 @@ export default {
 					id: 71,
 					url: 'loans-for-livestock',
 					queryParams: 'status=fundRaising&activity=73&distributionModel=both',
+					flssLoanSearch: {
+						activityId: [73],
+					},
 				},
 				{
 					id: 72,

--- a/src/util/loanSearch/filterConfig.js
+++ b/src/util/loanSearch/filterConfig.js
@@ -11,6 +11,10 @@ import tags from '@/util/loanSearch/filters/tags';
 import lenderRepaymentTerms from '@/util/loanSearch/filters/lenderRepaymentTerms';
 import distributionModels from '@/util/loanSearch/filters/distributionModels';
 import partners from '@/util/loanSearch/filters/partners';
+import partnerRiskRating from '@/util/loanSearch/filters/partnerRiskRating';
+import partnerDefaultRate from '@/util/loanSearch/filters/partnerDefaultRate';
+import partnerAvgProfitability from '@/util/loanSearch/filters/partnerAvgProfitability';
+import activities from '@/util/loanSearch/filters/activities';
 
 /**
  * Configuration for the lend/filter FLSS-driven page
@@ -32,6 +36,8 @@ import partners from '@/util/loanSearch/filters/partners';
  * 		eventAction: undefined,
  * 		allOptionsTitle: undefined,
  * 		valueMap: undefined,
+ * 		isPercentage: false,
+ * 		displayedUnit: undefined,
  * 	},
  * 	getOptions: (allFacets, filteredFacets, extend) => ([]),
  * 	showSavedSearch: loanSearchState => (false),
@@ -57,6 +63,10 @@ const config = {
 	lenderRepaymentTerms,
 	distributionModels,
 	partners,
+	partnerRiskRating,
+	partnerDefaultRate,
+	partnerAvgProfitability,
+	activities,
 };
 
 /**

--- a/src/util/loanSearch/filters/activities.js
+++ b/src/util/loanSearch/filters/activities.js
@@ -1,6 +1,3 @@
-import { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
-import { isNumber } from '@/util/numberUtils';
-
 export default {
 	uiConfig: {
 		type: undefined,
@@ -11,7 +8,7 @@ export default {
 		itemHeaderKey: undefined,
 		placeholder: undefined,
 		facetsKey: undefined,
-		stateKey: 'pageLimit',
+		stateKey: 'activityId',
 		eventAction: undefined,
 		allOptionsTitle: undefined,
 		valueMap: undefined,
@@ -23,12 +20,10 @@ export default {
 	getFilterChips: () => ([]),
 	getRemovedFacet: () => ({}),
 	getSavedSearch: () => ({}),
-	getFlssFilter: () => ({}),
-	getValidatedSearchState: loanSearchState => ({
-		pageLimit: isNumber(loanSearchState?.pageLimit)
-			? loanSearchState.pageLimit
-			: getDefaultLoanSearchState().pageLimit
+	getFlssFilter: loanSearchState => ({
+		...(loanSearchState?.activityId && { activityId: { any: loanSearchState.activityId } })
 	}),
-	getFilterFromQuery: (_query, _allFacets, pageLimit) => ({ pageLimit }),
+	getValidatedSearchState: () => ({}),
+	getFilterFromQuery: () => ({}),
 	getQueryFromFilter: () => ({}),
 };

--- a/src/util/loanSearch/filters/distributionModels.js
+++ b/src/util/loanSearch/filters/distributionModels.js
@@ -45,6 +45,8 @@ export default {
 		eventAction: 'click-distributionModel-filter',
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}) => transformDistributionModelOptions(allFacets.distributionModelFacets),
 	showSavedSearch: loanSearchState => !!loanSearchState.distributionModel,

--- a/src/util/loanSearch/filters/genders.js
+++ b/src/util/loanSearch/filters/genders.js
@@ -39,6 +39,8 @@ export default {
 		eventAction: 'click-gender-filter',
 		allOptionsTitle: 'All genders',
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: allFacets => transformGenderOptions(allFacets.genderFacets),
 	showSavedSearch: loanSearchState => !!loanSearchState.gender,

--- a/src/util/loanSearch/filters/isIndividual.js
+++ b/src/util/loanSearch/filters/isIndividual.js
@@ -59,6 +59,8 @@ export default {
 		eventAction: 'click-isIndividual-filter',
 		allOptionsTitle: undefined,
 		valueMap: isIndividualValueMap,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: () => transformIsIndividualOptions(),
 	showSavedSearch: loanSearchState => loanSearchState.isIndividual !== null,

--- a/src/util/loanSearch/filters/keywordSearch.js
+++ b/src/util/loanSearch/filters/keywordSearch.js
@@ -14,6 +14,8 @@ export default {
 		eventAction: undefined,
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: () => [],
 	showSavedSearch: loanSearchState => !!loanSearchState.keywordSearch,

--- a/src/util/loanSearch/filters/lenderRepaymentTerms.js
+++ b/src/util/loanSearch/filters/lenderRepaymentTerms.js
@@ -58,6 +58,8 @@ export default {
 		eventAction: 'click-lenderRepaymentTerm-filter',
 		allOptionsTitle: undefined,
 		valueMap: lenderRepaymentTermValueMap,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: () => transformLenderRepaymentTermOptions(),
 	showSavedSearch: loanSearchState => !!loanSearchState.lenderRepaymentTerm,

--- a/src/util/loanSearch/filters/pageOffset.js
+++ b/src/util/loanSearch/filters/pageOffset.js
@@ -15,6 +15,8 @@ export default {
 		eventAction: undefined,
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: () => ([]),
 	showSavedSearch: () => (false),

--- a/src/util/loanSearch/filters/partnerAvgProfitability.js
+++ b/src/util/loanSearch/filters/partnerAvgProfitability.js
@@ -1,0 +1,92 @@
+import { getMinMaxRangeFilter, getMinMaxRangeQueryParam, createMinMaxRange } from '@/util/loanSearch/minMaxRange';
+import { getMinMaxRangeFromQueryParam } from '@/util/loanSearch/queryParseUtils';
+import { filterUiType, getDisplayedNumber } from '@/util/loanSearch/filterUtils';
+
+/**
+ * The min average profitability value
+ */
+export const MIN = -160;
+
+/**
+ * The max average profitability rate value
+ */
+export const MAX = 90;
+
+const IS_PERCENTAGE = false;
+const DISPLAYED_UNIT = '%';
+const STEP = 1;
+
+export default {
+	uiConfig: {
+		type: filterUiType.rangeSlider,
+		hasAccordion: false,
+		topLine: true,
+		bottomLine: false,
+		title: 'Profitability',
+		itemHeaderKey: undefined,
+		placeholder: undefined,
+		facetsKey: undefined,
+		stateKey: 'partnerAvgProfitability',
+		eventAction: 'change-partnerAvgProfitability-filter',
+		allOptionsTitle: undefined,
+		valueMap: undefined,
+		isPercentage: IS_PERCENTAGE,
+		displayedUnit: DISPLAYED_UNIT,
+	},
+	getOptions: () => ({ min: MIN, max: MAX, step: STEP }),
+	showSavedSearch: loanSearchState => !!loanSearchState.partnerAvgProfitability,
+	getFilterChips: loanSearchState => {
+		if (loanSearchState.partnerAvgProfitability) {
+			const minDisplayed = getDisplayedNumber(
+				loanSearchState.partnerAvgProfitability.min,
+				IS_PERCENTAGE,
+				DISPLAYED_UNIT,
+				STEP
+			);
+
+			const maxDisplayed = getDisplayedNumber(
+				loanSearchState.partnerAvgProfitability.max,
+				IS_PERCENTAGE,
+				DISPLAYED_UNIT,
+				STEP
+			);
+
+			return [{
+				name: `Profitability: ${minDisplayed} to ${maxDisplayed}`,
+				__typename: 'PartnerAvgProfitability'
+			}];
+		}
+		return [];
+	},
+	getRemovedFacet: () => ({ partnerAvgProfitability: null }),
+	getSavedSearch: loanSearchState => ({
+		// Create new simple object that can be saved to legacy "MinMaxRangeInput" type
+		profitability: loanSearchState?.partnerAvgProfitability
+			? {
+				min: loanSearchState.partnerAvgProfitability.min,
+				max: loanSearchState.partnerAvgProfitability.max
+			} : null,
+	}),
+	getFlssFilter: loanSearchState => ({
+		...(loanSearchState?.partnerAvgProfitability && {
+			partnerAvgProfitability: { range: getMinMaxRangeFilter(loanSearchState.partnerAvgProfitability) }
+		})
+	}),
+	getValidatedSearchState: loanSearchState => {
+		const min = loanSearchState?.partnerAvgProfitability?.min ?? MIN;
+		const max = loanSearchState?.partnerAvgProfitability?.max ?? MAX;
+		return {
+			partnerAvgProfitability: loanSearchState?.partnerAvgProfitability
+				? createMinMaxRange(min >= MIN ? min : MIN, max <= MAX ? max : MAX)
+				: null
+		};
+	},
+	getFilterFromQuery: query => ({
+		partnerAvgProfitability: getMinMaxRangeFromQueryParam(query.profitability) ?? null
+	}),
+	getQueryFromFilter: loanSearchState => ({
+		...(loanSearchState.partnerAvgProfitability && {
+			profitability: getMinMaxRangeQueryParam(loanSearchState.partnerAvgProfitability)
+		})
+	}),
+};

--- a/src/util/loanSearch/filters/partnerDefaultRate.js
+++ b/src/util/loanSearch/filters/partnerDefaultRate.js
@@ -1,0 +1,89 @@
+import { getMinMaxRangeFilter, getMinMaxRangeQueryParam, createMinMaxRange } from '@/util/loanSearch/minMaxRange';
+import { getMinMaxRangeFromQueryParam } from '@/util/loanSearch/queryParseUtils';
+import { filterUiType, getDisplayedNumber } from '@/util/loanSearch/filterUtils';
+
+/**
+ * The min default rate value
+ */
+export const MIN = 0;
+
+/**
+ * The max default rate value
+ */
+export const MAX = 1;
+
+const IS_PERCENTAGE = true;
+const DISPLAYED_UNIT = '%';
+const STEP = 0.001;
+
+export default {
+	uiConfig: {
+		type: filterUiType.rangeSlider,
+		hasAccordion: false,
+		topLine: true,
+		bottomLine: false,
+		title: 'Default rate',
+		itemHeaderKey: undefined,
+		placeholder: undefined,
+		facetsKey: undefined,
+		stateKey: 'partnerDefaultRate',
+		eventAction: 'change-partnerDefaultRate-filter',
+		allOptionsTitle: undefined,
+		valueMap: undefined,
+		isPercentage: IS_PERCENTAGE,
+		displayedUnit: DISPLAYED_UNIT,
+	},
+	getOptions: () => ({ min: MIN, max: MAX, step: STEP }),
+	showSavedSearch: loanSearchState => !!loanSearchState.partnerDefaultRate,
+	getFilterChips: loanSearchState => {
+		if (loanSearchState.partnerDefaultRate) {
+			const minDisplayed = getDisplayedNumber(
+				loanSearchState.partnerDefaultRate.min,
+				IS_PERCENTAGE,
+				DISPLAYED_UNIT,
+				STEP
+			);
+
+			const maxDisplayed = getDisplayedNumber(
+				loanSearchState.partnerDefaultRate.max,
+				IS_PERCENTAGE,
+				DISPLAYED_UNIT,
+				STEP
+			);
+
+			return [{ name: `Default rate: ${minDisplayed} to ${maxDisplayed}`, __typename: 'PartnerDefaultRate' }];
+		}
+		return [];
+	},
+	getRemovedFacet: () => ({ partnerDefaultRate: null }),
+	getSavedSearch: loanSearchState => ({
+		// Create new simple object that can be saved to legacy "MinMaxRangeInput" type
+		defaultRate: loanSearchState?.partnerDefaultRate
+			? {
+				min: loanSearchState.partnerDefaultRate.min,
+				max: loanSearchState.partnerDefaultRate.max
+			} : null,
+	}),
+	getFlssFilter: loanSearchState => ({
+		...(loanSearchState?.partnerDefaultRate && {
+			partnerDefaultRate: { range: getMinMaxRangeFilter(loanSearchState.partnerDefaultRate) }
+		})
+	}),
+	getValidatedSearchState: loanSearchState => {
+		const min = loanSearchState?.partnerDefaultRate?.min ?? MIN;
+		const max = loanSearchState?.partnerDefaultRate?.max ?? MAX;
+		return {
+			partnerDefaultRate: loanSearchState?.partnerDefaultRate
+				? createMinMaxRange(min >= MIN ? min : MIN, max <= MAX ? max : MAX)
+				: null
+		};
+	},
+	getFilterFromQuery: query => ({
+		partnerDefaultRate: getMinMaxRangeFromQueryParam(query.defaultRate) ?? null
+	}),
+	getQueryFromFilter: loanSearchState => ({
+		...(loanSearchState.partnerDefaultRate && {
+			defaultRate: getMinMaxRangeQueryParam(loanSearchState.partnerDefaultRate)
+		})
+	}),
+};

--- a/src/util/loanSearch/filters/partnerRiskRating.js
+++ b/src/util/loanSearch/filters/partnerRiskRating.js
@@ -1,0 +1,76 @@
+import { getMinMaxRangeFilter, getMinMaxRangeQueryParam, createMinMaxRange } from '@/util/loanSearch/minMaxRange';
+import { getMinMaxRangeFromQueryParam } from '@/util/loanSearch/queryParseUtils';
+import { filterUiType } from '@/util/loanSearch/filterUtils';
+
+/**
+ * The min risk rating value
+ */
+export const MIN = 0;
+
+/**
+ * The max risk rating value
+ */
+export const MAX = 5;
+
+export default {
+	uiConfig: {
+		type: filterUiType.rangeSlider,
+		hasAccordion: false,
+		topLine: true,
+		bottomLine: false,
+		title: 'Risk rating',
+		itemHeaderKey: undefined,
+		placeholder: undefined,
+		facetsKey: undefined,
+		stateKey: 'partnerRiskRating',
+		eventAction: 'change-partnerRiskRating-filter',
+		allOptionsTitle: undefined,
+		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
+	},
+	getOptions: () => ({ min: MIN, max: MAX, step: 0.5 }),
+	showSavedSearch: loanSearchState => !!loanSearchState.partnerRiskRating,
+	getFilterChips: loanSearchState => {
+		if (loanSearchState.partnerRiskRating) {
+			return [{
+				name: `Risk rating: ${
+					loanSearchState.partnerRiskRating.min
+				} to ${loanSearchState.partnerRiskRating.max}`,
+				__typename: 'PartnerRiskRating'
+			}];
+		}
+		return [];
+	},
+	getRemovedFacet: () => ({ partnerRiskRating: null }),
+	getSavedSearch: loanSearchState => ({
+		// Create new simple object that can be saved to legacy "MinMaxRangeInput" type
+		riskRating: loanSearchState?.partnerRiskRating
+			? {
+				min: loanSearchState.partnerRiskRating.min,
+				max: loanSearchState.partnerRiskRating.max
+			} : null,
+	}),
+	getFlssFilter: loanSearchState => ({
+		...(loanSearchState?.partnerRiskRating && {
+			partnerRiskRating: { range: getMinMaxRangeFilter(loanSearchState.partnerRiskRating) }
+		})
+	}),
+	getValidatedSearchState: loanSearchState => {
+		const min = loanSearchState?.partnerRiskRating?.min ?? MIN;
+		const max = loanSearchState?.partnerRiskRating?.max ?? MAX;
+		return {
+			partnerRiskRating: loanSearchState?.partnerRiskRating
+				? createMinMaxRange(min >= MIN ? min : MIN, max <= MAX ? max : MAX)
+				: null
+		};
+	},
+	getFilterFromQuery: query => ({
+		partnerRiskRating: getMinMaxRangeFromQueryParam(query.riskRating) ?? null
+	}),
+	getQueryFromFilter: loanSearchState => ({
+		...(loanSearchState.partnerRiskRating && {
+			riskRating: getMinMaxRangeQueryParam(loanSearchState.partnerRiskRating)
+		})
+	}),
+};

--- a/src/util/loanSearch/filters/partners.js
+++ b/src/util/loanSearch/filters/partners.js
@@ -62,6 +62,8 @@ export default {
 		eventAction: undefined,
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}) => transformPartners(allFacets?.partnerFacets ?? []),
 	showSavedSearch: loanSearchState => loanSearchState.partnerId.length > 0,

--- a/src/util/loanSearch/filters/regions.js
+++ b/src/util/loanSearch/filters/regions.js
@@ -143,6 +143,8 @@ export default {
 		eventAction: undefined,
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}, filteredFacets = {}) => {
 		return transformIsoCodes(filteredFacets.isoCodes, allFacets.countryFacets);

--- a/src/util/loanSearch/filters/sectors.js
+++ b/src/util/loanSearch/filters/sectors.js
@@ -36,6 +36,8 @@ export default {
 		eventAction: 'click-sector-filter',
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}, filteredFacets = {}) => {
 		return transformSectors(filteredFacets.sectors, allFacets.sectorFacets);

--- a/src/util/loanSearch/filters/sortOptions.js
+++ b/src/util/loanSearch/filters/sortOptions.js
@@ -91,6 +91,8 @@ export default {
 		eventAction: undefined,
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}, _filteredFacets, extend = false) => {
 		return formatSortOptions(allFacets.standardSorts ?? [], allFacets.flssSorts ?? [], extend);

--- a/src/util/loanSearch/filters/tags.js
+++ b/src/util/loanSearch/filters/tags.js
@@ -50,6 +50,8 @@ export default {
 		eventAction: 'click-tag-filter',
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}, filteredFacets = {}) => transformTags(filteredFacets.tags, allFacets.tagFacets),
 	showSavedSearch: loanSearchState => loanSearchState.tagId.length > 0,

--- a/src/util/loanSearch/filters/themes.js
+++ b/src/util/loanSearch/filters/themes.js
@@ -48,6 +48,8 @@ export default {
 		eventAction: 'click-theme-filter',
 		allOptionsTitle: undefined,
 		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
 	},
 	getOptions: (allFacets = {}, filteredFacets = {}) => {
 		return transformThemes(filteredFacets.themes, allFacets.themeFacets);

--- a/src/util/loanSearch/queryParamUtils.js
+++ b/src/util/loanSearch/queryParamUtils.js
@@ -12,7 +12,6 @@ export function hasExcludedQueryParams(query) {
 	const excludedParams = [
 		'activity',
 		'city_state',
-		'defaultRate',
 		'loanTags',
 		'state',
 		'loanLimit',

--- a/test/unit/specs/util/loanSearch/filters/activities.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/activities.spec.js
@@ -1,0 +1,19 @@
+import activities from '@/util/loanSearch/filters/activities';
+
+describe('activities.js', () => {
+	describe('activities', () => {
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(activities.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(activities.getFlssFilter({ activityId: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(activities.getFlssFilter({ activityId: [1] })).toEqual({ activityId: { any: [1] } });
+			});
+		});
+	});
+});

--- a/test/unit/specs/util/loanSearch/filters/partnerAvgProfitability.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/partnerAvgProfitability.spec.js
@@ -1,0 +1,88 @@
+import partnerAvgProfitability, { MIN, MAX } from '@/util/loanSearch/filters/partnerAvgProfitability';
+import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
+import { createMinMaxRange } from '@/util/loanSearch/minMaxRange';
+import { mockAllFacets, mockState } from '../../../../fixtures/mockLoanSearchData';
+
+describe('partnerAvgProfitability.js', () => {
+	describe('partnerAvgProfitability', () => {
+		describe('getFilterChips', () => {
+			it('should handle undefined', () => {
+				expect(partnerAvgProfitability.getFilterChips({}, mockAllFacets)).toEqual([]);
+			});
+
+			it('should return chips', () => {
+				const result = partnerAvgProfitability.getFilterChips({
+					partnerAvgProfitability: { min: 1, max: 2 }
+				}, mockAllFacets);
+
+				expect(result).toEqual([{
+					name: 'Profitability: 1% to 2%',
+					__typename: 'PartnerAvgProfitability'
+				}]);
+			});
+		});
+
+		describe('getRemovedFacet', () => {
+			it('should remove facet', () => {
+				expect(partnerAvgProfitability.getRemovedFacet()).toEqual({ partnerAvgProfitability: null });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				const result = partnerAvgProfitability.getValidatedSearchState({}, mockAllFacets, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ partnerAvgProfitability: null });
+			});
+
+			it('should validate average profitability', () => {
+				const state = { partnerAvgProfitability: { min: -1000, max: 600 } };
+
+				const result = partnerAvgProfitability.getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ partnerAvgProfitability: { min: MIN, max: MAX, __typename: 'MinMaxRange' } });
+			});
+		});
+
+		describe('getFilterFromQuery', () => {
+			it('it should get filter', () => {
+				const query = { profitability: '1,2' };
+
+				const result = partnerAvgProfitability.getFilterFromQuery(
+					query,
+					mockAllFacets,
+					mockState.pageLimit,
+					FLSS_QUERY_TYPE
+				);
+
+				expect(result).toEqual({ partnerAvgProfitability: createMinMaxRange(1, 2) });
+			});
+		});
+
+		describe('getQueryFromFilter', () => {
+			it('should push average profitability', () => {
+				const state = { partnerAvgProfitability: { min: 1, max: 2 } };
+
+				const result = partnerAvgProfitability.getQueryFromFilter(state, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ profitability: '1,2' });
+			});
+		});
+
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(partnerAvgProfitability.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(partnerAvgProfitability.getFlssFilter({ partnerAvgProfitability: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(partnerAvgProfitability
+					.getFlssFilter({ partnerAvgProfitability: { min: 1, max: 2, __typename: 'MinMaxRange' } }))
+					.toEqual({ partnerAvgProfitability: { range: { gte: 1, lte: 2 } } });
+			});
+		});
+	});
+});

--- a/test/unit/specs/util/loanSearch/filters/partnerDefaultRate.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/partnerDefaultRate.spec.js
@@ -1,0 +1,85 @@
+import partnerDefaultRate, { MIN, MAX } from '@/util/loanSearch/filters/partnerDefaultRate';
+import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
+import { createMinMaxRange } from '@/util/loanSearch/minMaxRange';
+import { mockAllFacets, mockState } from '../../../../fixtures/mockLoanSearchData';
+
+describe('partnerDefaultRate.js', () => {
+	describe('partnerDefaultRate', () => {
+		describe('getFilterChips', () => {
+			it('should handle undefined', () => {
+				expect(partnerDefaultRate.getFilterChips({}, mockAllFacets)).toEqual([]);
+			});
+
+			it('should return chips', () => {
+				const result = partnerDefaultRate.getFilterChips({
+					partnerDefaultRate: { min: 1, max: 2 }
+				}, mockAllFacets);
+
+				expect(result).toEqual([{ name: 'Default rate: 100% to 200%', __typename: 'PartnerDefaultRate' }]);
+			});
+		});
+
+		describe('getRemovedFacet', () => {
+			it('should remove facet', () => {
+				expect(partnerDefaultRate.getRemovedFacet()).toEqual({ partnerDefaultRate: null });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				const result = partnerDefaultRate.getValidatedSearchState({}, mockAllFacets, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ partnerDefaultRate: null });
+			});
+
+			it('should validate default rate', () => {
+				const state = { partnerDefaultRate: { min: -1, max: 6 } };
+
+				const result = partnerDefaultRate.getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ partnerDefaultRate: { min: MIN, max: MAX, __typename: 'MinMaxRange' } });
+			});
+		});
+
+		describe('getFilterFromQuery', () => {
+			it('it should get filter', () => {
+				const query = { defaultRate: '1,2' };
+
+				const result = partnerDefaultRate.getFilterFromQuery(
+					query,
+					mockAllFacets,
+					mockState.pageLimit,
+					FLSS_QUERY_TYPE
+				);
+
+				expect(result).toEqual({ partnerDefaultRate: createMinMaxRange(1, 2) });
+			});
+		});
+
+		describe('getQueryFromFilter', () => {
+			it('should push default rate', () => {
+				const state = { partnerDefaultRate: { min: 1, max: 2 } };
+
+				const result = partnerDefaultRate.getQueryFromFilter(state, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ defaultRate: '1,2' });
+			});
+		});
+
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(partnerDefaultRate.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(partnerDefaultRate.getFlssFilter({ partnerDefaultRate: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(partnerDefaultRate
+					.getFlssFilter({ partnerDefaultRate: { min: 1, max: 2, __typename: 'MinMaxRange' } }))
+					.toEqual({ partnerDefaultRate: { range: { gte: 1, lte: 2 } } });
+			});
+		});
+	});
+});

--- a/test/unit/specs/util/loanSearch/filters/partnerRiskRating.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/partnerRiskRating.spec.js
@@ -1,0 +1,85 @@
+import partnerRiskRating, { MIN, MAX } from '@/util/loanSearch/filters/partnerRiskRating';
+import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
+import { createMinMaxRange } from '@/util/loanSearch/minMaxRange';
+import { mockAllFacets, mockState } from '../../../../fixtures/mockLoanSearchData';
+
+describe('partnerRiskRating.js', () => {
+	describe('partnerRiskRating', () => {
+		describe('getFilterChips', () => {
+			it('should handle undefined', () => {
+				expect(partnerRiskRating.getFilterChips({}, mockAllFacets)).toEqual([]);
+			});
+
+			it('should return chips', () => {
+				const result = partnerRiskRating.getFilterChips({
+					partnerRiskRating: { min: 1, max: 2 }
+				}, mockAllFacets);
+
+				expect(result).toEqual([{ name: 'Risk rating: 1 to 2', __typename: 'PartnerRiskRating' }]);
+			});
+		});
+
+		describe('getRemovedFacet', () => {
+			it('should remove facet', () => {
+				expect(partnerRiskRating.getRemovedFacet()).toEqual({ partnerRiskRating: null });
+			});
+		});
+
+		describe('getValidatedSearchState', () => {
+			it('should handle undefined', () => {
+				const result = partnerRiskRating.getValidatedSearchState({}, mockAllFacets, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ partnerRiskRating: null });
+			});
+
+			it('should validate risk rating', () => {
+				const state = { partnerRiskRating: { min: -1, max: 6 } };
+
+				const result = partnerRiskRating.getValidatedSearchState(state, mockAllFacets, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ partnerRiskRating: { min: MIN, max: MAX, __typename: 'MinMaxRange' } });
+			});
+		});
+
+		describe('getFilterFromQuery', () => {
+			it('it should get filter', () => {
+				const query = { riskRating: '1,2' };
+
+				const result = partnerRiskRating.getFilterFromQuery(
+					query,
+					mockAllFacets,
+					mockState.pageLimit,
+					FLSS_QUERY_TYPE
+				);
+
+				expect(result).toEqual({ partnerRiskRating: createMinMaxRange(1, 2) });
+			});
+		});
+
+		describe('getQueryFromFilter', () => {
+			it('should push risk rating', () => {
+				const state = { partnerRiskRating: { min: 1, max: 2 } };
+
+				const result = partnerRiskRating.getQueryFromFilter(state, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ riskRating: '1,2' });
+			});
+		});
+
+		describe('getFlssFilter', () => {
+			it('should handle missing', () => {
+				expect(partnerRiskRating.getFlssFilter({})).toEqual({});
+			});
+
+			it('should handle empty', () => {
+				expect(partnerRiskRating.getFlssFilter({ partnerRiskRating: null })).toEqual({});
+			});
+
+			it('should return filters', () => {
+				expect(partnerRiskRating
+					.getFlssFilter({ partnerRiskRating: { min: 1, max: 2, __typename: 'MinMaxRange' } }))
+					.toEqual({ partnerRiskRating: { range: { gte: 1, lte: 2 } } });
+			});
+		});
+	});
+});

--- a/test/unit/specs/util/loanSearch/queryParamUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/queryParamUtils.spec.js
@@ -26,7 +26,6 @@ describe('queryParamUtils.js', () => {
 		it('should return true', () => {
 			expect(hasExcludedQueryParams({ activity: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ city_state: [] })).toBe(true);
-			expect(hasExcludedQueryParams({ defaultRate: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ loanTags: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ state: [] })).toBe(true);
 			expect(hasExcludedQueryParams({ loanLimit: [] })).toBe(true);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1326
https://kiva.atlassian.net/browse/VUE-1372
https://kiva.atlassian.net/browse/VUE-1327

- Added parter risk rating, partner default rate, and partner profitability range slider filters
- Range slider added as option to `LoanSearchFilter` for rendering range slider filters
- Added `activities` filter (not displayed) so that the loan channels with `activity` work - there was also a mapping missing

![image](https://user-images.githubusercontent.com/16867161/199858169-5062fafe-f094-4903-ac70-ce66821569d6.png)

![image](https://user-images.githubusercontent.com/16867161/199858203-6ea22413-5943-4688-be94-3e4e223b5e31.png)

![image](https://user-images.githubusercontent.com/16867161/199858266-974a216b-b720-4cb7-b5ec-e0b8abdcf60d.png)