### PR TITLE
fix: updated Apollo updateQuery usage for downgrade

### DIFF
--- a/src/api/fixtures/AutolendProfile.js
+++ b/src/api/fixtures/AutolendProfile.js
@@ -14,7 +14,6 @@ export default function AutolendProfile() {
 		lendAfterDaysIdle: 90,
 		idleCreditOptIn: true,
 		cIdleStartTime: null,
-		pauseUntil: null,
 		enableAfter: 0,
 		kivaChooses: true,
 		loanSearchCriteria: LoanSearchCriteria(),

--- a/src/api/fixtures/AutolendProfile.js
+++ b/src/api/fixtures/AutolendProfile.js
@@ -14,6 +14,7 @@ export default function AutolendProfile() {
 		lendAfterDaysIdle: 90,
 		idleCreditOptIn: true,
 		cIdleStartTime: null,
+		pauseUntil: null,
 		enableAfter: 0,
 		kivaChooses: true,
 		loanSearchCriteria: LoanSearchCriteria(),

--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 import _get from 'lodash/get';
-import _merge from 'lodash/merge';
 import logFormatter from '@/util/logFormatter';
 import bothProfilesQuery from '@/graphql/query/autolending/bothProfiles.graphql';
 import loanCountQuery from '@/graphql/query/loanCount.graphql';
@@ -36,7 +35,10 @@ function writeAutolendingData(cache, { currentProfile, savedProfile, ...fields }
 	cache.writeQuery({
 		query: bothProfilesQuery,
 		data: {
-			autolending: _merge(AutolendProfile(), data.autolending, autolending)
+			autolending: {
+				...data.autolending,
+				...autolending
+			}
 		}
 	});
 }

--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import _get from 'lodash/get';
+import _merge from 'lodash/merge';
 import logFormatter from '@/util/logFormatter';
 import bothProfilesQuery from '@/graphql/query/autolending/bothProfiles.graphql';
 import loanCountQuery from '@/graphql/query/loanCount.graphql';
@@ -35,10 +36,7 @@ function writeAutolendingData(cache, { currentProfile, savedProfile, ...fields }
 	cache.writeQuery({
 		query: bothProfilesQuery,
 		data: {
-			autolending: {
-				...data.autolending,
-				...autolending
-			}
+			autolending: _merge(AutolendProfile(), data.autolending, autolending)
 		}
 	});
 }

--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -31,12 +31,16 @@ function writeAutolendingData(cache, { currentProfile, savedProfile, ...fields }
 		autolending.savedProfile = getCacheableProfile(savedProfile);
 	}
 	// Update autolending object in the cache
-	cache.updateQuery({ query: bothProfilesQuery }, data => ({
-		autolending: {
-			...data.autolending,
-			...autolending
+	const data = cache.readQuery({ query: bothProfilesQuery });
+	cache.writeQuery({
+		query: bothProfilesQuery,
+		data: {
+			autolending: {
+				...data.autolending,
+				...autolending
+			}
 		}
-	}));
+	});
 }
 
 let loanCountObservable;

--- a/src/api/localResolvers/loanSearch.js
+++ b/src/api/localResolvers/loanSearch.js
@@ -42,14 +42,16 @@ export default () => {
 			Mutation: {
 				updateLoanSearch(_, { searchParams }, { cache }) {
 					// Patch the new params into the existing state in the cache
-					const updatedResult = cache.updateQuery({ query: loanSearchStateQuery }, data => ({
-						loanSearchState: {
-							...data.loanSearchState,
-							...searchParams
+					const data = cache.readQuery({ query: loanSearchStateQuery });
+					cache.writeQuery({
+						query: loanSearchStateQuery,
+						data: {
+							loanSearchState: {
+								...data.loanSearchState,
+								...searchParams
+							}
 						}
-					}));
-					// Return the latest state
-					return updatedResult.loanSearchState;
+					});
 				}
 			}
 		}

--- a/src/api/localResolvers/tipMessage.js
+++ b/src/api/localResolvers/tipMessage.js
@@ -23,24 +23,32 @@ export default () => {
 		resolvers: {
 			Mutation: {
 				showTipMessage(_, { message = '', persist = false, type = '' }, context) {
-					context.cache.updateQuery({ query: tipMessageDataQuery }, data => ({
-						tip: {
-							...data.tip,
-							message,
-							persist,
-							type,
-							visible: true,
+					const data = context.cache.readQuery({ query: tipMessageDataQuery });
+					context.cache.writeQuery({
+						query: tipMessageDataQuery,
+						data: {
+							tip: {
+								...data.tip,
+								message,
+								persist,
+								type,
+								visible: true,
+							}
 						}
-					}));
+					});
 					return true;
 				},
 				closeTipMessage(_, args, context) {
-					context.cache.updateQuery({ query: tipMessageDataQuery }, data => ({
-						tip: {
-							...data.tip,
-							visible: false,
+					const data = context.cache.readQuery({ query: tipMessageDataQuery });
+					context.cache.writeQuery({
+						query: tipMessageDataQuery,
+						data: {
+							tip: {
+								...data.tip,
+								visible: false,
+							}
 						}
-					}));
+					});
 					return true;
 				},
 			},

--- a/test/unit/specs/api/localResolvers/loanSearch.spec.js
+++ b/test/unit/specs/api/localResolvers/loanSearch.spec.js
@@ -1,32 +1,21 @@
-import loanSearchFactory, { getDefaultLoanSearchState } from '@/api/localResolvers/loanSearch';
-
-const defaultLoanSearchState = getDefaultLoanSearchState();
+import loanSearchFactory from '@/api/localResolvers/loanSearch';
 
 describe('loanSearch.js', () => {
 	describe('Mutation.updateLoanSearch', () => {
 		it('Returns a default loan search object with gender set', () => {
 			const { resolvers } = loanSearchFactory();
 
-			// The updateLoanSearch mutation checks the cache
-			// then blends new variables into the previous state
-			const loanSearchPlusGender = {
-				loanSearchState: {
-					...defaultLoanSearchState.loanSearchState,
-					...{ gender: 'male' }
-				}
-			};
-
 			const context = {
 				cache: {
-					updateQuery: jest.fn().mockReturnValue(loanSearchPlusGender),
+					readQuery: jest.fn().mockReturnValue({}),
+					writeQuery: jest.fn(),
 				},
 			};
 
-			const result = resolvers.Mutation.updateLoanSearch(null, { searchParams: { gender: 'male' } }, context);
+			resolvers.Mutation.updateLoanSearch(null, { searchParams: { gender: 'male' } }, context);
 
-			expect(context.cache.updateQuery.mock.calls.length).toBe(1);
-
-			expect(result).toEqual(loanSearchPlusGender.loanSearchState);
+			expect(context.cache.readQuery.mock.calls.length).toBe(1);
+			expect(context.cache.writeQuery.mock.calls.length).toBe(1);
 		});
 	});
 });


### PR DESCRIPTION
- The `updateQuery` method is simply `readQuery` followed by `writeQuery`
- Realized that the `writeQuery` doesn't actually return the updated state, and the return wasn't being used, so removed from `loanSearch`

https://github.com/apollographql/apollo-client/pull/8382/files