### PR TITLE
fix: downgrade @apollo/client to v3.3.21 to address memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "kvue",
-	"version": "2.488.0",
+	"version": "2.491.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.488.0",
+			"version": "2.491.3",
 			"license": "UNLICENSED",
 			"dependencies": {
-				"@apollo/client": "^3.6.9",
+				"@apollo/client": "^3.3.21",
 				"@babel/eslint-parser": "^7.18.2",
 				"@babel/polyfill": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -185,33 +185,30 @@
 			}
 		},
 		"node_modules/@apollo/client": {
-			"version": "3.6.9",
-			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.9.tgz",
-			"integrity": "sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==",
+			"version": "3.3.21",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.21.tgz",
+			"integrity": "sha512-RAmZReFuKCKx0Rs5C0nVJwKomAHUHn+gGP/YvbEsXQWu0sXoncEUZa71UqlfCPVXa/0MkYOIbCXSQdOcuRrHgw==",
 			"dependencies": {
-				"@graphql-typed-document-node/core": "^3.1.1",
+				"@graphql-typed-document-node/core": "^3.0.0",
+				"@types/zen-observable": "^0.8.0",
 				"@wry/context": "^0.6.0",
 				"@wry/equality": "^0.5.0",
-				"@wry/trie": "^0.3.0",
-				"graphql-tag": "^2.12.6",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graphql-tag": "^2.12.0",
 				"hoist-non-react-statics": "^3.3.2",
-				"optimism": "^0.16.1",
+				"optimism": "^0.16.0",
 				"prop-types": "^15.7.2",
 				"symbol-observable": "^4.0.0",
-				"ts-invariant": "^0.10.3",
-				"tslib": "^2.3.0",
-				"zen-observable-ts": "^1.2.5"
+				"ts-invariant": "^0.8.0",
+				"tslib": "^1.10.0",
+				"zen-observable": "^0.8.14"
 			},
 			"peerDependencies": {
-				"graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
-				"graphql-ws": "^5.5.5",
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-				"subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
+				"graphql": "^14.0.0 || ^15.0.0",
+				"react": "^16.8.0 || ^17.0.0",
+				"subscriptions-transport-ws": "^0.9.0"
 			},
 			"peerDependenciesMeta": {
-				"graphql-ws": {
-					"optional": true
-				},
 				"react": {
 					"optional": true
 				},
@@ -231,6 +228,11 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@apollo/client/node_modules/@wry/context/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+		},
 		"node_modules/@apollo/client/node_modules/@wry/equality": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.2.tgz",
@@ -241,6 +243,11 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/@apollo/client/node_modules/@wry/equality/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/@apollo/client/node_modules/optimism": {
 			"version": "0.16.1",
@@ -260,9 +267,9 @@
 			}
 		},
 		"node_modules/@apollo/client/node_modules/ts-invariant": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-			"integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.8.2.tgz",
+			"integrity": "sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==",
 			"dependencies": {
 				"tslib": "^2.1.0"
 			},
@@ -270,18 +277,15 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@apollo/client/node_modules/tslib": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+		"node_modules/@apollo/client/node_modules/ts-invariant/node_modules/tslib": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
-		"node_modules/@apollo/client/node_modules/zen-observable-ts": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-			"integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-			"dependencies": {
-				"zen-observable": "0.8.15"
-			}
+		"node_modules/@apollo/client/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@apollo/protobufjs": {
 			"version": "1.0.5",
@@ -8459,6 +8463,11 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
+		},
+		"node_modules/@types/zen-observable": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+			"integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
 		},
 		"node_modules/@typescript-eslint/experimental-utils": {
 			"version": "5.6.0",
@@ -39674,22 +39683,23 @@
 	},
 	"dependencies": {
 		"@apollo/client": {
-			"version": "3.6.9",
-			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.9.tgz",
-			"integrity": "sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==",
+			"version": "3.3.21",
+			"resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.3.21.tgz",
+			"integrity": "sha512-RAmZReFuKCKx0Rs5C0nVJwKomAHUHn+gGP/YvbEsXQWu0sXoncEUZa71UqlfCPVXa/0MkYOIbCXSQdOcuRrHgw==",
 			"requires": {
-				"@graphql-typed-document-node/core": "^3.1.1",
+				"@graphql-typed-document-node/core": "^3.0.0",
+				"@types/zen-observable": "^0.8.0",
 				"@wry/context": "^0.6.0",
 				"@wry/equality": "^0.5.0",
-				"@wry/trie": "^0.3.0",
-				"graphql-tag": "^2.12.6",
+				"fast-json-stable-stringify": "^2.0.0",
+				"graphql-tag": "^2.12.0",
 				"hoist-non-react-statics": "^3.3.2",
-				"optimism": "^0.16.1",
+				"optimism": "^0.16.0",
 				"prop-types": "^15.7.2",
 				"symbol-observable": "^4.0.0",
-				"ts-invariant": "^0.10.3",
-				"tslib": "^2.3.0",
-				"zen-observable-ts": "^1.2.5"
+				"ts-invariant": "^0.8.0",
+				"tslib": "^1.10.0",
+				"zen-observable": "^0.8.14"
 			},
 			"dependencies": {
 				"@wry/context": {
@@ -39698,6 +39708,13 @@
 					"integrity": "sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==",
 					"requires": {
 						"tslib": "^2.3.0"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+							"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+						}
 					}
 				},
 				"@wry/equality": {
@@ -39706,6 +39723,13 @@
 					"integrity": "sha512-oVMxbUXL48EV/C0/M7gLVsoK6qRHPS85x8zECofEZOVvxGmIPLA9o5Z27cc2PoAyZz1S2VoM2A7FLAnpfGlneA==",
 					"requires": {
 						"tslib": "^2.3.0"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+							"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+						}
 					}
 				},
 				"optimism": {
@@ -39723,25 +39747,24 @@
 					"integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ=="
 				},
 				"ts-invariant": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-					"integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+					"version": "0.8.2",
+					"resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.8.2.tgz",
+					"integrity": "sha512-VI1ZSMW8soizP5dU8DsMbj/TncHf7bIUqavuE7FTeYeQat454HHurJ8wbfCnVWcDOMkyiBUWOW2ytew3xUxlRw==",
 					"requires": {
 						"tslib": "^2.1.0"
+					},
+					"dependencies": {
+						"tslib": {
+							"version": "2.5.0",
+							"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+							"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+						}
 					}
 				},
 				"tslib": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-					"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
-				},
-				"zen-observable-ts": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-					"integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-					"requires": {
-						"zen-observable": "0.8.15"
-					}
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
@@ -46032,6 +46055,11 @@
 			"requires": {
 				"@types/node": "*"
 			}
+		},
+		"@types/zen-observable": {
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+			"integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw=="
 		},
 		"@typescript-eslint/experimental-utils": {
 			"version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"deploy-storybook": "storybook-to-ghpages"
 	},
 	"dependencies": {
-		"@apollo/client": "^3.6.9",
+		"@apollo/client": "^3.3.21",
 		"@babel/eslint-parser": "^7.18.2",
 		"@babel/polyfill": "^7.10.4",
 		"@babel/runtime": "^7.12.5",


### PR DESCRIPTION
Hoping this will address the memory leak we've been seeing, based on https://github.com/apollographql/apollo-client/issues/9712#issuecomment-1197225283