### PR TITLE
feat: field partner replaced by lending partner at bottom of bp

### DIFF
--- a/src/components/BorrowerProfile/DetailsTabs.vue
+++ b/src/components/BorrowerProfile/DetailsTabs.vue
@@ -26,7 +26,7 @@
 					data-testid="bp-detail-field-partner-tab"
 					v-kv-track-event="['Borrower Profile', `click-Field-Partner-tab`, 'Field Partner']"
 				>
-					Field Partner
+					Lending Partner
 				</kv-tab>
 				<kv-tab
 					:for-panel="trusteeTabId" v-if="hasTrustee"

--- a/src/components/BorrowerProfile/FieldPartnerDetails.vue
+++ b/src/components/BorrowerProfile/FieldPartnerDetails.vue
@@ -82,7 +82,7 @@
 							linkText: 'Field Partner risk rating'
 						})"
 					>
-						Field Partner risk rating
+						Lending Partner risk rating
 					</button>
 				</dt>
 				<dd>


### PR DESCRIPTION
- Field Partner text replaced by Lending Partner at bottom of borrower profile page