### PR TITLE
feat: prop added to new loan card to hide more cta in use component

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -6,7 +6,7 @@
 		:style="{ minWidth: '230px', maxWidth: cardWidth }"
 	>
 		<div class="tw-grow">
-			<div>
+			<div :class="{ 'loan-card-active-hover': !allSharesReserved }">
 				<!-- Borrower image -->
 				<kv-loading-placeholder
 					v-if="isLoading"
@@ -83,7 +83,7 @@
 								:borrower-count="loanBorrowerCount"
 								:name="borrowerName"
 								:distribution-model="distributionModel"
-								:show-more="true"
+								:show-more="enableMoreCta"
 							/>
 						</router-link>
 					</div>
@@ -230,7 +230,11 @@ export default {
 		enableFiveDollarsNotes: {
 			type: Boolean,
 			default: false
-		}
+		},
+		enableMoreCta: {
+			type: Boolean,
+			default: false
+		},
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [percentRaisedMixin, timeLeftMixin],
@@ -499,10 +503,13 @@ export default {
 
 <style lang="postcss" scoped>
 
-.loan-card-use,
 .loan-card-use:hover,
 .loan-card-use:focus {
-	@apply tw-text-primary tw-no-underline;
+	@apply tw-text-primary;
+}
+
+.loan-card-active-hover:hover .loan-card-use {
+	@apply tw-underline;
 }
 
 .loan-card-progress >>> [role=progressbar] {
@@ -523,4 +530,5 @@ export default {
 #loanProgress >>> h4 {
 	text-transform: lowercase;
 }
+
 </style>

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -64,8 +64,8 @@
 				<!-- Loan tag -->
 				<router-link
 					:to="customLoanDetails ? '' : `/lend/${loanId}`"
-					v-kv-track-event="['Lending', 'click-Read more', 'Photo', loanId]"
-					class="tw-flex hover:tw-no-underline"
+					v-kv-track-event="['Lending', 'click-Read more', 'Tag', loanId]"
+					class="tw-flex hover:tw-no-underline focus:tw-no-underline"
 				>
 					<loan-tag-v2 v-if="showTags && !isLoading" :loan="loan" :amount-left="amountLeft" />
 				</router-link>

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -6,7 +6,7 @@
 		:style="{ minWidth: '230px', maxWidth: cardWidth }"
 	>
 		<div class="tw-grow">
-			<div :class="{ 'loan-card-active-hover': !allSharesReserved }">
+			<div class="loan-card-active-hover">
 				<!-- Borrower image -->
 				<kv-loading-placeholder
 					v-if="isLoading"

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -63,26 +63,25 @@
 
 				<!-- Loan tag -->
 				<router-link
-					v-if="showTags && !isLoading"
 					:to="customLoanDetails ? '' : `/lend/${loanId}`"
-					v-kv-track-event="['Lending', 'click-Read more', 'Use', loanId]"
-					class="tw-text-primary hover:tw-no-underline"
+					v-kv-track-event="['Lending', 'click-Read more', 'Photo', loanId]"
+					class="tw-flex hover:tw-no-underline"
 				>
-					<loan-tag-v2 :loan="loan" :amount-left="amountLeft" />
+					<loan-tag-v2 v-if="showTags && !isLoading" :loan="loan" :amount-left="amountLeft" />
 				</router-link>
 
-				<!-- Loan use  -->
-				<div class="tw-mb-1.5 tw-mt-1">
-					<kv-loading-paragraph
-						v-if="isLoading"
-						:style="{ width: '100%', height: '5.5rem' }"
-					/>
-					<div v-else>
-						<router-link
-							:to="customLoanDetails ? '' : `/lend/${loanId}`"
-							v-kv-track-event="['Lending', 'click-Read more', 'Use', loanId]"
-							class="loan-card-use tw-text-primary"
-						>
+				<router-link
+					:to="customLoanDetails ? '' : `/lend/${loanId}`"
+					v-kv-track-event="['Lending', 'click-Read more', 'Use', loanId]"
+					class="loan-card-use tw-text-primary"
+				>
+					<!-- Loan use  -->
+					<div class="tw-mb-1.5 tw-pt-1">
+						<kv-loading-paragraph
+							v-if="isLoading"
+							:style="{ width: '100%', height: '5.5rem' }"
+						/>
+						<div v-else>
 							<loan-use
 								:use="loanUse"
 								:loan-amount="loanAmount"
@@ -92,9 +91,9 @@
 								:distribution-model="distributionModel"
 								:show-more="enableMoreCta"
 							/>
-						</router-link>
+						</div>
 					</div>
-				</div>
+				</router-link>
 			</div>
 
 			<!-- Loan call outs -->

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -62,7 +62,14 @@
 				</div>
 
 				<!-- Loan tag -->
-				<loan-tag-v2 v-if="showTags && !isLoading" :loan="loan" :amount-left="amountLeft" />
+				<router-link
+					v-if="showTags && !isLoading"
+					:to="customLoanDetails ? '' : `/lend/${loanId}`"
+					v-kv-track-event="['Lending', 'click-Read more', 'Use', loanId]"
+					class="tw-text-primary hover:tw-no-underline"
+				>
+					<loan-tag-v2 :loan="loan" :amount-left="amountLeft" />
+				</router-link>
 
 				<!-- Loan use  -->
 				<div class="tw-mb-1.5 tw-mt-1">

--- a/src/components/LoanCards/LoanTags/LoanTagV2.vue
+++ b/src/components/LoanCards/LoanTags/LoanTagV2.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="!!variation && timeLeftMs > 0"
-		class="tw-text-small tw-font-medium tw-mt-0.5 tw-line-clamp-1"
+		class="tw-text-small tw-font-medium tw-pt-0.5 tw-line-clamp-1"
 		style="color: #CE4A00;"
 	>
 		{{ tagText }}


### PR DESCRIPTION
`KivaClassicBasicLoanCardExp` component updated based in this requirements:

Let’s add the hover state back and remove the “more” cta for the next version of the test. 
Test group
category page, filter page, homepage include new loan card without the “more” (original design)

Control:
original /old loan cards in each of those loan card

Lending Home
by the time this ticket is done, we’ll have data on LH, so we can roll out the test and the loan card there can a/b more vs. no more 

Prop added to control lending home test in the future