### PR TITLE
fix: comment out lp route handling for cms-page-server verification

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -445,6 +445,8 @@ module.exports = [
 		path: '/lp/support-refugees',
 		redirect: '/refugees'
 	},
+	// Preserved for cms-page-server rollout, will remove after validation
+	/*
 	{
 		path: '/lp/:dynamicRoute',
 		component: () => import('@/pages/ContentfulPage'),
@@ -454,6 +456,7 @@ module.exports = [
 			unbouncePopUp: true,
 		},
 	},
+	*/
 	{
 		path: '/hp/:dynamicRoute',
 		component: () => import('@/pages/ContentfulPage'),


### PR DESCRIPTION
Commenting out `/lp` route handling. This ensures links from Ui handled landing pages or the footer aren't loaded from UI.

https://github.com/kiva/puppet/pull/345