### PR TITLE
fix: css for order totals

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -893,7 +893,9 @@ export default {
 				'basket_donate_modules',
 				'EXP-ACK-440-Oct2022'
 			);
-			this.donateItemExperimentVersion = version;
+			if (version) {
+				this.donateItemExperimentVersion = version;
+			}
 		}
 
 		this.setupContentfulContent();

--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -1,6 +1,10 @@
 <template>
 	<div class="order-totals" data-testid="basket-order-totals-section">
-		<div v-if="showPromoCreditTotal" class="order-total" data-testid="basket-order-total">
+		<div
+			v-if="showPromoCreditTotal"
+			class="order-total tw-text-left md:tw-text-right"
+			data-testid="basket-order-total"
+		>
 			<strong>Order Total: <span class="total-value">{{ itemTotal }}</span></strong>
 		</div>
 
@@ -45,7 +49,7 @@
 		</div>
 
 		<div v-if="showPromoCreditTotal">
-			<div class="order-total" data-testid="basket-promo-total">
+			<div class="order-total tw-text-left md:tw-text-right" data-testid="basket-promo-total">
 				<template v-if="availablePromoTotal">
 					{{ availablePromoTotal }}
 				</template>
@@ -186,7 +190,7 @@ export default {
 	data() {
 		return {
 			promoOptOutLightboxVisible: false,
-			donateItemExperimentVersion: null
+			donateItemExperimentVersion: 'a' // control version
 		};
 	},
 	computed: {
@@ -383,7 +387,9 @@ export default {
 				'basket_donate_modules',
 				'EXP-ACK-440-Oct2022'
 			);
-			this.donateItemExperimentVersion = version;
+			if (version) {
+				this.donateItemExperimentVersion = version;
+			}
 		}
 	},
 };


### PR DESCRIPTION
A couple of changes after testing the donation e variant. 

Forgot to add css classes to the promo credit line, `order-total` class. I'm also running into an issue where the experiment version is returning `null` I tried debugging this, but don't understand why it happens, I'm seeing it for other experiments as well in the Apollo cache. -- Added a null check so that when  the experiment is enabled and it happens to return null, we don't change the component variable and we still show a donation variant (usuallly the default variant)