### PR TITLE
feat: journal updates on borrower profile

### DIFF
--- a/src/components/BorrowerProfile/JournalUpdates.vue
+++ b/src/components/BorrowerProfile/JournalUpdates.vue
@@ -1,0 +1,188 @@
+<template>
+	<section>
+		<!-- Display Content -->
+		<h2 class="tw-text-h2 tw-mb-3" :data-testid="`bp-updates-header`">
+			<!-- eslint-disable-next-line max-len -->
+			{{ sectionTitle }} <kv-loading-placeholder v-if="firstLoading" class="tw-inline-block tw-align-middle tw-mb-0.5" :style="{width: '27%', height: '28px' }" />
+		</h2>
+
+		<div
+			:data-testid="`bp-updates-section`"
+		>
+			<update-details
+				v-for="(journal, index) in journals" :key="journal.id"
+				:body="journal.body"
+				:date="journal.date"
+				:subject="journal.subject"
+				:index="totalItemCount - index"
+				:image-url="journal.image ? journal.image.url : null"
+			/>
+		</div>
+
+		<div v-if="loading" class="tw-rounded tw-bg-primary tw-p-3 tw-mb-3">
+			<!-- Loading placeholder for journal elements -->
+			<kv-loading-placeholder
+				class="tw-rounded tw-mb-2 tw-w-full" :style="{ height: '121px' }"
+			/>
+			<kv-loading-placeholder
+				class="tw-mb-2" :style="{ height: '14px', width: '96%' }"
+			/>
+			<kv-loading-placeholder
+				class="tw-mb-2" :style="{ height: '14px', width: '41%' }"
+			/>
+			<div class="tw-flex tw-justify-between tw-align-baseline">
+				<kv-loading-placeholder class="tw-mb-2" :style="{height: '28px', width: '33%'}" />
+				<kv-loading-placeholder class="tw-mb-2" :style="{height: '14px', width: '24%'}" />
+			</div>
+		</div>
+
+		<!-- Load More Button -->
+		<div v-if="journals.length < totalItemCount" class="tw-mb-3 tw-text-center">
+			<kv-button
+				class="tw-mb-3"
+				@click="loadMore"
+				variant="secondary"
+				:disabled="loading"
+				:state="buttonState"
+				:aria-label="`See older updates`"
+			>
+				See older updates
+			</kv-button>
+		</div>
+	</section>
+</template>
+
+<script>
+import { gql } from '@apollo/client';
+import { createIntersectionObserver } from '@/util/observerUtils';
+// TODO: replace the loading placeholder with component from kv-components when available.
+import KvLoadingPlaceholder from '@/components/Kv/KvLoadingPlaceholder';
+import UpdateDetails from './UpdateDetails';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+
+const updatesQuery = gql`query updatesQuery($loanId: Int!, $limit: Int, $offset: Int) {
+	lend {
+		loan(id: $loanId) {
+			id
+			name
+			updates(limit: $limit, offset: $offset ) {
+				totalCount
+				values {
+					id
+					body
+					subject
+					date
+					image {
+						id
+						url
+					}
+				}
+			}
+		}
+	}
+}`;
+
+export default {
+	name: 'JournalUpdates',
+	components: {
+		KvButton,
+		KvLoadingPlaceholder,
+		UpdateDetails
+	},
+	inject: ['apollo', 'cookieStore'],
+	props: {
+		loanId: {
+			type: Number,
+			default: 0,
+		},
+	},
+	data() {
+		return {
+			observer: null,
+			loading: true,
+			loanName: '',
+			journals: [],
+			itemQueryOffset: 0,
+			itemQueryLimit: 3,
+			totalItemCount: 0,
+		};
+	},
+	computed: {
+		sectionTitle() {
+			return `Updates from ${this.loanName}`;
+		},
+		firstLoading() {
+			return this.loading && this.journals.length === 0;
+		},
+		buttonState() {
+			if (this.loading) return 'loading';
+			return '';
+		},
+	},
+	methods: {
+		createObserver() {
+			// Watch for this element being close to entering the viewport
+			this.observer = createIntersectionObserver({
+				targets: [this.$el],
+				rootMargin: '500px',
+				callback: entries => {
+					entries.forEach(entry => {
+						if (entry.target === this.$el && entry.intersectionRatio > 0) {
+							// exit if already initialized
+							if (this.journals.length) return false;
+							// This element is close to being in the viewport, so load the data.
+							// Because of the apollo cache it's safe to call this repeatedly.
+							this.fetchItems();
+						}
+					});
+				}
+			});
+			if (!this.observer) {
+				// Observer was not created, so call fetchItems right away as a fallback.
+				this.fetchItems();
+			}
+		},
+		destroyObserver() {
+			if (this.observer) {
+				this.observer.disconnect();
+			}
+		},
+		fetchItems() {
+			if (this.loanId === 0) return false;
+
+			this.loading = true;
+
+			const updateVars = {
+				loanId: this.loanId,
+				limit: this.itemQueryLimit,
+				offset: this.itemQueryOffset,
+			};
+
+			// run apollo query
+			this.apollo.query({
+				query: updatesQuery,
+				variables: updateVars,
+			}).then(({ data }) => {
+				this.loanName = data?.lend?.loan?.name ?? '';
+
+				this.totalItemCount = data?.lend?.loan?.updates?.totalCount ?? 0;
+				if (!this.totalItemCount) {
+					this.$emit('hide-section');
+				}
+				this.journals = this.journals.concat(data?.lend?.loan?.updates?.values ?? []);
+				this.loading = false;
+			});
+		},
+		loadMore() {
+			this.itemQueryOffset += this.itemQueryLimit;
+			this.fetchItems();
+		},
+	},
+	mounted() {
+		this.createObserver();
+	},
+	beforeDestroy() {
+		this.destroyObserver();
+	},
+};
+</script>

--- a/src/components/BorrowerProfile/UpdateDetails.vue
+++ b/src/components/BorrowerProfile/UpdateDetails.vue
@@ -1,0 +1,66 @@
+<template>
+	<div class="tw-rounded tw-bg-primary tw-p-3 tw-mb-3">
+		<img
+			v-if="imageUrl"
+			class="tw-rounded tw-mb-2"
+			:src="imageUrl"
+			:alt="'photo of borrower'"
+		>
+		<div class="tw-prose tw-pb-2">
+			<p v-html="subject"></p>
+			<p v-html="body"></p>
+		</div>
+
+		<div>
+			<div class="tw-flex tw-justify-between tw-align-baseline">
+				<div>
+					<!-- TODO Share component goes here -->
+					<!-- <span class="tw-text-small tw-text-secondary">Share this Update</span> -->
+				</div>
+				<div>
+					<!-- eslint-disable-next-line max-len -->
+					<span class="tw-text-small tw-text-secondary">Update #{{ index }}</span>
+					<span class="tw-text-small tw-text-secondary tw-px-1.5">&#x2022;</span>
+					<span class="tw-text-small tw-text-secondary">{{ formattedJournalDate }}</span>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { format, parseISO } from 'date-fns';
+
+export default {
+	name: 'UpdateDetails',
+	components: {
+	},
+	props: {
+		body: {
+			type: String,
+			default: '',
+		},
+		date: {
+			type: String,
+			default: '',
+		},
+		subject: {
+			type: String,
+			default: '',
+		},
+		index: {
+			type: Number,
+			default: 1,
+		},
+		imageUrl: {
+			type: String,
+			default: '',
+		},
+	},
+	computed: {
+		formattedJournalDate() {
+			return format(parseISO(this.date), 'MMMM dd, yyyy');
+		}
+	},
+};
+</script>

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -116,6 +116,13 @@
 					display-type="teams"
 					@hide-section="showTeams = false"
 				/>
+				<journal-updates
+					v-if="showUpdates"
+					data-testid="bp-updates"
+					class="tw-mb-5 md:tw-mb-6 lg:tw-mb-8"
+					:loan-id="loanId"
+					@hide-section="showUpdates = false"
+				/>
 			</content-container>
 			<div class="tw-bg-primary">
 				<content-container>
@@ -160,6 +167,7 @@ import MoreAboutLoan from '@/components/BorrowerProfile/MoreAboutLoan';
 import WhySpecial from '@/components/BorrowerProfile/WhySpecial';
 import TopBannerPfp from '@/components/BorrowerProfile/TopBannerPfp';
 import ShareButton from '@/components/BorrowerProfile/ShareButton';
+import JournalUpdates from '@/components/BorrowerProfile/JournalUpdates';
 
 import {
 	getExperimentSettingCached,
@@ -297,6 +305,7 @@ export default {
 		LendCta,
 		LendersAndTeams,
 		LoanStory,
+		JournalUpdates,
 		MoreAboutLoan,
 		SidebarContainer,
 		ShareButton,
@@ -388,6 +397,7 @@ export default {
 			countryName: '',
 			showLenders: true,
 			showTeams: true,
+			showUpdates: true,
 			isUrgencyExpVersionShown: false,
 			hasThreeDaysOrLessLeft: false,
 			// meta fields


### PR DESCRIPTION
ACK-470

Adds updates to borrower profile: 

Loading state: 
![Screen Shot 2023-01-09 at 12 16 36 PM](https://user-images.githubusercontent.com/4371888/211652059-090c4860-9147-4f7b-8cb7-ce8c9d08040b.png)


Loaded: 
![Screen Shot 2023-01-10 at 12 53 16 PM](https://user-images.githubusercontent.com/4371888/211652072-2f841dd8-46ad-4c0d-90d2-22afddae46c6.png)

Updates load 3 at a time, this section is using the same pattern of loading as the other sections of the borrower profile to ensure that we don't slow down the main query in the borrower profile. 

Additional functionality coming in future PR's. (social sharing, linking)
Related backend change: https://github.com/kiva/kiva/pull/11265 to reverse the order of the API return. 
