### PR TITLE
Fix apollo resolvers

### DIFF
--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-underscore-dangle */
 import { ApolloLink, ApolloClient, InMemoryCache } from '@apollo/client/core';
-
 import Auth0LinkCreator from './Auth0Link';
 import BasketLinkCreator from './BasketLink';
 import ContentfulPreviewLink from './ContentfulPreviewLink';
@@ -18,12 +16,9 @@ export default function createApolloClient({
 	uri,
 	fetch
 }) {
-	const { typePolicies } = initState({ appConfig, cookieStore, kvAuth0 });
-
 	const cache = new InMemoryCache({
 		possibleTypes: types,
 		typePolicies: {
-			...typePolicies,
 			Mergable: {
 				merge: true,
 			},
@@ -32,6 +27,8 @@ export default function createApolloClient({
 			},
 		}
 	});
+
+	const { resolvers } = initState({ appConfig, cookieStore, kvAuth0 });
 
 	const client = new ApolloClient({
 		link: ApolloLink.from([
@@ -44,6 +41,7 @@ export default function createApolloClient({
 			HttpLinkCreator({ kvAuth0, uri, fetch }),
 		]),
 		cache,
+		resolvers,
 		defaultOptions: {
 			watchQuery: {
 				errorPolicy: 'all',

--- a/src/api/localResolvers/activeLoan.js
+++ b/src/api/localResolvers/activeLoan.js
@@ -29,7 +29,7 @@ export default () => {
 				},
 			});
 		},
-		typePolicies: {
+		resolvers: {
 			Mutation: {
 				updateActiveLoan(
 					_,

--- a/src/api/localResolvers/addToBasketInterstitial.js
+++ b/src/api/localResolvers/addToBasketInterstitial.js
@@ -18,7 +18,7 @@ export default () => {
 				},
 			});
 		},
-		typePolicies: {
+		resolvers: {
 			Mutation: {
 				updateAddToBasketInterstitial(_, { active = false, visible = false, loanId = 0 }, context) {
 					const data = {

--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -168,7 +168,7 @@ export default () => {
 				}
 			});
 		},
-		typePolicies: {
+		resolvers: {
 			AutolendingMutation: {
 				/**
 				 * Fetches autolend profile information and sets up local autolending state

--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -10,7 +10,7 @@ export default ({ cookieStore }) => {
 	// initialize the assignments from the experiment cookie
 	const assignments = parseExpCookie(cookieStore.get('uiab'));
 	return {
-		typePolicies: {
+		resolvers: {
 			Query: {
 				experiment(_, { id }, { cache }) {
 					// get the existing assigned version for this experiment id

--- a/src/api/localResolvers/loan.js
+++ b/src/api/localResolvers/loan.js
@@ -195,7 +195,7 @@ function unreservedAmount(loan) {
 
 export default () => {
 	return {
-		typePolicies: {
+		resolvers: {
 			LoanPartner: {
 				fundraisingPercent,
 				fundraisingTimeLeft,

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -34,7 +34,7 @@ export default () => {
 				},
 			});
 		},
-		typePolicies: {
+		resolvers: {
 			Mutation: {
 				updateLoanSearch(_, { searchParams }, { cache }) {
 					// Patch the new params into the existing state in the cache

--- a/src/api/localResolvers/my.js
+++ b/src/api/localResolvers/my.js
@@ -2,7 +2,7 @@ import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql
 
 export default ({ cookieStore, kvAuth0 }) => {
 	return {
-		typePolicies: {
+		resolvers: {
 			My: {
 				lastLoginTimestamp() {
 					return kvAuth0.getLastLogin();

--- a/src/api/localResolvers/tipMessage.js
+++ b/src/api/localResolvers/tipMessage.js
@@ -20,7 +20,7 @@ export default () => {
 				},
 			});
 		},
-		typePolicies: {
+		resolvers: {
 			Mutation: {
 				showTipMessage(_, { message = '', persist = false, type = '' }, context) {
 					context.cache.updateQuery({ query: tipMessageDataQuery }, data => ({

--- a/src/api/localResolvers/usingTouch.js
+++ b/src/api/localResolvers/usingTouch.js
@@ -10,7 +10,7 @@ export default () => {
 				data: { usingTouch: false },
 			});
 		},
-		typePolicies: {
+		resolvers: {
 			Mutation: {
 				updateUsingTouch(_, { usingTouch = false }, context) {
 					context.cache.writeQuery({

--- a/src/api/localResolvers/verificationLightbox.js
+++ b/src/api/localResolvers/verificationLightbox.js
@@ -27,7 +27,7 @@ export default () => {
 		defaults(cache) {
 			writeVerificationLightboxData({ cache, visible: false });
 		},
-		typePolicies: {
+		resolvers: {
 			Mutation: {
 				showVerificationLightbox(_, args, { cache }) {
 					writeVerificationLightboxData({ cache, visible: true });

--- a/src/graphql/mutation/autolending/initAutolending.graphql
+++ b/src/graphql/mutation/autolending/initAutolending.graphql
@@ -1,5 +1,6 @@
 mutation initAutolending {
 	autolending @client {
+		id
 		initAutolending
 	}
 }

--- a/src/graphql/mutation/autolending/saveChanges.graphql
+++ b/src/graphql/mutation/autolending/saveChanges.graphql
@@ -1,5 +1,6 @@
 mutation saveAutolendingChanges {
 	autolending @client {
+		id
 		saveProfile
 	}
 }

--- a/src/graphql/mutation/updateActiveLoan.graphql
+++ b/src/graphql/mutation/updateActiveLoan.graphql
@@ -1,5 +1,6 @@
 mutation updateActiveLoan($xCoordinate: Int, $yCoordinate: Int, $hoverLoanId: Int, $loan: String, $tracking: String) {
 	updateActiveLoan(xCoordinate: $xCoordinate, yCoordinate: $yCoordinate, hoverLoanId: $hoverLoanId, loan: $loan, tracking: $tracking ) @client {
+		id
 		hoverLoanId
 	}
 }

--- a/src/graphql/query/autolending/countryList.graphql
+++ b/src/graphql/query/autolending/countryList.graphql
@@ -1,5 +1,6 @@
 query countryList {
 	autolending @client {
+		id
 		currentProfile {
 			id
 			loanSearchCriteria {

--- a/src/graphql/query/autolending/partnerList.graphql
+++ b/src/graphql/query/autolending/partnerList.graphql
@@ -1,5 +1,6 @@
 query partnerList {
 	autolending @client {
+		id
 		currentProfile {
 			id
 			loanSearchCriteria {

--- a/src/graphql/query/autolending/sectorList.graphql
+++ b/src/graphql/query/autolending/sectorList.graphql
@@ -1,5 +1,6 @@
 query sectorList {
 	autolending @client {
+		id
 		currentProfile {
 			id
 			loanSearchCriteria {

--- a/src/graphql/query/autolending/themeList.graphql
+++ b/src/graphql/query/autolending/themeList.graphql
@@ -1,5 +1,6 @@
 query themeList {
 	autolending @client {
+		id
 		currentProfile {
 			id
 			loanSearchCriteria {

--- a/src/graphql/query/checkout/basketVerificationState.graphql
+++ b/src/graphql/query/checkout/basketVerificationState.graphql
@@ -10,6 +10,7 @@ query basketVerificationState($basketId: String) {
 		}
 	}
 	verificationLightbox @client {
+		id
 		visible
 	}
 }

--- a/src/pages/Autolending/AttributeFilter.vue
+++ b/src/pages/Autolending/AttributeFilter.vue
@@ -68,6 +68,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation updateThemes($themes: [String]) {
 					autolending @client {
+						id
 						editProfile(profile: {
 							loanSearchCriteria: {
 								filters: {

--- a/src/pages/Autolending/AutolendingSettingsPage.vue
+++ b/src/pages/Autolending/AutolendingSettingsPage.vue
@@ -29,6 +29,7 @@ import AutolendingWho from './AutolendingWho';
 
 const pageQuery = gql`query autolendProfileEnabled {
 	autolending @client {
+		id
 		profileChanged
 		currentProfile {
 			id

--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -119,6 +119,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileStatus {
 			autolending @client {
+				id
 				profileChanged
 				currentProfile {
 					id
@@ -159,6 +160,7 @@ export default {
 					this.apollo.mutate({
 						mutation: gql`mutation pauseAutolending($pauseUntilDate: Date) {
 							autolending @client {
+								id
 								editProfile(profile: {
 									isEnabled: true,
 									pauseUntil: $pauseUntilDate
@@ -175,6 +177,7 @@ export default {
 					this.apollo.mutate({
 						mutation: gql`mutation enableAutolending {
 							autolending @client {
+								id
 								editProfile(profile: { isEnabled: true, pauseUntil: null })
 							}
 						}`,
@@ -185,6 +188,7 @@ export default {
 					this.apollo.mutate({
 						mutation: gql`mutation disableAutolending {
 							autolending @client {
+								id
 								editProfile(profile: { isEnabled: false, pauseUntil: null })
 							}
 						}`,
@@ -221,6 +225,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation saveAutolendProfile {
 					autolending @client {
+						id
 						saveProfile
 					}
 				}`

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -134,6 +134,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileWhen {
 			autolending @client {
+				id
 				profileChanged
 				currentProfile {
 					id
@@ -170,6 +171,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation editDonation($donation: Int) {
 						autolending @client {
+							id
 							editProfile(profile: { donationPercentage: $donation })
 						}
 					}`,
@@ -199,6 +201,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation saveProfile {
 					autolending @client {
+						id
 						saveProfile
 					}
 				}`

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -196,6 +196,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileWho {
 			autolending @client {
+				id
 				profileChanged
 				currentProfile {
 					id

--- a/src/pages/Autolending/CountryFilter.vue
+++ b/src/pages/Autolending/CountryFilter.vue
@@ -97,6 +97,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation updateCountries($countries: [String]) {
 					autolending @client {
+						id
 						editProfile(profile: {
 							loanSearchCriteria: {
 								filters: {

--- a/src/pages/Autolending/DefaultRateDropdown.vue
+++ b/src/pages/Autolending/DefaultRateDropdown.vue
@@ -54,6 +54,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileDefaultRate {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -81,6 +82,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateDefaultRate($defaultRate: Float) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/GenderRadios.vue
+++ b/src/pages/Autolending/GenderRadios.vue
@@ -46,6 +46,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileGender {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -67,6 +68,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateGender($gender: GenderEnum) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/GroupRadios.vue
+++ b/src/pages/Autolending/GroupRadios.vue
@@ -46,6 +46,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileIsGroup {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -80,6 +81,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateIsGroup($isGroup: Boolean) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/InlineCounter.vue
+++ b/src/pages/Autolending/InlineCounter.vue
@@ -40,6 +40,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileLoanCount {
 			autolending @client {
+				id
 				currentLoanCount
 				countingLoans
 				warningThreshold

--- a/src/pages/Autolending/KivaChoosesRadios.vue
+++ b/src/pages/Autolending/KivaChoosesRadios.vue
@@ -38,6 +38,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileKivaChooses {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					kivaChooses
@@ -55,6 +56,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateKivaChooses($kivaChooses: Boolean!) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								kivaChooses: $kivaChooses
 							})

--- a/src/pages/Autolending/LendTimingDropdown.vue
+++ b/src/pages/Autolending/LendTimingDropdown.vue
@@ -71,6 +71,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateLendAfterDaysIdle($value: Int) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								enableAfter: 0
 								lendAfterDaysIdle: $value
@@ -93,6 +94,7 @@ export default {
 				}
 			}
 			autolending @client {
+				id
 				currentProfile {
 					id
 					isEnabled

--- a/src/pages/Autolending/LendTimingMessaging.vue
+++ b/src/pages/Autolending/LendTimingMessaging.vue
@@ -127,6 +127,7 @@ export default {
 				}
 			}
 			autolending @client {
+				id
 				currentProfile {
 					id
 					isEnabled

--- a/src/pages/Autolending/LoanIncrementDropdown.vue
+++ b/src/pages/Autolending/LoanIncrementDropdown.vue
@@ -51,6 +51,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileLoanLimit {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -72,6 +73,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateLoanLimit($loanLimit: Int) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/LoanTermDropdown.vue
+++ b/src/pages/Autolending/LoanTermDropdown.vue
@@ -42,6 +42,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileLoanTerm {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -65,6 +66,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateLoamTerm($max: Float) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/PartnerDelRateDropdown.vue
+++ b/src/pages/Autolending/PartnerDelRateDropdown.vue
@@ -45,6 +45,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileArrearsRate {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -69,6 +70,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateArrearsRate($max: Float) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/PartnerFilter.vue
+++ b/src/pages/Autolending/PartnerFilter.vue
@@ -72,6 +72,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation updatePartners($partners: [Int]) {
 					autolending @client {
+						id
 						editProfile(profile: {
 							loanSearchCriteria: {
 								filters: {

--- a/src/pages/Autolending/RiskRatingDropdown.vue
+++ b/src/pages/Autolending/RiskRatingDropdown.vue
@@ -42,6 +42,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileRiskRating {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					loanSearchCriteria {
@@ -69,6 +70,7 @@ export default {
 				this.apollo.mutate({
 					mutation: gql`mutation updateRiskRating($min: Float) {
 						autolending @client {
+							id
 							editProfile(profile: {
 								loanSearchCriteria: {
 									filters: {

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -86,6 +86,7 @@ export default {
 	apollo: {
 		query: gql`query autolendProfileChanged {
 			autolending @client {
+				id
 				currentLoanCount
 				profileChanged
 				savingProfile
@@ -121,6 +122,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation saveProfile {
 					autolending @client {
+						id
 						saveProfile
 					}
 				}`

--- a/src/pages/Autolending/SectorFilter.vue
+++ b/src/pages/Autolending/SectorFilter.vue
@@ -68,6 +68,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation updateSectors($sectors: [Int]) {
 					autolending @client {
+						id
 						editProfile(profile: {
 							loanSearchCriteria: {
 								filters: {

--- a/src/pages/Autolending/WhoYoullSupportText.vue
+++ b/src/pages/Autolending/WhoYoullSupportText.vue
@@ -74,6 +74,7 @@ export default {
 	apollo: {
 		query: gql`query whoYoullSupport {
 			autolending @client {
+				id
 				currentProfile {
 					id
 					kivaChooses

--- a/src/plugins/any-or-selected-autolending-radio-mixin.js
+++ b/src/plugins/any-or-selected-autolending-radio-mixin.js
@@ -19,6 +19,7 @@ export default {
 			this.apollo.mutate({
 				mutation: gql`mutation saveAny($filters: LoanSearchFiltersInput!) {
 							autolending @client {
+								id
 								editProfile(profile: {
 									loanSearchCriteria: {
 										filters: $filters


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1451

- Turns out that Apollo local resolvers weren't being called
- While [Apollo does recommend type policies + local only fields](https://www.apollographql.com/docs/react/local-state/local-resolvers/), local resolvers still work as before
- The pages that encountered Apollo errors (borrower profile, lend/filter, etc.) seem to work fine now
- Before being able to push to git, the missing `id` fields had to be added to a number of local resolver queries/mutations

**Notes**
- I assumed there was a new requirement for these `id` fields with Apollo 3, and I didn't test these use cases
- The MARS-178 branch needs changes from `main` before it can be merged
- I created a branch off the feature branch to isolate these new changes for review