### PR TITLE
fix: redirect visits from /lp/how-kiva-works to /about/how

### DIFF
--- a/lighthouserc-dev.js
+++ b/lighthouserc-dev.js
@@ -13,7 +13,7 @@ module.exports = {
 				'http://localhost:8888/lend-by-category/women',
 				'http://localhost:8888/ui-site-map',
 				// 'http://localhost:8888/cc/kiva-universal',
-				'http://localhost:8888/lp/how-kiva-works'
+				'http://localhost:8888/about/how'
 			],
 			numberOfRuns: 5,
 		},

--- a/lighthouserc-prod.js
+++ b/lighthouserc-prod.js
@@ -17,7 +17,7 @@ module.exports = {
 				'https://www.kiva.org/lp/support-refugees',
 				'https://www.kiva.org/lptmp/support-refugees',
 				'https://www.kiva.org/lptmp/how-kiva-works',
-				'https://www.kiva.org/lp/how-kiva-works',
+				'https://www.kiva.org/about/how',
 				'https://www.kiva.org/lptmp/qw',
 				'https://www.kiva.org/lp/qw',
 				'https://www.kiva.org/design',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -31,6 +31,10 @@ module.exports = [
 		},
 	},
 	{
+		path: '/lp/how-kiva-works',
+		redirect: '/about/how'
+	},
+	{
 		path: '/about/press-center',
 		component: () => import('@/pages/ContentfulPage'),
 		meta: {


### PR DESCRIPTION
Handling any external links we can't control