### PR TITLE
feat: add 5th donation item variant as line item in order totals

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -1,7 +1,10 @@
 <template>
 	<!-- DO NOT REMOVE basket-donation-item class -->
 	<div class="basket-donation-item">
-		<template v-if="donateItemExperimentVersion === 'a'">
+		<template
+			v-if="donateItemExperimentVersion === 'a' ||
+				(donateItemExperimentVersion === 'e' && !hasLoans)"
+		>
 			<div class="tw-flex tw-flex-col md:tw-flex-row tw-pb-5">
 				<!-- donation image -->
 				<div class="tw-hidden md:tw-block tw-flex-none md:tw-mr-3 lg:tw-mr-4.5">
@@ -663,6 +666,93 @@
 				</div>
 			</div>
 		</template>
+		<template v-if="donateItemExperimentVersion === 'e' && orderTotalVariant && hasLoans">
+			<div class="tw-flex tw-flex-col tw-w-full tw-pb-4">
+				<div class="tw-flex tw-flex-row tw-w-full">
+					<!-- donation text -->
+					<div class="tw-w-auto tw-text-left md:tw-text-right tw-flex-1">
+						<h2
+							class="tw-text-h3"
+							data-testid="basket-donation-title"
+						>
+							Donate to Kiva:
+						</h2>
+					</div>
+
+					<!-- donation total -->
+					<div
+						class="tw-flex-none tw-w-auto"
+					>
+						<div
+							v-show="!editDonation"
+							class="tw-block tw-text-right tw-ml-1"
+						>
+							<button
+								class="donation-amount tw-text-h3"
+								data-testid="basket-donation-edit-button-combined"
+								v-kv-track-event="['basket', 'Edit Donation']"
+								@click="enterEditDonation"
+								title="Edit Donation"
+							>
+								{{ formattedAmount }}
+								<kv-material-icon
+									role="img"
+									aria-label="Edit Donation"
+									title="Edit Donation"
+									class="edit-donation
+											tw-text-action
+											tw-w-2.5
+											tw-ml-2
+											tw-h-3.5
+											tw-py-0.5
+											tw-align-bottom
+									"
+									name="pencil"
+									:icon="mdiPencil"
+								/>
+							</button>
+						</div>
+						<div v-show="editDonation" class="small-12 columns donation-amount-input-wrapper">
+							<kv-text-input
+								class="donation-amount-input"
+								data-testid="basket-donation-edit-input"
+								name="donation"
+								id="donation"
+								v-model="amount"
+								@blur="validateInput"
+								@keyup.enter.prevent="updateDonation()"
+							/>
+							<kv-button
+								variant="secondary"
+								class="update-donation-inline-button"
+								data-testid="basket-donation-edit-submit"
+								@click="updateDonation()"
+							>
+								Update
+							</kv-button>
+							<button
+								class="show-for-medium remove-wrapper"
+								@click="updateLoanAmount('remove')"
+								data-testid="basket-donation-remove"
+							>
+								<kv-material-icon
+									class="remove-x tw-text-tertiary"
+									name="small-x"
+									:from-sprite="true"
+									title="Remove donation"
+								/>
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<donate-repayments
+					v-if="hasLoans"
+					@updating-totals="$emit('updating-totals', $event)"
+					@refreshtotals="$emit('refreshtotals')"
+				/>
+			</div>
+		</template>
 		<!-- Donation nudge lightbox -->
 		<donation-nudge-lightbox
 			ref="nudgeLightbox"
@@ -760,6 +850,10 @@ export default {
 			type: Number,
 			default: 0,
 		},
+		orderTotalVariant: {
+			type: Boolean,
+			default: false
+		},
 	},
 	data() {
 		return {
@@ -790,8 +884,8 @@ export default {
 		}
 	},
 	created() {
-		const ecoChallengeExpData = getExperimentSettingCached(this.apollo, 'basket_donate_modules');
-		if (ecoChallengeExpData?.enabled) {
+		const donateModuleExpData = getExperimentSettingCached(this.apollo, 'basket_donate_modules');
+		if (donateModuleExpData?.enabled) {
 			const { version } = trackExperimentVersion(
 				this.apollo,
 				this.$kvTrackEvent,

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -38,7 +38,12 @@
 							@refreshtotals="refreshTotals($event)"
 							@updating-totals="setUpdatingTotals"
 						/>
-						<div class="upsellContainer">
+						<div
+							class="upsellContainer" v-if="!upsellCookieActive &&
+								showUpsellModule &&
+								upsellLoan.name
+							"
+						>
 							<upsell-module
 								v-if="!upsellCookieActive &&
 									showUpsellModule &&


### PR DESCRIPTION
Variant looks like this, when there are loans in the basket, else show the control (variant a)
<img width="804" alt="Screen Shot 2022-12-07 at 2 19 57 PM" src="https://user-images.githubusercontent.com/4371888/206542215-ceb18582-f961-468a-8fa4-578890b9012c.png">
<img width="804" alt="Screen Shot 2022-12-07 at 2 19 43 PM" src="https://user-images.githubusercontent.com/4371888/206542221-61b93fd1-1085-435d-b5be-037449e69a7c.png">
