### PR TITLE
feat: query forced saved in cookie assignment

### DIFF
--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -86,6 +86,7 @@ export default ({ cookieStore, url = '' }) => {
 								: assignVersionForLoginId(experimentSetting, getLoginId(cookieStore)),
 							hash,
 							population,
+							queryForced: currentAssignment.queryForced,
 						};
 
 						// Update the "uiab" cookie if the assignment was forced via the "setuiab" query string param

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -112,6 +112,7 @@ export function parseExpCookie(cookie) {
 				version: expValues[1],
 				hash: parseInt(expValues[2], 10),
 				population: parseFloat(expValues[3]),
+				queryForced: expValues[4]?.toUpperCase() === true.toString().toUpperCase(),
 			};
 		}
 	});
@@ -133,9 +134,10 @@ export function serializeExpCookie(assignments) {
 
 	// eslint-disable-next-line no-unused-vars
 	const expStrings = Object.entries(assignments).map(([_, {
-		id, version, hash, population
+		id, version, hash, population, queryForced
 	}]) => {
-		return `${id}:${version}:${hash || 'no-hash'}:${population || 'no-pop'}`;
+		// eslint-disable-next-line max-len
+		return `${id}:${version}:${hash || 'no-hash'}:${population || 'no-pop'}:${queryForced === true ? true.toString() : false.toString()}`;
 	});
 
 	// Filter out strings that end with a ':', as they have no assignment
@@ -282,6 +284,7 @@ export const getForcedAssignment = (cookieStore, url, id, experimentSetting) => 
 	const cookieAssignment = getCookieAssignments(cookieStore)[id];
 	const forcedExp = setuiab?.split('.') ?? [];
 	const queryForced = forcedExp[0] === id && !!forcedExp[1];
+	const cookieQueryForced = !!cookieAssignment?.queryForced;
 	const forcedVersion = (queryForced && encodeURIComponent(forcedExp[1])) || cookieAssignment?.version;
 
 	// Return forced assignment if the version wasn't undefined
@@ -292,7 +295,7 @@ export const getForcedAssignment = (cookieStore, url, id, experimentSetting) => 
 			...experimentSetting,
 			version: forcedVersion,
 			...(forcedHash && { hash: forcedHash }),
-			queryForced
+			queryForced: queryForced || cookieQueryForced,
 		};
 	}
 };

--- a/test/unit/specs/util/experiment/experimentUtils.spec.js
+++ b/test/unit/specs/util/experiment/experimentUtils.spec.js
@@ -259,24 +259,132 @@ describe('experimentUtils.js', () => {
 					version: 'x',
 					hash: NaN,
 					population: NaN,
+					queryForced: false,
 				},
 				cd: {
 					id: 'cd',
 					version: 'y',
 					hash: 1234,
 					population: 0.4,
+					queryForced: false,
 				},
 				ef: {
 					id: 'ef',
 					version: 'z',
 					hash: NaN,
 					population: NaN,
+					queryForced: false,
 				},
 				gh: {
 					id: 'gh',
 					version: 'w',
 					hash: 1234,
 					population: NaN,
+					queryForced: false,
+				},
+			});
+		});
+
+		it('should return a correctly parsed cookie object with query forced', () => {
+			expect(parseExpCookie('ab:x:no-hash:no-pop:false|cd:y:1234:0.4:true|xd:z:3421:0.5:false')).toEqual({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+					queryForced: false,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+					queryForced: true
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+					queryForced: false
+				},
+			});
+		});
+
+		it('should return a correctly parsed cookie object with query forced missing', () => {
+			expect(parseExpCookie('ab:x:no-hash:no-pop|cd:y:1234:0.4|xd:z:3421:0.5')).toEqual({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+					queryForced: false,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+					queryForced: false
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+					queryForced: false
+				},
+			});
+		});
+
+		it('should return a correctly parsed cookie object with bad query forced string', () => {
+			expect(parseExpCookie('ab:x:no-hash:no-pop:asd|cd:y:1234:0.4:|xd:z:3421:0.5:1')).toEqual({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+					queryForced: false,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+					queryForced: false
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+					queryForced: false
+				},
+			});
+		});
+
+		it('should return a correctly parsed cookie object with query forced case insensitive', () => {
+			expect(parseExpCookie('ab:x:no-hash:no-pop:TRUE|cd:y:1234:0.4:True|xd:z:3421:0.5:trUE')).toEqual({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+					queryForced: true,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+					queryForced: true
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+					queryForced: true
 				},
 			});
 		});
@@ -313,7 +421,89 @@ describe('experimentUtils.js', () => {
 					version: 'w',
 					hash: 1234,
 				},
-			})).toBe('ab:x:no-hash:no-pop|cd:y:1234:0.4|ef:z:no-hash:no-pop|gh:w:1234:no-pop');
+			})).toBe('ab:x:no-hash:no-pop:false|cd:y:1234:0.4:false|ef:z:no-hash:no-pop:false|gh:w:1234:no-pop:false');
+		});
+
+		it('should return a correctly serialized cookie string with query forced', () => {
+			expect(serializeExpCookie({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+					queryForced: false,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+					queryForced: true
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+					queryForced: true
+				},
+			})).toBe('ab:x:no-hash:no-pop:false|cd:y:1234:0.4:true|xd:z:3421:0.5:true');
+		});
+
+		it('should return a correctly serialized cookie string with missing query forced', () => {
+			expect(serializeExpCookie({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+				},
+			})).toBe('ab:x:no-hash:no-pop:false|cd:y:1234:0.4:false|xd:z:3421:0.5:false');
+		});
+
+		it('should return a correctly serialized cookie string with bad query forced values', () => {
+			expect(serializeExpCookie({
+				ab: {
+					id: 'ab',
+					version: 'x',
+					hash: NaN,
+					population: NaN,
+					queryForced: null,
+				},
+				cd: {
+					id: 'cd',
+					version: 'y',
+					hash: 1234,
+					population: 0.4,
+					queryForced: undefined,
+				},
+				xd: {
+					id: 'xd',
+					version: 'z',
+					hash: 3421,
+					population: 0.5,
+					queryForced: '',
+				},
+				zz: {
+					id: 'zz',
+					version: 'y',
+					hash: 54,
+					population: 0.3,
+					queryForced: 'true',
+				},
+			})).toBe('ab:x:no-hash:no-pop:false|cd:y:1234:0.4:false|xd:z:3421:0.5:false|zz:y:54:0.3:false');
 		});
 	});
 
@@ -578,7 +768,8 @@ describe('experimentUtils.js', () => {
 					id: 'ab',
 					version: 'variant',
 					hash: 1753809052,
-					population: 0.5
+					population: 0.5,
+					queryForced: false,
 				}
 			});
 		});
@@ -612,7 +803,7 @@ describe('experimentUtils.js', () => {
 
 			setCookieAssignments(cookieStore, mockAssignments);
 
-			expect(cookieStore.getSetCookies()[0]).toBe('uiab=ab:variant:1753809052:0.5; Path=/');
+			expect(cookieStore.getSetCookies()[0]).toBe('uiab=ab:variant:1753809052:0.5:false; Path=/');
 		});
 	});
 
@@ -699,6 +890,30 @@ describe('experimentUtils.js', () => {
 				...experimentSetting,
 				version: 'unassigned',
 				hash,
+				queryForced: false
+			});
+		});
+
+		it('should get query forced setting from cookie', () => {
+			const hash1 = 1753809052;
+			const hash2 = 456;
+			const cookieStore = new CookieStore({ uiab: `asd:variant:${hash1}:0.5:true|qwe:a:${hash2}:0.1:false` });
+
+			let result = getForcedAssignment(cookieStore, '', 'asd', experimentSetting);
+
+			expect(result).toEqual({
+				...experimentSetting,
+				version: 'variant',
+				hash: hash1,
+				queryForced: true
+			});
+
+			result = getForcedAssignment(cookieStore, '', 'qwe', experimentSetting);
+
+			expect(result).toEqual({
+				...experimentSetting,
+				version: 'a',
+				hash: hash2,
 				queryForced: false
 			});
 		});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1238

- Whether the assignment was query forced is now saved to the cookie value
- This is a temporary need while we have experiments active from before this refactor, since moving forward we won't need to store assignments in the cookie unless query forced, but this also isn't a bad addition to the cookie value
- The forced assignment lives regardless of distribution and population changes and will only be disregarded if the experiment is removed from the active_experiments