### PR TITLE
fix: hide isMatchable filter

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -246,7 +246,6 @@ export default {
 				filterConfig.config.partnerRiskRating.uiConfig.stateKey,
 				filterConfig.config.partnerDefaultRate.uiConfig.stateKey,
 				filterConfig.config.partnerAvgProfitability.uiConfig.stateKey,
-				filterConfig.config.isMatchable.uiConfig.stateKey,
 			].includes(filterConfig.config[key].uiConfig.stateKey);
 
 			// Paging and activities filters are not currently part of the filter panel

--- a/src/util/loanSearch/filterConfig.js
+++ b/src/util/loanSearch/filterConfig.js
@@ -9,7 +9,6 @@ import sectors from '@/util/loanSearch/filters/sectors';
 import themes from '@/util/loanSearch/filters/themes';
 import tags from '@/util/loanSearch/filters/tags';
 import lenderRepaymentTerms from '@/util/loanSearch/filters/lenderRepaymentTerms';
-import isMatchable from '@/util/loanSearch/filters/isMatchable';
 import distributionModels from '@/util/loanSearch/filters/distributionModels';
 import partners from '@/util/loanSearch/filters/partners';
 import partnerRiskRating from '@/util/loanSearch/filters/partnerRiskRating';
@@ -62,7 +61,6 @@ const config = {
 	themes,
 	tags,
 	lenderRepaymentTerms,
-	isMatchable,
 	distributionModels,
 	partners,
 	partnerRiskRating,


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1417

- `isMatchable` isn't being used anywhere else (not in the query map), so we can just remove it for now from the config