### PR TITLE
fix: added loan amount to ATB events on category and lend/filter pages

### DIFF
--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -1,6 +1,5 @@
 <template>
 	<kv-button
-		v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
 		:state="buttonState"
 		@click="addToBasket"
 	>
@@ -40,6 +39,13 @@ export default {
 	},
 	methods: {
 		addToBasket() {
+			this.$kvTrackEvent(
+				'Lending',
+				'Add to basket',
+				'lend-button-click',
+				this.loanId,
+				this.price
+			);
 			this.setLoading(true);
 			this.apollo.mutate({
 				mutation: updateLoanReservation,

--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -38,7 +38,6 @@
 						class="tw-inline-flex tw-flex-1"
 						data-testid="bp-lend-cta-lend-button"
 						type="submit"
-						v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
 					>
 						{{ ctaButtonText }}
 					</kv-ui-button>
@@ -46,11 +45,10 @@
 					<!-- Lend again/lent previously button -->
 					<kv-ui-button
 						key="lendAgainButton"
-						v-if="isLentTo && !isLessThan25"
+						v-if="showLendAgain"
 						class="lend-again"
 						data-testid="bp-lend-cta-lend-again-button"
 						type="submit"
-						v-kv-track-event="['Lending', 'Add to basket', 'Lend again', loanId, loanId]"
 					>
 						Lend again
 					</kv-ui-button>
@@ -151,10 +149,14 @@ export default {
 	},
 	methods: {
 		async addToBasket() {
-			this.$emit(
-				'add-to-basket',
-				isLessThan25(this.unreservedAmount) ? this.unreservedAmount : this.selectedOption
+			this.$kvTrackEvent(
+				'Lending',
+				'Add to basket',
+				this.showLendAgain ? 'Lend again' : 'lend-button-click',
+				this.loanId,
+				this.amountToLend
 			);
+			this.$emit('add-to-basket', this.amountToLend);
 		},
 	},
 	watch: {
@@ -281,6 +283,12 @@ export default {
 		isFunded() {
 			return this.state === 'funded'
 				|| this.state === 'fully-reserved';
+		},
+		amountToLend() {
+			return this.isLessThan25 ? this.unreservedAmount : this.selectedOption;
+		},
+		showLendAgain() {
+			return this.isLentTo && !this.isLessThan25;
 		},
 	},
 };


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1147

- The ATB events for category pages and lend/filter did not include the loan amount
- We want to track the amount to help decide if $5 notes is a success
- Moved tracking off HTML, since the analytics mixin doesn't work with dynamic data (it's set on render and isn't reactive)