### PR TITLE
fix: ensure e2e test uses ui header

### DIFF
--- a/test/e2e/specs/HeaderNavigation.cy.js
+++ b/test/e2e/specs/HeaderNavigation.cy.js
@@ -10,7 +10,8 @@ describe('Header Navigation', () => {
 		});
 
 		// Go to the lend/filter page
-		cy.visit('lend/filter?setuiab=lend_menu_buttons.a');
+		cy.visit('ui-site-map');
+		cy.visit('ui-site-map?setuiab=lend_menu_buttons.a');
 		// Type 'f' in the search bar
 		cy.findByPlaceholderText('Search all loans').type('f');
 		// Wait for search results request to complete
@@ -18,7 +19,7 @@ describe('Header Navigation', () => {
 		// Click on the "Fabrics" tag in the search results
 		cy.contains('Fabrics').click();
 		// Expect to visit the lend page
-		cy.location('pathname').should('eq', '/lend/filter');
+		cy.location('pathname', { timeout: 10000 }).should('eq', '/lend/filter');
 		// Wait for loan facets to load
 		cy.wait('@gqlflssLoanFacetsQuery');
 		// Expect "Fabrics" filter chip to exist

--- a/test/e2e/specs/HeaderNavigation.cy.js
+++ b/test/e2e/specs/HeaderNavigation.cy.js
@@ -9,8 +9,8 @@ describe('Header Navigation', () => {
 			aliasQuery(req, 'flssLoanFacets');
 		});
 
-		// Go to the home page
-		cy.visit('/');
+		// Go to the lend/filter page
+		cy.visit('lend/filter?setuiab=lend_menu_buttons.a');
 		// Type 'f' in the search bar
 		cy.findByPlaceholderText('Search all loans').type('f');
 		// Wait for search results request to complete


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1142

- The one failure was due to there being a slight delay in focus listener in CPS when compared with ui for the search bar -> the test now just looks to a ui page for the time being, and disables a header exp