### PR TITLE
feat: add test id based on loan type to bp

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -1,6 +1,7 @@
 <template>
 	<www-page
 		id="borrower-profile"
+		:data-testid="loanType"
 	>
 		<article v-if="showFundraising" class="tw-relative tw-bg-secondary">
 			<div class="tw-relative">
@@ -559,6 +560,13 @@ export default {
 		},
 		showFundraising() {
 			return this.amountLeft && this.status === 'fundraising';
+		},
+		loanType() {
+			// eslint-disable-next-line no-underscore-dangle
+			if (this.loan?.__typename === 'LoanDirect') {
+				return 'direct-loan';
+			}
+			return 'partner-loan';
 		}
 	},
 	created() {


### PR DESCRIPTION
ACK-552

Will add the `data-testid` to the main div in the borrower profile. Allowing us to use this property for exclusion of loans in optimizely tests.

looks like:
`<div class="www-page" id="borrower-profile" data-testid="partner-loan">`