### PR TITLE
fix: redirect to lend-classic for unhandled loan statuses, allow rais…

### DIFF
--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -115,6 +115,7 @@
 </template>
 
 <script>
+import { ALLOWED_LOAN_STATUSES } from '@/util/loanUtils';
 import CountdownTimer from '@/components/BorrowerProfile/CountdownTimer';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
 
@@ -150,22 +151,7 @@ export default {
 			default: 'fundraising',
 			validator: value => {
 				// Uncomment loan statuses as they become supported
-				return [
-					// 'defaulted',
-					// 'deleted',
-					// 'ended',
-					'expired',
-					'funded',
-					'fundraising',
-					'inactive',
-					// 'inactiveExpired',
-					// 'issue',
-					// 'payingBack',
-					'pfp',
-					'raised',
-					// 'refunded',
-					// 'reviewed'
-				].indexOf(value) !== -1;
+				return ALLOWED_LOAN_STATUSES.indexOf(value) !== -1;
 			}
 		},
 		numberOfLenders: {

--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -13,7 +13,7 @@
 			:value="progressPercent * 100"
 		/>
 		<figcaption class="tw-flex">
-			<div v-if="loanStatus === 'funded'">
+			<div v-if="loanStatus === 'funded' || loanStatus === 'raised'">
 				<p class="tw-text-h3 tw-m-0" data-testid="bp-summary-amount-to-go">
 					This loan is fully funded!
 				</p>
@@ -162,7 +162,7 @@ export default {
 					// 'issue',
 					// 'payingBack',
 					'pfp',
-					// 'raised',
+					'raised',
 					// 'refunded',
 					// 'reviewed'
 				].indexOf(value) !== -1;

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -440,8 +440,26 @@ export default {
 						});
 					}
 
+					// Check for loan and loan status
 					const loan = data?.lend?.loan;
-					if (loan === null || loan === 'undefined') {
+					// TODO: This list is replicated in LoanProgress.vue de-duplicate
+					const loanStatusAllowed = [
+						// 'defaulted',
+						// 'deleted',
+						// 'ended',
+						'expired',
+						'funded',
+						'fundraising',
+						'inactive',
+						// 'inactiveExpired',
+						// 'issue',
+						// 'payingBack',
+						'pfp',
+						'raised',
+						// 'refunded',
+						// 'reviewed'
+					].indexOf(loan?.status) !== -1;
+					if (loan === null || loan === 'undefined' || !loanStatusAllowed) {
 						// redirect to legacy borrower profile
 						const { query = {} } = route;
 						query.minimal = false;

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -137,6 +137,7 @@
 
 <script>
 import { getKivaImageUrl } from '@/util/imageUtils';
+import { ALLOWED_LOAN_STATUSES } from '@/util/loanUtils';
 import {
 	format, parseISO, differenceInCalendarDays
 } from 'date-fns';
@@ -442,23 +443,7 @@ export default {
 
 					// Check for loan and loan status
 					const loan = data?.lend?.loan;
-					// TODO: This list is replicated in LoanProgress.vue de-duplicate
-					const loanStatusAllowed = [
-						// 'defaulted',
-						// 'deleted',
-						// 'ended',
-						'expired',
-						'funded',
-						'fundraising',
-						'inactive',
-						// 'inactiveExpired',
-						// 'issue',
-						// 'payingBack',
-						'pfp',
-						'raised',
-						// 'refunded',
-						// 'reviewed'
-					].indexOf(loan?.status) !== -1;
+					const loanStatusAllowed = ALLOWED_LOAN_STATUSES.indexOf(loan?.status) !== -1;
 					if (loan === null || loan === 'undefined' || !loanStatusAllowed) {
 						// redirect to legacy borrower profile
 						const { query = {} } = route;

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -4,6 +4,26 @@ import _get from 'lodash/get';
 /** Utility functions for working with loan objects */
 
 /**
+ * Loan Statuses Available on borrower profile
+ */
+export const ALLOWED_LOAN_STATUSES = [
+	// 'defaulted',
+	// 'deleted',
+	// 'ended',
+	'expired',
+	'funded',
+	'fundraising',
+	'inactive',
+	// 'inactiveExpired',
+	// 'issue',
+	// 'payingBack',
+	'pfp',
+	'raised',
+	// 'refunded',
+	// 'reviewed'
+];
+
+/**
  * Returns true if loan is fundraising / can be lent to
  *
  * @param {object} loan


### PR DESCRIPTION
…ed status

Previous broken "raised" status:
![image](https://user-images.githubusercontent.com/1862756/211080313-37e05114-675c-4d6a-b61d-e72fe1695b36.png)

Previous broken "paying_back" status, this now redirects to `/lend-classic`
![image](https://user-images.githubusercontent.com/1862756/211083699-d2813a0f-2059-4dfb-95ba-86d45a0b5c34.png)

Fixed "raised" status:
![image](https://user-images.githubusercontent.com/1862756/211080482-c9b43285-8728-44d4-9539-44f5072136da.png)

