### PR TITLE
fix: validation of boolean as string

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -655,16 +655,16 @@ export default {
 			}
 		}
 
-		userHasLentBefore(hasLentBefore);
-		userHasDepositBefore(hasDepositBefore);
+		userHasLentBefore(this.cookieStore.get(hasLentBeforeCookie) === 'true');
+		userHasDepositBefore(this.cookieStore.get(hasLentBeforeCookie) === 'true');
 	},
 	mounted() {
 		// MARS-246 Hotjar user attributes
 		setHotJarUserAttributes({
 			userId: this.userId,
 			hasEverLoggedIn: this.hasEverLoggedIn,
-			hasLentBefore: Boolean(this.cookieStore.get(hasLentBeforeCookie)),
-			hasDepositBefore: Boolean(this.cookieStore.get(hasDepositBeforeCookie)),
+			hasLentBefore: this.cookieStore.get(hasLentBeforeCookie) === 'true',
+			hasDepositBefore: this.cookieStore.get(hasDepositBeforeCookie) === 'true',
 		});
 	},
 	methods: {


### PR DESCRIPTION
Boolean was parsing a string (Got from cookies) so it was setting user attributes to `true` for `hasLentBefore` and `hasDepositBefore`. 

This only happened in `TheHeader` component