### PR TITLE
fix: header rendering (added a fallback option when promoName is false)

### DIFF
--- a/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
+++ b/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
@@ -2,9 +2,20 @@
 	<div class="loan-filters">
 		<div class="loan-filters__top-row">
 			<span class="tw-mb-2 md:tw-mb-0">
-				<div class="tw-inline-flex tw-items-center">
+				<div
+					v-if="promoName"
+					class="tw-inline-flex tw-items-center"
+				>
 					<h2 class="tw-text-center">
 						{{ promoName }} recommends these people
+					</h2>
+				</div>
+				<div
+					v-else
+					class="tw-inline-flex tw-items-center"
+				>
+					<h2 class="tw-text-center">
+						Support causes you care about
 					</h2>
 				</div>
 			</span>


### PR DESCRIPTION
Current issue: Header displays promoName in dev but not in prod- more time is needed to figure out and fully fix this issue however for now, this PR is a solution that works and allows us to eventually figure out this bug. 

Banner falls back to prior header when campaign is not active: 
![Screen Shot 2023-03-15 at 10 38 14 AM](https://user-images.githubusercontent.com/54958840/225395891-6c553e42-c7ae-4945-80a8-c200b56945d8.png)

Banner displays promoName when campaign is active:
![Screen Shot 2023-03-15 at 10 38 35 AM](https://user-images.githubusercontent.com/54958840/225395978-5e0b847e-81f0-4aaa-b1e6-1580530c633c.png)
