### PR TITLE
fix: filter faq content

### DIFF
--- a/src/util/contentful/richTextRenderer.js
+++ b/src/util/contentful/richTextRenderer.js
@@ -132,8 +132,10 @@ export function richTextRenderer(content) {
 						:source-sizes="${sourceSetArrayAsString}" />`;
 		}
 		if (isFAQ) {
+			const questions = formatContentTypes(entryContent?.fields?.contents)
+				.filter(entry => entry.contentType === 'richTextContent');
 			return `<kv-frequently-asked-questions
-						:questions="${htmlSafeStringify(formatContentTypes(entryContent?.fields?.contents))}"
+						:questions="${htmlSafeStringify(questions)}"
 					/>`;
 		}
 		return '';


### PR DESCRIPTION
When using `UI Setting` on FAQ content group, pages that uses FAQ inside a dynamic hero returns a [500 error](https://www.dev.kiva.org/hp/crowdfund-for-good). 

This pr filters only the content for faq.