### PR TITLE
test: always set user attributes in Header

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -650,13 +650,13 @@ export default {
 
 				this.cookieStore.set(hasLentBeforeCookie, hasLentBefore, { path: '/' });
 				this.cookieStore.set(hasDepositBeforeCookie, hasDepositBefore, { path: '/' });
-
-				userHasLentBefore(hasLentBefore);
-				userHasDepositBefore(hasDepositBefore);
 			} catch (e) {
 				logReadQueryError(e, 'User Data For Optimizely Metrics');
 			}
 		}
+
+		userHasLentBefore(hasLentBefore);
+		userHasDepositBefore(hasDepositBefore);
 	},
 	mounted() {
 		// MARS-246 Hotjar user attributes


### PR DESCRIPTION
Due to `has_lent_before` and `has_deposited_before` values are not being sent to Optimizely in Borrower Profile page (where the experiment is running). We want to test if this is caused by the condition wrapping the call.