### PR TITLE
fix: use revenue tag for custom optimizely events MARS-330

### DIFF
--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -308,7 +308,18 @@ export default {
 						type: 'event',
 						eventName: 'loan_share_purchase',
 						tags: {
-							loan_share_purchase_amount: transactionData.loanTotal,
+							revenue: transactionData.loanTotal * 100,
+							loan_share_purchase_amount: transactionData.loanTotal
+						}
+					});
+				}
+
+				if (transactionData.donationTotal) {
+					window.optimizely.push({
+						type: 'event',
+						eventName: 'donation',
+						tags: {
+							revenue: transactionData.donationTotal * 100,
 							donation_amount: transactionData.donationTotal
 						}
 					});


### PR DESCRIPTION
Custom events should use the `revenue` or `value` tags for metrics  https://docs.developers.optimizely.com/web/docs/event#parameters.

Based on fix from kiva/ui#4410