### PR TITLE
Revert "fix: add additional checks for modern subscriptions"

### DIFF
--- a/src/components/Settings/SubscriptionsSettingsCards.vue
+++ b/src/components/Settings/SubscriptionsSettingsCards.vue
@@ -10,7 +10,7 @@
 
 		<!-- Monthly Good Settings -->
 		<subscriptions-monthly-good
-			v-if="!isOnetime && !hasModernSub"
+			v-if="!isOnetime"
 			@cancel-subscription="cancelSubscription"
 			@unsaved-changes="setUnsavedChanges"
 			ref="subscriptionsMonthlyGoodComponent"

--- a/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
+++ b/src/pages/MonthlyGood/MonthlyGoodLandingPage.vue
@@ -349,8 +349,9 @@ export default {
 		},
 		result({ data }) {
 			this.isMonthlyGoodSubscriber = data?.my?.autoDeposit?.isSubscriber ?? false;
-			const modernSubscriptions = data?.mySubscriptions?.values ?? [];
-			this.hasModernSub = modernSubscriptions.length !== 0;
+			// TODO! Add this back in when service supports non-logged in users
+			// const modernSubscriptions = data?.mySubscriptions?.values ?? [];
+			// this.hasModernSub = modernSubscriptions.length !== 0;
 
 			// mg_hero_show_loans
 			// Hero Loan Visibility Experiment - CORE-451


### PR DESCRIPTION
Reverts kiva/ui#4432

Bug reported by Melissa -- I did not realize that MG subscriptions are now modern subscriptions and this change disabled the subscriptions settings box for everyone