### PR TITLE
feat: updated loan use for direct loans

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -82,6 +82,7 @@
 					:status="loanStatus"
 					:borrower-count="loanBorrowerCount"
 					:name="borrowerName"
+					:distribution-model="distributionModel"
 				/>
 			</router-link>
 		</div>

--- a/src/components/LoanCards/LoanUse.vue
+++ b/src/components/LoanCards/LoanUse.vue
@@ -67,7 +67,7 @@ export default {
 				+ `${isGroup ? 'a member of ' : ''}`
 				+ `${this.name} `
 				+ `${this.isDirect ? `${this.helpLanguage} ` : ''}`
-				+ `${this.use}`;
+				+ `${this.use.charAt(0).toLowerCase() + this.use.slice(1)}`;
 		},
 	}
 };

--- a/src/components/LoanCards/LoanUse.vue
+++ b/src/components/LoanCards/LoanUse.vue
@@ -7,6 +7,8 @@
 <script>
 import numeral from 'numeral';
 
+const DIRECT = 'direct';
+
 export default {
 	name: 'LoanUse',
 	props: {
@@ -38,6 +40,10 @@ export default {
 			type: Number,
 			default: 100,
 		},
+		distributionModel: {
+			type: String,
+			default: DIRECT
+		},
 	},
 	computed: {
 		helpLanguage() {
@@ -45,6 +51,9 @@ export default {
 				return 'helps';
 			}
 			return 'helped';
+		},
+		isDirect() {
+			return this.distributionModel === DIRECT;
 		},
 		loanUse() {
 			if (this.anonymizationLevel === 'full' || this.use.length === 0) {
@@ -54,9 +63,10 @@ export default {
 			const isGroup = this.borrowerCount > 1;
 
 			return `${numeral(this.loanAmount).format('$0,0')} `
-				+ `${this.helpLanguage} `
+				+ `${this.isDirect ? 'to' : this.helpLanguage} `
 				+ `${isGroup ? 'a member of ' : ''}`
 				+ `${this.name} `
+				+ `${this.isDirect ? `${this.helpLanguage} ` : ''}`
 				+ `${this.use}`;
 		},
 	}

--- a/test/unit/specs/components/LoanCards/LoanUse.spec.js
+++ b/test/unit/specs/components/LoanCards/LoanUse.spec.js
@@ -135,4 +135,18 @@ describe('LoanUse', () => {
 
 		getByText('$100 to a member of Group Name helps to buy supplies.');
 	});
+
+	it('should display loan use with lower case first letter', () => {
+		const { getByText } = render(LoanUse, {
+			props: {
+				use: 'To buy supplies.',
+				loanAmount: '100',
+				status: 'fundraising',
+				borrowerCount: 2,
+				name: 'Group Name',
+			},
+		});
+
+		getByText('$100 to a member of Group Name helps to buy supplies.');
+	});
 });

--- a/test/unit/specs/components/LoanCards/LoanUse.spec.js
+++ b/test/unit/specs/components/LoanCards/LoanUse.spec.js
@@ -30,6 +30,7 @@ describe('LoanUse', () => {
 				loanAmount: '100',
 				status: 'fundraising',
 				name: 'Bob',
+				distributionModel: 'fieldPartner',
 			},
 		});
 
@@ -43,6 +44,7 @@ describe('LoanUse', () => {
 				loanAmount: '100',
 				status: 'inactive',
 				name: 'Bob',
+				distributionModel: 'fieldPartner',
 			},
 		});
 
@@ -56,6 +58,7 @@ describe('LoanUse', () => {
 				loanAmount: '100',
 				status: 'reviewed',
 				name: 'Bob',
+				distributionModel: 'fieldPartner',
 			},
 		});
 
@@ -69,6 +72,7 @@ describe('LoanUse', () => {
 				loanAmount: '100',
 				status: 'other',
 				name: 'Bob',
+				distributionModel: 'fieldPartner',
 			},
 		});
 
@@ -83,6 +87,7 @@ describe('LoanUse', () => {
 				status: 'fundraising',
 				borrowerCount: 2,
 				name: 'Group Name',
+				distributionModel: 'fieldPartner',
 			},
 		});
 
@@ -102,5 +107,32 @@ describe('LoanUse', () => {
 		});
 
 		expect(container.getElementsByClassName('tw-line-clamp-4').length).toBe(1);
+	});
+
+	it('should display loan use for direct single borrower loan', () => {
+		const { getByText } = render(LoanUse, {
+			props: {
+				use: 'to buy supplies.',
+				loanAmount: '100',
+				status: 'fundraising',
+				name: 'Bob',
+			},
+		});
+
+		getByText('$100 to Bob helps to buy supplies.');
+	});
+
+	it('should display loan use for direct group loan', () => {
+		const { getByText } = render(LoanUse, {
+			props: {
+				use: 'to buy supplies.',
+				loanAmount: '100',
+				status: 'fundraising',
+				borrowerCount: 2,
+				name: 'Group Name',
+			},
+		});
+
+		getByText('$100 to a member of Group Name helps to buy supplies.');
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1069

- Changed loan use statement string building for direct loans, since they have a more free-form loan data entry

![image](https://user-images.githubusercontent.com/16867161/217959045-3d6f00d2-d4b3-4d7d-aa17-294d348a103c.png)
