### PR TITLE
fix: only send optimizely events if tracked value is greater than 0

### DIFF
--- a/src/plugins/kv-analytics-plugin.js
+++ b/src/plugins/kv-analytics-plugin.js
@@ -292,7 +292,7 @@ export default {
 				});
 			},
 			trackOPTransaction: transactionData => {
-				if (transactionData.depositTotal) {
+				if (transactionData.depositTotal > 0) {
 					window.optimizely.push({
 						type: 'event',
 						eventName: 'deposit',
@@ -303,7 +303,7 @@ export default {
 					});
 				}
 
-				if (transactionData.loanTotal) {
+				if (transactionData.loanTotal > 0) {
 					window.optimizely.push({
 						type: 'event',
 						eventName: 'loan_share_purchase',
@@ -314,7 +314,7 @@ export default {
 					});
 				}
 
-				if (transactionData.donationTotal) {
+				if (transactionData.donationTotal > 0) {
 					window.optimizely.push({
 						type: 'event',
 						eventName: 'donation',


### PR DESCRIPTION
`donationTotal` and `loanTotal` are both strings, so the if statements were always returning true. That means the events were always firing for every transaction, even when `donationTotal` and/or `loanTotal` are $0. We only want the events to fire when the amounts are greater than $0.