### PR TITLE
fix: resolve errors with read/write query for autolending

### DIFF
--- a/src/api/localResolvers/autolending.js
+++ b/src/api/localResolvers/autolending.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import _get from 'lodash/get';
+import _mergeWith from 'lodash/mergeWith';
 import logFormatter from '@/util/logFormatter';
 import bothProfilesQuery from '@/graphql/query/autolending/bothProfiles.graphql';
 import loanCountQuery from '@/graphql/query/loanCount.graphql';
@@ -30,17 +31,13 @@ function writeAutolendingData(cache, { currentProfile, savedProfile, ...fields }
 	if (savedProfile) {
 		autolending.savedProfile = getCacheableProfile(savedProfile);
 	}
+	// Create copy of cached object to remove readonly from props since lodash doesn't merge readonly props
+	const cached = JSON.parse(JSON.stringify(cache.readQuery({ query: bothProfilesQuery })?.autolending ?? {}));
+	// Use customizer to overwrite array props instead of merging
+	const customizer = (_a, b) => (Array.isArray(b) ? b : undefined);
+	const data = _mergeWith(cached, autolending, customizer);
 	// Update autolending object in the cache
-	const data = cache.readQuery({ query: bothProfilesQuery });
-	cache.writeQuery({
-		query: bothProfilesQuery,
-		data: {
-			autolending: {
-				...data.autolending,
-				...autolending
-			}
-		}
-	});
+	cache.writeQuery({ query: bothProfilesQuery, data: { autolending: data } });
 }
 
 let loanCountObservable;
@@ -51,7 +48,7 @@ function updateCurrentLoanCount({ cache, client, currentProfile }) {
 	writeAutolendingData(cache, { countingLoans: true });
 
 	// Get criteria input from current profile
-	const { filters } = getSearchableCriteria(currentProfile.loanSearchCriteria);
+	const { filters } = getSearchableCriteria(currentProfile?.loanSearchCriteria);
 
 	// Cancel the currently in-flight query
 	if (loanCountObservable) loanCountObservable.unsubscribe();
@@ -204,7 +201,7 @@ export default () => {
 								const profile = _get(result, 'data.my.autolendProfile') || AutolendProfile();
 								return {
 									...profile,
-									loanSearchCriteria: profile.loanSearchCriteria || LoanSearchCriteria(),
+									loanSearchCriteria: profile?.loanSearchCriteria || LoanSearchCriteria(),
 								};
 							})
 							// Replace any legacy filter values
@@ -264,7 +261,7 @@ export default () => {
 					});
 
 					// If the search filters haven't changed, return immediately instead of getting a new loan count
-					if (criteriaAreEqual(profileBeforeChange.loanSearchCriteria, currentProfile.loanSearchCriteria)) {
+					if (criteriaAreEqual(profileBeforeChange?.loanSearchCriteria, currentProfile?.loanSearchCriteria)) {
 						return true;
 					}
 

--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -89,10 +89,10 @@ import {
 
 import KvButton from '@/components/Kv/KvButton';
 import KvSelect from '@/components/Kv/KvSelect';
-import KvLightbox from '@/components/Kv/KvLightbox';
 import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 import KvRadio from '@/components/Kv/KvRadio';
 import KvSettingsCard from '@/components/Kv/KvSettingsCard';
+import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
 
 export default {
 	name: 'AutolendingStatus',

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -98,10 +98,10 @@ import _isFinite from 'lodash/isFinite';
 
 import KvButton from '@/components/Kv/KvButton';
 import KvSelect from '@/components/Kv/KvSelect';
-import KvLightbox from '@/components/Kv/KvLightbox';
 import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
 import KvRadio from '@/components/Kv/KvRadio';
 import KvSettingsCard from '@/components/Kv/KvSettingsCard';
+import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
 
 import LendTimingDropdown from './LendTimingDropdown';
 import LendTimingMessaging from './LendTimingMessaging';

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -132,8 +132,8 @@ import { gql } from '@apollo/client';
 
 import KvExpandable from '@/components/Kv/KvExpandable';
 import KvIcon from '@/components/Kv/KvIcon';
-import KvLightbox from '@/components/Kv/KvLightbox';
 import KvSettingsCard from '@/components/Kv/KvSettingsCard';
+import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
 
 import AttributeFilter from './AttributeFilter';
 import AttributeRadios from './AttributeRadios';

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -40,8 +40,8 @@
 import _get from 'lodash/get';
 import { gql } from '@apollo/client';
 import KvButton from '@/components/Kv/KvButton';
-import KvLightbox from '@/components/Kv/KvLightbox';
 import KvLoadingSpinner from '@/components/Kv/KvLoadingSpinner';
+import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
 
 export default {
 	name: 'SaveButton',


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1148

- Resolved issues in autolending local resolver with the `readQuery` and `writeQuery` combo that was needed to replace the `updateQuery` after Apollo downgrade
- Used lodash `mergeWith` in order to create a deep copy + overwrite arrays (specifically country list in `LoanSearchFilters`
- I would randomly get a weird "init" error when testing my autolending changes, and I eventually tracked it down to the 3rd party `FocusLock` component in the `KvLightbox` - I replaced the usages with the lightbox from our component library