### PR TITLE
feat: loading state for quick filter genders

### DIFF
--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -3,9 +3,8 @@
 		<div
 			class="tw-flex"
 			:class="{
-				'tw-px-1 lg:tw-pr-0 tw-justify-start md:tw-gap-1 tw-flex-wrap lg:tw-flex-nowrap'
-					: !withCategories,
-				'tw-gap-2 tw-flex-col lg:tw-flex-row tw-w-full' : withCategories
+				'tw-px-1 lg:tw-pr-0 tw-justify-start md:tw-gap-1 tw-flex-wrap lg:tw-flex-nowrap': !withCategories,
+				'tw-gap-2 tw-flex-col lg:tw-flex-row tw-w-full': withCategories
 			}"
 		>
 			<div v-if="withCategories" class="tw-flex tw-flex-col tw-grow">
@@ -39,7 +38,7 @@
 				/>
 				<div v-if="!filtersLoaded" class="tw-flex tw-gap-1 placeholder">
 					<kv-loading-placeholder
-						style="height: 2.75rem; width: 100px;"
+						style="width: 100px;"
 						v-for="(index) in 3"
 						:key="index"
 					/>
@@ -102,15 +101,15 @@
 					</label>
 					<div
 						class="
-						pill-container
-						tw-rounded
-						tw-transition
-						tw-bg-white
-						tw-h-full
-						md:tw-w-auto
-						tw-relative
-						tw-pointer-events-none
-					"
+							pill-container
+							tw-rounded
+							tw-transition
+							tw-bg-white
+							tw-h-full
+							md:tw-w-auto
+							tw-relative
+							tw-pointer-events-none
+						"
 					>
 						<kv-material-icon
 							:icon="mdiSort"
@@ -120,16 +119,16 @@
 						<select
 							id="sortBy"
 							class="
-							tw-bg-transparent
-							tw-font-medium
-							tw-transition
-							tw-rounded
-							filter-pill
-							tw-w-full
-							tw-h-full
-							tw-pointer-events-auto
-							tw-cursor-pointer
-						"
+								tw-bg-transparent
+								tw-font-medium
+								tw-transition
+								tw-rounded
+								filter-pill
+								tw-w-full
+								tw-h-full
+								tw-pointer-events-auto
+								tw-cursor-pointer
+							"
 							:disabled="!filtersLoaded"
 							v-model="sortBy"
 						>
@@ -171,7 +170,8 @@
 			</div>
 			<div class="tw-flex md:tw-flex-row tw-items-start">
 				<span v-show="filtersLoaded" class="tw-text-base">
-					<span class="md:tw-inline tw-hidden">Showing</span> {{ totalLoans }} loans </span>
+					<span class="md:tw-inline tw-hidden">Showing</span> {{ totalLoans }} loans
+				</span>
 				<!-- eslint-disable-next-line max-len -->
 				<button v-show="filtersLoaded && !hideReset" class="tw-ml-2 tw-text-base tw-text-action" @click="resetFilters">
 					<span>Reset</span><span class="md:tw-inline tw-hidden"> filters</span>
@@ -279,8 +279,8 @@ export default {
 				this.presetFilterActive.endingSoon = true;
 			} else {
 				if (catId === 33 || catId === 96) { // mission-driven-orgs, covid-19
-				// we don't currently have this option for these categories, also irrelevant since
-				// the user has a sort by dropdown available to them
+					// we don't currently have this option for these categories, also irrelevant since
+					// the user has a sort by dropdown available to them
 					delete categoryFilter.sortBy;
 				}
 				this.$emit('update-filters', categoryFilter);

--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -30,13 +30,20 @@
 					</option>
 				</kv-select>
 			</div>
-			<div v-if="!removeGenderDropdown && !withCategories" class="tw-overflow-x-auto tw-pb-1">
+			<div v-if="!removeGenderDropdown && !withCategories" class="tw-flex tw-gap-1 tw-overflow-x-auto tw-pb-1">
 				<filter-pills
 					:filters-loaded="filtersLoaded"
 					:options="filterOptions.gender"
 					:selected-values="selectedGenders"
 					@update-values="updateGenders($event)"
 				/>
+				<div v-if="!filtersLoaded" class="tw-flex tw-gap-1 placeholder">
+					<kv-loading-placeholder
+						style="height: 2.75rem; width: 100px;"
+						v-for="(index) in 3"
+						:key="index"
+					/>
+				</div>
 			</div>
 
 			<div v-if="!removeGenderDropdown && withCategories" class="tw-flex tw-flex-col tw-grow">
@@ -180,6 +187,7 @@ import loanChannelQueryMapMixin from '@/plugins/loan-channel-query-map';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import LocationSelector from './LocationSelector';
 import KvSelect from '~/@kiva/kv-components/vue/KvSelect';
+import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 import FilterPills from './FilterPills';
 
 export default {
@@ -219,7 +227,8 @@ export default {
 		KvSelect,
 		LocationSelector,
 		KvMaterialIcon,
-		FilterPills
+		FilterPills,
+		KvLoadingPlaceholder,
 	},
 	data() {
 		return {
@@ -234,7 +243,7 @@ export default {
 				women: false,
 				kivaUs: false,
 				endingSoon: false,
-			}
+			},
 		};
 	},
 	mixins: [
@@ -403,6 +412,20 @@ export default {
 </script>
 
 <style lang="postcss" scoped>
+	.placeholder > div {
+		@apply tw-rounded !important;
+	}
+
+	.placeholder {
+		display: none;
+	}
+
+	@media screen and (min-width: 600px) {
+		.placeholder {
+			display: flex;
+		}
+	}
+
 	.overflow-container {
 		overflow-x: auto;
 	}


### PR DESCRIPTION
This PR adds a loading state to the gender filter pills using placeholders when all of our filters are on one line. This ensures that the location selector and select sort dropdowns don't shift over dramatically once the data loads which can be confusing and jarring for the ux.

![Screen Shot 2023-03-01 at 11 45 56 AM](https://user-images.githubusercontent.com/15318176/222207166-8c249149-e919-4f1e-b579-1a5c671d51bf.png)
![Screen Shot 2023-03-01 at 11 46 09 AM](https://user-images.githubusercontent.com/15318176/222207169-13836ee5-652f-4192-b958-4d37525a503d.png)
