### PR TITLE
fix: touch should toggle categories menu

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -130,6 +130,7 @@
 								@pointerenter.stop="onLendLinkPointerEnter"
 								@pointerleave.stop="onLendLinkPointerLeave"
 								@pointerup.stop="onLendLinkPointerEnter"
+								@click="onCategoriesClick"
 							>
 								<span class="tw-flex tw-items-center">Categories
 									<kv-material-icon
@@ -778,6 +779,11 @@ export default {
 				this.$router.push({
 					path: '/lend-by-category'
 				}).catch(() => {});
+			}
+		},
+		onCategoriesClick(e) {
+			if (e.pointerType === 'touch') {
+				this.toggleLendMenu();
 			}
 		},
 		onLendLinkClick(e) {


### PR DESCRIPTION
- I thought I had tested mobile click, but apparently I just tested smaller browsers for this situation
- Touching the categories button in mobile should toggle the menu