### PR TITLE
Missing sort options

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -313,7 +313,11 @@ export default {
 			// Merge all facet options with filtered options
 			this.facets = filterConfig.keys.reduce((prev, next) => {
 				// eslint-disable-next-line no-param-reassign
-				prev[next] = filterConfig.config[next].getOptions(this.allFacets, filteredFacets);
+				prev[next] = filterConfig.config[next].getOptions(
+					this.allFacets,
+					filteredFacets,
+					this.extendFlssFilters
+				);
 				return prev;
 			}, {});
 		},

--- a/src/util/loanSearch/filters/lenderRepaymentTerms.js
+++ b/src/util/loanSearch/filters/lenderRepaymentTerms.js
@@ -6,7 +6,7 @@ import { getMinMaxRangeFromQueryParam } from '@/util/loanSearch/queryParseUtils'
 export const EIGHT_MONTHS_KEY = 'EIGHT_MONTHS';
 export const SIXTEEN_MONTHS_KEY = 'SIXTEEN_MONTHS';
 export const TWO_YEARS_KEY = 'TWO_YEARS';
-export const MORE_THAN_TWO_YEARS_KEY = 'MORE_THAN_TWO_YEARS_KEY';
+export const MORE_THAN_TWO_YEARS_KEY = 'MORE_THAN_TWO_YEARS';
 
 /**
  * Maps the lender repayment term keys to display names


### PR DESCRIPTION
During functional testing found these issues:
- Experiment sort options weren't visible
- One of the keys for loan length had "key" incorrectly in it