### PR TITLE
fix: shorten year review share title for twitter requirements

### DIFF
--- a/src/pages/Homepage/Homepage.vue
+++ b/src/pages/Homepage/Homepage.vue
@@ -179,7 +179,7 @@ export default {
 			const countries = numeral(this.$route?.query?.nyc);
 			const countryString = `${countries.format('0,0')} ${countries.value() === 1 ? 'country' : 'countries'}`;
 			return {
-				yearReviewTitle: `I helped fund the dreams of ${borrowerString} in 2022! | Kiva – Loans that change lives`, // eslint-disable-line max-len
+				yearReviewTitle: `I helped fund the dreams of ${borrowerString} in 2022! | Kiva – Changing lives`, // eslint-disable-line max-len
 				yearReviewDescription: `In 2022, I contributed to ${loanString}, helping fund the dreams of ${borrowerString} in ${countryString}. ` // eslint-disable-line max-len
 				+ 'With as little as $25, you can become a Kiva lender and help expand financial opportunity worldwide!'
 			};


### PR DESCRIPTION
Twitter stops showing the title in the preview when it gets longer than 81 characters. Their docs say that it shouldn't be longer than 70 characters, but they apparently have some wiggle room.