### PR TITLE
Core 939 add loan labels to mvp

### DIFF
--- a/.storybook/stories/GridLoanCard.stories.js
+++ b/.storybook/stories/GridLoanCard.stories.js
@@ -72,3 +72,26 @@ export const Default = (args, { argTypes }) => ({
 		/>
 	`,
 });
+
+export const Tags = (args, { argTypes }) => ({
+	props: Object.keys(argTypes),
+	mixins: [apolloStoryMixin()],
+	components: {
+		GridLoanCard,
+	},
+	template: `
+		<grid-loan-card
+			:items-in-basket="itemsInBasket"
+			:loan="loan"
+			:amount-left="amountLeft"
+			:expiring-soon-message="expiringSoonMessage"
+			:is-favorite="isFavorite"
+			:is-funded="isFunded"
+			:is-selected-by-another="isSelectedByAnother"
+			:is-visitor="isVisitor"
+			:percent-raised="percentRaised"
+			:title="title"
+			:show-tags="true"
+		/>
+	`,
+});

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -4,9 +4,7 @@
 			{{ title }}
 		</h3>
 		<div class="grid-loan-card tw-bg-primary tw-border tw-border-tertiary">
-			<div v-if="showTags" class="tw-mt-1 tw-ml-1 tw-absolute tw-z-1">
-				<loan-tag v-if="getTagInfo()" :variation="getTagInfo()" />
-			</div>
+			<loan-tag v-if="showTags" :loan="loan" :amount-left="amountLeft" />
 			<loan-card-image
 				:loan-id="loan.id"
 				:name="loan.name"
@@ -76,7 +74,6 @@
 </template>
 
 <script>
-import { differenceInDays, parseISO } from 'date-fns';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import BorrowerInfo from '@/components/LoanCards/BorrowerInfo/BorrowerInfo';
 import FundraisingStatus from '@/components/LoanCards/FundraisingStatus/FundraisingStatus';
@@ -173,16 +170,6 @@ export default {
 				);
 			}
 		},
-		getTagInfo() {
-			if (differenceInDays(parseISO(this.loan?.plannedExpirationDate), Date.now()) <= 3) {
-				return 'ending-soon';
-			} if (this.amountLeft < 100 && this.amountLeft > 0) {
-				return 'almost-funded';
-			} if (this.loan?.matchingText) {
-				return 'matched-loan';
-			}
-			return null;
-		}
 	},
 };
 </script>

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -20,6 +20,7 @@
 				:to="customLoanDetails ? '' : `/lend/${loanId}`"
 				v-kv-track-event="['Lending', 'click-Read more', 'Photo', loanId]"
 			>
+				<loan-tag v-if="showTags" :loan="loan" :amount-left="amountLeft" />
 				<borrower-image
 					class="
 					tw-relative
@@ -251,6 +252,7 @@ import SummaryTag from '@/components/BorrowerProfile/SummaryTag';
 import { setLendAmount } from '@/util/basketUtils';
 import loanCardFieldsFragment from '@/graphql/fragments/loanCardFields.graphql';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
+import LoanTag from '@/components/LoanCards/LoanTags/LoanTag';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvUiButton from '~/@kiva/kv-components/vue/KvButton';
@@ -313,7 +315,11 @@ export default {
 		useFullWidth: {
 			type: Boolean,
 			default: false
-		}
+		},
+		showTags: {
+			type: Boolean,
+			default: false
+		},
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [percentRaisedMixin, timeLeftMixin],
@@ -329,6 +335,7 @@ export default {
 		SummaryTag,
 		KvUiButton,
 		ActionButton,
+		LoanTag,
 	},
 	data() {
 		return {

--- a/src/components/LoanCards/LoanMatchingText.vue
+++ b/src/components/LoanCards/LoanMatchingText.vue
@@ -19,7 +19,7 @@
 				:style="{ padding: '4px 0 2px 0', height: '1.2rem'}"
 			>
 		</span>
-		<h4 class="tw-inline-block" style="color: #A24536;">
+		<h4 class="tw-inline-block">
 			{{ constructedMatchingText }}
 		</h4>
 	</span>

--- a/src/components/LoanCards/LoanMatchingText.vue
+++ b/src/components/LoanCards/LoanMatchingText.vue
@@ -19,7 +19,7 @@
 				:style="{ padding: '4px 0 2px 0', height: '1.2rem'}"
 			>
 		</span>
-		<h4 class="tw-inline-block">
+		<h4 class="tw-inline-block" style="color: #A24536;">
 			{{ constructedMatchingText }}
 		</h4>
 	</span>

--- a/src/components/LoanCollections/KivaClassicLoanCarouselExp.vue
+++ b/src/components/LoanCollections/KivaClassicLoanCarouselExp.vue
@@ -30,12 +30,14 @@
 					:item-index="index"
 					:key="`loan-mfi-${loanId}`"
 					:loan-id="loanId"
+					:show-tags="showTags"
 				/>
 				<kiva-classic-basic-loan-card-exp
 					v-else
 					:item-index="index"
 					:key="`loan-${loanId}`"
 					:loan-id="loanId"
+					:show-tags="showTags"
 				/>
 			</template>
 		</kv-carousel>
@@ -92,6 +94,10 @@ export default {
 		isMfi: {
 			type: Boolean,
 			default: false
+		},
+		showTags: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -20,6 +20,7 @@
 						:item-index="index"
 						:loan-id="loan.id"
 						:show-action-button="true"
+						:show-tags="true"
 						class="tw-mr-2"
 						style="max-width: 100%;"
 						@add-to-basket="addToBasket"

--- a/src/components/LoanFinding/PartnerSpotlightSection.vue
+++ b/src/components/LoanFinding/PartnerSpotlightSection.vue
@@ -7,6 +7,7 @@
 				v-if="selectedChannelLoanIds.length > 0"
 				:selected-channel-loan-ids="selectedChannelLoanIds"
 				:selected-channel="selectedChannel"
+				:show-tags="true"
 				class="tw-py-4"
 			/>
 		</div>

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -38,6 +38,7 @@
 					:loan-id="loan.id"
 					:show-action-button="true"
 					:use-full-width="true"
+					:show-tags="true"
 					@add-to-basket="addToBasket"
 				/>
 			</div>

--- a/src/components/LoansByCategory/MFIRecommendations/MfiLoanCard.vue
+++ b/src/components/LoansByCategory/MFIRecommendations/MfiLoanCard.vue
@@ -13,6 +13,7 @@
 			v-if="!isLoading"
 			class="tw-relative"
 		>
+			<loan-tag v-if="showTags" :loan="loan" :amount-left="amountLeft" />
 			<borrower-image
 				class="
 				tw-relative
@@ -103,6 +104,7 @@
 </template>
 
 <script>
+import numeral from 'numeral';
 import { mdiChevronRight, mdiMapMarker } from '@mdi/js';
 import { gql } from '@apollo/client';
 import * as Sentry from '@sentry/vue';
@@ -116,6 +118,7 @@ import BorrowerName from '@/components/BorrowerProfile/BorrowerName';
 import KvLoadingParagraph from '@/components/Kv/KvLoadingParagraph';
 import SummaryTag from '@/components/BorrowerProfile/SummaryTag';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
+import LoanTag from '@/components/LoanCards/LoanTags/LoanTag';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
@@ -205,6 +208,10 @@ export default {
 			type: Boolean,
 			default: false
 		},
+		showTags: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [percentRaisedMixin, timeLeftMixin],
@@ -217,6 +224,7 @@ export default {
 		KvMaterialIcon,
 		SummaryTag,
 		ActionButton,
+		LoanTag,
 	},
 	data() {
 		return {
@@ -283,6 +291,11 @@ export default {
 		},
 		isFunded() {
 			return this.loan?.status === 'funded' ?? false;
+		},
+		amountLeft() {
+			const loanFundraisingInfo = this.loan?.loanFundraisingInfo ?? { fundedAmount: 0, reservedAmount: 0 };
+			const { fundedAmount, reservedAmount } = loanFundraisingInfo;
+			return numeral(this.loan?.loanAmount).subtract(fundedAmount).subtract(reservedAmount).value();
 		},
 	},
 	methods: {

--- a/src/components/LoansByCategory/MFIRecommendations/MfiLoansWrapper.vue
+++ b/src/components/LoansByCategory/MFIRecommendations/MfiLoansWrapper.vue
@@ -10,6 +10,7 @@
 			:show-view-more-card="true"
 			:is-personalized="true"
 			:is-mfi="true"
+			:show-tags="showTags"
 			id="carousel_exp"
 			class="-tw-mt-4"
 		/>
@@ -39,7 +40,11 @@ export default {
 		selectedChannel: {
 			type: Object,
 			default: () => {},
-		}
+		},
+		showTags: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	components: {
 		KivaClassicLoanCarouselExp


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-939

- The lending-home page uses 3 (the grid component is on the category page) different loan card components
- All 4 cards now have an option prop (default `false`) for adding loan tag pills to the top of the card
- Consolidated the loan tag logic (other than `amountLeft`) into the tag component itself
- Once we finalize the loan card in the next body of work, we can clean up the loan card tag usage
- Updated matching text to reddish color (see screenshots)

3 cards on lending-home (1 has two screenshots, since it's used twice):

![image](https://user-images.githubusercontent.com/16867161/213324710-aed04584-9331-4780-a19c-d3bd94c8a585.png)

![image](https://user-images.githubusercontent.com/16867161/213324735-f805da1b-bd68-4246-b758-21c2c5c89f20.png)

![image](https://user-images.githubusercontent.com/16867161/213324751-88da50f9-cf53-4af1-9f32-f87bf75c36cc.png)

![image](https://user-images.githubusercontent.com/16867161/213324775-b8129387-47a0-423b-9936-ea167aa31be5.png)
