### PR TITLE
fix: five dollar notes fixed for amounts left less than 25 dollars

### DIFF
--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -61,7 +61,7 @@
 					:show-now="false"
 					:amount-left="unreservedAmount"
 					@add-to-basket="addToBasket"
-					v-if="isLendAmountButton"
+					v-if="isLendAmountButton && !enableFiveDollarsNotes"
 				/>
 
 				<!-- Adding to basket button -->


### PR DESCRIPTION
- five dollar notes fixed for amounts left less than 25 dollars in lending home page; was showing duplicated buttons