### PR TITLE
Header /lend links

### DIFF
--- a/src/components/WwwFrame/LendMenu/CountryList.vue
+++ b/src/components/WwwFrame/LendMenu/CountryList.vue
@@ -1,14 +1,14 @@
 <template>
 	<ul class="tw-whitespace-nowrap tw-font-medium">
 		<li v-for="country in countries" :key="country.isoCode" class="lg:tw-w-[11rem]">
-			<router-link
+			<a
 				v-if="country.count > 0"
-				:to="{ path: '/lend', query: { country: country.isoCode }}"
+				:href="`/lend/filter?country=${country.isoCode}`"
 				v-kv-track-event="['TopNav', 'click-Lend-Country', country.name]"
 				class="tw-text-primary hover:tw-text-action-highlight tw-block tw-w-full tw-py-1"
 			>
 				{{ country.name }} ({{ country.count }})
-			</router-link>
+			</a>
 			<span v-else class="tw-block tw-py-1 tw-text-tertiary">
 				{{ country.name }} (0)
 			</span>

--- a/src/components/WwwFrame/SearchBar.vue
+++ b/src/components/WwwFrame/SearchBar.vue
@@ -239,7 +239,14 @@ export default {
 					filterUrl = '/lend';
 				}
 
-				window.location.href = `${filterUrl}?${new URLSearchParams(query).toString()}`;
+				// When already on the filter page, prevent identical paths from being pushed
+				if (this.$router.currentRoute.fullPath !== `${filterUrl}?${new URLSearchParams(query).toString()}`) {
+					this.$router.push({ path: filterUrl, query });
+				}
+
+				// Exit searching state, in case user is already on filter page
+				this.searching = false;
+				this.$refs.input.blur();
 			}
 		},
 		formatResult({ label, matches }) {

--- a/src/components/WwwFrame/SearchBar.vue
+++ b/src/components/WwwFrame/SearchBar.vue
@@ -1,8 +1,6 @@
 <template>
 	<form
 		class="search-form tw-relative"
-		action="/lend"
-		method="get"
 		autocomplete="off"
 		@submit.prevent="onSubmit"
 	>
@@ -90,6 +88,7 @@ import { indexIn } from '@/util/comparators';
 import { mdiMagnify } from '@mdi/js';
 import lockScrollUtils from '@/plugins/lock-scroll';
 import getCacheKey from '@/util/getCacheKey';
+import { hasExcludedQueryParams } from '@/util/loanSearch/queryParamUtils';
 import KvTextInput from '~/@kiva/kv-components/vue/KvTextInput';
 
 const engine = new SearchEngine();
@@ -233,7 +232,14 @@ export default {
 				} else {
 					query = { queryString: suggestion };
 				}
-				this.$router.push({ path: '/lend', query });
+
+				// Fallback to legacy filter if there's an unsupported query param
+				let filterUrl = '/lend/filter';
+				if (hasExcludedQueryParams(query)) {
+					filterUrl = '/lend';
+				}
+
+				window.location.href = `${filterUrl}?${new URLSearchParams(query).toString()}`;
 			}
 		},
 		formatResult({ label, matches }) {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1437
https://kiva.atlassian.net/browse/VUE-1443

- Search navigates either to new or old filter page based on query params
- Lend menu country list navigates to new filter page
- Used full navigation to ensure that `/lend/filter` state updates like expected - simpler solution than special handling if the navigation happens from the filter page