### PR TITLE
fix: assigment of ACK-440 exp was not working correctly

### DIFF
--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -180,6 +180,8 @@
 </template>
 
 <script>
+import { gql } from '@apollo/client';
+
 import numeral from 'numeral';
 import logFormatter from '@/util/logFormatter';
 import addCreditByType from '@/graphql/mutation/shopAddCreditByType.graphql';
@@ -411,7 +413,17 @@ export default {
 	apollo: {
 		preFetch(config, client) {
 			return client.query({
-				query: experimentQuery, variables: { id: 'basket_donate_modules' }
+				query: gql`
+						query generalExpQuery {
+							general {
+								basket_donate_modules: uiExperimentSetting(key: "basket_donate_modules") {
+									key
+									value
+								}
+							}
+						}`
+			}).then(() => {
+				return client.query({ query: experimentQuery, variables: { id: 'basket_donate_modules' } });
 			}).catch(errorResponse => {
 				logFormatter(errorResponse, 'error');
 			});


### PR DESCRIPTION
ACK-500

This experiment was initialized in 2 components `OrderTotals` and `DonationItem` But order totals was missing the setting query. It was working and then it stopped working. 

I believe the issue is that we cannot determine the order of the prefetch of child components. This seems to be determined at build time. After the release on 12/19, it seems that OrderTotals would prefetch before DonationItem, both being children components inside the Checkout Page. 

When OrderTotals would prefetch, it would run the experiment assignment query before knowing the results of the experiment setting query and this would disable the experiment assignment all together. 