### PR TITLE
fix: add private and no-cache headers for auth routes, add more priva…

### DIFF
--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -20,7 +20,7 @@ module.exports = function authRouter(config = {}) {
 
 	// Helper function to start slient authentication process
 	function attemptSilentAuth(req, res, next) {
-		res.set('Cache-Control', 'no-store, max-age=0, no-transform');
+		res.set('Cache-Control', 'no-cache, no-store, max-age=0, no-transform, private');
 		// Store current url to redirect to after auth
 		req.session.doneUrl = req.originalUrl;
 		req.session.silentAuth = true;
@@ -56,7 +56,7 @@ module.exports = function authRouter(config = {}) {
 
 	// Handle recoverable Auth0 errors
 	router.use('/error', (req, res, next) => {
-		res.set('Cache-Control', 'no-store, max-age=0, no-transform');
+		res.set('Cache-Control', 'no-cache, no-store, max-age=0, no-transform, private');
 		if (req.query.error_description && req.query.error_description.indexOf('OIDC-conformant') > -1) {
 			const loginRedirectUrl = config.auth0.loginRedirectUrls[req.query.client_id];
 			res.redirect(loginRedirectUrl);
@@ -67,7 +67,7 @@ module.exports = function authRouter(config = {}) {
 
 	// Handle login request
 	router.get('/ui-login', (req, res, next) => {
-		res.set('Cache-Control', 'no-store, max-age=0, no-transform');
+		res.set('Cache-Control', 'no-cache, no-store, max-age=0, no-transform, private');
 		const cookies = cookie.parse(req.headers.cookie || '');
 		const options = {
 			audience: config.auth0.apiAudience,
@@ -101,7 +101,7 @@ module.exports = function authRouter(config = {}) {
 
 	// Handle logout request
 	router.get('/ui-logout', (req, res) => {
-		res.set('Cache-Control', 'no-store, max-age=0, no-transform');
+		res.set('Cache-Control', 'no-cache, no-store, max-age=0, no-transform, private');
 		info(`LoginUI: execute logout, session id:${req.sessionID}, cookie:${getSyncCookie(req)}, user id:${req.user && req.user.id}`); // eslint-disable-line max-len
 		const returnUrl = encodeURIComponent(`https://${config.host}`);
 		const logoutUrl = `https://${config.auth0.domain}/v2/logout?returnTo=${returnUrl}`;
@@ -113,7 +113,7 @@ module.exports = function authRouter(config = {}) {
 	// Callback redirected to after Auth0 authentication
 	router.get('/process-ssr-auth', (req, res, next) => {
 		passport.authenticate('auth0', (authErr, user, authInfo) => {
-			res.set('Cache-Control', 'no-store, max-age=0, no-transform');
+			res.set('Cache-Control', 'no-cache, no-store, max-age=0, no-transform, private');
 			if (authErr) {
 				info(`LoginUI: auth error, session id:${req.sessionID}, error: ${authErr}`, { error: authErr });
 

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -74,7 +74,8 @@ module.exports = function createMiddleware({
 		// set html response headers
 		res.setHeader('Content-Type', 'text/html');
 		// Set strict cache-control headers for protected pages
-		if (req?.url?.match(/(settings|portfolio|lend\/saved-search)/g)?.length) {
+		// eslint-disable-next-line max-len
+		if (req?.url?.match(/(checkout|settings|portfolio|lend\/saved-search|monthlygood\/thanks|process-browser-auth|register|start-verification|confirm-instant-donation|instant-donation-thanks)/g)?.length) {
 			res.setHeader('Cache-Control', 'no-cache, no-store, max-age=0, no-transform, private');
 		} else {
 			res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');


### PR DESCRIPTION
…te routes

To better guard against request collapsing and ensure a cache pass.
https://developer.fastly.com/learning/concepts/request-collapsing/#hit-for-pass
- Request collapsing could cause concurrent requests to our servers as requests are queued as they wait on origin
    - This can extend the page load time as similar/matching requests are held until the first request's cacheability is determined. If it's determined non-cacheable it will go to origin and the other requests will be let through. However, if there are still a bunch of similar/matching requests they may end up in the queue again.
- To solve for this, we should signal requests that should not be cached with the private flag OR use custom VCL to force pass
    - https://developer.fastly.com/learning/concepts/request-collapsing/#uncacheable-and-private-responses
        - Private flag disables request collapsing