### PR TITLE
fix: styling of share update button and updaate info on mobile

### DIFF
--- a/src/components/BorrowerProfile/UpdateDetails.vue
+++ b/src/components/BorrowerProfile/UpdateDetails.vue
@@ -23,7 +23,7 @@
 		</div>
 
 		<div>
-			<div class="tw-flex tw-justify-between tw-align-center">
+			<div class="tw-flex tw-justify-between tw-align-center tw-flex-wrap">
 				<div class="tw-flex tw-items-center">
 					<kv-social-share-button
 						modal-title="Share this loan update"
@@ -35,8 +35,7 @@
 						Share this update
 					</kv-social-share-button>
 				</div>
-				<div class="tw-flex tw-items-center">
-					<!-- eslint-disable-next-line max-len -->
+				<div class="tw-flex tw-items-center tw-mt-2 md:tw-mt-0">
 					<span class="tw-text-secondary">Update #{{ index }}</span>
 					<span class="tw-text-secondary tw-px-1.5">&#x2022;</span>
 					<span class="tw-text-secondary">{{ formattedJournalDate }}</span>


### PR DESCRIPTION
Adding wrapping and spacing to journal info and button on mobile:
![Screen Shot 2023-01-24 at 1 02 46 PM](https://user-images.githubusercontent.com/4371888/214396970-352699de-6fb6-48cd-9a9d-3af5df1f8270.png)
