### PR TITLE
fix: missing optional chaining

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -315,7 +315,7 @@ export default {
 		}
 
 		// Check for contentful content
-		const pageEntry = data.contentful?.entries?.items?.[0] ?? null;
+		const pageEntry = data?.contentful?.entries?.items?.[0] ?? null;
 		this.pageData = pageEntry ? processPageContentFlat(pageEntry) : null;
 
 		if (this.showFocusedShareAsk) {

--- a/src/util/hotJarUserAttributes.js
+++ b/src/util/hotJarUserAttributes.js
@@ -8,14 +8,14 @@ export default function setHotJarUserAttributes(userData) {
 	}
 
 	if (window.hj) {
-		window.hj('identify', userData.userId, {
-			'Has ever logged in': userData.hasEverLoggedIn,
-			'Has lent before': userData.hasLentBefore,
-			'Has deposit before': userData.hasDepositBefore,
+		window.hj('identify', userData?.userId, {
+			'Has ever logged in': userData?.hasEverLoggedIn,
+			'Has lent before': userData?.hasLentBefore,
+			'Has deposit before': userData?.hasDepositBefore,
 		});
 
 		if (userData?.isFirstLoan !== undefined) {
-			window.hj('identify', userData.userId, {
+			window.hj('identify', userData?.userId, {
 				'First loan': userData?.isFirstLoan,
 				'Has direct loan': userData?.hasDirectLoan,
 				'Has core loan': userData?.hasCoreLoan,


### PR DESCRIPTION
- An error came through DD today for accessing props on null/undefined
- Location of error wasn't obvious, but I noticed a few missing usages optional chaining when compared to other similar usages of the affected objects

https://app.datadoghq.com/logs?query=service%3Akiva-ui%20env%3Aprod%20status%3Aerror&cols=host%2Cservice&event=AQAAAYZXipjnwxMHsgAAAABBWVpYaXBvLUFBQW40ZGUtTndNbUNnQUc&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1676504337021&to_ts=1676507937021&live=true

https://app.datadoghq.com/logs?query=service%3Akiva-ui%20env%3Aprod%20status%3Aerror&cols=host%2Cservice&event=AQAAAYZXipT_wxMHrwAAAABBWVpYaXBvLUFBQW40ZGUtTndNbUNnQUQ&index=%2A&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1676504337021&to_ts=1676507937021&live=true