### PR TITLE
fix: run experiment only for new users

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -537,18 +537,16 @@ export default {
 		}
 
 		// Async data fetch for MARS-317 and share button
-		if (this.enabledExperiment) {
-			const { data } = await this.apollo.query({
-				query: mountedQuery,
-				variables: {
-					loanId: this.loanId,
-				},
-			});
-			const loan = data?.lend?.loan;
-			this.partnerName = loan?.partnerName ?? '';
-			this.partnerCountry = loan?.partner?.countries[0]?.name ?? '';
-			this.lender = data?.my?.userAccount ?? {};
-		}
+		const { data } = await this.apollo.query({
+			query: mountedQuery,
+			variables: {
+				loanId: this.loanId,
+			},
+		});
+		const loan = data?.lend?.loan;
+		this.partnerName = loan?.partnerName ?? '';
+		this.partnerCountry = loan?.partner?.countries[0]?.name ?? '';
+		this.lender = data?.my?.userAccount ?? {};
 	},
 	computed: {
 		loanId() {


### PR DESCRIPTION
Experiment should only be shown and load for new users so there's a new computed that validates if the user is a non-lender, non-depositer nor has not logged in before.