### PR TITLE
fix: saved search link alignment

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -41,16 +41,18 @@
 					</kv-lightbox>
 				</div>
 				<div v-if="initialLoadComplete" class="tw-pt-1.5">
-					<p class="tw-inline-block tw-align-center">
-						{{ totalCount }} Loans
-					</p>
-					<loan-search-saved-search
-						class="tw-inline-block tw-align-center tw-justify-self-auto"
-						v-if="enableSavedSearch && showSavedSearch"
-						:loan-search-state="loanSearchState"
-						:all-facets="allFacets"
-						:user-id="userId"
-					/>
+					<div class="tw-flex tw-items-center tw-flex-wrap">
+						<p class="tw-inline-block tw-mr-2">
+							{{ totalCount }} Loans
+						</p>
+						<loan-search-saved-search
+							class="tw-inline-block"
+							v-if="enableSavedSearch && showSavedSearch"
+							:loan-search-state="loanSearchState"
+							:all-facets="allFacets"
+							:user-id="userId"
+						/>
+					</div>
 				</div>
 			</div>
 			<div class="tw-flex tw-mr-4">
@@ -75,16 +77,18 @@
 						@updated="handleUpdatedFilters"
 						@reset="handleResetFilters"
 					/>
-					<p class="tw-hidden lg:tw-inline-block tw-mt-1 tw-align-center">
-						{{ totalCount }} Loans
-					</p>
-					<loan-search-saved-search
-						class="tw-hidden lg:tw-inline-block tw-mt-1 tw-align-center tw-justify-self-auto"
-						v-if="enableSavedSearch && showSavedSearch"
-						:loan-search-state="loanSearchState"
-						:all-facets="allFacets"
-						:user-id="userId"
-					/>
+					<div class="tw-flex tw-mt-1 tw-items-center tw-flex-wrap">
+						<p class="tw-hidden lg:tw-inline-block tw-mr-2">
+							{{ totalCount }} Loans
+						</p>
+						<loan-search-saved-search
+							class="tw-hidden lg:tw-inline-block"
+							v-if="enableSavedSearch && showSavedSearch"
+							:loan-search-state="loanSearchState"
+							:all-facets="allFacets"
+							:user-id="userId"
+						/>
+					</div>
 				</div>
 				<template v-if="initialLoadComplete && totalCount === 0">
 					<h3 class="tw-text-center">

--- a/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
@@ -1,11 +1,11 @@
 <template>
 	<div>
 		<div
-			class="tw-flex tw-cursor-pointer tw-align-center"
+			class="tw-flex tw-cursor-pointer tw-items-center"
 			@click="openModal"
 		>
-			<icon-add class="tw-mr-1 tw-inline-block tw-align-baseline" />
-			<h4 class="tw-text-h4 tw-mb-1 tw-font-medium tw-text-action tw-align-baseline">
+			<icon-add class="tw-mr-1 tw-inline-block" />
+			<h4 class="tw-text-h4 tw-font-medium tw-text-action">
 				Save This Search
 			</h4>
 		</div>


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1390

- While waiting for deploys, I went ahead and adjusted the alignment of the new saved search link

Desktop:
![image](https://user-images.githubusercontent.com/16867161/201815318-38e36197-c7cd-4478-9d94-3cfe908e423a.png)

Mobile:
![image](https://user-images.githubusercontent.com/16867161/201815354-2348dd23-6270-4ebf-aa3f-c983aacd8e03.png)

![image](https://user-images.githubusercontent.com/16867161/201815376-c1ea24a8-25f7-499d-b525-a5adb3ad75e7.png)
