### PR TITLE
Core 1015 quick filters update when using help me choose

### DIFF
--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -376,7 +376,7 @@ export default {
 			selectedQuickFilters: {},
 			userData: {},
 			showQuickFiltersOverlay: false,
-			helpMeChooseSort: '',
+			helpMeChooseSort: null,
 			helpMeChooseLoans: [],
 			isLoadingHC: true,
 		};

--- a/src/util/loanChannelUtils.js
+++ b/src/util/loanChannelUtils.js
@@ -87,13 +87,15 @@ export function getCachedChannel(apollo, queryMap, channelUrl, loanQueryVars) {
  * @param {Array} queryMap The map mixin from loan-channel-query-map.js
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
+ * @param {Object} filterOverrides Filters that override or extend the query map filters (only for FLSS)
  * @returns {Object} The loan channel data, transformed if FLSS
  */
-export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars) {
+export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars, filterOverrides = {}) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
 
 	if (queryMapFLSS) {
-		return transformFLSSData(await fetchLoanChannel(apollo, queryMapFLSS, loanQueryVars));
+		const data = await fetchLoanChannel(apollo, { ...queryMapFLSS, ...filterOverrides }, loanQueryVars);
+		return transformFLSSData(data);
 	}
 
 	try {

--- a/test/unit/specs/util/loanChannelUtils.spec.js
+++ b/test/unit/specs/util/loanChannelUtils.spec.js
@@ -178,35 +178,33 @@ describe('loanChannelUtils.js', () => {
 		let spyGetLoanChannel;
 		const apollo = {
 			query: jest.fn(() => Promise.resolve()),
-			readQuery: jest.fn(() => Promise.resolve())
 		};
+
 		beforeEach(() => {
 			spyGetLoanChannel = jest.spyOn(flssUtils, 'fetchLoanChannel').mockImplementation(() => Promise.resolve());
 		});
 
 		afterEach(jest.clearAllMocks);
 
-		it('should handle channel without FLSS mapping', () => {
-			getLoanChannel(apollo, mockQueryMap, 'asd', mockLoanQueryVars);
+		it('should handle channel without FLSS mapping', async () => {
+			await getLoanChannel(apollo, mockQueryMap, 'asd', mockLoanQueryVars);
 
 			expect(apollo.query).toHaveBeenCalledTimes(1);
 			expect(apollo.query).toHaveBeenCalledWith({ query: loanChannelQuery, variables: mockLoanQueryVars });
 		});
 
-		it('should handle active assigned experiment', async () => {
+		it('should handle channel with FLSS mapping', async () => {
 			const mockData = {
 				shop: { id: 1 },
 				lend: { loanChannelsById: [{ id: 2 }] },
 				fundraisingLoans: { test: 3 },
 			};
 
-			apollo.readQuery.mockReturnValueOnce({ experiment: { version: 'b' } });
-
 			spyGetLoanChannel.mockReturnValueOnce(mockData);
 
 			const result = await getLoanChannel(apollo, mockQueryMap, 'women', mockLoanQueryVars);
 
-			expect(apollo.readQuery).toHaveBeenCalledTimes(0);
+			expect(apollo.query).toHaveBeenCalledTimes(0);
 			expect(result).toEqual({
 				shop: mockData.shop,
 				lend: {
@@ -215,15 +213,12 @@ describe('loanChannelUtils.js', () => {
 			});
 		});
 
-		it('should handle active unassigned experiment', async () => {
-			const data = {};
+		it('should pass filter overrides to FLSS', async () => {
+			await getLoanChannel(apollo, mockQueryMap, 'women', mockLoanQueryVars, { extra: 'asd' });
 
-			apollo.readQuery.mockReturnValueOnce({ experiment: { version: 'a' } }).mockReturnValueOnce(data);
+			const expectedFilters = { gender: 'female', extra: 'asd' };
 
-			await getLoanChannel(apollo, mockQueryMap, 'women', mockLoanQueryVars);
-
-			expect(apollo.readQuery).toHaveBeenCalledTimes(0);
-			expect(apollo.query).toHaveBeenCalledTimes(0);
+			expect(spyGetLoanChannel).toHaveBeenCalledWith(apollo, expectedFilters, mockLoanQueryVars);
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1059
https://kiva.atlassian.net/browse/CORE-990

- Help me choose now hidden for categories with a pre-defined sort, since help me choose are just sort options
- Help me choose results are now updated when QF change (though sort is not applied from QF)
- Added back in way to filter FLSS channel, since that was removed in a recent refactor
- Renamed "HelpMe" for variable naming consistency