### PR TITLE
feat: spacing and alignment pass on order totals line items

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -667,7 +667,7 @@
 			</div>
 		</template>
 		<template v-if="donateItemExperimentVersion === 'e' && orderTotalVariant && hasLoans">
-			<div class="tw-flex tw-flex-col tw-w-full tw-pb-4">
+			<div class="tw-flex tw-flex-col tw-w-full tw-pb-2">
 				<div class="tw-flex tw-flex-row tw-w-full">
 					<!-- donation text -->
 					<div class="tw-w-auto tw-text-left md:tw-text-right tw-flex-1">
@@ -681,25 +681,24 @@
 
 					<!-- donation total -->
 					<div
-						class="tw-flex-none tw-w-auto"
+						v-show="!editDonation"
+						class="tw-block tw-text-right"
 					>
-						<div
-							v-show="!editDonation"
-							class="tw-block tw-text-right tw-ml-1"
+						<button
+							class="donation-amount tw-text-h3 tw-flex"
+							data-testid="basket-donation-edit-button-combined"
+							v-kv-track-event="['basket', 'Edit Donation']"
+							@click="enterEditDonation"
+							title="Edit Donation"
 						>
-							<button
-								class="donation-amount tw-text-h3"
-								data-testid="basket-donation-edit-button-combined"
-								v-kv-track-event="['basket', 'Edit Donation']"
-								@click="enterEditDonation"
-								title="Edit Donation"
-							>
+							<div class="tw-text-right tw-inline-block tw-pl-2">
 								{{ formattedAmount }}
-								<kv-material-icon
-									role="img"
-									aria-label="Edit Donation"
-									title="Edit Donation"
-									class="edit-donation
+							</div>
+							<kv-material-icon
+								role="img"
+								aria-label="Edit Donation"
+								title="Edit Donation"
+								class="edit-donation
 											tw-text-action
 											tw-w-2.5
 											tw-ml-2
@@ -707,42 +706,41 @@
 											tw-py-0.5
 											tw-align-bottom
 									"
-									name="pencil"
-									:icon="mdiPencil"
-								/>
-							</button>
-						</div>
-						<div v-show="editDonation" class="small-12 columns donation-amount-input-wrapper">
-							<kv-text-input
-								class="donation-amount-input"
-								data-testid="basket-donation-edit-input"
-								name="donation"
-								id="donation"
-								v-model="amount"
-								@blur="validateInput"
-								@keyup.enter.prevent="updateDonation()"
+								name="pencil"
+								:icon="mdiPencil"
 							/>
-							<kv-button
-								variant="secondary"
-								class="update-donation-inline-button"
-								data-testid="basket-donation-edit-submit"
-								@click="updateDonation()"
-							>
-								Update
-							</kv-button>
-							<button
-								class="show-for-medium remove-wrapper"
-								@click="updateLoanAmount('remove')"
-								data-testid="basket-donation-remove"
-							>
-								<kv-material-icon
-									class="remove-x tw-text-tertiary"
-									name="small-x"
-									:from-sprite="true"
-									title="Remove donation"
-								/>
-							</button>
-						</div>
+						</button>
+					</div>
+					<div v-show="editDonation" class="donation-amount-input-wrapper">
+						<kv-text-input
+							class="donation-amount-input"
+							data-testid="basket-donation-edit-input"
+							name="donation"
+							id="donation"
+							v-model="amount"
+							@blur="validateInput"
+							@keyup.enter.prevent="updateDonation()"
+						/>
+						<kv-button
+							variant="secondary"
+							class="update-donation-inline-button"
+							data-testid="basket-donation-edit-submit"
+							@click="updateDonation()"
+						>
+							Update
+						</kv-button>
+						<button
+							class="show-for-medium remove-wrapper"
+							@click="updateLoanAmount('remove')"
+							data-testid="basket-donation-remove"
+						>
+							<kv-material-icon
+								class="remove-x tw-text-tertiary"
+								name="small-x"
+								:from-sprite="true"
+								title="Remove donation"
+							/>
+						</button>
 					</div>
 				</div>
 

--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -1,85 +1,122 @@
 <template>
-	<div class="order-totals" data-testid="basket-order-totals-section">
+	<div class="tw-mb-1" data-testid="basket-order-totals-section">
 		<div
 			v-if="showPromoCreditTotal"
-			class="order-total tw-text-left md:tw-text-right"
+			class="tw-flex tw-flex-row tw-w-full tw-mb-2 tw-text-h3"
 			data-testid="basket-order-total"
 		>
-			<strong>Order Total: <span class="total-value">{{ itemTotal }}</span></strong>
+			<div class="tw-w-auto tw-text-left md:tw-text-right tw-flex-1">
+				Order Total:
+			</div>
+			<span class="tw-float-right md:tw-float-none tw-text-right tw-pl-2">
+				{{ itemTotal }}</span>
+			<!-- icon spacer -->
+			<span class="tw-w-4.5"></span>
 		</div>
+
+		<!-- variant e on donate item experiment -->
+		<donation-item
+			v-if="donateItemExperimentVersion === 'e' && Number(totals.loanReservationTotal) > 0 "
+			data-testid="basket-donation"
+			:donation="donationObject"
+			:order-total-variant="donateItemExperimentVersion === 'e'"
+			:loan-count="Number(totals.loanReservationTotal) > 0 ? 1 : 0"
+			:loan-reservation-total="Number(totals.loanReservationTotal)"
+			@refreshtotals="$emit('refreshtotals')"
+			@updating-totals="$emit('updating-totals', $event)"
+		/>
 
 		<div
 			v-if="showKivaCredit"
-			class="kiva-credit tw-font-medium tw-mb-2 tw-text-left md:tw-text-right"
+			class="tw-flex tw-flex-row tw-w-full tw-mb-2 tw-text-h3"
 			data-testid="basket-kiva-credit"
 		>
-			<span v-if="showRemoveKivaCredit">
-				Kiva credit: <span
-					data-testid="applied-kiva-credit-amount"
-					class="total-value"
-				>({{ kivaCredit }})</span>
-			</span>
-			<span v-if="showApplyKivaCredit">
-				<del>Kiva credit:</del> <span
-					data-testid="removed-kiva-credit-amount"
-					class="total-value"
-				><del>({{ kivaCredit }})</del></span>
-			</span>
-			<button
-				v-if="showRemoveKivaCredit"
-				class="remove-credit"
-				@click="removeCredit('kiva_credit')"
-				data-testid="basket-remove-kiva-credit"
-			>
-				<kv-icon
-					class="remove-credit-icon tw-fill-current tw-text-tertiary"
-					name="small-x"
-					:from-sprite="true"
-					title="Remove Credit"
-				/>
-			</button>
-			<button
-				v-if="showApplyKivaCredit"
-				class="apply-credit tw-text-small tw-font-book"
-				@click="addCredit('kiva_credit')"
-				data-testid="basket-apply-kiva-credit"
-			>
-				Apply
-			</button>
+			<template v-if="showRemoveKivaCredit">
+				<div class="tw-w-auto tw-text-left md:tw-text-right tw-flex-1">
+					Kiva Credit:
+				</div>
+				<div
+					class="tw-flex-none tw-w-auto tw-flex tw-items-center"
+				>
+					<span
+						data-testid="applied-kiva-credit-amount"
+						class="tw-pl-2 tw-text-right tw-whitespace-nowrap"
+					>- {{ kivaCredit }}</span>
+					<button
+						v-if="showRemoveKivaCredit"
+						@click="removeCredit('kiva_credit')"
+						data-testid="basket-remove-kiva-credit"
+						class="tw-h-2.5 tw-flex"
+					>
+						<kv-material-icon
+							class="tw-text-secondary tw-ml-2 tw-w-2.5"
+							:icon="mdiClose"
+						/>
+					</button>
+				</div>
+			</template>
+			<template v-if="showApplyKivaCredit">
+				<div class="tw-w-auto tw-text-left md:tw-text-right tw-flex-1">
+					<del>Kiva Credit:</del>
+				</div>
+				<div
+					class="tw-flex-none tw-w-auto tw-flex"
+				>
+					<span
+						data-testid="removed-kiva-credit-amount"
+						class="tw-pl-2 tw-text-right tw-whitespace-nowrap"
+					><del>- {{ kivaCredit }}</del></span>
+					<button
+						class="tw-text-small tw-ml-2"
+						@click="addCredit('kiva_credit')"
+						data-testid="basket-apply-kiva-credit"
+					>
+						Apply
+					</button>
+				</div>
+			</template>
 		</div>
 
 		<div v-if="showPromoCreditTotal">
-			<div class="order-total tw-text-left md:tw-text-right" data-testid="basket-promo-total">
-				<template v-if="availablePromoTotal">
-					{{ availablePromoTotal }}
-				</template>
-				<kv-button
-					class="text-link"
-					id="promo_name"
-					data-testid="basket-promo-name"
-					v-if="promoFundDisplayName"
-				>
-					{{ promoFundDisplayName }}
-				</kv-button> promotion: <span
-					data-testid="promo-amount"
-					class="total-value"
-				>({{ appliedPromoTotal }})</span>
-				<button
-					v-if="showRemoveActivePromoCredit"
-					class="remove-credit"
-					@click="promoOptOutLightboxVisible = true"
-					data-testid="basket-remove-active-promo"
-				>
-					<kv-icon
-						class="remove-credit-icon tw-fill-current tw-text-tertiary"
-						name="small-x"
-						:from-sprite="true"
-						title="Remove Credit"
-					/>
-				</button>
+			<div
+				class="tw-text-h3 tw-mb-2 tw-text-left md:tw-text-right
+			tw-flex tw-justify-end tw-items-center" data-testid="basket-promo-total"
+			>
+				<span class="tw-w-full">
+					<template v-if="availablePromoTotal">
+						{{ availablePromoTotal }}
+					</template>
+					<span
+						class="tw-text-brand"
+						id="promo_name"
+						data-testid="basket-promo-name"
+						v-if="promoFundDisplayName"
+					>
+						{{ promoFundDisplayName }}
+					</span> promotion:
+				</span>
+
+				<div class="tw-flex tw-items-center">
+					<span
+						data-testid="promo-amount"
+						class="tw-pl-2 tw-text-right tw-whitespace-nowrap"
+					>- {{ appliedPromoTotal }}</span>
+					<button
+						v-if="showRemoveActivePromoCredit"
+						@click="promoOptOutLightboxVisible = true"
+						data-testid="basket-remove-active-promo"
+						class="tw-h-2.5 tw-flex"
+					>
+						<kv-material-icon
+							class="tw-text-secondary tw-ml-2 tw-w-2.5"
+							:icon="mdiClose"
+						/>
+					</button>
+				</div>
+
 				<button
 					v-if="showApplyActivePromoCredit"
-					class="apply-credit tw-text-small"
+					class="tw-text-small tw-ml-2"
 					@click="applyPromoCredit"
 					data-testid="basket-apply-active-promo"
 				>
@@ -107,36 +144,38 @@
 			<matched-loan-kiva-credit :open-lightbox="openLightbox" />
 		</div>
 
-		<!-- variant e on donate item experiment -->
-		<donation-item
-			v-if="donateItemExperimentVersion === 'e' && Number(totals.loanReservationTotal) > 0 "
-			data-testid="basket-donation"
-			:donation="donationObject"
-			:order-total-variant="donateItemExperimentVersion === 'e'"
-			:loan-count="Number(totals.loanReservationTotal) > 0 ? 1 : 0"
-			:loan-reservation-total="Number(totals.loanReservationTotal)"
-			@refreshtotals="$emit('refreshtotals')"
-			@updating-totals="$emit('updating-totals', $event)"
-		/>
-		<div class="order-total tw-text-left md:tw-text-right" data-testid="total-due">
-			<strong>
-				<template v-if="!showPromoCreditTotal">Total: </template>
-				<template v-else>Total Due: </template>
-				<span class="total-value" data-testid="basket-total-due-amount">{{ creditAmountNeeded }}</span>
-			</strong>
-		</div>
+		<div class="tw-text-h3 tw-mb-1 tw-text-right" data-testid="total-due">
+			<div class="tw-flex tw-w-full tw-justify-end tw-items-center">
+				<div class="tw-w-auto tw-text-left md:tw-text-right tw-flex-1">
+					<template v-if="!showPromoCreditTotal">
+						Total:
+					</template>
+					<template v-else>
+						Total Due:
+					</template>
+				</div>
+				<div
+					class="tw-pl-2"
+					data-testid="basket-total-due-amount"
+				>
+					{{ creditAmountNeeded }}
+				</div>
+				<!-- icon spacer -->
+				<span class="tw-w-4.5"></span>
+			</div>
 
-		<!-- Warn about removing promo credit -->
-		<verify-remove-promo-credit
-			data-testid="basket-remove-promo-verification"
-			:visible="promoOptOutLightboxVisible"
-			:applied-promo-total="appliedPromoTotal"
-			:promo-fund-display-name="promoFundDisplayName"
-			:active-credit-type="activeCreditType"
-			@credit-removed="handleCreditRemoved"
-			@updating-totals="setUpdating($event)"
-			@promo-opt-out-lightbox-closed="promoOptOutLightboxVisible = false"
-		/>
+			<!-- Warn about removing promo credit -->
+			<verify-remove-promo-credit
+				data-testid="basket-remove-promo-verification"
+				:visible="promoOptOutLightboxVisible"
+				:applied-promo-total="appliedPromoTotal"
+				:promo-fund-display-name="promoFundDisplayName"
+				:active-credit-type="activeCreditType"
+				@credit-removed="handleCreditRemoved"
+				@updating-totals="setUpdating($event)"
+				@promo-opt-out-lightbox-closed="promoOptOutLightboxVisible = false"
+			/>
+		</div>
 	</div>
 </template>
 
@@ -146,8 +185,6 @@ import logFormatter from '@/util/logFormatter';
 import addCreditByType from '@/graphql/mutation/shopAddCreditByType.graphql';
 import { removeCredit } from '@/util/checkoutUtils';
 import showVerificationLightbox from '@/graphql/mutation/checkout/showVerificationLightbox.graphql';
-import KvButton from '@/components/Kv/KvButton';
-import KvIcon from '@/components/Kv/KvIcon';
 import KvTooltip from '@/components/Kv/KvTooltip';
 import VerifyRemovePromoCredit from '@/components/Checkout/VerifyRemovePromoCredit';
 import MatchedLoanKivaCredit from '@/components/Checkout/MatchedLoanKivaCredit';
@@ -157,16 +194,18 @@ import {
 	trackExperimentVersion
 } from '@/util/experimentUtils';
 import DonationItem from '@/components/Checkout/DonationItem';
+import { mdiClose } from '@mdi/js';
+
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
 export default {
 	name: 'OrderTotals',
 	components: {
-		KvButton,
-		KvIcon,
 		KvTooltip,
 		VerifyRemovePromoCredit,
 		MatchedLoanKivaCredit,
-		DonationItem
+		DonationItem,
+		KvMaterialIcon
 	},
 	inject: ['apollo', 'cookieStore'],
 	props: {
@@ -189,6 +228,7 @@ export default {
 	},
 	data() {
 		return {
+			mdiClose,
 			promoOptOutLightboxVisible: false,
 			donateItemExperimentVersion: 'a' // control version
 		};
@@ -399,30 +439,6 @@ export default {
 @import 'settings';
 
 .order-totals {
-	.remove-credit {
-		margin-left: 0.625rem;
-	}
-
-	.remove-credit-icon {
-		width: 1.1rem;
-		height: 1.1rem;
-		vertical-align: middle;
-	}
-
-	.order-total {
-		font-size: $featured-text-font-size;
-		margin-bottom: 1rem;
-	}
-
-	.total-value {
-		display: inline-block;
-		margin-left: rem-calc(5);
-		margin-right: rem-calc(3);
-		@include breakpoint(small only) {
-			float: right;
-		}
-	}
-
 	.tooltip {
 		text-align: left;
 	}


### PR DESCRIPTION
* Move the donation line item variant up in the order totals line items
* Refactor/css cleanup, use tailwind classes
* Alignment, spacing and font size changes
* Changes parenthesis to minus signs

Before: 
<img width="1331" alt="Screen Shot 2022-12-12 at 10 05 32 AM" src="https://user-images.githubusercontent.com/4371888/207388691-0ffeb293-0397-4bea-8acf-edee14753434.png">


After:
![Screen Shot 2022-12-12 at 3 27 32 PM](https://user-images.githubusercontent.com/4371888/207388614-58643075-6e07-47a0-971e-f33cd594260a.png)
![Screen Shot 2022-12-12 at 3 25 58 PM](https://user-images.githubusercontent.com/4371888/207388618-de7da489-1488-4808-94b0-716067db2ffb.png)
