### PR TITLE
Core 1001 new monthlygood card style

### DIFF
--- a/src/components/LoanCards/PromoGridLoanCardExp.vue
+++ b/src/components/LoanCards/PromoGridLoanCardExp.vue
@@ -1,0 +1,89 @@
+<template>
+	<div
+		class="tw-overflow-hidden tw-relative tw-h-full tw-w-full tw-bg-primary tw-border tw-border-tertiary tw-rounded"
+	>
+		<kv-responsive-image
+			class="promo-background-image tw-object-cover"
+			:images="backgroundImage" loading="lazy" alt=""
+		/>
+		<div class="tw-pb-1 tw-px-1.5 tw-absolute tw-bottom-1">
+			<div class="tw-flex tw-flex-col tw-gap-1 md:tw-gap-0.5" style="color: #F5F5F5;">
+				<h3 class="tw-mb-1 tw-text-h2 md:tw-text-h3">
+					Make a monthly impact
+				</h3>
+				<p class="tw-text-base" v-if="categoryLabel">
+					We’ll lend to {{ categoryLabel }} for you every month with a Monthly Good subscription.
+				</p>
+				<p class="tw-text-base" v-else>
+					We’ll make a loan for you every month with a Monthly Good subscription.
+				</p>
+				<router-link
+					style="background: #212121; color: #F5F5F5;"
+					class="tw-rounded tw-block tw-mt-2 tw-px-3 tw-py-1.5 tw-text-center tw-w-auto"
+					:to="categoryUrl"
+					v-kv-track-event="['Lending', 'PromoGridCard-click-Learn more', 'CASH-1426 Dec2019']"
+				>
+					Learn about Monthly Good
+				</router-link>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { paramCase } from 'change-case';
+import KvResponsiveImage from '@/components/Kv/KvResponsiveImage';
+import getCacheKey from '@/util/getCacheKey';
+
+const promoLoanImageRequire = require.context('@/assets/images/mg-promo-loan-card/', true);
+
+export default {
+	name: 'PromoGridLoanCardExp',
+	serverCacheKey: props => getCacheKey(`${props.categoryLabel}-${props.categoryUrl}-exp`),
+	components: {
+		KvResponsiveImage
+	},
+	props: {
+		categoryLabel: {
+			type: String,
+			default: ''
+		},
+		categoryUrl: {
+			type: String,
+			default: '/monthlygood',
+		},
+	},
+	computed: {
+		backgroundImage() {
+			if (this.categoryLabel) {
+				return [
+					['small', promoLoanImageRequire(`./mg-promo-${paramCase(this.categoryLabel)}-std.jpg`)],
+					['small retina', promoLoanImageRequire(`./mg-promo-${paramCase(this.categoryLabel)}-retina.jpg`)],
+				];
+			}
+			return [
+				['small', promoLoanImageRequire('./mg-promo-default-std.jpg')],
+				['small retina', promoLoanImageRequire('./mg-promo-default-retina.jpg')],
+			];
+		}
+	},
+};
+</script>
+
+<style lang="scss" scoped>
+
+.promo-background-image {
+
+	&::after {
+		display: block;
+		content: '';
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		background: linear-gradient(transparent 25%, rgb(0, 0, 0) 75%);
+	}
+}
+
+</style>

--- a/src/components/LoanCards/PromoGridLoanCardExp.vue
+++ b/src/components/LoanCards/PromoGridLoanCardExp.vue
@@ -70,19 +70,17 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style scoped>
 
-.promo-background-image {
-	&::after {
-		display: block;
-		content: '';
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		background: linear-gradient(transparent 25%, rgb(0, 0, 0) 75%);
-	}
+.promo-background-image::after {
+	display: block;
+	content: '';
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background: linear-gradient(transparent 25%, rgb(0, 0, 0) 75%);
 }
 
 </style>

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -109,7 +109,13 @@
 					</template>
 
 					<div class="column column-block">
+						<promo-grid-loan-card-exp
+							v-if="enableLoanCardExp"
+							:category-url="mgTargetCategory.url"
+							:category-label="mgTargetCategory.label"
+						/>
 						<promo-grid-loan-card
+							v-else
 							:category-url="mgTargetCategory.url"
 							:category-label="mgTargetCategory.label"
 						/>
@@ -184,6 +190,7 @@ import LoanCardController from '@/components/LoanCards/LoanCardController';
 import DonationCTA from '@/components/Lend/DonationCTA';
 import KvPagination from '@/components/Kv/KvPagination';
 import PromoGridLoanCard from '@/components/LoanCards/PromoGridLoanCard';
+import PromoGridLoanCardExp from '@/components/LoanCards/PromoGridLoanCardExp';
 import KvLoadingOverlay from '@/components/Kv/KvLoadingOverlay';
 import updateLoanReservation from '@/graphql/mutation/updateLoanReservation.graphql';
 import {
@@ -330,6 +337,7 @@ export default {
 		HelpmeChooseWrapper,
 		DonationCTA,
 		KivaClassicBasicLoanCardExp,
+		PromoGridLoanCardExp,
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [


### PR DESCRIPTION
New `PromoGridLoanCardExp` component added to show new style for new loan card experiment
Based in existing component `PromoGridLoanCard`

Desktop:
<img width="317" alt="Screenshot 2023-02-07 at 14 15 02" src="https://user-images.githubusercontent.com/94026278/217356397-9fd97199-d632-4f80-baa5-c16d1d5360c0.png">

Mobile:
<img width="402" alt="Screenshot 2023-02-07 at 14 15 15" src="https://user-images.githubusercontent.com/94026278/217356467-2151687e-78d5-4f2c-8827-d68e87f7f163.png">
