### PR TITLE
Old category redirects MARS-335

### DIFF
--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -15,7 +15,7 @@ function handleError(err, req, res, next) {
 	// redirect to url if provided in the error
 	// -> this is how we handle vue-router links to external kiva pages
 	if (err.url) {
-		res.redirect(err.url);
+		res.redirect(err.code ?? 302, err.url);
 	// respond with 404 specifically set
 	} else if (err.code === 404) {
 		res.status(404).send('404 | Page Not Found');

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -19,9 +19,6 @@ module.exports = [
 	{
 		path: '/homepage-classic',
 		redirect: '/',
-		meta: {
-			excludeFromStaticSitemap: true,
-		}
 	},
 	{ path: '/15', component: () => import('@/pages/15Years/15Years') },
 	{
@@ -264,6 +261,114 @@ module.exports = [
 	{
 		path: '/lend-by-category/loans-for-education',
 		redirect: '/lend-by-category/education'
+	},
+	{
+		path: '/lend-by-category/1-billion-in-change',
+		redirect: '/lend-by-category'
+	},
+	{
+		path: '/lend-by-category/arts-loans',
+		redirect: '/lend-by-category/arts',
+	},
+	{
+		path: '/lend-by-category/choose-a-woman-borrower',
+		redirect: '/lend-by-category/women',
+	},
+	{
+		path: '/lend-by-category/eco-friendly-loans',
+		redirect: '/lend-by-category/eco-friendly',
+	},
+	{
+		path: '/lend-by-category/ecofriendly-loans',
+		redirect: '/lend-by-category/eco-friendly',
+	},
+	{
+		path: '/lend-by-category/flash-match',
+		redirect: '/lend-by-category',
+	},
+	{
+		path: '/lend-by-category/food-loans',
+		redirect: '/lend-by-category/food',
+	},
+	{
+		path: '/lend-by-category/group-loans',
+		redirect: '/lend-by-category/groups',
+	},
+	{
+		path: '/lend-by-category/hitachi-employees-helping-c-o-v-i-d-impacted-businesses',
+		redirect: '/cc/hitachi',
+	},
+	{
+		path: '/lend-by-category/hitachi-employees-helping-to-ignite-a-dream',
+		redirect: '/cc/hitachi',
+	},
+	{
+		path: '/lend-by-category/hitachis-c-o-v-i-d-19-response',
+		redirect: '/cc/hitachi',
+	},
+	{
+		path: '/lend-by-category/human-flow-fund-support-refugees-and-i-d-ps',
+		redirect: '/lend-by-category/refugees-and-i-d-ps',
+	},
+	{
+		path: '/lend-by-category/i-t-cosmetics-confidence',
+		redirect: '/itcosmetics',
+	},
+	{
+		path: '/lend-by-category/international-womens-day',
+		redirect: '/lend-by-category/women',
+	},
+	{
+		path: '/lend-by-category/loans-for-healthcare',
+		redirect: '/lend-by-category/health',
+	},
+	{
+		path: '/lend-by-category/loans-for-livestock',
+		redirect: '/lend-by-category/livestock',
+	},
+	{
+		path: '/lend-by-category/loans-for-retail-businesses',
+		redirect: '/lend-by-category/retail-businesses',
+	},
+	{
+		path: '/lend-by-category/loans-for-shelter',
+		redirect: '/lend-by-category/shelter',
+	},
+	{
+		path: '/lend-by-category/loans-that-are-ending-soon',
+		redirect: '/lend-by-category/ending-soon',
+	},
+	{
+		path: '/lend-by-category/loans-to-artisans',
+		redirect: '/lend-by-category/arts',
+	},
+	{
+		path: '/lend-by-category/loans-to-single-parents',
+		redirect: '/lend-by-category/single-parents',
+	},
+	{
+		path: '/lend-by-category/loans-to-women',
+		redirect: '/lend-by-category/women',
+	},
+	{
+		path: '/lend-by-category/recommended-by-lend-by-categoryers',
+		redirect: '/lend-by-category/recommended-by-lenders',
+	},
+	{
+		path: '/lend-by-category/retail-loans',
+		redirect: '/lend-by-category/retail-businesses',
+	},
+	{
+		path: '/lend-by-category/super-power-a-woman-on-kiva',
+		redirect: '/lend-by-category/women',
+	},
+	{
+		path: '/lend-by-category/world-refugee-day',
+		redirect: '/lend-by-category/refugees-and-i-d-ps',
+	},
+	{
+		path: '/lend-by-category/blackrock',
+		redirect: '/lend-by-category',
 	},
 	{
 		path: '/lend-by-category',
@@ -590,9 +695,6 @@ module.exports = [
 	{
 		path: '/styleguide/*',
 		redirect: '/styleguide',
-		meta: {
-			excludeFromStaticSitemap: true,
-		}
 	},
 	{
 		path: '/ui-site-map',

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -347,10 +347,6 @@ module.exports = [
 		redirect: '/lend-by-category/single-parents',
 	},
 	{
-		path: '/lend-by-category/loans-to-women',
-		redirect: '/lend-by-category/women',
-	},
-	{
 		path: '/lend-by-category/recommended-by-lend-by-categoryers',
 		redirect: '/lend-by-category/recommended-by-lenders',
 	},

--- a/src/server-entry.js
+++ b/src/server-entry.js
@@ -144,7 +144,8 @@ export default context => {
 		// redirect to the resolved url if it does not match the requested url
 		const { fullPath } = router.resolve(url).route;
 		if (fullPath !== url) {
-			return reject({ url: fullPath });
+			// redirects defined in routes.js use a permanent (301) redirect
+			return reject({ url: fullPath, code: 301 });
 		}
 
 		// render content for template


### PR DESCRIPTION
1. Redirects in routes.js now use status 301 (permanent) instead of 302 (temporary) so that google stops indexing the old routes
2. Added redirects for old category pages