### PR TITLE
feat: add follow button to scroll to links on us loans

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -228,11 +228,17 @@
 						:class="isLoggedIn ? 'tw-justify-between' : 'tw-justify-end'"
 					>
 						<loan-bookmark
-							v-if="isLoggedIn"
+							v-if="bookmarkVersion === 'bookmark'"
 							data-testid="bp-lend-cta-loan-bookmark"
 							:loan-id="loanId"
 							class="tw-hidden md:tw-inline-block lg:tw-hidden"
 						/>
+						<loan-follow
+							v-if="bookmarkVersion === 'follow'"
+							data-testid="bp-lend-cta-loan-follow"
+							class="tw-hidden md:tw-inline-block lg:tw-hidden tw-mr-2"
+						/>
+
 						<jump-links
 							class="tw-hidden md:tw-block lg:tw-mb-1.5 md:tw-mb-3"
 							data-testid="bp-lend-cta-jump-links"
@@ -361,6 +367,7 @@ import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.grap
 
 import JumpLinks from '@/components/BorrowerProfile/JumpLinks';
 import LoanBookmark from '@/components/BorrowerProfile/LoanBookmark';
+import LoanFollow from '@/components/BorrowerProfile/LoanFollow';
 import LendAmountButton from '@/components/LoanCards/Buttons/LendAmountButton';
 import CompleteLoanWrapper from '@/components/BorrowerProfile/CompleteLoanWrapper';
 
@@ -392,6 +399,7 @@ export default {
 		KvUiSelect,
 		JumpLinks,
 		LoanBookmark,
+		LoanFollow,
 		CompleteLoanWrapper,
 	},
 	data() {
@@ -426,7 +434,8 @@ export default {
 			slotMachineInterval: null,
 			currentSlotStat: '',
 			matchingHighlightExpShown: false,
-			inPfp: false
+			inPfp: false,
+			distributionModel: '',
 		};
 	},
 	apollo: {
@@ -436,6 +445,7 @@ export default {
 					loan(id: $loanId) {
 						id
 						status
+						distributionModel
 						name
 						minNoteSize
 						loanAmount
@@ -515,6 +525,7 @@ export default {
 			if (this.status === 'fundraising' && this.numLenders > 0) {
 				this.lenderCountVisibility = true;
 			}
+			this.distributionModel = loan?.distributionModel ?? '';
 
 			// Start cycling the stats slot now that loan data is available
 			this.cycleStatsSlot();
@@ -793,6 +804,17 @@ export default {
 		},
 		isLendAmountButton() {
 			return (this.lendButtonVisibility || this.state === 'lent-to') && (isLessThan25(this.unreservedAmount)); // eslint-disable-line max-len
+		},
+		bookmarkVersion() {
+			// Display follow for all US loans no matter login state
+			if (this.distributionModel === 'direct') {
+				return 'follow';
+			}
+			// Display bookmark for logged in users, non us loans
+			if (this.isLoggedIn) {
+				return 'bookmark';
+			}
+			return 'none';
 		}
 	},
 	mounted() {

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -436,6 +436,7 @@ export default {
 			matchingHighlightExpShown: false,
 			inPfp: false,
 			distributionModel: '',
+			followUsLoansEnabled: false,
 		};
 	},
 	apollo: {
@@ -490,6 +491,10 @@ export default {
 						key
 						value
 					}
+					followUsLoans: uiConfigSetting(key: "follow_us_loans") {
+						key
+						value
+					}
 				}
 			}
 		`,
@@ -526,6 +531,7 @@ export default {
 				this.lenderCountVisibility = true;
 			}
 			this.distributionModel = loan?.distributionModel ?? '';
+			this.followUsLoansEnabled = result?.data?.general?.followUsLoans?.value === 'true' || false;
 
 			// Start cycling the stats slot now that loan data is available
 			this.cycleStatsSlot();
@@ -807,10 +813,10 @@ export default {
 		},
 		bookmarkVersion() {
 			// Display follow for all US loans no matter login state
-			if (this.distributionModel === 'direct') {
+			if (this.distributionModel === 'direct' && this.followUsLoansEnabled) {
 				return 'follow';
 			}
-			// Display bookmark for logged in users, non us loans
+			// Display bookmark for logged in users, non us loans or if follow setting is disabled
 			if (this.isLoggedIn) {
 				return 'bookmark';
 			}

--- a/src/components/BorrowerProfile/LoanFollow.vue
+++ b/src/components/BorrowerProfile/LoanFollow.vue
@@ -1,0 +1,33 @@
+<template>
+	<div>
+		<a
+			class="tw-text-action tw-inline-flex tw-cursor-pointer
+			tw-whitespace-nowrap tw-font-medium hover:tw-no-underline"
+			href="#follow"
+			v-kv-track-event="['borrower-profile', 'click', 'follow']"
+		>
+			<kv-material-icon
+				class="tw-text-action tw-w-3 tw-mr-0.5"
+				:icon="`${mdiBookmarkOutline}`"
+			/>
+			Follow
+		</a>
+	</div>
+</template>
+<script>
+import { mdiBookmarkOutline } from '@mdi/js';
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
+
+export default {
+	name: 'LoanFollow',
+	components: {
+		KvMaterialIcon,
+	},
+	inject: ['apollo', 'cookieStore'],
+	data() {
+		return {
+			mdiBookmarkOutline,
+		};
+	},
+};
+</script>

--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -46,7 +46,10 @@
 					>
 					</div>
 				</div>
-
+			</div>
+			<!-- "Follow" button for US loans links here from SummaryCard and LendCta -->
+			<a name="follow"></a>
+			<div v-if="!partnerName && !loading">
 				<borrower-business-details
 					class="tw-mb-2"
 					:borrower-business-name="borrowerBusinessName"

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -80,12 +80,16 @@
 				</summary-tag>
 			</template>
 
-			<!-- only show option to bookmark loan if user is logged in -->
 			<loan-bookmark
-				v-if="isLoggedIn"
+				v-if="bookmarkVersion === 'bookmark'"
 				:loan-id="loanId"
 				class="tw-hidden lg:tw-inline-flex tw-ml-auto tw-items-center"
 				data-testid="bp-summary-bookmark"
+			/>
+			<loan-follow
+				v-if="bookmarkVersion === 'follow'"
+				class="tw-hidden lg:tw-inline-flex tw-ml-auto tw-items-center"
+				data-testid="bp-summary-follow"
 			/>
 		</div>
 		<slot name="sharebutton"></slot>
@@ -96,10 +100,15 @@
 		>
 			<!-- only show option to bookmark loan if user is logged in -->
 			<loan-bookmark
-				v-if="isLoggedIn"
+				v-if="bookmarkVersion === 'bookmark'"
 				:loan-id="loanId"
 				class="md:tw-hidden tw-mt-1"
 				data-testid="bp-mobile-summary-bookmark"
+			/>
+			<loan-follow
+				v-if="bookmarkVersion === 'follow'"
+				class="md:tw-hidden tw-mt-0.5 tw-mr-2"
+				data-testid="bp-mobile-summary-follow"
 			/>
 
 			<jump-links class="md:tw-hidden tw-my-2" data-testid="bp-summary-card-jump-links" />
@@ -116,6 +125,7 @@ import BorrowerName from './BorrowerName';
 import LoanProgress from './LoanProgress';
 import SummaryTag from './SummaryTag';
 import LoanBookmark from './LoanBookmark';
+import LoanFollow from './LoanFollow';
 import JumpLinks from './JumpLinks';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 
@@ -194,6 +204,7 @@ export default {
 		LoanProgress,
 		SummaryTag,
 		LoanBookmark,
+		LoanFollow,
 		JumpLinks,
 		KvLoadingPlaceholder,
 	},
@@ -240,6 +251,17 @@ export default {
 				return formattedString;
 			}
 			return this.countryName;
+		},
+		bookmarkVersion() {
+			// Display follow for all US loans no matter login state
+			if (this.distributionModel === 'direct') {
+				return 'follow';
+			}
+			// Display bookmark for logged in users, non us loans
+			if (this.isLoggedIn) {
+				return 'bookmark';
+			}
+			return 'none';
 		}
 	},
 	async mounted() {

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -154,6 +154,12 @@ const preFetchQuery = gql`
 				id
 			}
 		}
+		general {
+			followUsLoans: uiConfigSetting(key: "follow_us_loans") {
+				key
+				value
+			}
+		}
 	}
 `;
 
@@ -235,6 +241,7 @@ export default {
 			inPfp: false,
 			pfpMinLenders: 0,
 			numLenders: 0,
+			followUsLoansEnabled: false,
 		};
 	},
 	computed: {
@@ -254,10 +261,10 @@ export default {
 		},
 		bookmarkVersion() {
 			// Display follow for all US loans no matter login state
-			if (this.distributionModel === 'direct') {
+			if (this.distributionModel === 'direct' && this.followUsLoansEnabled) {
 				return 'follow';
 			}
-			// Display bookmark for logged in users, non us loans
+			// Display bookmark for logged in users, non us loans or if follow setting is disabled
 			if (this.isLoggedIn) {
 				return 'bookmark';
 			}
@@ -311,6 +318,7 @@ export default {
 			this.name = loan?.name ?? '';
 			this.status = loan?.status ?? '';
 			this.use = loan?.fullLoanUse ?? '';
+			this.followUsLoansEnabled = result?.data?.general?.followUsLoans?.value === 'true' || false;
 		},
 	},
 };


### PR DESCRIPTION
We want to replace the save button with a follow button for us loans that just scrolls down the page. See ACK-569 for more details. 

Screenshots:

<img width="395" alt="Screen Shot 2023-03-30 at 2 34 13 PM" src="https://user-images.githubusercontent.com/4371888/228958953-e790ca34-5492-4e8d-a7e7-f037c3f70d65.png">
<img width="657" alt="Screen Shot 2023-03-30 at 2 32 21 PM" src="https://user-images.githubusercontent.com/4371888/228958980-99a535e4-e0e2-457a-9a3f-ad2c96f4654d.png">

ACK-569