### PR TITLE
Core 1008 UI header change for logged out lending home page

### DIFF
--- a/src/graphql/query/lendByCategory/lendByCategory.graphql
+++ b/src/graphql/query/lendByCategory/lendByCategory.graphql
@@ -1,17 +1,6 @@
 query lendByCategory($basketId: String) {
+	hasEverLoggedIn @client
 	general {
-		mlServiceBandit: uiExperimentSetting(key: "EXP-ML-Service-Bandit-LendByCategory") {
-			key
-			value
-		}
-		mfiRecommendations: uiExperimentSetting(key: "mfi_recommendations") {
-			key
-			value
-		}
-		lbcCategoryServiceRows: uiExperimentSetting(key: "flss_category_service") {
-			key
-			value
-		}
 		loanFindingPage: uiExperimentSetting(key: "loan_finding_page") {
 			key
 			value

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -12,13 +12,14 @@
 			<!-- eslint-disable-next-line max-len -->
 			<div class="tw-mx-auto tw-p-2 tw-py-1 lg:tw-pt-3 tw-px-2.5 md:tw-px-4 lg:tw-px-8" style="max-width: 1200px;">
 				<h3 class="tw-text-h3 tw-text-primary">
-					Welcome back, <span class="tw-text-action data-hj-suppress">{{ firstName }}</span>
+					Welcome back{{ firstName ? ', ' : '' }}
+					<span v-if="firstName" class="tw-text-action data-hj-suppress">{{ firstName }}</span>
 				</h3>
 			</div>
 			<!-- First category row: Recommended loans section -->
 			<lending-category-section
-				title="Recommended for you"
-				subtitle="Loans handpicked for you based on your lending history"
+				:title="recommendedTitle"
+				:subtitle="recommendedSubtitle"
 				:loans="recommendedLoans"
 				:per-step="2"
 				:enable-loan-card-exp="enableLoanCardExp"
@@ -136,6 +137,9 @@ export default {
 		}
 	},
 	computed: {
+		isLoggedIn() {
+			return !!this.userInfo?.id;
+		},
 		firstName() {
 			return this.userInfo?.firstName ?? '';
 		},
@@ -148,7 +152,15 @@ export default {
 		},
 		activeSpotlightData() {
 			return spotlightData[this.spotlightIndex] ?? {};
-		}
+		},
+		recommendedTitle() {
+			return this.isLoggedIn ? 'Recommended for you' : 'Recommended by others';
+		},
+		recommendedSubtitle() {
+			return this.isLoggedIn
+				? 'Loans handpicked for you based on your lending history'
+				: 'These borrowers need your support. Log in for personalized recommendations.';
+		},
 	},
 	methods: {
 		async getRecommendedLoans() {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -408,7 +408,6 @@ module.exports = [
 		component: () => import('@/pages/LoanFinding/LoanFinding'),
 		meta: {
 			excludeFromStaticSitemap: true,
-			authenticationRequired: true,
 		}
 	},
 	{


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1121
https://kiva.atlassian.net/browse/CORE-1008
https://kiva.atlassian.net/browse/CORE-1006

- Checks for `hasEverLoggedIn` instead of just logged in - the `kvu` cookie is create during log in process
- Removed experiment setting + assignment cookies that aren't needed in `preFetch`, since those get prefetched in parent wwwpage component
- Header text changed for logged out users

![Screen Shot 2023-03-07 at 1 57 08 PM](https://user-images.githubusercontent.com/16867161/223563419-a5a4fb66-9414-41f0-8181-8c1bad5c270d.png)

![Screen Shot 2023-03-07 at 1 57 53 PM](https://user-images.githubusercontent.com/16867161/223563463-d2d4989e-e07c-41e6-bb04-8a25741bc3ce.png)