### PR TITLE
fix: add thanks-message testid to simplify automated thanks page test

### DIFF
--- a/src/components/Thanks/ShareStepper.vue
+++ b/src/components/Thanks/ShareStepper.vue
@@ -12,7 +12,7 @@
 				</template>
 			</div>
 		</div>
-		<p class="tw-text-center tw-mt-4 tw-text-subhead">
+		<p class="tw-text-center tw-mt-4 tw-text-subhead" data-testid="thanks-message">
 			<template v-if="showLenderName">
 				<span class="fs-mask">{{ lenderName }}</span>, complete your support by sharing.
 			</template>

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -25,6 +25,7 @@
 								'tw-text-base tw-mb-0': showAutoDepositUpsell,
 								'tw-text-subhead tw-mb-2': !showAutoDepositUpsell
 							}"
+							data-testid="thanks-message"
 						>
 							Thanks for supporting <span class="fs-mask">{{ borrowerSupport }}</span>.<br>
 						</p>


### PR DESCRIPTION
Adds a test id on the 2 different thanks messages that may be shown. This will allow us to stop checking against copy that continues to change.
https://github.com/kiva/kiva-tests/pull/25