### PR TITLE
fix: remove organizationType due to redundancy and being not used

### DIFF
--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/TrusteeInfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/TrusteeInfoPanel.vue
@@ -24,12 +24,6 @@
 						{{ trusteeName }}
 					</span>
 				</div>
-				<div v-if="this.organizationType">
-					<dt>Organization type:</dt>
-					<dd class="tw-text-brand tw-my-0.5 tw-capitalize">
-						{{ organizationType }}
-					</dd>
-				</div>
 				<div v-if="this.trusteeLocation">
 					<dt>Location:</dt>
 					<dd class="tw-text-brand tw-my-0.5">
@@ -132,7 +126,6 @@ export default {
 		return {
 			// borrowerName: '',
 			trusteeName: '',
-			organizationType: '',
 			trusteeLocation: '',
 			timeOnKiva: '',
 			numBorrowers: '',
@@ -156,7 +149,6 @@ export default {
 		result({ data }) {
 			// this.borrowerName = _get(data, 'lend.loan.name');
 			this.trusteeName = _get(data, 'lend.loan.trustee.organizationName');
-			this.organizationType = _get(data, 'lend.loan.trustee.organizationType');
 			this.trusteeLocation = _get(data, 'lend.loan.trustee.trusteeLocation');
 			this.timeOnKiva = _get(data, 'lend.loan.trustee.memberSince');
 			this.numBorrowers = _get(data, 'lend.loan.trustee.trusteeStats.numLoansEndorsedPublic');

--- a/src/graphql/query/loanPartner.graphql
+++ b/src/graphql/query/loanPartner.graphql
@@ -26,7 +26,6 @@ query loanPartnerTrustee(
 				trustee {
 					id
 					organizationName
-					organizationType
 					contactRecord {
 						state
 					}


### PR DESCRIPTION
Removing organizationType due to redundancy from template (Bellow image) and being not used in Borrower profile.

![image](https://user-images.githubusercontent.com/56947778/224357345-63285cec-bed2-468c-a76c-100ca35ad08e.png)
