### PR TITLE
fix: show donation item tagline when there are no loans

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -73,7 +73,7 @@
 							</button>
 						</div>
 
-						<div v-if="hasLoans">
+						<div>
 							<div
 								class="donation-tagline tw-text-small tw-text-secondary tw-my-1"
 								data-testid="basket-donation-tagline"
@@ -241,7 +241,7 @@
 							</button>
 						</div>
 
-						<div v-if="hasLoans">
+						<div>
 							<div
 								class="donation-tagline tw-text-small tw-text-secondary tw-my-1 tw-max-w-2xl"
 								data-testid="basket-donation-tagline"
@@ -392,7 +392,7 @@
 							</button>
 						</div>
 
-						<div v-if="hasLoans">
+						<div>
 							<div
 								class="donation-tagline tw-text-small tw-text-secondary tw-mb-1 tw-max-w-2xl"
 								data-testid="basket-donation-tagline"


### PR DESCRIPTION
ACK-485

When a user adds only a donation to cart, through the supportus page, the donation item has no donation tagline text. This happens for all variants of the donation item. This check was added as part of CASH-173, many moons ago. 

This removes the `hasLoans` check on these taglines