### PR TITLE
feat: add user attribute for when a user has a us loan in basket

### DIFF
--- a/src/components/Checkout/BasketItemsList.vue
+++ b/src/components/Checkout/BasketItemsList.vue
@@ -38,6 +38,7 @@
 import BasketItem from '@/components/Checkout/BasketItem';
 import DonationItem from '@/components/Checkout/DonationItem';
 import KivaCardItem from '@/components/Checkout/KivaCardItem';
+import { userUsLoanCheckout } from '@/util/optimizelyUserMetrics';
 
 export default {
 	name: 'BasketItemsList',
@@ -79,6 +80,13 @@ export default {
 		BasketItem,
 		DonationItem,
 		KivaCardItem
-	}
+	},
+	watch: {
+		loans(loansInBasket) {
+			// eslint-disable-next-line no-underscore-dangle
+			const hasUsLoan = loansInBasket.some(reservation => reservation?.loan?.__typename === 'LoanDirect');
+			userUsLoanCheckout(hasUsLoan);
+		}
+	},
 };
 </script>

--- a/src/util/optimizelyUserMetrics.js
+++ b/src/util/optimizelyUserMetrics.js
@@ -17,6 +17,14 @@ function setUserAttribute(key, value) {
 }
 
 /**
+ * Checks if user is checking out with a US Direct Loan.
+ * @param {Boolean} hasUsLoan
+ */
+export function userUsLoanCheckout(hasUsLoan) {
+	setUserAttribute('us_loan_checkout', hasUsLoan ? 'yes' : 'no');
+}
+
+/**
  * Checks if user has visted kiva before on the.
  * @param {Boolean} hasEverLoggedIn
  */


### PR DESCRIPTION
ACK-540

I thought the `BasketItemList` would be a cleaner place to put this as opposed to the `CheckoutPage`. This fires a user attribute to signal that a user has a US loan in basket. I added this attribute on optimizely already, the idea is that we would like to exclude users with this attribute from the thanks page experiment. 