### PR TITLE
fix: padding fix for quick filters feat in category page

### DIFF
--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -13,54 +13,52 @@
 		</div>
 		<div
 			class="tw-flex tw-flex-col lg:tw-flex-row tw-gap-2 tw-w-full"
-			:class="{'tw-pr-2 lg:tw-pr-0' : !withCategories}"
+			:class="{'tw-pr-0 md:tw-pr-1 lg:tw-pr-0' : !withCategories}"
 		>
-			<div class="tw-flex tw-gap-2 tw-w-full lg:tw-w-auto">
-				<div v-if="withCategories" class="tw-flex tw-flex-col tw-grow">
-					<label
-						class="tw-text-h4"
-						for="category"
+			<div v-if="withCategories" class="tw-flex tw-flex-col tw-grow">
+				<label
+					class="tw-text-h4"
+					for="category"
+				>
+					Category
+				</label>
+				<kv-select
+					:disabled="!filtersLoaded"
+					v-model="selectedCategory"
+					id="category"
+					style="min-width: 160px;"
+				>
+					<option
+						v-for="category in filterOptions.categories"
+						:key="category.key"
+						:value="category.key"
 					>
-						Category
-					</label>
-					<kv-select
-						:disabled="!filtersLoaded"
-						v-model="selectedCategory"
-						id="category"
-						style="min-width: 160px;"
+						{{ category.title }}
+					</option>
+				</kv-select>
+			</div>
+			<div v-if="!removeGenderDropdown" class="tw-flex tw-flex-col tw-grow">
+				<label
+					class="tw-text-h4"
+					for="gender"
+				>
+					Gender
+				</label>
+				<kv-select
+					:disabled="!filtersLoaded"
+					v-model="selectedGender"
+					id="gender"
+					style="min-width: 140px;"
+					@click.native="trackDropdownClick('gender')"
+				>
+					<option
+						v-for="gender in filterOptions.gender"
+						:key="gender.key"
+						:value="gender.key"
 					>
-						<option
-							v-for="category in filterOptions.categories"
-							:key="category.key"
-							:value="category.key"
-						>
-							{{ category.title }}
-						</option>
-					</kv-select>
-				</div>
-				<div v-if="!removeGenderDropdown" class="tw-flex tw-flex-col tw-grow">
-					<label
-						class="tw-text-h4"
-						for="gender"
-					>
-						Gender
-					</label>
-					<kv-select
-						:disabled="!filtersLoaded"
-						v-model="selectedGender"
-						id="gender"
-						style="min-width: 140px;"
-						@click.native="trackDropdownClick('gender')"
-					>
-						<option
-							v-for="gender in filterOptions.gender"
-							:key="gender.key"
-							:value="gender.key"
-						>
-							{{ gender.title }}
-						</option>
-					</kv-select>
-				</div>
+						{{ gender.title }}
+					</option>
+				</kv-select>
 			</div>
 
 			<location-selector

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -36,7 +36,7 @@
 
 		<div class="row">
 			<quick-filters
-				class="tw-ml-2 tw-z-2"
+				class="tw-m-1 md:tw-ml-2 lg:tw-mr-2 tw-z-2"
 				:total-loans="totalCount"
 				:filter-options="quickFiltersOptions"
 				:filters-loaded="filtersLoaded"
@@ -325,6 +325,10 @@ export default {
 				gender: [{
 					key: '',
 					title: 'All genders'
+				}],
+				sorting: [{
+					key: 'personalized',
+					title: 'Recommended'
 				}]
 			},
 			filtersLoaded: false,


### PR DESCRIPTION
Quick filters padding issue fixed for category page
Tested in:
/lend-by-category/livestock
/lend-by-category/women
/lend-by-category/kiva-u-s
/lend-by-category/ending-soon
/lending-home

for mobile, tablet and desktop

Default value added to sorting options in category page avoiding empty state in the dropdown