### PR TITLE
fix: ensure login links always go to login MARS-327

### DIFF
--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -77,16 +77,17 @@ module.exports = function authRouter(config = {}) {
 			options.prompt = 'login';
 		}
 		// Go to register instead of login if the user has not logged in before
-		if (!cookies.kvu) {
+		if (req.query.autoPage === 'true' && !cookies.kvu) {
 			options.login_hint = 'signUp';
 		}
+		// Used by guest checkout to start account claiming process (password reset)
 		if (req.query.forgot === 'true') {
 			options.prompt = 'login';
 			options.login_hint = `forgotPassword|${JSON.stringify({
 				guest: true,
 			})}`;
 		}
-
+		// Override the login hint with whatever hint is set in the request
 		if (req.query.loginHint) {
 			options.login_hint = req.query.loginHint;
 		}

--- a/src/components/Checkout/InContext/InContextCheckout.vue
+++ b/src/components/Checkout/InContext/InContextCheckout.vue
@@ -163,7 +163,7 @@ export default {
 			return appliedCreditsPromoFunds[0] || null;
 		},
 		registerOrLoginHref() {
-			return `/ui-login?force=true&doneUrl=${encodeURIComponent(this.$route.fullPath)}`;
+			return `/ui-login?autoPage=true&force=true&doneUrl=${encodeURIComponent(this.$route.fullPath)}`;
 		},
 		showKivaCreditButton() {
 			return parseFloat(this.creditNeeded) === 0;

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -133,7 +133,7 @@
 									id="login-to-continue-button"
 									data-testid="login-to-continue-button"
 									v-kv-track-event="['basket', 'click-register-cta', 'Continue']"
-									:href="'/ui-login?force=true&doneUrl=/checkout'"
+									:href="'/ui-login?autoPage=true&force=true&doneUrl=/checkout'"
 									:state="continueButtonState"
 								>
 									Continue
@@ -146,7 +146,7 @@
 									id="create-account-continue-button"
 									data-testid="create-account-continue-button"
 									v-kv-track-event="['basket', 'click-register-cta', 'Create an account']"
-									:href="'/ui-login?force=true&doneUrl=/checkout'"
+									:href="'/ui-login?loginHint=signUp&force=true&doneUrl=/checkout'"
 									:state="continueButtonState"
 								>
 									Create an account
@@ -177,7 +177,7 @@
 							>
 								<span>Already have an account?</span>
 								<a
-									href="/login?force=true&amp;loginHint=login&amp;doneUrl=checkout"
+									href="/ui-login?force=true&amp;doneUrl=%2Fcheckout"
 									v-kv-track-event="['basket', 'click-sign—in-cta', 'Sign in here']"
 									title="Sign in here"
 									data-testid="sign-in-button"


### PR DESCRIPTION
Lenders often return to the site without any cookies (new sessions, new devices, etc.) which includes the `kvu` cookie. That cookie is used to determine whether to send users to login or to sign-up by default, and without it the users are sent to sign-up. This is very confusing behavior when clicking a login button, and it has led to several lenders unintentionally creating new accounts. The PR forces all the existing login buttons to always go to login (which is the expected ux). The previous default behavior is now accessed with the `autoPage=true` url parameter to support the checkout "continue" buttons.