### PR TITLE
Core 932 borrower profile bug

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -390,7 +390,6 @@ export default {
 		return {
 			businessName: null,
 			countryName: '',
-			loanId: Number(this.$route.params.id || 0),
 			showLenders: true,
 			showTeams: true,
 			isUrgencyExpVersionShown: false,
@@ -544,6 +543,9 @@ export default {
 		this.lender = data?.my?.userAccount ?? {};
 	},
 	computed: {
+		loanId() {
+			return Number(this.$route.params.id || 0);
+		},
 		enabledExperimentVariant() {
 			return this.userContextExpVariant === 'a';
 		},


### PR DESCRIPTION
loanId added as computed property to borrower profile page to fix the bug: 
`when you reach a fully funded borrower profile and click on any recommended borrower profiles (through their loan card) the information is incorrect.`

here to reproduce it https://www.kiva.org/lend/2456251