### PR TITLE
feat: changed distribution model query to use and expect legacy values

### DIFF
--- a/src/util/loanSearch/filters/distributionModels.js
+++ b/src/util/loanSearch/filters/distributionModels.js
@@ -17,8 +17,16 @@ export const distributionModelDisplayMap = {
  * Maps the FLSS enum values to the lend API enum values
  */
 const distributionModelEnumMap = {
-	FIELDPARTNER: 'fieldPartner',
-	DIRECT: 'direct'
+	[FIELDPARTNER_KEY]: 'fieldPartner',
+	[DIRECT_KEY]: 'direct'
+};
+
+/**
+ * Maps the FLSS enum values to the legacy query values
+ */
+const distributionModelQueryMap = {
+	[FIELDPARTNER_KEY]: 'field_partner',
+	[DIRECT_KEY]: 'direct'
 };
 
 /**
@@ -76,10 +84,13 @@ export default {
 	getFilterFromQuery: (query, allFacets) => ({
 		distributionModel: getEnumNameFromQueryParam(
 			query.distributionModel,
-			allFacets.distributionModelFacets
+			allFacets.distributionModelFacets,
+			distributionModelQueryMap
 		) ?? null
 	}),
 	getQueryFromFilter: loanSearchState => ({
-		...(loanSearchState.distributionModel && { distributionModel: loanSearchState.distributionModel })
+		...(loanSearchState.distributionModel && {
+			distributionModel: distributionModelQueryMap[loanSearchState.distributionModel]
+		})
 	}),
 };

--- a/src/util/loanSearch/queryParseUtils.js
+++ b/src/util/loanSearch/queryParseUtils.js
@@ -6,10 +6,20 @@ import { createMinMaxRange } from '@/util/loanSearch/minMaxRange';
  *
  * @param {string} param The query param
  * @param {Array} facets Facets from the API
+ * @param {Object} queryMap Maps query values to expected values
  * @returns The valid enum value
  */
-export function getEnumNameFromQueryParam(param, facets) {
+export function getEnumNameFromQueryParam(param, facets, queryMap) {
 	if (param) {
+		if (queryMap) {
+			Object.keys(queryMap).forEach(key => {
+				if (queryMap[key] === param) {
+					// eslint-disable-next-line no-param-reassign
+					param = key;
+				}
+			});
+		}
+
 		return facets.find(f => f.name.toUpperCase() === param.toUpperCase())?.name;
 	}
 }

--- a/test/unit/specs/util/loanSearch/filters/distributionModels.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/distributionModels.spec.js
@@ -47,7 +47,7 @@ describe('distributionModels.js', () => {
 
 		describe('getFilterFromQuery', () => {
 			it('it should get filter', () => {
-				const query = { distributionModel: 'DIRECT' };
+				const query = { distributionModel: 'direct' };
 
 				const result = distributionModels.getFilterFromQuery(
 					query,
@@ -60,7 +60,7 @@ describe('distributionModels.js', () => {
 			});
 
 			it('should handle different distribution model casing', () => {
-				const query = { distributionModel: 'direct' };
+				const query = { distributionModel: 'DIRECT' };
 
 				const result = distributionModels.getFilterFromQuery(
 					query,
@@ -71,6 +71,19 @@ describe('distributionModels.js', () => {
 
 				expect(result).toEqual({ distributionModel: 'DIRECT' });
 			});
+
+			it('should handle legacy value', () => {
+				const query = { distributionModel: 'field_partner' };
+
+				const result = distributionModels.getFilterFromQuery(
+					query,
+					mockAllFacets,
+					mockState.pageLimit,
+					FLSS_QUERY_TYPE
+				);
+
+				expect(result).toEqual({ distributionModel: 'FIELDPARTNER' });
+			});
 		});
 
 		describe('getQueryFromFilter', () => {
@@ -79,7 +92,15 @@ describe('distributionModels.js', () => {
 
 				const result = distributionModels.getQueryFromFilter(state, FLSS_QUERY_TYPE);
 
-				expect(result).toEqual({ distributionModel: 'DIRECT' });
+				expect(result).toEqual({ distributionModel: 'direct' });
+			});
+
+			it('should push legacy distribution model', () => {
+				const state = { distributionModel: 'FIELDPARTNER' };
+
+				const result = distributionModels.getQueryFromFilter(state, FLSS_QUERY_TYPE);
+
+				expect(result).toEqual({ distributionModel: 'field_partner' });
 			});
 		});
 

--- a/test/unit/specs/util/loanSearch/queryParseUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/queryParseUtils.spec.js
@@ -29,6 +29,11 @@ describe('queryParseUtils.js', () => {
 			expect(getEnumNameFromQueryParam('A', facets)).toBe('a');
 			expect(getEnumNameFromQueryParam('a', facets.map(f => ({ name: f.name.toUpperCase() })))).toBe('A');
 		});
+
+		it('should get mapped value', () => {
+			expect(getEnumNameFromQueryParam('asd', facets, {})).toBe(undefined);
+			expect(getEnumNameFromQueryParam('asd', facets, { a: 'asd' })).toBe('a');
+		});
 	});
 
 	describe('getBooleanValueFromQueryParam', () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1396

- The distribution model used and expected for the query is now the legacy format, `field_partner` and `direct`