### PR TITLE
Core 1047 update matched loans to flss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.472.0",
+	"version": "2.488.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.472.0",
+			"version": "2.488.0",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@apollo/client": "^3.6.9",
@@ -19,7 +19,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.12.1",
-				"@kiva/kv-components": "^3.11.2",
+				"@kiva/kv-components": "^3.12.0",
 				"@kiva/kv-tokens": "^2.4.0",
 				"@mdi/js": "^7",
 				"@sentry/tracing": "^6.19.6",
@@ -4213,9 +4213,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.11.2",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.11.2.tgz",
-			"integrity": "sha512-bs3CGwefZa/RiZZkib/z6c6aFDy7nkrjx6A5sYIl/WCW3d79Rz2o6e+bAHwJlYFHIJzpPQgutU6m6WxUx1iZDQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.12.0.tgz",
+			"integrity": "sha512-JiivlXQRoY+/u/+3Qe3uyEf/wLaSluENDmRi0oCBmMOUE21yJo0LLI09aXDfVLWwGsaypprjqNWwjbpnSLHWIw==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^2.4.1",
 				"@mdi/js": "^5.9.55",
@@ -42833,9 +42833,9 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "3.11.2",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.11.2.tgz",
-			"integrity": "sha512-bs3CGwefZa/RiZZkib/z6c6aFDy7nkrjx6A5sYIl/WCW3d79Rz2o6e+bAHwJlYFHIJzpPQgutU6m6WxUx1iZDQ==",
+			"version": "3.12.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.12.0.tgz",
+			"integrity": "sha512-JiivlXQRoY+/u/+3Qe3uyEf/wLaSluENDmRi0oCBmMOUE21yJo0LLI09aXDfVLWwGsaypprjqNWwjbpnSLHWIw==",
 			"requires": {
 				"@kiva/kv-tokens": "^2.4.1",
 				"@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.12.1",
-		"@kiva/kv-components": "^3.11.2",
+		"@kiva/kv-components": "^3.12.0",
 		"@kiva/kv-tokens": "^2.4.0",
 		"@mdi/js": "^7",
 		"@sentry/tracing": "^6.19.6",

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -248,11 +248,12 @@ export default {
 				filterConfig.config.partnerAvgProfitability.uiConfig.stateKey,
 			].includes(filterConfig.config[key].uiConfig.stateKey);
 
-			// Paging and activities filters are not currently part of the filter panel
+			// These filters are not currently part of the filter panel
 			const hiddenFilters = [
 				filterConfig.config.pageOffset.uiConfig.stateKey,
 				filterConfig.config.pageLimit.uiConfig.stateKey,
 				filterConfig.config.activities.uiConfig.stateKey,
+				filterConfig.config.isMatchable.uiConfig.stateKey,
 			].includes(filterConfig.config[key].uiConfig.stateKey);
 
 			return !hiddenFilters && (this.extendFlssFilters || !isExperimentFilter);

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -150,7 +150,7 @@ export default {
 		},
 		showToast() {
 			if (!this.cookieStore.get('lending-home-toast')) {
-				this.$refs.welcomeToastMessage.show('', 'kiva-logo', true);
+				this.$refs.welcomeToastMessage.show('', 'kiva-logo', false, 10000);
 				this.cookieStore.set('lending-home-toast', true);
 				this.$kvTrackEvent('event-tracking', 'show', 'lending-home-toast-showed');
 			}

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -73,7 +73,6 @@ import QuickFiltersSection from '@/components/LoanFinding/QuickFiltersSection';
 import PartnerSpotlightSection from '@/components/LoanFinding/PartnerSpotlightSection';
 import { runLoansQuery } from '@/util/loanSearch/dataUtils';
 import { FLSS_ORIGIN_LENDING_HOME } from '@/util/flssUtils';
-import { gql } from '@apollo/client';
 import WelcomeLightbox from '@/components/LoanFinding/WelcomeLightbox';
 import { getExperimentSettingCached, trackExperimentVersion } from '@/util/experimentUtils';
 import KvToast from '~/@kiva/kv-components/vue/KvToast';
@@ -136,22 +135,12 @@ export default {
 			this.recommendedLoans = loans;
 		},
 		async getMatchedLoans() {
-			// TODO: replace with FLSS query once "isMatchable" is stable in FLSS
-			const { data } = await this.apollo.query({
-				query: gql`
-					query lendMatchingData {
-						lend {
-							loans(filters: { isMatched: true }, limit: 9) {
-								values {
-									id
-								}
-							}
-						}
-					}
-				`,
-			});
-
-			this.matchedLoans = data?.lend?.loans?.values ?? [];
+			const { loans } = await runLoansQuery(
+				this.apollo,
+				{ isMatchable: true, sortBy: 'personalized', pageLimit: 9 },
+				FLSS_ORIGIN_LENDING_HOME
+			);
+			this.matchedLoans = loans;
 		},
 		trackCategory({ success }, category) {
 			if (success) this.$kvTrackEvent('loan-card', 'add-to-basket', `${category}-lending-home`);

--- a/src/util/loanSearch/filterConfig.js
+++ b/src/util/loanSearch/filterConfig.js
@@ -15,6 +15,7 @@ import partnerRiskRating from '@/util/loanSearch/filters/partnerRiskRating';
 import partnerDefaultRate from '@/util/loanSearch/filters/partnerDefaultRate';
 import partnerAvgProfitability from '@/util/loanSearch/filters/partnerAvgProfitability';
 import activities from '@/util/loanSearch/filters/activities';
+import isMatchable from '@/util/loanSearch/filters/isMatchable';
 
 /**
  * Configuration for the lend/filter FLSS-driven page
@@ -67,6 +68,7 @@ const config = {
 	partnerDefaultRate,
 	partnerAvgProfitability,
 	activities,
+	isMatchable,
 };
 
 /**


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1047
https://kiva.atlassian.net/browse/CORE-1052

- Changed lending-home matched loans section to use FLSS
- The toast shown to new users of lending-home now stays open for 10s (didn't disappear previously)

![image](https://user-images.githubusercontent.com/16867161/217973078-98b81028-b4e2-4a79-8b8e-32fd68d0eb97.png)
