### PR TITLE
feat: hover on card update, cleaned up stories

### DIFF
--- a/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
+++ b/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
@@ -40,8 +40,6 @@ const story = (args = {}, isLoading = false, extraLoanProps = {}, extraData = {}
 		template: `
 			<kiva-classic-basic-loan-card-exp
 				:loan-id="loanId"
-				:lend-now-button="lendNowButton"
-				:show-action-button="showActionButton"
 				:use-full-width="useFullWidth"
 				:show-tags="showTags"
 				:per-row="perRow"
@@ -60,16 +58,6 @@ export const Loading = story({
 	loanId: loan.id,
 }, true);
 
-export const LendNowButton = story({
-	loanId: loan.id,
-	lendNowButton: true
-});
-
-export const ShowActionButton = story({
-	loanId: loan.id,
-	showActionButton: true
-});
-
 export const UseFullWidth = story({
 	loanId: loan.id,
 	useFullWidth: true
@@ -80,13 +68,18 @@ export const ShowTags = story({
 	showTags: true
 });
 
+export const Matched = story({
+	loanId: loan.id,
+	showTags: true,
+}, false, { matchingText: 'Matched by Ebay', matchRatio: 1, loanFundraisingInfo: {
+	fundedAmount: '200.00',
+	isExpiringSoon: false,
+	reservedAmount: '0.00'
+} });
+
 export const AllSharesReserved = story({
 	loanId: loan.id,
 }, false, { unreservedAmount: '0.00', fundraisingPercent: 1 });
-
-export const Matched = story({
-	loanId: loan.id,
-}, false, { matchingText: 'Matched by Ebay', matchRatio: 1 });
 
 export const InBasket = story({
 	loanId: loan.id,

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -2,102 +2,103 @@
 	<div
 		:id="`${loanId}-loan-card`"
 		class="tw-flex tw-flex-col tw-p-1 tw-bg-white tw-rounded tw-w-full"
-		:class="{ 'loan-card-active-hover': !allSharesReserved }"
 		style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);"
 		:style="{ minWidth: '230px', maxWidth: cardWidth }"
 	>
-		<!-- Borrower image -->
-		<kv-loading-placeholder
-			v-if="isLoading"
-			class="tw-mb-1 tw-rounded" :style="{ width: '100%', height: imgPlaceholderHeight }"
-		/>
-		<div
-			v-else
-			class="tw-relative"
-			@click="showLoanDetails"
-		>
-			<router-link
-				:is="allSharesReserved ? 'span' : 'router-link'"
-				:to="customLoanDetails ? '' : `/lend/${loanId}`"
-				v-kv-track-event="['Lending', 'click-Read more', 'Photo', loanId]"
-				class="tw-flex"
-			>
-				<borrower-image
-					class="
-					tw-relative
-					tw-w-full
-					tw-bg-black
-					tw-rounded
-				"
-					:alt="`Photo of ${borrowerName}`"
-					:aspect-ratio="3 / 4"
-					:default-image="{ width: 336 }"
-					:hash="imageHash"
-					:images="[
-						{ width: largestImageWidth, viewSize: 1024 },
-						{ width: largestImageWidth, viewSize: 768 },
-						{ width: 416, viewSize: 480 },
-						{ width: 374, viewSize: 414 },
-						{ width: 335, viewSize: 375 },
-						{ width: 280 },
-					]"
-				/>
-
-				<div v-if="countryName">
-					<summary-tag
-						id="locationPill"
-						class="tw-absolute tw-bottom-1 tw-left-1 tw-text-primary"
-						:city="city"
-						:state="state"
-						:country-name="countryName"
-					>
-						<kv-material-icon
-							class="tw-h-2 tw-w-2"
-							:icon="mdiMapMarker"
-						/>
-						{{ formattedLocation }}
-					</summary-tag>
-				</div>
-			</router-link>
-		</div>
-
 		<div class="tw-grow">
-			<!-- Loan tag -->
-			<loan-tag-v2 v-if="showTags && !isLoading" :loan="loan" :amount-left="amountLeft" />
-
-			<!-- Loan use  -->
-			<div class="tw-mb-1.5 tw-mt-1">
-				<kv-loading-paragraph
-					v-if="isLoading"
-					:style="{ width: '100%', height: '5.5rem' }"
-				/>
-
-				<router-link
-					v-else
-					:is="allSharesReserved ? 'span' : 'router-link'"
-					:to="customLoanDetails ? '' : `/lend/${loanId}`"
-					v-kv-track-event="['Lending', 'click-Read more', 'Use', loanId]"
-					class="loan-card-use tw-text-primary"
-				>
-					<loan-use
-						:use="loanUse"
-						:loan-amount="loanAmount"
-						:status="loanStatus"
-						:borrower-count="loanBorrowerCount"
-						:name="borrowerName"
-						:distribution-model="distributionModel"
-					/>
-				</router-link>
-
-				<!-- Loan call outs -->
+			<div :class="{ 'loan-card-active-hover': !allSharesReserved }">
+				<!-- Borrower image -->
 				<kv-loading-placeholder
-					v-if="typeof loanCallouts === 'undefined'"
-					class="tw-mt-1.5 tw-mb-2"
-					:style="{ width: '60%', height: '1.75rem', 'border-radius': '500rem' }"
+					v-if="isLoading"
+					class="tw-mb-1 tw-rounded" :style="{ width: '100%', height: imgPlaceholderHeight }"
 				/>
+				<div
+					v-else
+					class="tw-relative"
+					@click="showLoanDetails"
+				>
+					<router-link
+						:is="allSharesReserved ? 'span' : 'router-link'"
+						:to="customLoanDetails ? '' : `/lend/${loanId}`"
+						v-kv-track-event="['Lending', 'click-Read more', 'Photo', loanId]"
+						class="tw-flex"
+					>
+						<borrower-image
+							class="
+								tw-relative
+								tw-w-full
+								tw-bg-black
+								tw-rounded
+							"
+							:alt="`Photo of ${borrowerName}`"
+							:aspect-ratio="3 / 4"
+							:default-image="{ width: 336 }"
+							:hash="imageHash"
+							:images="[
+								{ width: largestImageWidth, viewSize: 1024 },
+								{ width: largestImageWidth, viewSize: 768 },
+								{ width: 416, viewSize: 480 },
+								{ width: 374, viewSize: 414 },
+								{ width: 335, viewSize: 375 },
+								{ width: 280 },
+							]"
+						/>
 
-				<loan-callouts v-else :callouts="loanCallouts" class="tw-mt-1.5" />
+						<div v-if="countryName">
+							<summary-tag
+								id="locationPill"
+								class="tw-absolute tw-bottom-1 tw-left-1 tw-text-primary"
+								:city="city"
+								:state="state"
+								:country-name="countryName"
+							>
+								<kv-material-icon
+									class="tw-h-2 tw-w-2"
+									:icon="mdiMapMarker"
+								/>
+								{{ formattedLocation }}
+							</summary-tag>
+						</div>
+					</router-link>
+				</div>
+
+				<!-- Loan tag -->
+				<loan-tag-v2 v-if="showTags && !isLoading" :loan="loan" :amount-left="amountLeft" />
+
+				<!-- Loan use  -->
+				<div class="tw-mb-1.5 tw-mt-1">
+					<kv-loading-paragraph
+						v-if="isLoading"
+						:style="{ width: '100%', height: '5.5rem' }"
+					/>
+
+					<router-link
+						v-else
+						:is="allSharesReserved ? 'span' : 'router-link'"
+						:to="customLoanDetails ? '' : `/lend/${loanId}`"
+						v-kv-track-event="['Lending', 'click-Read more', 'Use', loanId]"
+						class="loan-card-use tw-text-primary"
+					>
+						<loan-use
+							:use="loanUse"
+							:loan-amount="loanAmount"
+							:status="loanStatus"
+							:borrower-count="loanBorrowerCount"
+							:name="borrowerName"
+							:distribution-model="distributionModel"
+						/>
+					</router-link>
+				</div>
 			</div>
+
+			<!-- Loan call outs -->
+			<kv-loading-placeholder
+				v-if="isLoading || typeof loanCallouts === 'undefined'"
+				class="tw-mt-1.5 tw-mb-2"
+				:style="{ width: '60%', height: '1.75rem', 'border-radius': '500rem' }"
+			/>
+
+			<loan-callouts v-else :callouts="loanCallouts" class="tw-mt-1.5" />
 		</div>
 
 		<div class="tw-flex tw-justify-between tw-mt-2">
@@ -208,23 +209,7 @@ export default {
 			type: Number,
 			required: true,
 		},
-		expLabel: {
-			type: String,
-			default: ''
-		},
-		lendNowButton: {
-			type: Boolean,
-			default: false
-		},
-		customCheckoutRoute: {
-			type: String,
-			default: ''
-		},
 		customLoanDetails: {
-			type: Boolean,
-			default: false
-		},
-		showActionButton: {
 			type: Boolean,
 			default: false
 		},


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1114

- Updated new loan cards to only underline loan use statement when the image, loan callouts, or use statement hovered - before the underline occurred when any part of the card was hovered
- Cleaned up the props - we had several unused props
- Cleaned up the stories - we had stories that no longer did what was expected