### PR TITLE
fix: paragraph spacing in expandable questions

### DIFF
--- a/src/components/Kv/KvExpandableQuestion.vue
+++ b/src/components/Kv/KvExpandableQuestion.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<button
-			class="tw-w-full tw-py-2 tw-flex tw-justify-between"
+			class="tw-w-full tw-py-2 tw-flex tw-justify-between tw-not-prose"
 			@click="toggleFaq"
 		>
 			<h3 class="tw-text-subhead tw-text-left">

--- a/src/components/Kv/KvFrequentlyAskedQuestions.vue
+++ b/src/components/Kv/KvFrequentlyAskedQuestions.vue
@@ -5,7 +5,7 @@
 				{{ headline }}
 			</h2>
 		</div>
-		<div v-if="questions" class="tw-divide-y tw-not-prose tw-whitespace-normal">
+		<div v-if="questions" class="tw-divide-y tw-whitespace-normal">
 			<kv-expandable-question
 				v-for="(question, index) in questions"
 				:key="index"


### PR DESCRIPTION
There was not space between paragraphs in expandable questions. This bug was introduced while working on show one answer at a time. 

## Before
<img width="969" alt="image" src="https://user-images.githubusercontent.com/56947778/210439453-f283b7dd-5cef-415c-bb21-5702e96395cf.png">

## After
<img width="978" alt="image" src="https://user-images.githubusercontent.com/56947778/210439387-ec5304c3-0bec-43bf-99ae-c6fc0f875165.png">

