### PR TITLE
feat: update progress text when amount left is low

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -85,6 +85,7 @@
 				:money-left="unreservedAmount"
 				:progress-percent="fundraisingPercent"
 				:time-left="timeLeftMessage"
+				:enable-loan-card-exp="true"
 			/>
 		</router-link>
 

--- a/src/components/LoanCards/LoanProgressGroup.vue
+++ b/src/components/LoanCards/LoanProgressGroup.vue
@@ -1,6 +1,6 @@
 <template>
 	<figure>
-		<h4 class="tw-mb-0.5">
+		<h4 class="tw-mb-0.5" :class="{ 'progress-group-amount-low': amountLow }">
 			{{ fundingText }}
 		</h4>
 		<kv-progress-bar
@@ -33,15 +33,32 @@ export default {
 			type: String,
 			default: '',
 		},
+		enableLoanCardExp: {
+			type: Boolean,
+			default: false
+		}
 	},
 	computed: {
+		numeralLeft() {
+			return numeral(this.moneyLeft);
+		},
+		amountLow() {
+			// Changing UI state based on amount left is currently under experiment
+			return this.enableLoanCardExp && this.numeralLeft.value() < 100;
+		},
 		fundingText() {
-			const formattedMoneyLeft = numeral(this.moneyLeft).format('$0,0[.]00');
+			const formattedMoneyLeft = this.numeralLeft.format('$0,0[.]00');
 			const formattedTimeLeft = `${this.timeLeft !== '' ? `. ${this.timeLeft}` : ''}`;
-
-			const formatttedFundingText = `${formattedMoneyLeft} to go${formattedTimeLeft}`;
-			return 	formatttedFundingText;
+			// Some time left strings already include an exclamation mark
+			const exclamationMark = this.amountLow && !formattedTimeLeft.includes('!') ? '!' : '';
+			return `${formattedMoneyLeft} to go${formattedTimeLeft}${exclamationMark}`;
 		}
 	}
 };
 </script>
+
+<style scoped>
+.progress-group-amount-low {
+	color: #FF5C00;
+}
+</style>

--- a/test/unit/specs/components/LoanCards/LoanProgressGroup.spec.js
+++ b/test/unit/specs/components/LoanCards/LoanProgressGroup.spec.js
@@ -1,0 +1,96 @@
+import { render } from '@testing-library/vue';
+import LoanProgressGroup from '@/components/LoanCards/LoanProgressGroup';
+
+describe('LoanProgressGroup', () => {
+	it('should display default message', () => {
+		const { getByText } = render(LoanProgressGroup);
+
+		getByText('$0 to go');
+	});
+
+	it('should display amount left', () => {
+		const { getByText } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '12.34'
+			},
+		});
+
+		getByText('$12.34 to go');
+	});
+
+	it('should display time left', () => {
+		const { getByText } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '12.34',
+				timeLeft: '1 day left.'
+			},
+		});
+
+		getByText('$12.34 to go. 1 day left.');
+	});
+
+	it('should display exclamation mark with experiment and low amount', () => {
+		const { getByText } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '12.34',
+				enableLoanCardExp: true
+			},
+		});
+
+		getByText('$12.34 to go!');
+	});
+
+	it('should not display double exclamation mark with experiment and low amount', () => {
+		const { getByText } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '12.34',
+				timeLeft: '1 day left!',
+				enableLoanCardExp: true
+			},
+		});
+
+		getByText('$12.34 to go. 1 day left!');
+	});
+
+	it('should not use orange color without experiment', () => {
+		const { container } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '12.34',
+			},
+		});
+
+		expect(container.getElementsByClassName('progress-group-amount-low').length).toBe(0);
+	});
+
+	it('should use orange color with experiment and low amount', () => {
+		const { container } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '12.34',
+				enableLoanCardExp: true
+			},
+		});
+
+		expect(container.getElementsByClassName('progress-group-amount-low').length).toBe(1);
+	});
+
+	it('should not use orange color with experiment and not low amount', () => {
+		const { container } = render(LoanProgressGroup, {
+			props: {
+				moneyLeft: '500',
+				enableLoanCardExp: true
+			},
+		});
+
+		expect(container.getElementsByClassName('progress-group-amount-low').length).toBe(0);
+	});
+
+	it('should pass percentage to progress bar', () => {
+		const { container } = render(LoanProgressGroup, {
+			props: {
+				progressPercent: 0.5,
+			},
+		});
+
+		expect(container.querySelector('[role="progressbar"]').getAttribute('aria-valuenow')).toBe('50');
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1031

- Progress bar text is now orange when amount left is under $100
- Exclamation mark added, if time left doesn't already add it
- Unit tests added to confirm behavior

![image](https://user-images.githubusercontent.com/16867161/215933218-dd44a58c-51b5-4ab4-a1ac-3385e223db88.png)
