### PR TITLE
fix: location QF wasn't working after first selection

### DIFF
--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -133,8 +133,8 @@ export async function fetchLoans(
 export function getLoanChannelVariables(queryMapFLSS, loanQueryVars) {
 	return {
 		ids: [...loanQueryVars.ids],
-		filterObject: getFlssFilters(queryMapFLSS),
-		sortBy: queryMapFLSS.sortBy,
+		filterObject: getFlssFilters({ ...queryMapFLSS, ...loanQueryVars }),
+		sortBy: loanQueryVars.sortBy || queryMapFLSS.sortBy,
 		pageNumber: loanQueryVars.offset / loanQueryVars.limit,
 		pageLimit: loanQueryVars.limit,
 		basketId: loanQueryVars.basketId,

--- a/src/util/loanChannelUtils.js
+++ b/src/util/loanChannelUtils.js
@@ -110,21 +110,17 @@ export async function getLoanChannel(apollo, queryMap, channelUrl, loanQueryVars
  *
  * @param {Object} apollo The Apollo client instance
  * @param {Array} queryMap The map mixin from loan-channel-query-map.js
- * @param {Object} selectedQuickFilters Selected quick filters
  * @param {string} channelUrl The URL of the loan channel
  * @param {Object} loanQueryVars The loan channel query variables
  * @param {function} next The function to call in the observer subscription next callback
  * @param {function} watch The function to call to setup the component watch
  * @returns {Object} The Apollo watch observer
  */
-export function watchChannelQuery(apollo, queryMap, selectedQuickFilters, channelUrl, loanQueryVars, next, watch) {
+export function watchChannelQuery(apollo, queryMap, channelUrl, loanQueryVars, next, watch) {
 	const queryMapFLSS = getFLSSQueryMap(queryMap, channelUrl);
-
-	const filterObj = { ...queryMapFLSS, ...selectedQuickFilters };
-
 	// Check if current user should see the FLSS experiment
 	const observer = queryMapFLSS
-		? watchLoanChannel(apollo, filterObj, loanQueryVars)
+		? watchLoanChannel(apollo, queryMapFLSS, loanQueryVars)
 		: apollo.watchQuery({ query: loanChannelQuery, variables: loanQueryVars });
 
 	if (observer) {
@@ -136,7 +132,7 @@ export function watchChannelQuery(apollo, queryMap, selectedQuickFilters, channe
 
 		watch(vars => {
 			// eslint-disable-next-line max-len
-			observer.setVariables(queryMapFLSS ? getLoanChannelVariables(filterObj, vars) : vars);
+			observer.setVariables(queryMapFLSS ? getLoanChannelVariables(queryMapFLSS, vars) : vars);
 		});
 
 		return observer;

--- a/test/unit/specs/util/flssUtils.spec.js
+++ b/test/unit/specs/util/flssUtils.spec.js
@@ -131,6 +131,48 @@ describe('flssUtils.js', () => {
 			expect(result.pageLimit).toBe(loanQueryVars.limit);
 			expect(result.basketId).toBe(loanQueryVars.basketId);
 		});
+
+		it('should use loanQueryVars as override', () => {
+			const queryMap = { sector: [1, 2, 3], sortBy: 'expiringSoon' };
+			const loanQueryVars = {
+				ids: [3],
+				offset: 10,
+				limit: 5,
+				basketId: 'asd',
+				sector: [1],
+				sortBy: 'personalized'
+			};
+
+			const result = getLoanChannelVariables(queryMap, loanQueryVars);
+
+			expect(result.ids).toEqual(loanQueryVars.ids);
+			expect(result.filterObject).toEqual(getFlssFilters(queryMap, loanQueryVars));
+			expect(result.sortBy).toEqual(loanQueryVars.sortBy);
+			expect(result.pageNumber).toBe(loanQueryVars.offset / loanQueryVars.limit);
+			expect(result.pageLimit).toBe(loanQueryVars.limit);
+			expect(result.basketId).toBe(loanQueryVars.basketId);
+		});
+
+		it('should use correct sortBy fallback', () => {
+			const queryMap = { sector: [1, 2, 3], sortBy: 'expiringSoon' };
+			const loanQueryVars = {
+				ids: [3],
+				offset: 10,
+				limit: 5,
+				basketId: 'asd',
+				sector: [1],
+				sortBy: null
+			};
+
+			const result = getLoanChannelVariables(queryMap, loanQueryVars);
+
+			expect(result.ids).toEqual(loanQueryVars.ids);
+			expect(result.filterObject).toEqual(getFlssFilters(queryMap, loanQueryVars));
+			expect(result.sortBy).toEqual(queryMap.sortBy);
+			expect(result.pageNumber).toBe(loanQueryVars.offset / loanQueryVars.limit);
+			expect(result.pageLimit).toBe(loanQueryVars.limit);
+			expect(result.basketId).toBe(loanQueryVars.basketId);
+		});
 	});
 
 	describe('fetchLoanChannel', () => {

--- a/test/unit/specs/util/loanChannelUtils.spec.js
+++ b/test/unit/specs/util/loanChannelUtils.spec.js
@@ -230,7 +230,7 @@ describe('loanChannelUtils.js', () => {
 			subscribe: jest.fn(options => { subscribeNextCallback = options.next; }),
 			setVariables: jest.fn()
 		};
-		const apollo = { readQuery: jest.fn(), watchQuery: jest.fn(() => observer) };
+		const apollo = { watchQuery: jest.fn(() => observer) };
 		const watch = jest.fn(callback => { watchCallback = callback; });
 
 		beforeEach(() => {
@@ -242,7 +242,7 @@ describe('loanChannelUtils.js', () => {
 		it('should handle channel without FLSS mapping', () => {
 			const next = jest.fn();
 
-			const result = watchChannelQuery(apollo, mockQueryMap, {}, 'asd', mockLoanQueryVars, next, watch);
+			const result = watchChannelQuery(apollo, mockQueryMap, 'asd', mockLoanQueryVars, next, watch);
 
 			expect(spyWatchLoanChannel).toHaveBeenCalledTimes(0);
 			expect(apollo.watchQuery).toHaveBeenCalledTimes(1);
@@ -262,16 +262,13 @@ describe('loanChannelUtils.js', () => {
 			expect(observer.setVariables).toHaveBeenCalledWith(mockLoanQueryVars);
 		});
 
-		it('should handle active assigned experiment', () => {
-			apollo.readQuery.mockReturnValueOnce({ experiment: { version: 'b' } });
-
+		it('should handle channel with FLSS mapping', () => {
 			spyWatchLoanChannel.mockReturnValueOnce(observer);
 
 			const next = jest.fn();
 
-			const result = watchChannelQuery(apollo, mockQueryMap, {}, 'women', mockLoanQueryVars, next, watch);
+			const result = watchChannelQuery(apollo, mockQueryMap, 'women', mockLoanQueryVars, next, watch);
 
-			expect(apollo.readQuery).toHaveBeenCalledTimes(0);
 			expect(spyWatchLoanChannel).toHaveBeenCalledTimes(1);
 			expect(spyWatchLoanChannel).toHaveBeenCalledWith(apollo, mockWomenMap.flssLoanSearch, mockLoanQueryVars);
 			expect(result.subscribe).toHaveBeenCalledTimes(1);
@@ -293,15 +290,12 @@ describe('loanChannelUtils.js', () => {
 		});
 
 		it('should handle active unassigned experiment', () => {
-			apollo.readQuery.mockReturnValueOnce({ experiment: { version: 'unassigned' } });
-
 			spyWatchLoanChannel.mockReturnValueOnce(observer);
 
 			const next = jest.fn();
 
-			const result = watchChannelQuery(apollo, mockQueryMap, {}, 'women', mockLoanQueryVars, next, watch);
+			const result = watchChannelQuery(apollo, mockQueryMap, 'women', mockLoanQueryVars, next, watch);
 
-			expect(apollo.readQuery).toHaveBeenCalledTimes(0);
 			expect(spyWatchLoanChannel).toHaveBeenCalledTimes(1);
 			expect(apollo.watchQuery).toHaveBeenCalledTimes(0);
 			expect(result.subscribe).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1060

- The last fix was incomplete
- Instead of tracking down why recreating an apollo watch query wasn't working, I instead fixed what apollo was watching, since re-creating a watch shouldn't be necessary