### PR TITLE
Core 1242 experiment assignment setuiab should be allowed multiple times in url

### DIFF
--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -15,7 +15,7 @@ export default function createApolloClient({
 	types,
 	uri,
 	fetch,
-	url = '',
+	route,
 }) {
 	const cache = new InMemoryCache({
 		possibleTypes: types,
@@ -33,7 +33,7 @@ export default function createApolloClient({
 		appConfig,
 		cookieStore,
 		kvAuth0,
-		url,
+		route,
 	});
 
 	const client = new ApolloClient({

--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -15,7 +15,7 @@ import logFormatter from '@/util/logFormatter';
  * Local resolvers for experiment assignment
  *
  * @param {Object} param0.cookieStore The cookie mixin
- * @param {String} param0.route The initial route resolved by the Vue router
+ * @param {Object} param0.route The initial route resolved by the Vue router
  * @returns {Object} The local resolvers
  */
 export default ({ cookieStore, route }) => {

--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -15,10 +15,10 @@ import logFormatter from '@/util/logFormatter';
  * Local resolvers for experiment assignment
  *
  * @param {Object} param0.cookieStore The cookie mixin
- * @param {String} param0.url The initial URL loaded by the application
+ * @param {String} param0.route The initial route resolved by the Vue router
  * @returns {Object} The local resolvers
  */
-export default ({ cookieStore, url = '' }) => {
+export default ({ cookieStore, route }) => {
 	return {
 		resolvers: {
 			Query: {
@@ -53,7 +53,7 @@ export default ({ cookieStore, url = '' }) => {
 					}
 
 					// Get forced assignment if there's an assignment in "setuiab" query string param or "uiab" cookie
-					const forcedAssignment = getForcedAssignment(cookieStore, url, id, experimentSetting);
+					const forcedAssignment = getForcedAssignment(cookieStore, route, id, experimentSetting);
 
 					// Create initial current assignment object
 					let currentAssignment = { ...(forcedAssignment || { id }) };

--- a/src/main.js
+++ b/src/main.js
@@ -52,16 +52,18 @@ export default function createApp({
 		});
 	}
 
+	const router = createRouter();
+	const { route } = router.resolve(url);
+
 	const apolloClient = createApolloClient({
 		...apollo,
 		appConfig,
 		cookieStore,
 		kvAuth0,
 		fetch,
-		url,
+		route,
 	});
 
-	const router = createRouter();
 	// Checking that sentry is enabled & is not server side
 	if (appConfig.enableSentry && typeof window !== 'undefined') {
 		Sentry.init({

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -269,23 +269,31 @@ export const setCookieAssignments = (cookieStore, assignments) => {
  * Get current experiment assignments forced via either query string or cookie
  *
  * @param {string} cookieStore The cookie mixin
- * @param {string} url The URL to check for query forced assignments
+ * @param {Object} route The initial route resolved by the Vue router
  * @param {string} id The ID of the assignment to check
  * @param {Object} experimentSetting The experiment settings
  * @returns The forced experiment assignment
  */
-export const getForcedAssignment = (cookieStore, url, id, experimentSetting) => {
-	// Get setuiab value
-	const { setuiab } = new Proxy(new URLSearchParams(url?.split('?')?.[1] ?? ''), {
-		get: (searchParams, prop) => searchParams.get(prop),
-	});
-
-	// Parse forced experiment assignment
+export const getForcedAssignment = (cookieStore, route, id, experimentSetting) => {
+	// Get previous cookie assignment
 	const cookieAssignment = getCookieAssignments(cookieStore)[id];
-	const forcedExp = setuiab?.split('.') ?? [];
-	const queryForced = forcedExp[0] === id && !!forcedExp[1];
 	const cookieQueryForced = !!cookieAssignment?.queryForced;
-	const forcedVersion = (queryForced && encodeURIComponent(forcedExp[1])) || cookieAssignment?.version;
+
+	let queryForced;
+	let forcedVersion = cookieAssignment?.version;
+
+	// Look through setuiab assignments
+	const setuiabQuery = route?.query?.setuiab;
+	// Route query param will be an array if more than one instance in URL
+	const setuiab = typeof setuiabQuery === 'string' ? [setuiabQuery] : (setuiabQuery ?? []);
+	for (let i = 0; i < setuiab.length; i += 1) {
+		const forcedExp = setuiab[i]?.split('.') ?? [];
+		if (forcedExp[0] === id) {
+			queryForced = !!forcedExp[1];
+			forcedVersion = (queryForced && encodeURIComponent(forcedExp[1])) || forcedVersion;
+			break;
+		}
+	}
 
 	// Return forced assignment if the version wasn't undefined
 	if (typeof forcedVersion !== 'undefined') {

--- a/test/unit/specs/api/localResolvers/experiment.spec.js
+++ b/test/unit/specs/api/localResolvers/experiment.spec.js
@@ -399,5 +399,24 @@ describe('experiment.js', () => {
 			expect(getCookieAssignmentsSpy).toHaveBeenCalledTimes(0);
 			expect(setCookieAssignmentsSpy).toHaveBeenCalledTimes(0);
 		});
+
+		it('should pass expected params to get forced assignment', async () => {
+			const cookieStore = { asd: 1 };
+			const route = { qwe: 2 };
+			const { resolvers } = expResolverFactory({ cookieStore, route });
+			assignVersionForLoginIdSpy.mockReturnValue(undefined);
+
+			const result = await resolvers.Query.experiment(null, { id: EXP_ID }, {});
+
+			expect(result).toEqual(Experiment({ id: EXP_ID, version: undefined }));
+			expect(getActiveExperimentsSpy).toHaveBeenCalledTimes(1);
+			expect(getExperimentSettingSpy).toHaveBeenCalledTimes(1);
+			expect(getForcedAssignmentSpy).toHaveBeenCalledWith(cookieStore, route, EXP_ID, experiment);
+			expect(calculateHashSpy).toHaveBeenCalledTimes(1);
+			expect(assignVersionForLoginIdSpy).toHaveBeenCalledTimes(1);
+			expect(getLoginIdSpy).toHaveBeenCalledTimes(1);
+			expect(getCookieAssignmentsSpy).toHaveBeenCalledTimes(0);
+			expect(setCookieAssignmentsSpy).toHaveBeenCalledTimes(0);
+		});
 	});
 });

--- a/test/unit/specs/util/experiment/experimentUtils.spec.js
+++ b/test/unit/specs/util/experiment/experimentUtils.spec.js
@@ -897,13 +897,15 @@ describe('experimentUtils.js', () => {
 
 		it('should handle bad query string', () => {
 			const cookieStore = new CookieStore();
-			const route = { query: { setuiab: 'asd' } };
+			let route = { query: { setuiab: 'asd' } };
 
 			let result = getForcedAssignment(cookieStore, route, 'asd', experimentSetting);
 
 			expect(result).toEqual(undefined);
 
-			result = getForcedAssignment(cookieStore, route, 'asd.', experimentSetting);
+			route = { query: { setuiab: 'asd.' } };
+
+			result = getForcedAssignment(cookieStore, route, 'asd', experimentSetting);
 
 			expect(result).toEqual(undefined);
 		});

--- a/test/unit/specs/util/experiment/experimentUtils.spec.js
+++ b/test/unit/specs/util/experiment/experimentUtils.spec.js
@@ -829,24 +829,54 @@ describe('experimentUtils.js', () => {
 
 			expect(result).toBe(undefined);
 
-			result = getForcedAssignment(cookieStore, 'asd', undefined, experimentSetting);
+			result = getForcedAssignment(cookieStore, {}, undefined, experimentSetting);
+
+			expect(result).toBe(undefined);
+
+			result = getForcedAssignment(cookieStore, { query: {} }, undefined, experimentSetting);
+
+			expect(result).toBe(undefined);
+
+			result = getForcedAssignment(cookieStore, { query: { setuiab: [] } }, undefined, experimentSetting);
+
+			expect(result).toBe(undefined);
+
+			result = getForcedAssignment(cookieStore, { query: { setuiab: '' } }, undefined, experimentSetting);
+
+			expect(result).toBe(undefined);
+
+			result = getForcedAssignment(cookieStore, { query: { setuiab: null } }, undefined, experimentSetting);
 
 			expect(result).toBe(undefined);
 		});
 
 		it('should get forced assignment from query string', () => {
 			const cookieStore = new CookieStore();
+			const route = { query: { setuiab: 'asd.x' } };
 
-			const result = getForcedAssignment(cookieStore, '?setuiab=asd.x', 'asd', experimentSetting);
+			const result = getForcedAssignment(cookieStore, route, 'asd', experimentSetting);
 
 			expect(result).toEqual({ ...experimentSetting, version: 'x', queryForced: true });
+		});
+
+		it('should get multiple forced assignments from query string', () => {
+			const cookieStore = new CookieStore();
+			const route = { query: { setuiab: ['asd.x', 'qwe.b'] } };
+
+			let result = getForcedAssignment(cookieStore, route, 'asd', experimentSetting);
+
+			expect(result).toEqual({ ...experimentSetting, version: 'x', queryForced: true });
+
+			result = getForcedAssignment(cookieStore, route, 'qwe', experimentSetting);
+
+			expect(result).toEqual({ ...experimentSetting, version: 'b', queryForced: true });
 		});
 
 		it('should get forced assignment from cookie', () => {
 			const hash = 1753809052;
 			const cookieStore = new CookieStore({ uiab: `asd:variant:${hash}:0.5` });
 
-			const result = getForcedAssignment(cookieStore, '', 'asd', experimentSetting);
+			const result = getForcedAssignment(cookieStore, {}, 'asd', experimentSetting);
 
 			expect(result).toEqual({
 				...experimentSetting,
@@ -858,16 +888,22 @@ describe('experimentUtils.js', () => {
 
 		it('should ensure query forced assignment matches', () => {
 			const cookieStore = new CookieStore();
+			const route = { query: { setuiab: 'asd.x' } };
 
-			const result = getForcedAssignment(cookieStore, '?setuiab=asd.x', 'a', experimentSetting);
+			const result = getForcedAssignment(cookieStore, route, 'a', experimentSetting);
 
 			expect(result).toEqual(undefined);
 		});
 
 		it('should handle bad query string', () => {
 			const cookieStore = new CookieStore();
+			const route = { query: { setuiab: 'asd' } };
 
-			const result = getForcedAssignment(cookieStore, '?setuiab=asd', 'a', experimentSetting);
+			let result = getForcedAssignment(cookieStore, route, 'asd', experimentSetting);
+
+			expect(result).toEqual(undefined);
+
+			result = getForcedAssignment(cookieStore, route, 'asd.', experimentSetting);
 
 			expect(result).toEqual(undefined);
 		});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1242

- Resolved `route` from Vue router now passed to apollo init, makes grabbing query params much easier
- Multiple `setuiab` query params can now be added to the URL