### PR TITLE
fix: update cypress meta tests to use new lbc and category title format

### DIFF
--- a/test/e2e/specs/MetaInfo.cy.js
+++ b/test/e2e/specs/MetaInfo.cy.js
@@ -20,16 +20,16 @@ describe('Meta information', () => {
 	it('Lend By Category Page', () => {
 		cy.visit('/lend-by-category');
 
-		cy.title().should('eq', 'See loans by category | Kiva');
+		cy.title().should('eq', 'Make a loan, change a life | Loans by category');
 		cy.document().get('head meta[name="description"]')
 			.should('have.attr', 'content', 'Choose a category, lend to borrowers, and make an impact. '
-					+ 'Each Kiva loan helps people build a better future for themselves and their families.');
+				+ 'Each Kiva loan helps people build a better future for themselves and their families.');
 	});
 
 	it('Lend By Women Category', () => {
 		cy.visit('/lend-by-category/women');
 
-		cy.title().should('eq', 'Loan to women around the world | Kiva');
+		cy.title().should('eq', 'Women | Invest & Support | Kiva');
 	});
 
 	it('Auto Deposit Landing Page', () => {


### PR DESCRIPTION
Noticed this was failing since the recent updates