### PR TITLE
feat: add id to experiment log message

### DIFF
--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -41,14 +41,14 @@ export default ({ cookieStore, route }) => {
 
 					// Check if the requested experiment is active
 					if (!activeExperiments.includes(id)) {
-						logFormatter('Experiment is not in active experiments list', 'warn');
+						logFormatter(`Experiment is not in active experiments list: ${id}`, 'warn');
 						return Experiment({ id });
 					}
 
 					// Get the settings of the experiment (name, distribution, population)
 					const experimentSetting = await getExperimentSetting(id, client);
 					if (!experimentSetting.name) {
-						logFormatter('Experiment setting is missing', 'warn');
+						logFormatter(`Experiment setting is missing: ${id}`, 'warn');
 						return Experiment({ id });
 					}
 

--- a/test/unit/specs/api/localResolvers/experiment.spec.js
+++ b/test/unit/specs/api/localResolvers/experiment.spec.js
@@ -81,7 +81,7 @@ describe('experiment.js', () => {
 			expect(result).toEqual(Experiment({ id: 'x' }));
 			expect(getActiveExperimentsSpy).toHaveBeenCalledTimes(1);
 			// eslint-disable-next-line max-len
-			expect(consoleWarnSpy).toHaveBeenCalledWith('{"meta":{},"level":"warn","message":"Experiment is not in active experiments list"}');
+			expect(consoleWarnSpy).toHaveBeenCalledWith('{"meta":{},"level":"warn","message":"Experiment is not in active experiments list: x"}');
 			expect(getExperimentSettingSpy).toHaveBeenCalledTimes(0);
 			expect(getForcedAssignmentSpy).toHaveBeenCalledTimes(0);
 			expect(calculateHashSpy).toHaveBeenCalledTimes(0);
@@ -101,7 +101,7 @@ describe('experiment.js', () => {
 			expect(getActiveExperimentsSpy).toHaveBeenCalledTimes(1);
 			expect(getExperimentSettingSpy).toHaveBeenCalledTimes(1);
 			// eslint-disable-next-line max-len
-			expect(consoleWarnSpy).toHaveBeenCalledWith('{"meta":{},"level":"warn","message":"Experiment setting is missing"}');
+			expect(consoleWarnSpy).toHaveBeenCalledWith('{"meta":{},"level":"warn","message":"Experiment setting is missing: test_experiment"}');
 			expect(getForcedAssignmentSpy).toHaveBeenCalledTimes(0);
 			expect(calculateHashSpy).toHaveBeenCalledTimes(0);
 			expect(assignVersionForLoginIdSpy).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
This seems like a nice quality of life add. Maybe it'll motivate developers to get rid of stale experiments?