### PR TITLE
feat: loan callouts on loan cards

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -245,7 +245,7 @@ export default {
 		},
 		categoryPageName: {
 			type: String,
-			default: null,
+			default: '',
 		}
 	},
 	inject: ['apollo', 'cookieStore'],
@@ -281,8 +281,8 @@ export default {
 	computed: {
 		loanCallouts() {
 			const callouts = [];
-			const activityName = this.loan?.activity.name;
-			const sectorName = this.loan?.sector.name;
+			const activityName = this.loan?.activity.name ?? '';
+			const sectorName = this.loan?.sector.name ?? '';
 			const tags = this.loan?.tags.filter(tag => tag.charAt(0) === '#')
 				.map(tag => tag.substring(1)) ?? [];
 			const themes = this.loan?.themes ?? [];
@@ -305,21 +305,28 @@ export default {
 			}
 
 			// P2 Activity
-			if (this.categoryPageName !== activityName) {
+			if (this.categoryPageName.toUpperCase() !== activityName.toUpperCase()) {
 				callouts.push(activityName);
 			}
 
 			// P3 Sector
 			if (sectorName
-			&& (activityName !== sectorName)
-			&& (sectorName !== this.categoryPageName)
+			&& (activityName.toUpperCase() !== sectorName.toUpperCase())
+			&& (sectorName.toUpperCase() !== this.categoryPageName.toUpperCase())
 			&& callouts.length < 2) {
 				callouts.push(sectorName);
 			}
 
 			// P4 Tag
-			if (tags && callouts.length < 2) {
-				callouts.push(tags[0]);
+			if (!!tags.length && callouts.length < 2) {
+				const position = Math.floor(Math.random() * tags.length);
+				callouts.push(tags[position]);
+			}
+
+			// P5 Tag
+			if (!!themes.length && callouts.length < 2) {
+				const position = Math.floor(Math.random() * themes.length);
+				callouts.push(themes[position]);
 			}
 
 			return callouts;

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -152,7 +152,12 @@ import numeral from 'numeral';
 import { mdiChevronRight, mdiMapMarker, mdiCheckCircleOutline } from '@mdi/js';
 import { gql } from '@apollo/client';
 import * as Sentry from '@sentry/vue';
-import { isMatchAtRisk, readLoanFragment, watchLoanData } from '@/util/loanUtils';
+import {
+	isMatchAtRisk,
+	readLoanFragment,
+	watchLoanData,
+	loanCallouts
+} from '@/util/loanUtils';
 import { createIntersectionObserver } from '@/util/observerUtils';
 import LoanUse from '@/components/LoanCards/LoanUse';
 import percentRaisedMixin from '@/plugins/loan/percent-raised-mixin';
@@ -280,56 +285,7 @@ export default {
 	},
 	computed: {
 		loanCallouts() {
-			const callouts = [];
-			const activityName = this.loan?.activity.name ?? '';
-			const sectorName = this.loan?.sector.name ?? '';
-			const tags = this.loan?.tags.filter(tag => tag.charAt(0) === '#')
-				.map(tag => tag.substring(1)) ?? [];
-			const themes = this.loan?.themes ?? [];
-			const categories = {
-				ecoFriendly: tags.includes('Eco-friendly') || tags.includes('Sustainable Ag'),
-				refugeesIdps: themes.includes('Refugees/Displaced'),
-				singleParents: tags.includes('Single Parent')
-			};
-
-			// P1 Category
-			// Exp limited to: Eco-friendly, Refugees and IDPs, Single Parents
-			if (!this.categoryPageName) {
-				if (categories.ecoFriendly) {
-					callouts.push('Eco-friendly');
-				} else if (categories.refugeesIdps) {
-					callouts.push('Refugees and IDPs');
-				} else if (categories.singleParents) {
-					callouts.push('Single Parent');
-				}
-			}
-
-			// P2 Activity
-			if (this.categoryPageName.toUpperCase() !== activityName.toUpperCase()) {
-				callouts.push(activityName);
-			}
-
-			// P3 Sector
-			if (sectorName
-			&& (activityName.toUpperCase() !== sectorName.toUpperCase())
-			&& (sectorName.toUpperCase() !== this.categoryPageName.toUpperCase())
-			&& callouts.length < 2) {
-				callouts.push(sectorName);
-			}
-
-			// P4 Tag
-			if (!!tags.length && callouts.length < 2) {
-				const position = Math.floor(Math.random() * tags.length);
-				callouts.push(tags[position]);
-			}
-
-			// P5 Tag
-			if (!!themes.length && callouts.length < 2) {
-				const position = Math.floor(Math.random() * themes.length);
-				callouts.push(themes[position]);
-			}
-
-			return callouts;
+			return loanCallouts(this.loan, this.categoryPageName);
 		},
 		cardWidth() {
 			return this.useFullWidth ? '100%' : '374px';

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -253,7 +253,6 @@ import loanCardFieldsFragment from '@/graphql/fragments/loanCardFields.graphql';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import LoanTag from '@/components/LoanCards/LoanTags/LoanTag';
 import LoanCallouts from '@/components/LoanCards/LoanTags/LoanCallouts';
-import loanChannelQueryMapMixin from '@/plugins/loan-channel-query-map';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvUiButton from '~/@kiva/kv-components/vue/KvButton';
@@ -331,7 +330,7 @@ export default {
 		}
 	},
 	inject: ['apollo', 'cookieStore'],
-	mixins: [percentRaisedMixin, timeLeftMixin, loanChannelQueryMapMixin],
+	mixins: [percentRaisedMixin, timeLeftMixin],
 	components: {
 		BorrowerImage,
 		KvLoadingPlaceholder,

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -115,6 +115,9 @@
 					@show-loan-details="showLoanDetails"
 				/>
 			</router-link>
+
+			<!-- Loan callouts -->
+			<loan-callouts :callouts="loanCallouts" class="tw-mt-1" />
 		</div>
 
 		<!-- Matching text  -->
@@ -249,6 +252,8 @@ import { setLendAmount } from '@/util/basketUtils';
 import loanCardFieldsFragment from '@/graphql/fragments/loanCardFields.graphql';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import LoanTag from '@/components/LoanCards/LoanTags/LoanTag';
+import LoanCallouts from '@/components/LoanCards/LoanTags/LoanCallouts';
+import loanChannelQueryMapMixin from '@/plugins/loan-channel-query-map';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvUiButton from '~/@kiva/kv-components/vue/KvButton';
@@ -322,7 +327,7 @@ export default {
 		},
 	},
 	inject: ['apollo', 'cookieStore'],
-	mixins: [percentRaisedMixin, timeLeftMixin],
+	mixins: [percentRaisedMixin, timeLeftMixin, loanChannelQueryMapMixin],
 	components: {
 		BorrowerImage,
 		KvLoadingPlaceholder,
@@ -335,6 +340,7 @@ export default {
 		KvUiButton,
 		ActionButton,
 		LoanTag,
+		LoanCallouts
 	},
 	data() {
 		return {
@@ -350,6 +356,13 @@ export default {
 		};
 	},
 	computed: {
+		loanCallouts() {
+			// const sectorId = this.loan?.sector.id;
+			// const activityId = this.loan?.activity.id;
+			const sectorName = this.loan?.sector.name;
+			const activityName = this.loan?.activity.name;
+			return [sectorName, activityName];
+		},
 		cardWidth() {
 			return this.useFullWidth ? '100%' : '374px';
 		},

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -1,0 +1,32 @@
+<template>
+	<div>
+		<template v-for="tag in callouts">
+			<div
+				:key="tag"
+				class="
+				tw-rounded-full
+				tw-bg-tertiary
+				tw-font-medium
+				tw-inline-flex
+				tw-py-0.5
+				tw-px-1
+				tw-mr-0.5
+				tw-text-small"
+			>
+				{{ tag }}
+			</div>
+		</template>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'LoanCallouts',
+	props: {
+		callouts: {
+			type: Array,
+			required: true
+		}
+	},
+};
+</script>

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -1,5 +1,5 @@
 <template>
-	<div>
+	<div class="tw-line-clamp-1">
 		<template v-for="tag in callouts">
 			<div
 				:key="tag"
@@ -11,7 +11,9 @@
 				tw-py-0.5
 				tw-px-1
 				tw-mr-0.5
-				tw-text-small"
+				tw-mb-0.5
+				tw-text-small
+				"
 			>
 				{{ tag }}
 			</div>

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -1,23 +1,34 @@
 <template>
-	<div class="tw-line-clamp-1">
-		<template v-for="tag in callouts">
-			<div
-				:key="tag"
-				class="
-				tw-rounded-full
-				tw-bg-tertiary
-				tw-font-medium
-				tw-inline-flex
-				tw-py-0.5
-				tw-px-1
-				tw-mr-0.5
-				tw-mb-0.5
-				tw-text-small
+	<div class="tw-overflow-hidden" style="width:inherit;">
+		<div
+			class="
+				tw-text-ellipsis
+				tw-overflow-hidden
+				tw-inline-block
+				tw-whitespace-nowrap
+				tw-w-full
+				tw-h-4
 				"
-			>
-				{{ tag }}
-			</div>
-		</template>
+		>
+			<template v-for="tag in callouts">
+				<span
+					:key="tag"
+					class="
+                callout
+                tw-rounded-full
+                tw-bg-tertiary
+                tw-font-medium
+                tw-py-0.5
+                tw-px-1
+                tw-mr-0.5
+                tw-mb-0.5
+                tw-text-small
+                "
+				>
+					{{ tag }}
+				</span>
+			</template>
+		</div>
 	</div>
 </template>
 

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -14,16 +14,15 @@
 				<span
 					:key="tag"
 					class="
-                callout
-                tw-rounded-full
-                tw-bg-tertiary
-                tw-font-medium
-                tw-py-0.5
-                tw-px-1
-                tw-mr-0.5
-                tw-mb-0.5
-                tw-text-small
-                "
+						tw-rounded-full
+						tw-bg-tertiary
+						tw-font-medium
+						tw-py-0.5
+						tw-px-1
+						tw-mr-0.5
+						tw-mb-0.5
+						tw-text-small
+					"
 				>
 					{{ tag }}
 				</span>

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="tw-overflow-hidden" style="width:inherit;">
+	<div class="tw-overflow-hidden" style="width: inherit;">
 		<div
 			class="
 				tw-text-ellipsis

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -2,31 +2,32 @@
 	<div class="tw-overflow-hidden" style="width: inherit;">
 		<div
 			class="
-				tw-text-ellipsis
-				tw-overflow-hidden
-				tw-inline-block
+				tw-flex
 				tw-whitespace-nowrap
 				tw-w-full
 				tw-h-4
-				"
+			"
 		>
-			<template v-for="tag in callouts">
-				<span
-					:key="tag"
-					class="
-						tw-rounded-full
-						tw-bg-tertiary
-						tw-font-medium
-						tw-py-0.5
-						tw-px-1
-						tw-mr-0.5
-						tw-mb-0.5
-						tw-text-small
-					"
-				>
-					{{ tag }}
-				</span>
-			</template>
+			<span
+				v-for="tag in callouts"
+				:key="tag"
+				:title="tag"
+				class="
+					loan-callout
+					tw-text-ellipsis
+					tw-overflow-hidden
+					tw-rounded-full
+					tw-bg-tertiary
+					tw-font-medium
+					tw-py-0.5
+					tw-px-1
+					tw-mr-0.5
+					tw-mb-0.5
+					tw-text-small
+				"
+			>
+				{{ tag }}
+			</span>
 		</div>
 	</div>
 </template>
@@ -42,3 +43,9 @@ export default {
 	},
 };
 </script>
+
+<style scoped>
+.loan-callout {
+	max-width: 50%;
+}
+</style>

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -32,7 +32,7 @@
 				</h2>
 			</div>
 			<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4 tw-mt-2">
-				<kiva-classic-basic-loan-card
+				<kiva-classic-basic-loan-card-exp
 					v-for="(loan, index) in loans"
 					:key="index"
 					:item-index="index"
@@ -75,7 +75,7 @@ import QuickFilters from '@/components/LoansByCategory/QuickFilters/QuickFilters
 import { runFacetsQueries, fetchLoanFacets, runLoansQuery } from '@/util/loanSearch/dataUtils';
 import { fetchCategories, FLSS_ORIGIN_LENDING_HOME } from '@/util/flssUtils';
 import { transformIsoCodes } from '@/util/loanSearch/filters/regions';
-import KivaClassicBasicLoanCard from '@/components/LoanCards/KivaClassicBasicLoanCard';
+import KivaClassicBasicLoanCardExp from '@/components/LoanCards/KivaClassicBasicLoanCardExp';
 import KvPagination from '@/components/Kv/KvPagination';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
@@ -83,7 +83,7 @@ export default {
 	name: 'QuickFiltersSection',
 	components: {
 		QuickFilters,
-		KivaClassicBasicLoanCard,
+		KivaClassicBasicLoanCardExp,
 		KvPagination,
 		KvButton
 	},

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -32,7 +32,7 @@
 				</h2>
 			</div>
 			<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4 tw-mt-2">
-				<kiva-classic-basic-loan-card-exp
+				<kiva-classic-basic-loan-card
 					v-for="(loan, index) in loans"
 					:key="index"
 					:item-index="index"
@@ -75,7 +75,7 @@ import QuickFilters from '@/components/LoansByCategory/QuickFilters/QuickFilters
 import { runFacetsQueries, fetchLoanFacets, runLoansQuery } from '@/util/loanSearch/dataUtils';
 import { fetchCategories, FLSS_ORIGIN_LENDING_HOME } from '@/util/flssUtils';
 import { transformIsoCodes } from '@/util/loanSearch/filters/regions';
-import KivaClassicBasicLoanCardExp from '@/components/LoanCards/KivaClassicBasicLoanCardExp';
+import KivaClassicBasicLoanCard from '@/components/LoanCards/KivaClassicBasicLoanCard';
 import KvPagination from '@/components/Kv/KvPagination';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
@@ -83,7 +83,7 @@ export default {
 	name: 'QuickFiltersSection',
 	components: {
 		QuickFilters,
-		KivaClassicBasicLoanCardExp,
+		KivaClassicBasicLoanCard,
 		KvPagination,
 		KvButton
 	},

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
@@ -45,6 +45,7 @@
 					:show-action-button="true"
 					:show-tags="enableLoanTags"
 					:in-grid="true"
+					:category-page-name="loanChannelName"
 				/>
 				<loan-card-controller
 					v-else

--- a/src/graphql/fragments/loanCardFields.graphql
+++ b/src/graphql/fragments/loanCardFields.graphql
@@ -24,6 +24,7 @@ fragment loanCardFields on LoanBasic {
 		id
 		name
 	}
+	tags
 	whySpecial
 	lenderRepaymentTerm
 	loanAmount

--- a/src/graphql/fragments/loanCardFields.graphql
+++ b/src/graphql/fragments/loanCardFields.graphql
@@ -54,6 +54,7 @@ fragment loanCardFields on LoanBasic {
 	}
 	... on LoanPartner {
 		partnerName
+		themes
 	}
 	...on LoanDirect {
 		trusteeName

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -62,6 +62,7 @@
 							:lend-now-button="true"
 							:show-tags="enableLoanTags"
 							:in-grid="true"
+							:category-page-name="loanChannelName"
 						/>
 						<loan-card-controller
 							v-else
@@ -96,6 +97,7 @@
 							:lend-now-button="true"
 							:show-tags="enableLoanTags"
 							:in-grid="true"
+							:category-page-name="loanChannelName"
 						/>
 						<loan-card-controller
 							v-else
@@ -124,6 +126,7 @@
 							:lend-now-button="true"
 							:show-tags="enableLoanTags"
 							:in-grid="true"
+							:category-page-name="loanChannelName"
 						/>
 						<loan-card-controller
 							v-else

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -217,3 +217,56 @@ export function isBetween25And50(unreservedAmount) {
 export function isBetween25And500(unreservedAmount) {
 	return unreservedAmount < 500 && unreservedAmount >= 25;
 }
+
+export function loanCallouts(loan, categoryPageName) {
+	const callouts = [];
+	const activityName = loan?.activity.name ?? '';
+	const sectorName = loan?.sector.name ?? '';
+	const tags = loan?.tags.filter(tag => tag.charAt(0) === '#')
+		.map(tag => tag.substring(1)) ?? [];
+	const themes = loan?.themes ?? [];
+	const categories = {
+		ecoFriendly: tags.includes('Eco-friendly') || tags.includes('Sustainable Ag'),
+		refugeesIdps: themes.includes('Refugees/Displaced'),
+		singleParents: tags.includes('Single Parent')
+	};
+
+	// P1 Category
+	// Exp limited to: Eco-friendly, Refugees and IDPs, Single Parents
+	if (!categoryPageName) {
+		if (categories.ecoFriendly) {
+			callouts.push('Eco-friendly');
+		} else if (categories.refugeesIdps) {
+			callouts.push('Refugees and IDPs');
+		} else if (categories.singleParents) {
+			callouts.push('Single Parent');
+		}
+	}
+
+	// P2 Activity
+	if (categoryPageName.toUpperCase() !== activityName.toUpperCase()) {
+		callouts.push(activityName);
+	}
+
+	// P3 Sector
+	if (sectorName
+	&& (activityName.toUpperCase() !== sectorName.toUpperCase())
+	&& (sectorName.toUpperCase() !== categoryPageName.toUpperCase())
+	&& callouts.length < 2) {
+		callouts.push(sectorName);
+	}
+
+	// P4 Tag
+	if (!!tags.length && callouts.length < 2) {
+		const position = Math.floor(Math.random() * tags.length);
+		callouts.push(tags[position]);
+	}
+
+	// P5 Tag
+	if (!!themes.length && callouts.length < 2) {
+		const position = Math.floor(Math.random() * themes.length);
+		callouts.push(themes[position]);
+	}
+
+	return callouts;
+}


### PR DESCRIPTION
implements loan callouts on new loan cards with the following priority tag order (only show a max of 2):
p1: category (limited only to eco-friendly, refugees + IDP, + single parents)
p2: activity 
p3: sector (if it's not the same as activity)
p4: random public tag
p5: random theme

![Screen Shot 2023-02-08 at 5 51 30 PM](https://user-images.githubusercontent.com/15318176/217669472-b4639e35-5aac-40b7-a38f-8cdccf440c1d.png)
![Screen Shot 2023-02-07 at 5 30 58 PM](https://user-images.githubusercontent.com/15318176/217382800-65d742f3-663e-4fe1-bec0-079adeabfbba.png)
![Screen Shot 2023-02-07 at 5 31 13 PM](https://user-images.githubusercontent.com/15318176/217382804-7167c5fc-8a40-4f82-b2b2-2274e88ba09d.png)

we also ignore p1 on category pages to avoid redundancy. 
