### PR TITLE
Filter update cleanup

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -13,6 +13,7 @@
 					:key="key"
 					:is="filterConfig.config[key].uiConfig.hasAccordion ? KvAccordionItem : 'div'"
 					:id="`${key}-filter-container`"
+					class="tw-mb-0.5"
 				>
 					<template #header v-if="filterConfig.config[key].uiConfig.hasAccordion">
 						<h2 class="tw-text-h4">

--- a/src/components/Lend/LoanSearch/LoanSearchRadioGroupFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchRadioGroupFilter.vue
@@ -64,11 +64,12 @@ export default {
 		}
 	},
 	methods: {
+		getFilterKey(value) {
+			return this.valueMap ? getFilterKeyFromValue(value, this.valueMap) : value;
+		},
 		getOptionFromValue(value) {
-			const filterKey = this.valueMap ? getFilterKeyFromValue(value, this.valueMap) : value;
-
 			// The KvRadio component can't handle a null value
-			return this.options.find(o => o.name === filterKey)?.name ?? '';
+			return this.options.find(o => o.name === this.getFilterKey(value))?.name ?? '';
 		},
 		setSelected(nextName) {
 			if (nextName !== this.selectedOption) {
@@ -79,7 +80,7 @@ export default {
 
 					this.$emit('updated', { [this.filterKey]: next.value });
 
-					this.$kvTrackEvent('Lending', this.eventAction, next.value);
+					this.$kvTrackEvent('Lending', this.eventAction, this.getFilterKey(next.value));
 				}
 			}
 		},


### PR DESCRIPTION
Found some bugs while testing the new filter work. Logged a couple to the backlog, fix a couple others in this PR without logging them.

- Some whitespace added around filters for consistency
- Radio group that used value maps + object values (loan length) weren't passing readable values to analytics
- This also changes the value sent by is individual, from boolean to a string key - this filter isn't live yet, so changing the analytics value should be OK

![image](https://user-images.githubusercontent.com/16867161/200088673-267175c9-8f88-4e58-86a7-0f6020e807d9.png)
