### PR TITLE
Vue 1407 saved search doesnt refresh in lend menu

### DIFF
--- a/src/components/WwwFrame/LendMenu/MonthlyGoodExpMenuWrapper.vue
+++ b/src/components/WwwFrame/LendMenu/MonthlyGoodExpMenuWrapper.vue
@@ -51,7 +51,6 @@ export default {
 	},
 	methods: {
 		onBorrowerMenuShow() {
-			this.$refs.lendMenuDesktop.onOpen();
 			this.$kvTrackEvent('TopNav', 'hover-Borrower-menu', 'Find a borrower');
 		},
 		onBorrowerMenuHide() {

--- a/src/components/WwwFrame/LendMenu/TheLendMenu.vue
+++ b/src/components/WwwFrame/LendMenu/TheLendMenu.vue
@@ -124,7 +124,7 @@ export default {
 			this.$refs.list.onClose();
 			this.$refs.mega.onClose();
 		},
-		onLoad() {
+		async onLoad() {
 			this.apollo.watchQuery({
 				query: gql`query countryFacets {
 					lend {
@@ -152,23 +152,22 @@ export default {
 					this.isChannelsLoading = false;
 				}
 			});
+
+			if (this.hasUserId) {
+				const { data } = await this.apollo.query({
+					query: privateLendMenuQuery,
+					variables: {
+						userId: this.userId,
+					},
+					fetchPolicy: 'network-only',
+				});
+
+				this.favoritesCount = data?.lend?.loans?.totalCount ?? 0;
+				this.savedSearches = data?.my?.savedSearches?.values ?? [];
+			}
 		},
 	},
 	mounted() {
-		if (this.hasUserId) {
-			this.apollo.watchQuery({
-				query: privateLendMenuQuery,
-				variables: {
-					userId: this.userId,
-				},
-			}).subscribe({
-				next: ({ data }) => {
-					this.favoritesCount = data?.lend?.loans?.totalCount ?? 0;
-					this.savedSearches = data?.my?.savedSearches?.values ?? [];
-				}
-			});
-		}
-
 		// CORE-641 NEW MG ENTRYPOINT
 		// this experiment is assigned in experimentPreFetch.js
 		const newMgEntrypointExperiment = this.apollo.readFragment({

--- a/src/components/WwwFrame/LendMenu/TheLendMenu.vue
+++ b/src/components/WwwFrame/LendMenu/TheLendMenu.vue
@@ -35,7 +35,7 @@ import _groupBy from 'lodash/groupBy';
 import _map from 'lodash/map';
 import _sortBy from 'lodash/sortBy';
 import gql from 'graphql-tag';
-
+import logReadQueryError from '@/util/logReadQueryError';
 import { indexIn } from '@/util/comparators';
 import publicLendMenuQuery from '@/graphql/query/lendMenuData.graphql';
 import privateLendMenuQuery from '@/graphql/query/lendMenuPrivateData.graphql';
@@ -121,14 +121,11 @@ export default {
 		},
 	},
 	methods: {
-		onOpen() {
-			this.$refs?.mega?.onOpen?.();
-		},
 		onClose() {
 			this.$refs.list.onClose();
 			this.$refs.mega.onClose();
 		},
-		onLoad() {
+		async onLoad() {
 			this.apollo.watchQuery({
 				query: gql`query countryFacets {
 					lend {
@@ -149,35 +146,36 @@ export default {
 					this.isRegionsLoading = false;
 				}
 			});
+
 			this.apollo.watchQuery({ query: publicLendMenuQuery }).subscribe({
 				next: ({ data }) => {
 					this.categories = _get(data, 'lend.loanChannels.values');
 					this.isChannelsLoading = false;
 				}
 			});
+
+			if (this.hasUserId) {
+				try {
+					const { data } = await this.apollo.query({
+						query: privateLendMenuQuery,
+						variables: {
+							userId: this.userId,
+						},
+						fetchPolicy: 'network-only',
+					});
+
+					this.favoritesCount = data?.lend?.loans?.totalCount;
+					this.savedSearches = data?.my?.savedSearches?.values;
+				} catch (e) {
+					this.favoritesCount = 0;
+					this.savedSearches = [];
+
+					logReadQueryError(e, 'TheLendMenu privateLendMenuQuery');
+				}
+			}
 		},
 	},
 	mounted() {
-		if (this.hasUserId) {
-			this.apollo.query({
-				query: privateLendMenuQuery,
-				variables: {
-					userId: this.userId,
-				}
-			}).then(({ data, errors }) => {
-				if (!errors) {
-					this.favoritesCount = _get(data, 'lend.loans.totalCount');
-					this.savedSearches = _get(data, 'my.savedSearches.values');
-				} else {
-					this.favoritesCount = 0;
-					this.savedSearches = [];
-				}
-			}).finally(() => {
-				// data might have changed since the initial render, so trigger any needed updates
-				this.onOpen();
-			});
-		}
-
 		// CORE-641 NEW MG ENTRYPOINT
 		// this experiment is assigned in experimentPreFetch.js
 		const newMgEntrypointExperiment = this.apollo.readFragment({

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -669,6 +669,8 @@ export default {
 	},
 	methods: {
 		toggleLendMenu(immediate = false) {
+			const wasVisible = this.isLendMenuVisible;
+
 			if (immediate) {
 				// if touch, toggle immediately
 				this.isLendMenuVisible = !this.isLendMenuVisible;
@@ -685,7 +687,9 @@ export default {
 					}
 				}, 500);
 			}
-			if (this.isLendMenuVisible) {
+
+			// If the menu was previously hidden and is now visible, run onLoad
+			if (!wasVisible && this.isLendMenuVisible) {
 				this.$refs?.lendMenu?.onLoad?.();
 			}
 		},

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -669,6 +669,11 @@ export default {
 	},
 	methods: {
 		toggleLendMenu(immediate = false) {
+			if (!this.isLendMenuVisible) {
+				// If menu was previously hidden, run menu onLoad
+				this.$refs?.lendMenu?.onLoad?.();
+			}
+
 			if (immediate) {
 				// if touch, toggle immediately
 				this.isLendMenuVisible = !this.isLendMenuVisible;
@@ -684,9 +689,6 @@ export default {
 						this.isLendMenuVisible = false;
 					}
 				}, 500);
-			}
-			if (this.isLendMenuVisible) {
-				this.$refs?.lendMenu?.onLoad?.();
 			}
 		},
 		onLendLinkPointerEnter(e) {

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -669,11 +669,6 @@ export default {
 	},
 	methods: {
 		toggleLendMenu(immediate = false) {
-			if (!this.isLendMenuVisible) {
-				// If menu was previously hidden, run menu onLoad
-				this.$refs?.lendMenu?.onLoad?.();
-			}
-
 			if (immediate) {
 				// if touch, toggle immediately
 				this.isLendMenuVisible = !this.isLendMenuVisible;
@@ -689,6 +684,9 @@ export default {
 						this.isLendMenuVisible = false;
 					}
 				}, 500);
+			}
+			if (this.isLendMenuVisible) {
+				this.$refs?.lendMenu?.onLoad?.();
 			}
 		},
 		onLendLinkPointerEnter(e) {

--- a/src/util/loanSearch/searchStateUtils.js
+++ b/src/util/loanSearch/searchStateUtils.js
@@ -59,6 +59,6 @@ export async function createSavedSearch(apollo, loanQueryFilters, queryString, s
 			name: savedSearchName,
 			queryString,
 			filters: loanQueryFilters
-		},
+		}
 	});
 }

--- a/src/util/loanSearch/searchStateUtils.js
+++ b/src/util/loanSearch/searchStateUtils.js
@@ -1,5 +1,6 @@
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
 import createSavedSearchMutation from '@/graphql/mutation/createSavedSearch.graphql';
+import privateLendMenuQuery from '@/graphql/query/lendMenuPrivateData.graphql';
 import filterConfig from '@/util/loanSearch/filterConfig';
 
 /**
@@ -59,6 +60,7 @@ export async function createSavedSearch(apollo, loanQueryFilters, queryString, s
 			name: savedSearchName,
 			queryString,
 			filters: loanQueryFilters
-		}
+		},
+		refetchQueries: [{ query: privateLendMenuQuery }],
 	});
 }

--- a/src/util/loanSearch/searchStateUtils.js
+++ b/src/util/loanSearch/searchStateUtils.js
@@ -1,6 +1,5 @@
 import updateLoanSearchMutation from '@/graphql/mutation/updateLoanSearchState.graphql';
 import createSavedSearchMutation from '@/graphql/mutation/createSavedSearch.graphql';
-import privateLendMenuQuery from '@/graphql/query/lendMenuPrivateData.graphql';
 import filterConfig from '@/util/loanSearch/filterConfig';
 
 /**
@@ -61,6 +60,5 @@ export async function createSavedSearch(apollo, loanQueryFilters, queryString, s
 			queryString,
 			filters: loanQueryFilters
 		},
-		refetchQueries: [{ query: privateLendMenuQuery }],
 	});
 }


### PR DESCRIPTION
https://kiva.atlassian.net/browse/VUE-1407

- I investigated updating the Apollo cache again, but ran into the same general issue: the bookmark query needs the user ID, and some bookmark mutations are ran by loan card controller, which doesn't have the user ID and is used in a bunch of places
- This solution is a safer version of my previous PR - it still only runs `onLoad` when the lend menu was previously closed, but it uses the updated version of `isLendMenuVisible`
- Previously the `onLoad` was being ran every time a user hovers over the lend menu button in the header, regardless of whether it was open - the existing watch queries ran each time (pulling from cache) - getting the new data needs to skip the cache, so that existing behavior was sending off a network query with each hover - this solution resolves that