### PR TITLE
feat: add loan ids to various social share events

### DIFF
--- a/src/components/BorrowerProfile/ShareButton.vue
+++ b/src/components/BorrowerProfile/ShareButton.vue
@@ -8,6 +8,7 @@
 		:utm-content="utmContent"
 		:linked-in-title="linkedInTitle"
 		:open-lightbox="forceLightbox"
+		:loan-id="loan.id"
 	>
 		<template #modal-content>
 			<!-- eslint-disable-next-line max-len -->

--- a/src/components/Checkout/SocialShareV2.vue
+++ b/src/components/Checkout/SocialShareV2.vue
@@ -13,7 +13,7 @@
 				data-testid="share-facebook-button"
 				class="social__btn social__btn--facebook"
 				:href="facebookShareUrl"
-				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Facebook-share']"
+				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Facebook-share', selectedLoanId]"
 			>
 				<kv-icon name="facebook-round" title="Facebook" class="social__icon" />
 				<span>Share</span>
@@ -24,7 +24,7 @@
 				:href="twitterShareUrl"
 				target="_blank"
 				rel="noopener"
-				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Twitter-share']"
+				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Twitter-share', selectedLoanId]"
 				@click="$showTipMsg('Thanks for tweeting!')"
 			>
 				<kv-icon name="twitter" title="Twitter" class="social__icon" />
@@ -36,7 +36,7 @@
 				:href="linkedInShareUrl"
 				target="_blank"
 				rel="noopener"
-				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-LinkedIn-share']"
+				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-LinkedIn-share', selectedLoanId]"
 				@click="$showTipMsg('Thanks for sharing to LinkedIn!')"
 			>
 				<kv-icon name="linkedin" title="LinkedIn" class="social__icon" />
@@ -47,11 +47,11 @@
 				class="social__btn social__btn--link tw-text-link tw-border-tertiary tw-border"
 				:class="copyStatus.class"
 				:disabled="copyStatus.disabled"
-				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Copy-link-share']"
+				v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Copy-link-share', selectedLoanId]"
 				@click="copyLink"
 			>
 				<kv-icon name="clipboard" class="social__icon" />
-				<span>{{ this.copyStatus.text }}</span>
+				<span>{{ copyStatus.text }}</span>
 			</button>
 		</div>
 	</section>
@@ -105,6 +105,9 @@ export default {
 			const orderedLoans = orderBy(this.loans, ['unreservedAmount'], ['desc']);
 			return orderedLoans[0] || {};
 		},
+		selectedLoanId() {
+			return this.selectedLoan?.id ?? undefined;
+		},
 		placeholderMessage() {
 			return this.selectedLoan.name ? `Why did you lend to ${this.selectedLoan.name}?` : '';
 		},
@@ -128,8 +131,8 @@ export default {
 		},
 		shareLink() {
 			const base = `https://${this.$appConfig.host}`;
-			if (this.selectedLoan.id) {
-				return `${base}/invitedby/${this.lender.inviterName}/for/${this.selectedLoan.id}?utm_content=${this.utmContent}`; // eslint-disable-line max-len
+			if (this.selectedLoanId) {
+				return `${base}/invitedby/${this.lender.inviterName}/for/${this.selectedLoanId}?utm_content=${this.utmContent}`; // eslint-disable-line max-len
 			}
 
 			return `${base}?utm_content=${this.utmContent}&utm_campaign=social_share_checkout_scle_${this.shareCardLanguageVersion}`; // eslint-disable-line max-len
@@ -175,6 +178,12 @@ export default {
 					if (code !== '4201') {
 						this.$showTipMsg(`There was a problem sharing to Facebook: ${message}`, 'warning');
 					}
+					this.$kvTrackEvent(
+						'thanks',
+						'click-Facebook-share',
+						'error-Social-Share-Lightbox',
+						this.selectedLoanId
+					);
 				} else {
 					this.$showTipMsg('Thanks for sharing to Facebook!');
 				}

--- a/src/components/Kv/KvSocialShareButton.vue
+++ b/src/components/Kv/KvSocialShareButton.vue
@@ -29,7 +29,7 @@
 					:href="facebookShareUrl"
 					target="_blank"
 					rel="noopener"
-					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-Facebook-share']"
+					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-Facebook-share', loanId]"
 					@click="$showTipMsg('Thanks for sharing to Facebook!')"
 				>
 					<kv-material-icon
@@ -45,7 +45,7 @@
 					:href="twitterShareUrl"
 					target="_blank"
 					rel="noopener"
-					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-Twitter-share']"
+					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-Twitter-share', loanId]"
 					@click="$showTipMsg('Thanks for tweeting!')"
 				>
 					<kv-material-icon
@@ -61,7 +61,7 @@
 					:href="linkedInShareUrl"
 					target="_blank"
 					rel="noopener"
-					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-LinkedIn-share']"
+					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-LinkedIn-share', loanId]"
 					@click="$showTipMsg('Thanks for sharing to LinkedIn!')"
 				>
 					<kv-material-icon
@@ -75,14 +75,14 @@
 					class="social-button "
 					data-testid="share-copy-link-button"
 					:disabled="copyStatus.disabled"
-					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-Copy-link-share']"
+					v-kv-track-event="['Lending', 'Social-Share-Lightbox', 'click-Copy-link-share', loanId]"
 					@click="copyLink"
 				>
 					<kv-material-icon
 						class="tw-w-4.5 tw-h-4.5 tw-pointer-events-none tw-inline-block tw-align-middle"
 						:icon="mdiLink"
 					/>
-					<span class="tw-font-medium">{{ this.copyStatus.text }}</span>
+					<span class="tw-font-medium">{{ copyStatus.text }}</span>
 				</kv-button>
 			</div>
 		</kv-lightbox>
@@ -171,6 +171,11 @@ export default {
 			type: Boolean,
 			required: false
 		},
+		loanId: {
+			type: String,
+			required: false,
+			default: ''
+		},
 	},
 	data() {
 		return {
@@ -239,6 +244,12 @@ export default {
 					if (code !== '4201') {
 						this.$showTipMsg(`There was a problem sharing to Facebook: ${message}`, 'warning');
 					}
+					this.$kvTrackEvent(
+						'thanks',
+						'click-Facebook-share',
+						'error-Social-Share-Lightbox',
+						this.loanId
+					);
 				} else {
 					this.$showTipMsg('Thanks for sharing to Facebook!');
 				}

--- a/src/components/Thanks/ThanksPageShare.vue
+++ b/src/components/Thanks/ThanksPageShare.vue
@@ -1,6 +1,6 @@
 <template>
 	<div>
-		<ShareStepper :lender-name="this.lender.firstName" :show-lender-name="showLenderName" />
+		<ShareStepper :lender-name="lender.firstName" :show-lender-name="showLenderName" />
 		<div class="row page-content">
 			<div class="large-2"></div>
 			<div class="small-12 large-8 columns thanks">
@@ -79,10 +79,10 @@
 							<!-- eslint-disable-next-line max-len -->
 							<template v-if="categoryShareVersion === 'a' && categoryName">
 								<!-- eslint-disable-next-line max-len -->
-								<span class="fs-mask data-hj-suppress">{{ this.lender.firstName }}</span>, share now to find allies in the fight against economic inequity for {{ this.categoryName }}.
+								<span class="fs-mask data-hj-suppress">{{ lender.firstName }}</span>, share now to find allies in the fight against economic inequity for {{ categoryName }}.
 							</template>
 							<template v-else-if="categoryShareVersion === 'b' && categoryName">
-								More loans like yours mean more opportunities for {{ this.categoryName }}.
+								More loans like yours mean more opportunities for {{ categoryName }}.
 							</template>
 							<template v-else>
 								Can you share this loan with one more person?
@@ -91,10 +91,10 @@
 						<p class="tw-text-h3 tw-m-0 thanks__base-text">
 							<template v-if="categoryShareVersion === 'c' || !categoryName">
 								<!-- eslint-disable-next-line max-len -->
-								{{ this.loan.name }} only needs {{ calculatePeopleQtyToGoal() }} more people to lend $25 and their loan could be fully funded in a matter of hours!
+								{{ loan.name }} only needs {{ calculatePeopleQtyToGoal() }} more people to lend $25 and their loan could be fully funded in a matter of hours!
 							</template>
 							<template v-else>
-								{{ this.thanksPageBody }}
+								{{ thanksPageBody }}
 							</template>
 						</p>
 					</template>
@@ -107,7 +107,8 @@
 										data-testid="share-facebook-button"
 										class="social__btn social__btn--facebook"
 										:href="facebookShareUrl"
-										v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Facebook-share']"
+										v-kv-track-event="
+											['thanks', 'Social-Share-Lightbox', 'click-Facebook-share', loanId]"
 									>
 										<kv-icon name="facebook-round" title="Facebook" class="social__icon" />
 										<span>Share on Facebook</span>
@@ -117,7 +118,8 @@
 										class="social__btn social__btn--link tw-text-link tw-border-tertiary tw-border"
 										:class="copyStatus.class"
 										:disabled="copyStatus.disabled"
-										v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Copy-link-share']"
+										v-kv-track-event="
+											['thanks', 'Social-Share-Lightbox', 'click-Copy-link-share', loanId]"
 										@click="copyLink"
 									>
 										<kv-material-icon
@@ -125,7 +127,7 @@
 											class="social__icon"
 											:icon="mdiLink"
 										/>
-										<span>{{ this.copyStatus.text }}</span>
+										<span>{{ copyStatus.text }}</span>
 									</button>
 									<a
 										data-testid="share-twitter-button"
@@ -133,7 +135,8 @@
 										:href="twitterShareUrl"
 										target="_blank"
 										rel="noopener"
-										v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-Twitter-share']"
+										v-kv-track-event="
+											['thanks', 'Social-Share-Lightbox', 'click-Twitter-share', loanId]"
 										@click="$showTipMsg('Thanks for tweeting!')"
 									>
 										<kv-icon name="twitter" title="Twitter" class="social__icon" />
@@ -145,7 +148,8 @@
 										:href="linkedInShareUrl"
 										target="_blank"
 										rel="noopener"
-										v-kv-track-event="['thanks', 'Social-Share-Lightbox', 'click-LinkedIn-share']"
+										v-kv-track-event="
+											['thanks', 'Social-Share-Lightbox', 'click-LinkedIn-share', loanId]"
 										@click="$showTipMsg('Thanks for sharing to LinkedIn!')"
 									>
 										<kv-icon name="linkedin" title="LinkedIn" class="social__icon" />
@@ -244,6 +248,9 @@ export default {
 		};
 	},
 	computed: {
+		loanId() {
+			return this.loan?.id ?? undefined;
+		},
 		suggestedMessage() {
 			if (this.loan.name) {
 				const location = this.loan?.geocode?.city || this.loan?.geocode?.country?.name;
@@ -278,8 +285,8 @@ export default {
 				categoryShareVersion = ['a', 'b'].includes(this.categoryShareVersion)
 					? `&category_share_version=${this.categoryShareVersion}`
 					: '';
-			} else if (this.loan.id) {
-				return `${base}/invitedby/${this.lender.inviterName}/for/${this.loan.id}?utm_content=${this.utmContent}${categoryShareVersion}${lender}`; // eslint-disable-line max-len
+			} else if (this.loanId) {
+				return `${base}/invitedby/${this.lender.inviterName}/for/${this.loanId}?utm_content=${this.utmContent}${categoryShareVersion}${lender}`; // eslint-disable-line max-len
 			}
 			return `${base}?utm_content=${this.utmContent}${this.getUtmCampaignVersion}${categoryShareVersion}${lender}`; // eslint-disable-line max-len
 		},
@@ -368,25 +375,15 @@ export default {
 				if (code) {
 					// The 4201 error code means the user pressed 'Cancel', so can be ignored
 					if (code !== '4201') {
-						this.$kvTrackEvent(
-							'thanks',
-							'click-Facebook-share',
-							'error-Social-Share-Lightbox'
-						);
 						this.$showTipMsg(`There was a problem sharing to Facebook: ${message}`, 'warning');
-					} else {
-						this.$kvTrackEvent(
-							'thanks',
-							'click-Facebook-share',
-							'error-Social-Share-Lightbox'
-						);
 					}
-				} else {
 					this.$kvTrackEvent(
 						'thanks',
 						'click-Facebook-share',
-						'error-Social-Share-Lightbox'
+						'error-Social-Share-Lightbox',
+						this.loanId
 					);
+				} else {
 					this.$showTipMsg('Thanks for sharing to Facebook!');
 				}
 			}


### PR DESCRIPTION
* Also removed `this` from inside templates
* Standardized `handleFacebookResponse` method. I believe one of these was firing an error event when it should not have

ACK-495