### PR TITLE
updates and fixes for MARS-317

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -190,12 +190,10 @@
 					</p>
 					<div
 						v-if="repaymentEnabled"
-						class="tw-hidden md:tw-flex tw-content-center tw-gap-2"
+						class="tw-hidden md:tw-flex tw-mt-2 lg:tw-mt-0 tw-content-center tw-gap-2"
 					>
-						<div>
-							<icon-clock />
-						</div>
-						<span>First expected repayment {{ repaymentDate }}</span>
+						<icon-clock />
+						<span>{{ repaymentDateCopy }}</span>
 					</div>
 					<hr
 						class="tw-hidden md:tw-block tw-border-tertiary tw-w-full tw-my-2"
@@ -307,10 +305,10 @@
 							leave-to-class="tw-transform tw-translate-y-2 tw-opacity-0"
 						>
 							<span
+								v-if="currentSlotStat === 'lenderCount'"
 								class="tw-inline-block tw-align-middle"
 								data-testid="bp-lend-cta-powered-by-text"
 								key="numLendersStat"
-								v-if="statScrollAnimation && !repaymentEnabled || loopItemTurn === 1"
 							>
 								<kv-material-icon
 									class="tw-w-2.5 tw-h-2.5 tw-pointer-events-none tw-inline-block tw-align-middle"
@@ -320,10 +318,10 @@
 							</span>
 
 							<span
+								v-if="currentSlotStat === 'matchingText'"
 								class="tw-inline-block tw-align-middle"
 								data-testid="bp-lend-cta-matched-text"
 								key="loanMatchingText"
-								v-if="showMatchingText"
 							>
 								<span
 									class="tw-text-h3 tw-inline-block tw-align-middle tw-px-1"
@@ -336,15 +334,13 @@
 							</span>
 
 							<span
-								v-if="showExpectedRepayment"
+								v-if="currentSlotStat === 'repaymentDate'"
 								class="md:tw-hidden tw-align-middle tw-flex tw-gap-1 tw-items-center"
 								data-testid="bp-lend-cta-expected-repayment"
 								key="expectedRepayment"
 							>
-								<div>
-									<icon-clock class="tw-pointer-events-none tw-inline-block tw-align-middle" />
-								</div>
-								<span> First expected repayment {{ repaymentDate }}</span>
+								<icon-clock class="tw-pointer-events-none tw-inline-block tw-align-middle" />
+								<span>{{ repaymentDateCopy }}</span>
 							</span>
 						</transition>
 					</div>
@@ -362,6 +358,12 @@
 
 <script>
 import { mdiLightningBolt } from '@mdi/js';
+import {
+	addMonths,
+	format,
+	parseISO,
+	isSameMonth,
+} from 'date-fns';
 import gql from 'graphql-tag';
 import { setLendAmount } from '@/util/basketUtils';
 import {
@@ -417,14 +419,6 @@ export default {
 			type: String,
 			default: 'c'
 		},
-		hasLentBefore: {
-			type: Boolean,
-			default: false
-		},
-		hasDepositBefore: {
-			type: Boolean,
-			default: false
-		}
 	},
 	components: {
 		LendersList,
@@ -457,7 +451,6 @@ export default {
 			numLenders: 0,
 			lenderCountVisibility: false,
 			matchingTextVisibility: false,
-			statScrollAnimation: false,
 			matchingText: '',
 			matchRatio: 0,
 			basketItems: [],
@@ -473,7 +466,10 @@ export default {
 			checkoutMilestoneProgresses: [],
 			isMobile: false,
 			repaymentInterval: '',
-			loopItemTurn: 0
+			plannedExpirationDate: '',
+			firstRepaymentDate: '',
+			slotMachineInterval: null,
+			currentSlotStat: '',
 		};
 	},
 	apollo: {
@@ -502,6 +498,12 @@ export default {
 							totalCount
 						}
 						repaymentInterval
+						plannedExpirationDate
+						terms {
+							expectedPayments {
+								dueToKivaDate
+							}
+						}
 					}
 				}
 				shop (basketId: $basketId) {
@@ -549,14 +551,21 @@ export default {
 			this.basketItems = basket?.items?.values ?? [];
 			this.matchingText = loan?.matchingText ?? '';
 			this.matchRatio = loan?.matchRatio ?? 0;
-			this.repaymentInterval = loan?.repaymentInterval ?? 0;
+			this.firstRepaymentDate = loan?.terms?.expectedPayments?.[0]?.dueToKivaDate ?? '';
+			this.plannedExpirationDate = loan?.plannedExpirationDate ?? '';
+			this.repaymentInterval = loan?.repaymentInterval ?? '';
 			this.name = loan?.name ?? '';
 			this.matchingTextVisibility = this.status === 'fundraising' && this.matchingText && !this.isMatchAtRisk;
 
 			if (this.status === 'fundraising' && this.numLenders > 0) {
 				this.lenderCountVisibility = !this.socialExpEnabled;
-				this.statScrollAnimation = !this.socialExpEnabled;
 			}
+
+			// Start cycling the stats slot now that loan data is available
+			this.cycleStatsSlot();
+
+			// Track this.repaymentDateCopy for MARS-317
+			this.$kvTrackEvent('borrower-profile', 'show', 'expected-repayment', this.repaymentDateCopy);
 		},
 	},
 	methods: {
@@ -640,37 +649,38 @@ export default {
 			);
 		},
 		cycleStatsSlot() {
-			let cycleSlotMachine = () => {};
-			if (this.matchingText.length) {
-				cycleSlotMachine = () => {
-					if (this.repaymentEnabled && this.isMobile) {
-						this.loopItemTurn += 1;
-						if (this.loopItemTurn > 3) {
-							this.loopItemTurn = 1;
-						}
-					} else if (!this.isMatchAtRisk) {
-						if (this.socialExpEnabled) {
-							this.statScrollAnimation = false;
-						} else {
-							this.statScrollAnimation = !this.statScrollAnimation;
-						}
-					} else {
-						this.statScrollAnimation = true;
-					}
-				};
-			} else {
-				cycleSlotMachine = () => {
-					this.loopItemTurn += 1;
-					if (this.loopItemTurn > 2) {
-						this.loopItemTurn = 1;
-					}
-					if (!this.isMobile) {
-						this.loopItemTurn = 1;
-					}
-				};
+			// Function can be skipped if slot machine interval is already set
+			if (this.slotMachineInterval) {
+				return;
 			}
 
-			setInterval(cycleSlotMachine, 5000);
+			// Change which stat is displayed in the stats slot
+			const cycleSlotMachine = () => {
+				const possibleStats = [];
+				// Add lender count
+				if (this.status === 'fundraising' && this.numLenders > 0 && !this.socialExpEnabled) {
+					possibleStats.push('lenderCount');
+				}
+				// Add matching text
+				if (this.status === 'fundraising' && this.matchingText.length && !this.isMatchAtRisk) {
+					possibleStats.push('matchingText');
+				}
+				// Add repayment date MARS-317
+				this.determineIfMobile();
+				if (this.isMobile && this.repaymentEnabled) {
+					possibleStats.push('repaymentDate');
+				}
+				// Cycle through the possible stats in the order they were added.
+				// If current slot stat is no longer in the possible stat list, this will cycle back to the first stat.
+				let nextStatIndex = possibleStats.indexOf(this.currentSlotStat) + 1;
+				nextStatIndex = nextStatIndex >= possibleStats.length ? 0 : nextStatIndex;
+				this.currentSlotStat = possibleStats[nextStatIndex] ?? '';
+			};
+
+			// Set inital stat
+			cycleSlotMachine();
+			// Start cycling
+			this.slotMachineInterval = setInterval(cycleSlotMachine, 5000);
 		},
 		toggleLightbox() {
 			this.$emit('togglelightbox');
@@ -699,24 +709,28 @@ export default {
 		},
 	},
 	computed: {
-		showMatchingText() {
-			return (!this.statScrollAnimation && !this.repaymentEnabled)
-			|| (this.loopItemTurn === 2 && this.matchingText.length);
-		},
-		showExpectedRepayment() {
-			return this.loopItemTurn === 3 || (this.loopItemTurn === 2 && !this.matchingText.length && this.isMobile);
-		},
 		repaymentEnabled() {
-			return this.userContextExpVariant === 'b' && (!this.hasLentBefore || !this.hasDepositBefore);
+			return this.userContextExpVariant === 'b';
 		},
 		repaymentDate() {
-			const date = new Date();
-			date.setMonth(date.getMonth() + 1);
-			const currentYear = date.getFullYear();
-			const currentMonth = new Intl.DateTimeFormat('en-US', { month: 'long' }).format(date);
-			return this.repaymentInterval === 'monthly'
-				? `${currentMonth.substring(0, 3)}, ${currentYear}`
-				: `Jun, ${currentYear + 1}`;
+			if (this.firstRepaymentDate) {
+				return format(parseISO(this.firstRepaymentDate), 'MMM yyyy');
+			}
+			if (this.plannedExpirationDate) {
+				const asSoonAs = addMonths(new Date(), 1);
+				const asLateAs = addMonths(parseISO(this.plannedExpirationDate), 1);
+				if (isSameMonth(asSoonAs, asLateAs)) {
+					return format(asSoonAs, 'MMM yyyy');
+				}
+				return `${format(asSoonAs, 'MMM yyyy')} or ${format(asLateAs, 'MMM yyyy')}`;
+			}
+			return '';
+		},
+		repaymentDateCopy() {
+			if (this.repaymentInterval === 'at_end') {
+				return `Expected repayment ${this.repaymentDate}`;
+			}
+			return `First expected repayment ${this.repaymentDate}`;
 		},
 		isInBasket() {
 			// eslint-disable-next-line no-underscore-dangle
@@ -861,12 +875,7 @@ export default {
 		}
 	},
 	mounted() {
-		if (this.repaymentEnabled) {
-			this.loopItemTurn = 1;
-		}
-		this.determineIfMobile();
 		this.createWrapperObserver();
-		this.cycleStatsSlot();
 	},
 	beforeDestroy() {
 		this.destroyWrapperObserver();

--- a/src/components/BorrowerProfile/LoanDescription.vue
+++ b/src/components/BorrowerProfile/LoanDescription.vue
@@ -10,15 +10,7 @@
 				{{ borrowerOrGroupName }}'s story
 			</h2>
 		</div>
-		<div v-if="chunkedStoryEnabled">
-			<p class="tw-my-4 tw-truncate">
-				{{ storyDescription.slice(0, 260) }}...
-			</p>
-			<kv-text-link @click="readMore = true">
-				Read more about {{ borrowerOrGroupName }}
-			</kv-text-link>
-		</div>
-		<div v-else class="tw-prose">
+		<div class="tw-prose" :class="{'tw-line-clamp-3': truncateBody}">
 			<section v-if="storyDescription">
 				<p
 					v-for="(paragraph, index) in storyDescriptionParagraphs"
@@ -79,6 +71,14 @@
 				</p>
 			</section>
 		</div>
+		<button
+			class="tw-text-link tw-mt-1"
+			@click="readMore = true"
+			v-show="showReadMore"
+			v-kv-track-event="['borrower-profile', 'click', 'loan-story', 'read-more']"
+		>
+			Read more about {{ borrowerOrGroupName }}
+		</button>
 		<kv-lightbox
 			data-testid="bp-lightbox-story-translate-original-language"
 			:visible="isLightboxVisible"
@@ -100,14 +100,12 @@
 import { toParagraphs } from '@/util/loanUtils';
 import previousLoanDescription from '@/components/BorrowerProfile/PreviousLoanDescription';
 import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
-import KvTextLink from '~/@kiva/kv-components/vue/KvTextLink';
 
 export default {
 	name: 'LoanDescription',
 	components: {
 		KvLightbox,
 		previousLoanDescription,
-		KvTextLink
 	},
 	props: {
 		partnerName: { // LoanPartner.partnerName
@@ -200,9 +198,12 @@ export default {
 		showReviewersName() {
 			return this.reviewer?.showName;
 		},
-		chunkedStoryEnabled() {
+		truncateBody() {
 			return this.enabledExperimentVariant && !this.readMore;
-		}
+		},
+		showReadMore() {
+			return this.enabledExperimentVariant && !this.readMore;
+		},
 	},
 	methods: {
 		openLightbox() {

--- a/src/components/BorrowerProfile/LoanStory.vue
+++ b/src/components/BorrowerProfile/LoanStory.vue
@@ -34,7 +34,7 @@
 				:key="statement.id" class="tw-flex tw-justify-around tw-mb-3 tw-gap-2"
 			>
 				<img class="tw-w-10 tw-h-10" alt="High five" :src="imageRequire(`./${statement.image}.svg`)">
-				<div>
+				<div class="tw-flex-grow">
 					<p class="tw-text-h3">
 						{{ statement.headline }}
 					</p>
@@ -248,7 +248,7 @@ export default {
 			return statements.filter(x => !!x);
 		},
 		calculateStatementRank() {
-			if (this.tags.includes('#Eco-friendly') || this.tags.includes('#Sustainable Ag')) {
+			if (this.tags?.includes('#Eco-friendly') || this.tags?.includes('#Sustainable Ag')) {
 				return {
 					id: '5',
 					headline: 'Supports climate action',
@@ -283,7 +283,7 @@ export default {
 					image: 'water'
 				};
 			}
-			if (this.loan?.gender === 'female') {
+			if (this.gender === 'female') {
 				return {
 					id: '9',
 					headline: 'Promotes gender equality',

--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -1,19 +1,20 @@
 <template>
 	<section>
-		<div class="tw-prose tw-break-words">
-			<h2 data-testid="bp-more-about-header">
-				More about this loan
-			</h2>
-			<div v-if="partnerName && !loading">
-				<p v-if="!partnerNameNA" data-testid="bp-more_about-facilitated">
-					This loan is facilitated by our Field Partner, {{ partnerName }}.
-					Field Partners are local organizations working in communities to vet
-					borrowers, provide services, and administer loans on the ground.
-				</p>
+		<h2 data-testid="bp-more-about-header">
+			More about this loan
+		</h2>
+		<div ref="body" :class="{'tw-line-clamp-3': truncateBody}">
+			<div class="tw-prose tw-break-words">
+				<div v-if="partnerName && !loading">
+					<p v-if="!partnerNameNA" data-testid="bp-more_about-facilitated">
+						This loan is facilitated by our Field Partner, {{ partnerName }}.
+						Field Partners are local organizations working in communities to vet
+						borrowers, provide services, and administer loans on the ground.
+					</p>
 
-				<template v-if="!enabledExperimentVariant && !readMore">
 					<div v-html="moreInfoAboutLoan" data-testid="bp-more-about-info">
 					</div>
+
 					<div v-if="loanAlertText" data-testid="bp-more-about-alert-text">
 						<h3>
 							About {{ partnerName }}:
@@ -31,72 +32,75 @@
 						<div v-html="dualStatementNote">
 						</div>
 					</div>
-				</template>
-				<template v-else>
-					<kv-text-link @click="readMore = true">
-						Read more
-					</kv-text-link>
-				</template>
+				</div>
 			</div>
-		</div>
-		<div v-if="!partnerName && !loading">
-			<div class="tw-prose tw-mb-2">
-				<h3>
-					Business description
-				</h3>
-				<div
-					data-testid="bp-more-about-direct-description"
-					key="businessDescription"
-					v-html="this.businessDescription"
-				>
+			<div v-if="!partnerName && !loading">
+				<div class="tw-prose tw-mb-2">
+					<h3>
+						Business description
+					</h3>
+					<div
+						data-testid="bp-more-about-direct-description"
+						key="businessDescription"
+						v-html="this.businessDescription"
+					>
+					</div>
+				</div>
+
+				<borrower-business-details
+					class="tw-mb-2"
+					:borrower-business-name="borrowerBusinessName"
+					:sector="sector"
+					:social-links="socialLinks"
+					:years-in-business="yearsInBusiness"
+					:loan-id="loanId"
+				/>
+
+				<div class="tw-prose" data-testid="bp-direct-loan-purpose">
+					<h3>
+						What is the purpose of this loan?
+					</h3>
+					<div
+						key="purpose"
+						v-html="this.purpose"
+					>
+					</div>
 				</div>
 			</div>
 
-			<borrower-business-details
-				class="tw-mb-2"
-				:borrower-business-name="borrowerBusinessName"
-				:sector="sector"
-				:social-links="socialLinks"
-				:years-in-business="yearsInBusiness"
-				:loan-id="loanId"
-			/>
-
-			<div class="tw-prose" data-testid="bp-direct-loan-purpose">
-				<h3>
-					What is the purpose of this loan?
-				</h3>
-				<div
-					key="purpose"
-					v-html="this.purpose"
-				>
+			<div
+				v-if="loading"
+			>
+				<kv-loading-placeholder
+					class="tw-mb-2" :style="{width: 60 + (Math.random() * 15) + '%', height: '1.6rem'}"
+				/>
+				<div v-for="i in 5" :key="`${i}pl1`">
+					<kv-loading-placeholder
+						class="tw-w-full tw-mb-1"
+						:style="{width: 80 + (Math.random() * 15) + '%', height: '1rem'}"
+					/>
 				</div>
+				<br>
+				<kv-loading-placeholder
+					class="tw-mb-2" :style="{width: 60 + (Math.random() * 15) + '%', height: '1.6rem'}"
+				/>
+				<div v-for="i in 5" :key="`${i}pl2`">
+					<kv-loading-placeholder
+						class="tw-w-full tw-mb-1"
+						:style="{width: 80 + (Math.random() * 15) + '%', height: '1rem'}"
+					/>
+				</div>
+				<br>
 			</div>
 		</div>
-
-		<div
-			v-if="loading"
+		<button
+			class="tw-text-link tw-mt-1"
+			@click="readMore = true"
+			v-show="showReadMore"
+			v-kv-track-event="['borrower-profile', 'click', 'more-about-loan', 'read-more']"
 		>
-			<kv-loading-placeholder
-				class="tw-mb-2" :style="{width: 60 + (Math.random() * 15) + '%', height: '1.6rem'}"
-			/>
-			<div v-for="i in 5" :key="`${i}pl1`">
-				<kv-loading-placeholder
-					class="tw-w-full tw-mb-1"
-					:style="{width: 80 + (Math.random() * 15) + '%', height: '1rem'}"
-				/>
-			</div>
-			<br>
-			<kv-loading-placeholder
-				class="tw-mb-2" :style="{width: 60 + (Math.random() * 15) + '%', height: '1.6rem'}"
-			/>
-			<div v-for="i in 5" :key="`${i}pl2`">
-				<kv-loading-placeholder
-					class="tw-w-full tw-mb-1"
-					:style="{width: 80 + (Math.random() * 15) + '%', height: '1rem'}"
-				/>
-			</div>
-			<br>
-		</div>
+			Read more
+		</button>
 	</section>
 </template>
 
@@ -106,7 +110,6 @@ import { createIntersectionObserver } from '@/util/observerUtils';
 import BorrowerBusinessDetails from '@/components/BorrowerProfile/BorrowerBusinessDetails';
 // TODO: replace the loading placeholder with component from kv-components when available.
 import KvLoadingPlaceholder from '@/components/Kv/KvLoadingPlaceholder';
-import KvTextLink from '~/@kiva/kv-components/vue/KvTextLink';
 
 export default {
 	name: 'MoreAboutLoan',
@@ -114,7 +117,6 @@ export default {
 	components: {
 		BorrowerBusinessDetails,
 		KvLoadingPlaceholder,
-		KvTextLink
 	},
 	props: {
 		loanId: {
@@ -162,7 +164,13 @@ export default {
 			return this.partnerName.indexOf('N/A') > -1
 				|| this.partnerName.indexOf('N/a') > -1
 				|| this.partnerName.indexOf('n/a') > -1;
-		}
+		},
+		truncateBody() {
+			return this.enabledExperimentVariant && !this.readMore;
+		},
+		showReadMore() {
+			return this.enabledExperimentVariant && !this.readMore;
+		},
 	},
 	methods: {
 		createObserver() {

--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -7,9 +7,14 @@
 			<div class="tw-prose tw-break-words">
 				<div v-if="partnerName && !loading">
 					<p v-if="!partnerNameNA" data-testid="bp-more_about-facilitated">
-						This loan is facilitated by our Field Partner, {{ partnerName }}.
-						Field Partners are local organizations working in communities to vet
-						borrowers, provide services, and administer loans on the ground.
+						<template v-if="enabledExperimentVariant">
+							This loan is facilitated by our Lending Partner, {{ partnerName }}.
+						</template>
+						<template v-else>
+							This loan is facilitated by our Field Partner, {{ partnerName }}.
+							Field Partners are local organizations working in communities to vet
+							borrowers, provide services, and administer loans on the ground.
+						</template>
 					</p>
 
 					<div v-html="moreInfoAboutLoan" data-testid="bp-more-about-info">

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -83,7 +83,7 @@
 			</div>
 			<content-container>
 				<div
-					v-if="enabledExperimentVariant"
+					v-if="enabledExperimentVariant && !partnerNameNA"
 					class="tw-rounded tw-bg-white tw-px-2 md:tw-px-4 tw-py-3 tw-mb-5 tw-flex tw-gap-2"
 				>
 					<div>
@@ -624,6 +624,11 @@ export default {
 	computed: {
 		enabledExperimentVariant() {
 			return this.userContextExpVariant === 'a';
+		},
+		partnerNameNA() {
+			return this.partnerName.indexOf('N/A') > -1
+				|| this.partnerName.indexOf('N/a') > -1
+				|| this.partnerName.indexOf('n/a') > -1;
 		},
 		vettedHeadline() {
 			if (this.isoCode === 'US') {

--- a/src/util/experimentUtils.js
+++ b/src/util/experimentUtils.js
@@ -77,12 +77,31 @@ export function matchTargets(targets, cookieStore) {
 	// User Segment Targets
 	if (typeof targets.users !== 'undefined') {
 		const kvu = cookieStore.get('kvu');
+		const kvuLb = cookieStore.get('kvu_lb');
+		const kvuDb = cookieStore.get('kvu_db');
+
 		// target cookied users only - kvu cookie is present
 		if (kvu && targets.users.indexOf('cookied') > -1) {
 			matched = true;
 		}
 		// target new or existing users without kvu cookie
 		if (!kvu && targets.users.indexOf('uncookied') > -1) {
+			matched = true;
+		}
+		// target users who have lent
+		if (kvuLb === 'true' && targets.users.indexOf('lender') > -1) {
+			matched = true;
+		}
+		// target users who have not lent
+		if (kvuLb !== 'true' && targets.users.indexOf('non-lender') > -1) {
+			matched = true;
+		}
+		// target users who have deposited
+		if (kvuDb === 'true' && targets.users.indexOf('depositor') > -1) {
+			matched = true;
+		}
+		// target users who have not deposited
+		if (kvuDb !== 'true' && targets.users.indexOf('non-depositor') > -1) {
 			matched = true;
 		}
 	}

--- a/test/unit/specs/util/experimentUtils.spec.js
+++ b/test/unit/specs/util/experimentUtils.spec.js
@@ -87,6 +87,8 @@ describe('experimentUtils.js', () => {
 			expect(matchTargets({})).toBe(false);
 		});
 
+		// Cookied/uncookied
+
 		it('Returns true when cookied users are targeted and the kvu cookie exists', () => {
 			const cookieStore = new CookieStore({ kvu: 'user id' });
 			expect(matchTargets({ users: ['cookied'] }, cookieStore)).toBe(true);
@@ -103,6 +105,66 @@ describe('experimentUtils.js', () => {
 
 		it('Returns true when uncookied users are targeted and the kvu cookie does not exist', () => {
 			expect(matchTargets({ users: ['uncookied'] }, new CookieStore())).toBe(true);
+		});
+
+		// Lender/non-lender
+
+		it('Returns false when lenders are targeted and the kvu_lb cookie does not exist', () => {
+			expect(matchTargets({ users: ['lender'] }, new CookieStore())).toBe(false);
+		});
+
+		it('Returns false when lenders are targeted and the kvu_lb cookie exists and is \'false\'', () => {
+			const cookieStore = new CookieStore({ kvu_lb: 'false' });
+			expect(matchTargets({ users: ['lender'] }, cookieStore)).toBe(false);
+		});
+
+		it('Returns true when lenders are targeted and the kvu_lb cookie exists and is \'true\'', () => {
+			const cookieStore = new CookieStore({ kvu_lb: 'true' });
+			expect(matchTargets({ users: ['lender'] }, cookieStore)).toBe(true);
+		});
+
+		it('Returns true when non-lenders are targeted and the kvu_lb cookie does not exist', () => {
+			expect(matchTargets({ users: ['non-lender'] }, new CookieStore())).toBe(true);
+		});
+
+		it('Returns true when non-lenders are targeted and the kvu_lb cookie exists and is \'false\'', () => {
+			const cookieStore = new CookieStore({ kvu_lb: 'false' });
+			expect(matchTargets({ users: ['non-lender'] }, cookieStore)).toBe(true);
+		});
+
+		it('Returns false when non-lenders are targeted and the kvu_lb cookie exists and is \'true\'', () => {
+			const cookieStore = new CookieStore({ kvu_lb: 'true' });
+			expect(matchTargets({ users: ['non-lender'] }, cookieStore)).toBe(false);
+		});
+
+		// Depositor/non-depositor
+
+		it('Returns false when depositors are targeted and the kvu_db cookie does not exist', () => {
+			expect(matchTargets({ users: ['depositor'] }, new CookieStore())).toBe(false);
+		});
+
+		it('Returns false when depositors are targeted and the kvu_db cookie exists and is \'false\'', () => {
+			const cookieStore = new CookieStore({ kvu_db: 'false' });
+			expect(matchTargets({ users: ['depositor'] }, cookieStore)).toBe(false);
+		});
+
+		it('Returns true when depositors are targeted and the kvu_db cookie exists and is \'true\'', () => {
+			const cookieStore = new CookieStore({ kvu_db: 'true' });
+			expect(matchTargets({ users: ['depositor'] }, cookieStore)).toBe(true);
+		});
+
+		it('Returns true when non-depositors are targeted and the kvu_db cookie does not exist', () => {
+			expect(matchTargets({ users: ['non-depositor'] }, new CookieStore())).toBe(true);
+		});
+
+		it('Returns true when non-depositors are targeted and the kvu_db cookie exists and is \'false\'', () => {
+			const cookieStore = new CookieStore({ kvu_db: 'false' });
+			expect(matchTargets({ users: ['non-depositor'] }, cookieStore)).toBe(true);
+		});
+
+		it('Returns false when non-depositors are targeted and the kvu_db cookie exists and is \'true\'', () => {
+			const cookieStore = new CookieStore({ kvu_db: 'true' });
+			expect(matchTargets({ users: ['non-depositor'] }, cookieStore)).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
Fixes and updates after product review:

- Expand experiment target matching ability with depositor and lender checks instead of checking that in vue components
- Change how the stats slot is cycled through to make it easier to add and remove items or change the conditions for when items display
- Use `expectedPayments` for repayment date when available
- Estimate first repayment date for loans without an expected payment date yet (non-disbursed loans)
- Drop 'First' language when there is only 1 payment (`repaymentInterval === 'at_end'`)
- Track what repayment date is displayed to the user
- Use line-clamp for truncating loan story and 'more about this loan' sections instead of character count
- Track when users click the 'read more' buttons
- A couple typo fixes