### PR TITLE
fix: height fixed for new loan cards in lendingcategorysection component

### DIFF
--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -25,6 +25,7 @@
 						:use-full-width="true"
 						:per-row="perStep"
 						@add-to-basket="addToBasket"
+						class="tw-h-full"
 					/>
 					<kiva-classic-basic-loan-card
 						v-else


### PR DESCRIPTION
height for new card in `LendingCategorySection` component fixed to adjust to the carousel height