### PR TITLE
fix: errors resolved for apollo cache on BP

### DIFF
--- a/src/components/BorrowerProfile/LoanStory.vue
+++ b/src/components/BorrowerProfile/LoanStory.vue
@@ -167,7 +167,7 @@ export default {
 			this.previousLoanId = loan?.previousLoanId ?? 0;
 		},
 	},
-	mounted() {
+	async mounted() {
 		const query = gql`query loanStoryContextExp($loanId: Int!) {
 			lend {
 				loan(id: $loanId) {
@@ -196,7 +196,7 @@ export default {
 		}`;
 
 		try {
-			const data = this.apollo.query({
+			const { data } = await this.apollo.query({
 				query,
 				variables: {
 					loanId: this.loanId,

--- a/src/components/BorrowerProfile/LoanStory.vue
+++ b/src/components/BorrowerProfile/LoanStory.vue
@@ -196,7 +196,7 @@ export default {
 		}`;
 
 		try {
-			const data = this.apollo.readQuery({
+			const data = this.apollo.query({
 				query,
 				variables: {
 					loanId: this.loanId,
@@ -252,7 +252,7 @@ export default {
 					image: 'leafheart'
 				};
 			}
-			if (this.sector?.name.toLowerCase() === 'education') {
+			if (this.sector?.name?.toLowerCase() === 'education') {
 				return {
 					id: '6',
 					headline: 'Increases earning potential',
@@ -260,7 +260,7 @@ export default {
 					image: 'water'
 				};
 			}
-			if (this.sector?.name.toLowerCase() === 'arts') {
+			if (this.sector?.name?.toLowerCase() === 'arts') {
 				return {
 					id: '7',
 					headline: 'Invest in their craft',
@@ -269,7 +269,7 @@ export default {
 					image: 'water'
 				};
 			}
-			if (this.sector?.name.toLowerCase() === 'agriculture') {
+			if (this.sector?.name?.toLowerCase() === 'agriculture') {
 				return {
 					id: '8',
 					headline: 'Supports their family',

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -542,7 +542,7 @@ export default {
 			this.isoCode = loan?.geocode?.country?.isoCode ?? '';
 		},
 	},
-	mounted() {
+	async mounted() {
 		// EXP-GROW-655-Aug2021
 		// This is cookie is set during the redirect and signifies the exp is active when landing on this page
 		const expCookieSignifier = this.cookieStore.get('kvlendborrowerbeta');
@@ -608,7 +608,7 @@ export default {
 		}`;
 
 		try {
-			const data = this.apollo.query({
+			const { data } = await this.apollo.query({
 				query,
 				variables: {
 					loanId: this.loanId,

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -217,6 +217,10 @@ const pageQuery = gql`
 				key
 				value
 			}
+			userContext: uiExperimentSetting(key: "new_users_context") {
+				key
+				value
+			}
 		}
 		lend {
 			loan(id: $loanId) {
@@ -604,7 +608,7 @@ export default {
 		}`;
 
 		try {
-			const data = this.apollo.readQuery({
+			const data = this.apollo.query({
 				query,
 				variables: {
 					loanId: this.loanId,


### PR DESCRIPTION
Earlier today some changes were merged that introduced a few invariant violation errors that occur when Apollo tries to read something from cache that doesn't exist. Those errors were blocking/confusing my borrower profile optimization work, so I spun out these fixes, since we are also currently seeing these errors on dev.

@christian14b Two items to look into:

1. I didn't want to add the experiment query to the `preFetch`, but I noticed that the experiment flag was used quite a bit in the template. If we can move this to clientside, please do in a follow-up PR.
2. I didn't spend time verifying that delaying this data fetching indeed works okay from a UX perspective (like if text pop-in is bad), since I'm not familiar with this new experiment. Please test this when you have a chance, because this PR enables the data to be loaded clientside, and before the changes in this PR, the data was not loading clientside (it was erroring out). An example is the change I made for `this.sector?.name?.toLowerCase()`. That was erroring out because sector hadn't loaded yet, but I didn't verify if this computed value causes bad pop-in when the data fetch is moved clientside. 
 
If you have any questions, please let me know.

Thanks!