### PR TITLE
Vue 1407 saved search doesnt refresh in lend menu

### DIFF
--- a/src/components/WwwFrame/LendMenu/MonthlyGoodExpMenuWrapper.vue
+++ b/src/components/WwwFrame/LendMenu/MonthlyGoodExpMenuWrapper.vue
@@ -51,7 +51,6 @@ export default {
 	},
 	methods: {
 		onBorrowerMenuShow() {
-			this.$refs.lendMenuDesktop.onOpen();
 			this.$kvTrackEvent('TopNav', 'hover-Borrower-menu', 'Find a borrower');
 		},
 		onBorrowerMenuHide() {

--- a/src/components/WwwFrame/LendMenu/TheLendMenu.vue
+++ b/src/components/WwwFrame/LendMenu/TheLendMenu.vue
@@ -35,7 +35,7 @@ import _groupBy from 'lodash/groupBy';
 import _map from 'lodash/map';
 import _sortBy from 'lodash/sortBy';
 import gql from 'graphql-tag';
-
+import logReadQueryError from '@/util/logReadQueryError';
 import { indexIn } from '@/util/comparators';
 import publicLendMenuQuery from '@/graphql/query/lendMenuData.graphql';
 import privateLendMenuQuery from '@/graphql/query/lendMenuPrivateData.graphql';
@@ -121,14 +121,11 @@ export default {
 		},
 	},
 	methods: {
-		onOpen() {
-			this.$refs?.mega?.onOpen?.();
-		},
 		onClose() {
 			this.$refs.list.onClose();
 			this.$refs.mega.onClose();
 		},
-		onLoad() {
+		async onLoad() {
 			this.apollo.watchQuery({
 				query: gql`query countryFacets {
 					lend {
@@ -149,35 +146,36 @@ export default {
 					this.isRegionsLoading = false;
 				}
 			});
+
 			this.apollo.watchQuery({ query: publicLendMenuQuery }).subscribe({
 				next: ({ data }) => {
 					this.categories = _get(data, 'lend.loanChannels.values');
 					this.isChannelsLoading = false;
 				}
 			});
+
+			if (this.hasUserId) {
+				try {
+					const { data } = await this.apollo.query({
+						query: privateLendMenuQuery,
+						variables: {
+							userId: this.userId,
+						},
+						fetchPolicy: 'network-only',
+					});
+
+					this.favoritesCount = data?.lend?.loans?.totalCount;
+					this.savedSearches = data?.my?.savedSearches?.values;
+				} catch (e) {
+					this.favoritesCount = 0;
+					this.savedSearches = [];
+
+					logReadQueryError(e, 'TheLendMenu privateLendMenuQuery');
+				}
+			}
 		},
 	},
 	mounted() {
-		if (this.hasUserId) {
-			this.apollo.query({
-				query: privateLendMenuQuery,
-				variables: {
-					userId: this.userId,
-				}
-			}).then(({ data, errors }) => {
-				if (!errors) {
-					this.favoritesCount = _get(data, 'lend.loans.totalCount');
-					this.savedSearches = _get(data, 'my.savedSearches.values');
-				} else {
-					this.favoritesCount = 0;
-					this.savedSearches = [];
-				}
-			}).finally(() => {
-				// data might have changed since the initial render, so trigger any needed updates
-				this.onOpen();
-			});
-		}
-
 		// CORE-641 NEW MG ENTRYPOINT
 		// this experiment is assigned in experimentPreFetch.js
 		const newMgEntrypointExperiment = this.apollo.readFragment({

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -669,6 +669,11 @@ export default {
 	},
 	methods: {
 		toggleLendMenu(immediate = false) {
+			if (!this.isLendMenuVisible) {
+				// If menu was previously hidden, run menu onLoad
+				this.$refs?.lendMenu?.onLoad?.();
+			}
+
 			if (immediate) {
 				// if touch, toggle immediately
 				this.isLendMenuVisible = !this.isLendMenuVisible;
@@ -684,9 +689,6 @@ export default {
 						this.isLendMenuVisible = false;
 					}
 				}, 500);
-			}
-			if (this.isLendMenuVisible) {
-				this.$refs?.lendMenu?.onLoad?.();
 			}
 		},
 		onLendLinkPointerEnter(e) {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1407

- The lend menu private user data was only being queried on mount - changed to query when the menu opened, so that we don't have to remember to refetch a query whenever changing data displayed in the lend menu (there are several locations currently where we'd need to, for saved loans and searches)
- Removed lend menu `onOpen` since it seems to no longer exist
- `onLoad` is only called when the lend menu is opened, and it's a relative lightweight gql query