### PR TITLE
Core 1121 enable lending home for logged out users who we know have logged in before existing lenders regardless of log in status

### DIFF
--- a/src/graphql/query/lendByCategory/lendByCategory.graphql
+++ b/src/graphql/query/lendByCategory/lendByCategory.graphql
@@ -1,17 +1,6 @@
 query lendByCategory($basketId: String) {
+	hasEverLoggedIn @client
 	general {
-		mlServiceBandit: uiExperimentSetting(key: "EXP-ML-Service-Bandit-LendByCategory") {
-			key
-			value
-		}
-		mfiRecommendations: uiExperimentSetting(key: "mfi_recommendations") {
-			key
-			value
-		}
-		lbcCategoryServiceRows: uiExperimentSetting(key: "flss_category_service") {
-			key
-			value
-		}
 		loanFindingPage: uiExperimentSetting(key: "loan_finding_page") {
 			key
 			value

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -408,7 +408,6 @@ module.exports = [
 		component: () => import('@/pages/LoanFinding/LoanFinding'),
 		meta: {
 			excludeFromStaticSitemap: true,
-			authenticationRequired: true,
 		}
 	},
 	{


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1121

- Checks for `hasEverLoggedIn` instead of just logged in - the `kvu` cookie is create during log in process
- Removed experiment setting + assignment cookies that aren't needed in `preFetch`, since those get prefetched in parent wwwpage component

**Creating a new PR to hopefully get coveralls to return status to the PR**