### PR TITLE
Core 1122 no add to basket event on new loan card

### DIFF
--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -18,6 +18,7 @@
 						id="LoanAmountDropdown"
 						class="tw-min-w-12"
 						v-model="selectedOption"
+						v-kv-track-event="['Lending', 'click-Modify loan amount', 'open dialog', loanId, loanId]"
 					>
 						<option
 							v-for="priceOption in prices"
@@ -37,6 +38,7 @@
 						class="tw-inline-flex tw-flex-1"
 						data-testid="bp-lend-cta-lend-button"
 						type="submit"
+						v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
 					>
 						{{ ctaButtonText }}
 					</kv-ui-button>
@@ -49,6 +51,7 @@
 					class="tw-inline-flex tw-flex-1"
 					data-testid="bp-lend-cta-lend-again-button"
 					type="submit"
+					v-kv-track-event="['Lending', 'Add to basket', 'Lend again', loanId, loanId]"
 				>
 					Lend again
 				</kv-ui-button>
@@ -80,6 +83,7 @@
 			class="tw-inline-flex tw-flex-1"
 			data-testid="bp-lend-cta-checkout-button"
 			to="/basket"
+			v-kv-track-event="['Lending', 'click-Continue-to-checkout', 'Continue to checkout', loanId, loanId]"
 		>
 			Checkout now
 		</kv-ui-button>
@@ -101,9 +105,7 @@ import {
 	isBetween25And50,
 	isBetween25And500
 } from '@/util/loanUtils';
-
 import LendAmountButton from '@/components/LoanCards/Buttons/LendAmountButton';
-
 import KvUiSelect from '~/@kiva/kv-components/vue/KvSelect';
 import KvUiButton from '~/@kiva/kv-components/vue/KvButton';
 
@@ -162,6 +164,9 @@ export default {
 		},
 	},
 	computed: {
+		loanId() {
+			return this.loan?.id;
+		},
 		status() {
 			return this.loan?.status ?? '';
 		},

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -363,6 +363,9 @@ export default {
 		loanBorrowerCount() {
 			return this.loan?.borrowerCount ?? 0;
 		},
+		lessThan25() {
+			return this.amountLeft < 25 && this.amountLeft !== 0;
+		},
 	},
 	methods: {
 		showLoanDetails(e) {
@@ -438,14 +441,22 @@ export default {
 			}).then(() => {
 				this.isAdding = false;
 				this.$emit('add-to-basket', { loanId: this.loanId, success: true });
+				this.$kvTrackEvent(
+					'loan-card',
+					'add-to-basket',
+					null,
+					this.loanId,
+					this.lessThan25 ? this.amountLeft : 25
+				);
 			}).catch(e => {
 				this.isAdding = false;
 				this.$emit('add-to-basket', { loanId: this.loanId, success: false });
-				const msg = e[0].extensions.code === 'reached_anonymous_basket_limit'
-					? e[0].message
+				const msg = e?.[0]?.extensions?.code === 'reached_anonymous_basket_limit'
+					? e?.[0]?.message
 					: 'There was a problem adding the loan to your basket';
-
 				this.$showTipMsg(msg, 'error');
+				this.$kvTrackEvent('Lending', 'Add-to-Basket', 'Failed to add loan. Please try again.');
+				Sentry.captureException(e);
 			});
 		},
 	},

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -1040,6 +1040,13 @@ export default {
 						tagId: [73]
 					},
 				},
+				{
+					id: 155,
+					url: 'matched-loans',
+					flssLoanSearch: {
+						isMatchable: true
+					},
+				},
 			]
 
 		};


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1122
https://kiva.atlassian.net/browse/CORE-1123

- Added matched-loans to the channel map file - enables QF on matched-loans category (before they were visible but not working)
- Added click + add to basket analytics for the new loan card - the analytics aren't new standard but match existing loan card analytics
- The one change from existing analytics is that I added `loanId` to all of the analytics (the existing loan card only has `loanId` when the lend button is clicked) and the existing grid loan cards incorrectly log add to basket whenever the lend amount dropdown is clicked
- Added Sentry logging to add to basket error, matching old `LendButton`