### PR TITLE
fix: add new error code when basket.shop is null and move retry atb t…

### DIFF
--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -14,7 +14,7 @@ import numeral from 'numeral';
 import * as Sentry from '@sentry/vue';
 import updateLoanReservation from '@/graphql/mutation/updateLoanReservation.graphql';
 import loanCardBasketed from '@/graphql/query/loanCardBasketed.graphql';
-import { handleInvalidBasket } from '@/util/basketUtils';
+import { handleInvalidBasket, hasBasketExpired } from '@/util/basketUtils';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 export default {
@@ -70,7 +70,7 @@ export default {
 								`Failed: ${error.message.substring(0, 40)}...`
 							);
 							Sentry.captureMessage(`Add to Basket: ${error.message}`);
-							if (['shop.invalidBasketId', 'shop.basketRequired'].includes(error?.extensions?.code)) {
+							if (hasBasketExpired(error?.extensions?.code)) {
 								// eslint-disable-next-line max-len
 								this.$showTipMsg('There was a problem adding the loan to your basket, refreshing the page to try again.', 'error');
 								return handleInvalidBasket({

--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -70,7 +70,7 @@ export default {
 								`Failed: ${error.message.substring(0, 40)}...`
 							);
 							Sentry.captureMessage(`Add to Basket: ${error.message}`);
-							if (error?.extensions?.code === 'shop.invalidBasketId') {
+							if (['shop.invalidBasketId', 'shop.basketRequired'].includes(error?.extensions?.code)) {
 								// eslint-disable-next-line max-len
 								this.$showTipMsg('There was a problem adding the loan to your basket, refreshing the page to try again.', 'error');
 								return handleInvalidBasket({

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -249,7 +249,7 @@ import KvLoadingParagraph from '@/components/Kv/KvLoadingParagraph';
 import LoanProgressGroup from '@/components/LoanCards/LoanProgressGroup';
 import LoanMatchingText from '@/components/LoanCards/LoanMatchingText';
 import SummaryTag from '@/components/BorrowerProfile/SummaryTag';
-import { setLendAmount } from '@/util/basketUtils';
+import { setLendAmount, handleInvalidBasket } from '@/util/basketUtils';
 import loanCardFieldsFragment from '@/graphql/fragments/loanCardFields.graphql';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import LoanTag from '@/components/LoanCards/LoanTags/LoanTag';
@@ -543,6 +543,17 @@ export default {
 			}).catch(e => {
 				this.isAdding = false;
 				this.$emit('add-to-basket', { loanId: this.loanId, success: false });
+				if (['shop.invalidBasketId', 'shop.basketRequired'].includes(e?.[0]?.extensions?.code)) {
+					// eslint-disable-next-line max-len
+					this.$showTipMsg('There was a problem adding the loan to your basket, refreshing the page to try again.', 'error');
+					return handleInvalidBasket({
+						cookieStore: this.cookieStore,
+						loan: {
+							id: this.loanId,
+							price: this.lendAmount
+						}
+					});
+				}
 				const msg = e[0].extensions.code === 'reached_anonymous_basket_limit'
 					? e[0].message
 					: 'There was a problem adding the loan to your basket';

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -249,7 +249,7 @@ import KvLoadingParagraph from '@/components/Kv/KvLoadingParagraph';
 import LoanProgressGroup from '@/components/LoanCards/LoanProgressGroup';
 import LoanMatchingText from '@/components/LoanCards/LoanMatchingText';
 import SummaryTag from '@/components/BorrowerProfile/SummaryTag';
-import { setLendAmount, handleInvalidBasket } from '@/util/basketUtils';
+import { setLendAmount, handleInvalidBasket, hasBasketExpired } from '@/util/basketUtils';
 import loanCardFieldsFragment from '@/graphql/fragments/loanCardFields.graphql';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import LoanTag from '@/components/LoanCards/LoanTags/LoanTag';
@@ -543,7 +543,7 @@ export default {
 			}).catch(e => {
 				this.isAdding = false;
 				this.$emit('add-to-basket', { loanId: this.loanId, success: false });
-				if (['shop.invalidBasketId', 'shop.basketRequired'].includes(e?.[0]?.extensions?.code)) {
+				if (hasBasketExpired(e?.[0]?.extensions?.code)) {
 					// eslint-disable-next-line max-len
 					this.$showTipMsg('There was a problem adding the loan to your basket, refreshing the page to try again.', 'error');
 					return handleInvalidBasket({

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -165,7 +165,7 @@ import BorrowerImage from '@/components/BorrowerProfile/BorrowerImage';
 import KvLoadingParagraph from '@/components/Kv/KvLoadingParagraph';
 import LoanProgressGroup from '@/components/LoanCards/LoanProgressGroup';
 import SummaryTag from '@/components/BorrowerProfile/SummaryTag';
-import { setLendAmount, handleInvalidBasket } from '@/util/basketUtils';
+import { setLendAmount, handleInvalidBasket, hasBasketExpired } from '@/util/basketUtils';
 import loanCardFieldsFragment from '@/graphql/fragments/loanCardFields.graphql';
 import ActionButton from '@/components/LoanCards/Buttons/ActionButton';
 import LoanCallouts from '@/components/LoanCards/LoanTags/LoanCallouts';
@@ -450,7 +450,7 @@ export default {
 				this.$kvTrackEvent('Lending', 'Add-to-Basket', 'Failed to add loan. Please try again.');
 				Sentry.captureException(e);
 				// Handle errors from adding to basket
-				if (['shop.invalidBasketId', 'shop.basketRequired'].includes(e?.[0]?.extensions?.code)) {
+				if (hasBasketExpired(e?.[0]?.extensions?.code)) {
 					// eslint-disable-next-line max-len
 					this.$showTipMsg('There was a problem adding the loan to your basket, refreshing the page to try again.', 'error');
 					return handleInvalidBasket({

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -450,7 +450,7 @@ export default {
 				this.$kvTrackEvent('Lending', 'Add-to-Basket', 'Failed to add loan. Please try again.');
 				Sentry.captureException(e);
 				// Handle errors from adding to basket
-				if (e?.[0]?.extensions?.code === 'shop.invalidBasketId') {
+				if (['shop.invalidBasketId', 'shop.basketRequired'].includes(e?.[0]?.extensions?.code)) {
 					// eslint-disable-next-line max-len
 					this.$showTipMsg('There was a problem adding the loan to your basket, refreshing the page to try again.', 'error');
 					return handleInvalidBasket({

--- a/src/plugins/retry-after-expired-basket-mixin.js
+++ b/src/plugins/retry-after-expired-basket-mixin.js
@@ -1,11 +1,9 @@
 import { setLendAmount } from '@/util/basketUtils';
 import checkInjections from '@/util/injectionCheck';
-import addToBasketInsterstitial from '@/plugins/add-to-basket-show-interstitial';
 
 const injections = ['apollo', 'cookieStore'];
 
 export default {
-	mixins: [addToBasketInsterstitial],
 	mounted() {
 		checkInjections(this, injections);
 
@@ -19,7 +17,7 @@ export default {
 				amount: loan.price,
 				loanId: loan.id,
 			}).then(() => {
-				this.triggerAddToBasketInterstitial(loan.id);
+				this.$showTipMsg('Your loan has been added to the basket.');
 				this.$emit('add-to-basket', { loanId: loan.id, success: true });
 			}).catch(e => {
 				const msg = e[0]?.extensions?.code === 'reached_anonymous_basket_limit'

--- a/src/plugins/retry-after-expired-basket-mixin.js
+++ b/src/plugins/retry-after-expired-basket-mixin.js
@@ -6,7 +6,7 @@ const injections = ['apollo', 'cookieStore'];
 
 export default {
 	mixins: [addToBasketInsterstitial],
-	created() {
+	mounted() {
 		checkInjections(this, injections);
 
 		// Handle expired basket cookie after refresh

--- a/src/util/basketUtils.js
+++ b/src/util/basketUtils.js
@@ -84,3 +84,7 @@ export function handleInvalidBasket({ loan, cookieStore }) {
 	cookieStore.set('kvatbid', JSON.stringify(loan));
 	window.location.reload();
 }
+
+export function hasBasketExpired(errorCode) {
+	return ['shop.invalidBasketId', 'shop.basketRequired'].includes(errorCode);
+}


### PR DESCRIPTION
…o mounted hook

When a basket cookie is expired and you refresh the page `basket.shop` is set to `null` and sending a different error code.

In `lending-home` page basket state on `TheHeader.vue` was not being updated within created hook. Moving on to the mounted hook fixes the problem.