### PR TITLE
fix: tracking was missing on new page

### DIFF
--- a/src/graphql/query/userInfo.graphql
+++ b/src/graphql/query/userInfo.graphql
@@ -7,4 +7,10 @@ query userInfo {
 			lastName
 		}
 	}
+	general {
+		loanFindingPage: uiExperimentSetting(key: "loan_finding_page") {
+			key
+			value
+		}
+	}
 }


### PR DESCRIPTION
- Turns out that we are missing "b" group tracking for the `loan_finding_page` experiment
- The existing tracking occurs in the LBC page, in `mounted`, so it never gets hit when the redirect happens