### PR TITLE
Core 957 qf channel improve page initialization

### DIFF
--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -293,7 +293,7 @@ export default {
 			this.selectedGender = '';
 			this.sortBy = 'amountLeft';
 			this.updateLocation([]);
-			this.$refs.locationSelector.emptyCountries();
+			this.$refs.locationSelector?.emptyCountries();
 			this.$kvTrackEvent(
 				this.trackingCategory,
 				'click',

--- a/src/pages/Lend/LoanChannelCategoryPage.vue
+++ b/src/pages/Lend/LoanChannelCategoryPage.vue
@@ -5,7 +5,6 @@
 	>
 		<component
 			:is="pageLayoutComponent"
-			:enable-quick-filters="enableQuickFilters"
 			:enable-helpme-choose="enableHelpmeChoose"
 			:enable-loan-tags="enableLoanTags"
 		/>
@@ -78,7 +77,6 @@ export default {
 			},
 			pageLayout: 'control',
 			pageLayoutComponent: null,
-			enableQuickFilters: false,
 			enableHelpmeChoose: false,
 			enableLoanTags: false,
 		};
@@ -194,13 +192,6 @@ export default {
 		this.initializeAddToBasketInterstitial();
 		// Experimental page layout
 		this.initializeExperimentalPageLayout();
-		// Initialize Quick Filters Experiment
-		if (this.targetedLoanChannel !== 'eco-friendly'
-				&& this.targetedLoanChannel !== 'mission-driven-orgs'
-				&& this.targetedLoanChannel !== 'short-term-loans'
-		) {
-			this.enableQuickFilters = true;
-		}
 		// Initialize Help Me Choose Experiment
 		if (this.targetedLoanChannel === 'women'
 				|| this.targetedLoanChannel === 'kiva-u-s'

--- a/src/util/loanChannelUtils.js
+++ b/src/util/loanChannelUtils.js
@@ -42,9 +42,8 @@ export function transformFLSSData(data) {
  * @param {Array} queryMap The map mixin from loan-channel-query-map.js
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
- * @param {Object} selectedQuickFilters Selected quick filters
  */
-export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVars, selectedQuickFilters) {
+export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVars) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
 
 	if (queryMapFLSS) {
@@ -62,7 +61,7 @@ export async function preFetchChannel(apollo, queryMap, channelUrl, loanQueryVar
 		}
 
 		if (experimentActive) {
-			const filterObj = { ...queryMapFLSS, ...selectedQuickFilters };
+			const filterObj = { ...queryMapFLSS };
 			return fetchLoanChannel(apollo, filterObj, loanQueryVars);
 		}
 	}


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-957
https://kiva.atlassian.net/browse/CORE-897

- Quick filters now enabled for all categories (3 used to be disabled)
- Category pages again use cached loan data (since the filters don't currently change on mount)
- Because prefetched data is being used again, the page no longer initially loads with "no loans found"