### PR TITLE
fix: put recommended at the bottom of the sort options

### DIFF
--- a/src/util/loanSearch/filters/sortOptions.js
+++ b/src/util/loanSearch/filters/sortOptions.js
@@ -66,6 +66,7 @@ export function formatSortOptions(standardSorts, flssSorts, extendFlssFilters) {
 			sortSrc: STANDARD_QUERY_TYPE,
 		};
 	}) ?? [];
+
 	const labeledFlssSorts = flssSorts?.reduce((prev, current) => {
 		const visibleOptions = extendFlssFilters ? experimentVisibleFLSSSortOptions : visibleFLSSSortOptions;
 		if (visibleOptions.includes(current.name)) {
@@ -74,7 +75,11 @@ export function formatSortOptions(standardSorts, flssSorts, extendFlssFilters) {
 
 		return prev;
 	}, []) ?? [];
-	return [...labeledStandardSorts, ...labeledFlssSorts];
+
+	// Personalized/recommended sort should go at the bottom of the options list to align with help text
+	const personalized = labeledFlssSorts.splice(labeledFlssSorts.findIndex(s => s.name === 'personalized'), 1);
+
+	return [...labeledStandardSorts, ...labeledFlssSorts, ...personalized];
 }
 
 export default {

--- a/test/unit/specs/util/loanSearch/filters/sortOptions.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/sortOptions.spec.js
@@ -104,5 +104,19 @@ describe('sortOptions.js', () => {
 					...mockFLSSSorts
 				]);
 		});
+
+		it('should place personalized at the end of the returned list', () => {
+			// Put personalized at the beginning to ensure it gets moved to the end
+			const originalMockSorts = [...mockFLSSSorts];
+			const sorts = [
+				...originalMockSorts.splice(originalMockSorts.findIndex(s => s.name === 'personalized'), 1),
+				...originalMockSorts
+			];
+
+			const result = formatSortOptions(mockStandardSorts, sorts);
+
+			expect(sorts.findIndex(s => s.name === 'personalized')).not.toBe(sorts.length - 1);
+			expect(result.findIndex(s => s.name === 'personalized')).toBe(result.length - 1);
+		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1002

- "Recommended" sort option is now at the bottom of the list in /lend/filter

![image](https://user-images.githubusercontent.com/16867161/216498245-4be00b4c-75eb-4f38-97d0-7ca16713ee6e.png)
