### PR TITLE
fix: qa fixes for quick filters on mvp lending page

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -91,6 +91,7 @@
 			:progress-percent="fundraisingPercent"
 			:time-left="timeLeftMessage"
 			:all-shares-reserved="allSharesReserved"
+			:use-new-progress="useNewProgress"
 		/>
 
 		<!-- LoanUse  -->
@@ -314,15 +315,9 @@ export default {
 			type: Boolean,
 			default: false
 		},
-		atcTrackingProps: {
-			type: Object,
-			default: () => {
-				return {
-					category: '',
-					action: '',
-					label: '',
-				};
-			}
+		useNewProgress: {
+			type: Boolean,
+			default: false,
 		}
 	},
 	inject: ['apollo', 'cookieStore'],
@@ -338,7 +333,7 @@ export default {
 		KvMaterialIcon,
 		SummaryTag,
 		KvUiButton,
-		ActionButton
+		ActionButton,
 	},
 	data() {
 		return {
@@ -552,13 +547,6 @@ export default {
 
 				this.$showTipMsg(msg, 'error');
 			});
-			if (this.atcTrackingProps.category) {
-				this.$kvTrackEvent(
-					this.atcTrackingProps.category,
-					this.atcTrackingProps.action,
-					this.atcTrackingProps.label
-				);
-			}
 		},
 	},
 	mounted() {

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -91,7 +91,6 @@
 			:progress-percent="fundraisingPercent"
 			:time-left="timeLeftMessage"
 			:all-shares-reserved="allSharesReserved"
-			:use-new-progress="useNewProgress"
 		/>
 
 		<!-- LoanUse  -->
@@ -314,10 +313,6 @@ export default {
 		useFullWidth: {
 			type: Boolean,
 			default: false
-		},
-		useNewProgress: {
-			type: Boolean,
-			default: false,
 		}
 	},
 	inject: ['apollo', 'cookieStore'],

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -3,7 +3,13 @@
 		<h4 class="tw-mb-0.5">
 			{{ fundingText }}
 		</h4>
+		<fundraising-status-meter
+			v-if="useNewProgress"
+			:is-funded="progressPercent === 100"
+			:percent-raised="progressPercent"
+		/>
 		<kv-progress-bar
+			v-else
 			class="tw-mb-1.5 lg:tw-mb-1"
 			aria-label="Percent the loan has funded"
 			:value="progressPercent * 100"
@@ -13,12 +19,14 @@
 
 <script>
 import numeral from 'numeral';
+import FundraisingStatusMeter from '@/components/LoanCards/FundraisingStatus/FundraisingStatusMeter';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
 
 export default {
 	name: 'LoanProgressGroup',
 	components: {
 		KvProgressBar,
+		FundraisingStatusMeter
 	},
 	props: {
 		moneyLeft: {
@@ -34,6 +42,10 @@ export default {
 			default: '',
 		},
 		allSharesReserved: {
+			type: Boolean,
+			default: false,
+		},
+		useNewProgress: {
 			type: Boolean,
 			default: false,
 		}

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -3,13 +3,7 @@
 		<h4 class="tw-mb-0.5">
 			{{ fundingText }}
 		</h4>
-		<fundraising-status-meter
-			v-if="useNewProgress"
-			:is-funded="progressPercent === 100"
-			:percent-raised="progressPercent"
-		/>
 		<kv-progress-bar
-			v-else
 			class="tw-mb-1.5 lg:tw-mb-1"
 			aria-label="Percent the loan has funded"
 			:value="progressPercent * 100"
@@ -19,14 +13,12 @@
 
 <script>
 import numeral from 'numeral';
-import FundraisingStatusMeter from '@/components/LoanCards/FundraisingStatus/FundraisingStatusMeter';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
 
 export default {
 	name: 'LoanProgressGroup',
 	components: {
 		KvProgressBar,
-		FundraisingStatusMeter
 	},
 	props: {
 		moneyLeft: {
@@ -45,10 +37,6 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		useNewProgress: {
-			type: Boolean,
-			default: false,
-		}
 	},
 	computed: {
 		fundingText() {

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -21,7 +21,6 @@
 					:show-action-button="true"
 					class="tw-mr-2"
 					style="max-width: 100%;"
-					:use-new-progress="true"
 					@add-to-basket="addToBasket"
 				/>
 			</template>

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -21,6 +21,7 @@
 					:show-action-button="true"
 					class="tw-mr-2"
 					style="max-width: 100%;"
+					:use-new-progress="true"
 					@add-to-basket="addToBasket"
 				/>
 			</template>

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -157,6 +157,9 @@ export default {
 			const params = new URLSearchParams(paramStr);
 			return `/lend/filter?${params.toString()}`;
 		},
+		// TODO: Rearchitect this at some point.
+		// This won't work for categories that have
+		// multiple criteria applied to their FLSSLoanSearch criteria.
 		async updateQuickFilters(filter) {
 			this.loanSearchState.pageOffset = 0;
 			if (filter.gender !== undefined) {

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -37,7 +37,6 @@
 				:loan-id="loan.id"
 				:show-action-button="true"
 				:use-full-width="true"
-				:use-new-progress="true"
 				@add-to-basket="addToBasket"
 			/>
 		</div>

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -37,11 +37,8 @@
 				:loan-id="loan.id"
 				:show-action-button="true"
 				:use-full-width="true"
-				:atc-tracking-props="{
-					category: 'lending-home',
-					action: 'add-to-basket',
-					label: 'quick-filters'
-				}"
+				:use-new-progress="true"
+				@add-to-basket="addToBasket"
 			/>
 		</div>
 		<div class="tw-w-full tw-my-4">
@@ -142,6 +139,9 @@ export default {
 		}
 	},
 	methods: {
+		addToBasket(payload) {
+			this.$emit('add-to-basket', payload);
+		},
 		filterPageUrl() {
 			const location = this.flssLoanSearch.countryIsoCode?.toString();
 			// parse, stringify, and undefined are all needed to ensure
@@ -172,6 +172,7 @@ export default {
 				delete this.flssLoanSearch.tagId;
 				delete this.flssLoanSearch.activityId;
 				delete this.flssLoanSearch.themeId;
+				delete this.flssLoanSearch.partnerId;
 				this.flssLoanSearch = {
 					...this.flssLoanSearch,
 					...filter

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -160,6 +160,7 @@ export default {
 		// TODO: Rearchitect this at some point.
 		// This won't work for categories that have
 		// multiple criteria applied to their FLSSLoanSearch criteria.
+		// See CORE-944
 		async updateQuickFilters(filter) {
 			this.loanSearchState.pageOffset = 0;
 			if (filter.gender !== undefined) {

--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -202,7 +202,6 @@ export default {
 			const queryMap = loanChannelQueryMapMixin.data().loanChannelQueryMap;
 			const categoryFilter = catId === 0 ? {} : queryMap
 				.find(channel => channel.id === catId)?.flssLoanSearch;
-			console.log(catId, categoryFilter);
 			if (this.presetFilterActive.women) {
 				this.resetGender();
 				this.presetFilterActive.women = false;
@@ -226,6 +225,11 @@ export default {
 				this.sortBy = 'expiringSoon';
 				this.presetFilterActive.endingSoon = true;
 			} else {
+				if (catId === 33 || catId === 96) { // mission-driven-orgs, covid-19
+				// we don't currently have this option for these categories, also irrelevant since
+				// the user has a sort by dropdown available to them
+					delete categoryFilter.sortBy;
+				}
 				this.$emit('update-filters', categoryFilter);
 			}
 

--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -109,14 +109,7 @@
 			</div>
 		</div>
 		<div class="tw-flex tw-justify-between tw-items-start tw-mt-2" v-if="withCategories">
-			<div class="tw-flex tw-flex-col md:tw-flex-row tw-items-start">
-				<span v-show="filtersLoaded" class="tw-text-small">Showing {{ totalLoans }} loans</span>
-				<!-- eslint-disable-next-line max-len -->
-				<button v-show="filtersLoaded" class="md:tw-ml-2 tw-mt-1 md:tw-mt-0 tw-text-small tw-text-action" @click="resetFilters">
-					Reset filters
-				</button>
-			</div>
-			<div id="customizedSortBySelector" class="tw-text-action tw-flex tw-items-center tw-gap-1 tw-text-small">
+			<div id="customizedSortBySelector" class="tw-text-action tw-flex tw-items-center tw-gap-1 tw-text-base">
 				<kv-material-icon :icon="mdiFilterVariant" class="tw-w-2 tw-h-2" />
 				Loan sort:
 				<kv-select
@@ -133,6 +126,13 @@
 						{{ sortType.title }}
 					</option>
 				</kv-select>
+			</div>
+			<div class="tw-flex tw-flex-col md:tw-flex-row tw-items-start">
+				<span v-show="filtersLoaded" class="tw-text-base">Showing {{ totalLoans }} loans</span>
+				<!-- eslint-disable-next-line max-len -->
+				<button v-show="filtersLoaded" class="md:tw-ml-2 tw-mt-1 md:tw-mt-0 tw-text-base tw-text-action" @click="resetFilters">
+					Reset filters
+				</button>
 			</div>
 		</div>
 	</div>
@@ -202,7 +202,7 @@ export default {
 			const queryMap = loanChannelQueryMapMixin.data().loanChannelQueryMap;
 			const categoryFilter = catId === 0 ? {} : queryMap
 				.find(channel => channel.id === catId)?.flssLoanSearch;
-
+			console.log(catId, categoryFilter);
 			if (this.presetFilterActive.women) {
 				this.resetGender();
 				this.presetFilterActive.women = false;
@@ -228,8 +228,19 @@ export default {
 			} else {
 				this.$emit('update-filters', categoryFilter);
 			}
+
+			this.$kvTrackEvent(
+				this.trackingCategory,
+				'filter',
+				'quick-filters-option',
+				categoryId === 0 ? 'All categories' : categoryId
+			);
 		},
 		selectedGender(gender) {
+			if (this.presetFilterActive.women && gender !== 'female') {
+				this.resetCategory();
+				this.presetFilterActive.women = false;
+			}
 			this.$emit('update-filters', { gender });
 			this.$kvTrackEvent(
 				this.trackingCategory,
@@ -239,6 +250,10 @@ export default {
 			);
 		},
 		sortBy(sortBy) {
+			if (this.presetFilterActive.endingSoon && sortBy !== 'expiringSoon') {
+				this.resetCategory();
+				this.presetFilterActive.endingSoon = false;
+			}
 			this.$emit('update-filters', { sortBy });
 			this.$kvTrackEvent(
 				this.trackingCategory,
@@ -249,6 +264,9 @@ export default {
 		}
 	},
 	methods: {
+		resetCategory() {
+			this.selectedCategory = 0;
+		},
 		resetGender() {
 			this.selectedGender = '';
 		},
@@ -263,6 +281,10 @@ export default {
 			this.$refs.locationSelector.setCountry(country);
 		},
 		updateLocation(location) {
+			if (this.presetFilterActive.kivaUs && JSON.stringify(location) !== '["US"]') {
+				this.resetCategory();
+				this.presetFilterActive.kivaUs = false;
+			}
 			this.$emit('update-filters', { country: location });
 			this.$kvTrackEvent(
 				this.trackingCategory,
@@ -324,7 +346,8 @@ export default {
 		border-style: none;
 		padding: 0 0 0 4px;
 		width: auto;
-		font-size: 0.875rem;
+		font-size: 1rem;
+		text-decoration: underline;
 		cursor: pointer;
 		height: auto;
 		background: transparent;

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -14,11 +14,14 @@
 				@add-to-basket="trackCategory($event, 'recommended')"
 			/>
 
-			<quick-filters-section class="tw-mt-6" />
+			<quick-filters-section
+				class="tw-mt-6"
+				@add-to-basket="trackCategory($event, 'quick-filters')"
+			/>
 
 			<!-- Second category row: Matched loans section -->
 			<lending-category-section
-				title="Matched lending"
+				title="matched lending"
 				subtitle="Stretch your funds further with the help of our partners and Kivans just like you"
 				:loans="matchedLoans"
 				class="tw-mt-6"

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -109,3 +109,9 @@ export default {
 	},
 };
 </script>
+
+<style lang="postcss" scoped>
+>>> [role=progressbar] {
+	@apply tw-bg-tertiary;
+}
+</style>

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -21,7 +21,7 @@
 
 			<!-- Second category row: Matched loans section -->
 			<lending-category-section
-				title="matched lending"
+				title="Matched lending"
 				subtitle="Stretch your funds further with the help of our partners and Kivans just like you"
 				:loans="matchedLoans"
 				class="tw-mt-6"

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -984,6 +984,13 @@ export default {
 					queryParams: 'status=fundRaising&riskRating=3,5&sector=1,9,5,14,17,12,8,7,4,3,13&theme=Islamic Finance,Youth,Start-Up,Water and Sanitation,Vulnerable Groups,Fair Trade,Rural Exclusion,Mobile Technology,Underfunded Areas,Conflict Zones,Job Creation,Growing Businesses,Disaster recovery,Innovative Loans,Refugees/Displaced,Social Enterprise,Crisis Support Loans&distributionModel=field_partner',
 					algoliaParams: '',
 				},
+				{
+					id: 157,
+					url: 'l-g-b-t-q',
+					flssLoanSearch: {
+						tagId: [73]
+					},
+				},
 			]
 
 		};


### PR DESCRIPTION
This PR addresses a few things that came out of QA'ing the Quick Filters section of the MVP Lending Page:
* Update the progress bar to use the fundraising bar (so UI works with the grey background)
* Update some tracking (added tracking for selecting a category and refactor existing tracking for loan cards ATB)
* Ensure that "special loans" that use `partnerId` for their filter object work correctly by factoring `partnerId`s into the filter object, and added an LGBTQ channel map entry so that it works with the FLSS query
* Fix other "special loan" edge cases (women/Kiva US/ending soon)
* Some UI fixes requested by design