### PR TITLE
fix: pass by reference issue for quick filters

### DIFF
--- a/src/components/LoansByCategory/QuickFilters/LocationSelector.vue
+++ b/src/components/LoansByCategory/QuickFilters/LocationSelector.vue
@@ -302,7 +302,7 @@ export default {
 	},
 	watch: {
 		selectedCountries() {
-			this.$emit('update-location', this.selectedCountries);
+			this.$emit('update-location', [...this.selectedCountries]);
 		}
 	}
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1060

- Pass by reference issue, location array reference never changed, so the apollo query didn't realize it wasn't the same
- The QF in general need to be refactored, but this was the smallest possible tweak for a hotfix :)