### PR TITLE
fix: resolve $5 notes issues

### DIFF
--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -40,7 +40,7 @@ export default ({ cookieStore, route }) => {
 					}
 
 					// Check if the requested experiment is active
-					if (!activeExperiments.split(',').includes(id)) {
+					if (!activeExperiments.includes(id)) {
 						logFormatter(`Experiment is not in active experiments list: ${id}`, 'warn');
 						return Experiment({ id });
 					}

--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -148,6 +148,7 @@ export default {
 	data() {
 		return {
 			completeLoanView: true,
+			selectedOption: '25',
 		};
 	},
 	methods: {
@@ -163,6 +164,13 @@ export default {
 		},
 	},
 	watch: {
+		unreservedAmount(newValue, previousValue) {
+			if (isBetween25And50(this.unreservedAmount)) {
+				this.selectedOption = Number(this.unreservedAmount).toFixed();
+			} else if (newValue !== previousValue && previousValue === '' && newValue < 25) {
+				this.selectedOption = parseInt(newValue, 10);
+			}
+		},
 		isCompleteLoanActive() {
 			if (this.isCompleteLoanActive && this.completeLoanView) {
 				this.completeLoanView = false;
@@ -286,12 +294,6 @@ export default {
 		showLendAgain() {
 			return this.isLentTo && !this.isLessThan25;
 		},
-		selectedOption() {
-			if (isBetween25And50(this.unreservedAmount) || isLessThan25(this.unreservedAmount)) {
-				return Number(this.unreservedAmount).toFixed();
-			}
-			return '25';
-		}
 	},
 };
 

--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -148,7 +148,7 @@ export default {
 	data() {
 		return {
 			completeLoanView: true,
-			selectedOption: '25',
+			selectedOption: this.getSelectedOption(this.loan?.unreservedAmount),
 		};
 	},
 	methods: {
@@ -162,13 +162,17 @@ export default {
 			);
 			this.$emit('add-to-basket', this.amountToLend);
 		},
+		getSelectedOption(unreservedAmount) {
+			if (isBetween25And50(unreservedAmount) || isLessThan25(unreservedAmount)) {
+				return Number(unreservedAmount).toFixed();
+			}
+			return '25';
+		},
 	},
 	watch: {
 		unreservedAmount(newValue, previousValue) {
-			if (isBetween25And50(this.unreservedAmount)) {
-				this.selectedOption = Number(this.unreservedAmount).toFixed();
-			} else if (newValue !== previousValue && previousValue === '' && newValue < 25) {
-				this.selectedOption = parseInt(newValue, 10);
+			if (newValue !== previousValue && previousValue === '') {
+				this.selectedOption = this.getSelectedOption(newValue);
 			}
 		},
 		isCompleteLoanActive() {

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -142,13 +142,10 @@ import {
 import { gql } from '@apollo/client';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
-
-import fiveDollarsTest from '@/plugins/five-dollars-test-mixin'; // returning enableFiveDollarsNotes from assignment
-
+import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 import {
 	trackExperimentVersion
 } from '@/util/experiment/experimentUtils';
-
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import ContentContainer from '@/components/BorrowerProfile/ContentContainer';
 import SidebarContainer from '@/components/BorrowerProfile/SidebarContainer';
@@ -457,6 +454,7 @@ export default {
 					return Promise.all([
 						client.query({ query: experimentAssignmentQuery, variables: { id: LEND_URGENCY_EXP } }),
 						client.query({ query: experimentAssignmentQuery, variables: { id: SHARE_LANGUAGE_EXP } }),
+						client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 					]);
 				});
 		},
@@ -641,6 +639,8 @@ export default {
 
 		const publicId = getPublicId(this.$route);
 		this.inviterIsGuestOrAnonymous = publicId === 'anonymous' || publicId === 'guest';
+
+		this.initializeFiveDollarsNotes();
 	},
 };
 </script>

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -306,6 +306,7 @@ import {
 	trackExperimentVersion
 } from '@/util/experiment/experimentUtils';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
+import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
@@ -313,7 +314,6 @@ import KvButton from '~/@kiva/kv-components/vue/KvButton';
 const iwdChallengeExpKey = 'iwd_challenge';
 const CHECKOUT_LOGIN_CTA_EXP = 'checkout_login_cta';
 const GUEST_CHECKOUT_CTA_EXP = 'guest_checkout_cta';
-const FIVE_DOLLARS_NOTES_EXP = 'five_dollars_notes';
 
 // Query to gather user Teams
 const myTeamsQuery = gql`query myTeamsQuery {
@@ -354,7 +354,7 @@ export default {
 		KvLoadingPlaceholder
 	},
 	inject: ['apollo', 'cookieStore', 'kvAuth0'],
-	mixins: [checkoutUtils],
+	mixins: [checkoutUtils, fiveDollarsTest],
 	metaInfo: {
 		title: 'Checkout'
 	},
@@ -527,20 +527,7 @@ export default {
 		});
 		this.matchedText = matchedLoansWithCredit[0]?.loan?.matchingText ?? '';
 
-		const fiveDollarsNotesEXP = this.apollo.readFragment({
-			id: `Experiment:${FIVE_DOLLARS_NOTES_EXP}`,
-			fragment: experimentVersionFragment,
-		}) || {};
-		this.enableFiveDollarsNotes = fiveDollarsNotesEXP.version ? fiveDollarsNotesEXP.version === 'b' : false;
-		if (fiveDollarsNotesEXP.version) {
-			trackExperimentVersion(
-				this.apollo,
-				this.$kvTrackEvent,
-				'Lending',
-				FIVE_DOLLARS_NOTES_EXP,
-				'EXP-CORE-1104-Mar2023'
-			);
-		}
+		this.initializeFiveDollarsNotes();
 	},
 	mounted() {
 		// update current time every second for reactivity

--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -102,7 +102,7 @@ import FavoriteCountryLoans from '@/components/LoansByCategory/FavoriteCountryLo
 import { createIntersectionObserver } from '@/util/observerUtils';
 import hasEverLoggedInQuery from '@/graphql/query/shared/hasEverLoggedIn.graphql';
 import retryAfterExpiredBasket from '@/plugins/retry-after-expired-basket-mixin';
-import fiveDollarsTest from '@/plugins/five-dollars-test-mixin'; // returning enableFiveDollarsNotes from assignment
+import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 
 const CATEGORIES_REDIRECT_EXP = 'categories_redirect';
 const LOAN_FINDING_EXP_KEY = 'loan_finding_page';
@@ -675,6 +675,7 @@ export default {
 							client.query({ query: experimentQuery, variables: { id: ADD_TO_BASKET_V2_EXP } }),
 							client.query({ query: experimentQuery, variables: { id: BANDIT_EXP } }),
 							client.query({ query: experimentQuery, variables: { id: FLSS_CATEGORY_SERVICE_EXP } }),
+							client.query({ query: experimentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 						]);
 					});
 			});
@@ -740,6 +741,8 @@ export default {
 				active: true,
 			}
 		});
+
+		this.initializeFiveDollarsNotes();
 	},
 	mounted() {
 		this.fetchCategoryIds = [...this.categorySetting];

--- a/src/pages/Lend/LoanChannelCategoryPage.vue
+++ b/src/pages/Lend/LoanChannelCategoryPage.vue
@@ -19,13 +19,11 @@ import { gql } from '@apollo/client';
 import updateAddToBasketInterstitial from '@/graphql/mutation/updateAddToBasketInterstitial.graphql';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
-
 import WwwPage from '@/components/WwwFrame/WwwPage';
 import AddToBasketInterstitial from '@/components/Lightboxes/AddToBasketInterstitial';
-
 import LoanChannelCategoryControl from '@/pages/Lend/LoanChannelCategoryControl';
 import retryAfterExpiredBasket from '@/plugins/retry-after-expired-basket-mixin';
-import fiveDollarsTest from '@/plugins/five-dollars-test-mixin'; // returning enableFiveDollarsNotes from assignment
+import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 
 const pageQuery = gql`
 	query LoanChannelCategoryPageExperiments {
@@ -76,6 +74,7 @@ export default {
 					client.query({ query: experimentAssignmentQuery, variables: { id: 'loan_tags' } }),
 					client.query({ query: experimentAssignmentQuery, variables: { id: 'new_loan_card' } }),
 					client.query({ query: experimentAssignmentQuery, variables: { id: 'filter_pills' } }),
+					client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 				]);
 			});
 		}
@@ -96,6 +95,8 @@ export default {
 
 		// Initialize Filter Pills Experimentx
 		this.initializeFilterPillsTest();
+
+		this.initializeFiveDollarsNotes();
 	},
 	methods: {
 		initializeNewLoanCardTest() {

--- a/src/pages/Lend/LoanSearchPage.vue
+++ b/src/pages/Lend/LoanSearchPage.vue
@@ -48,7 +48,7 @@ import { mdiEarth, mdiFilter, mdiClose } from '@mdi/js';
 import { gql } from '@apollo/client';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import experimentQuery from '@/graphql/query/experimentAssignment.graphql';
-import fiveDollarsTest from '@/plugins/five-dollars-test-mixin'; // returning enableFiveDollarsNotes from assignment
+import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
@@ -95,6 +95,7 @@ export default {
 				return Promise.all([
 					client.query({ query: experimentQuery, variables: { id: 'extend_flss_filters' } }),
 					client.query({ query: experimentQuery, variables: { id: 'EXP-FLSS-Lend-Filter' } }),
+					client.query({ query: experimentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 				]);
 			});
 		},
@@ -127,5 +128,8 @@ export default {
 			}
 		}
 	},
+	created() {
+		this.initializeFiveDollarsNotes();
+	}
 };
 </script>

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -90,7 +90,7 @@ import { getExperimentSettingCached, trackExperimentVersion } from '@/util/exper
 import { spotlightData } from '@/assets/data/components/LoanFinding/spotlightData.json';
 import flssLoansQuery from '@/graphql/query/flssLoansQuery.graphql';
 import retryAfterExpiredBasket from '@/plugins/retry-after-expired-basket-mixin';
-import fiveDollarsTest from '@/plugins/five-dollars-test-mixin'; // returning enableFiveDollarsNotes from assignment
+import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 import KvToast from '~/@kiva/kv-components/vue/KvToast';
 import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
@@ -144,6 +144,7 @@ export default {
 				client.query({ query: experimentAssignmentQuery, variables: { id: EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: LOAN_CARD_EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: CATEGORIES_REDIRECT_EXP_KEY } }),
+				client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 			]);
 		},
 		result({ data }) {
@@ -302,6 +303,8 @@ export default {
 			);
 			this.enableLoanCardExp = version === 'b' ?? false;
 		}
+
+		this.initializeFiveDollarsNotes();
 	},
 	mounted() {
 		this.getRecommendedLoans();

--- a/src/plugins/five-dollars-test-mixin.js
+++ b/src/plugins/five-dollars-test-mixin.js
@@ -1,8 +1,6 @@
 import { trackExperimentVersion } from '@/util/experiment/experimentUtils';
-import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
-import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 
-const FIVE_DOLLARS_NOTES_EXP = 'five_dollars_notes';
+export const FIVE_DOLLARS_NOTES_EXP = 'five_dollars_notes';
 
 export default {
 	data() {
@@ -10,21 +8,16 @@ export default {
 			enableFiveDollarsNotes: false
 		};
 	},
-	async mounted() {
-		await this.apollo.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } });
-		const fiveDollarsNotesEXP = this.apollo.readFragment({
-			id: `Experiment:${FIVE_DOLLARS_NOTES_EXP}`,
-			fragment: experimentVersionFragment,
-		}) || {};
-		this.enableFiveDollarsNotes = fiveDollarsNotesEXP.version ? fiveDollarsNotesEXP.version === 'b' : false;
-		if (fiveDollarsNotesEXP.version) {
-			trackExperimentVersion(
+	methods: {
+		initializeFiveDollarsNotes() {
+			const { version } = trackExperimentVersion(
 				this.apollo,
 				this.$kvTrackEvent,
 				'Lending',
 				FIVE_DOLLARS_NOTES_EXP,
 				'EXP-CORE-1104-Mar2023'
 			);
+			this.enableFiveDollarsNotes = version === 'b';
 		}
 	},
 };

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -24,7 +24,7 @@ export async function getActiveExperiments(cache, client) {
 	// First check if the active experiments are cached
 	try {
 		const data = cache.readQuery({ query: experimentIdsQuery });
-		activeExperiments = data?.general?.activeExperiments?.value;
+		activeExperiments = JSON.parse(data?.general?.activeExperiments?.value).split(',');
 	} catch {
 		// noop
 	}
@@ -33,7 +33,7 @@ export async function getActiveExperiments(cache, client) {
 	if (!activeExperiments?.length) {
 		try {
 			const { data } = await client.query({ query: experimentIdsQuery });
-			activeExperiments = data?.general?.activeExperiments?.value;
+			activeExperiments = JSON.parse(data?.general?.activeExperiments?.value).split(',');
 		} catch {
 			// noop
 		}

--- a/test/unit/specs/api/localResolvers/experiment.spec.js
+++ b/test/unit/specs/api/localResolvers/experiment.spec.js
@@ -40,7 +40,7 @@ describe('experiment.js', () => {
 		beforeEach(() => {
 			consoleWarnSpy = jest.spyOn(global.console, 'warn').mockImplementation();
 			getActiveExperimentsSpy = jest.spyOn(expUtils, 'getActiveExperiments')
-				.mockImplementation(() => Promise.resolve(EXP_ID));
+				.mockImplementation(() => Promise.resolve([EXP_ID]));
 			getExperimentSettingSpy = jest.spyOn(expUtils, 'getExperimentSetting')
 				.mockImplementation(() => Promise.resolve(experiment));
 			getForcedAssignmentSpy = jest.spyOn(expUtils, 'getForcedAssignment').mockReturnValue(undefined);
@@ -93,7 +93,7 @@ describe('experiment.js', () => {
 
 		it('should return undefined assignment when active experiments has similarly named experiment', async () => {
 			const { resolvers } = expResolverFactory({});
-			getActiveExperimentsSpy.mockImplementation(() => Promise.resolve(`asd_${EXP_ID}`));
+			getActiveExperimentsSpy.mockImplementation(() => Promise.resolve([`asd_${EXP_ID}`]));
 
 			const result = await resolvers.Query.experiment(null, { id: 'x' }, {});
 

--- a/test/unit/specs/util/experiment/experimentUtils.spec.js
+++ b/test/unit/specs/util/experiment/experimentUtils.spec.js
@@ -42,12 +42,11 @@ describe('experimentUtils.js', () => {
 		});
 
 		it('should get active experiments from cache', async () => {
-			const mockActiveExperiments = ['asd'];
 			const cache = {
 				readQuery: jest.fn().mockReturnValue({
 					general: {
 						activeExperiments: {
-							value: mockActiveExperiments
+							value: '"asd,qwe"'
 						}
 					}
 				})
@@ -58,13 +57,12 @@ describe('experimentUtils.js', () => {
 
 			const result = await getActiveExperiments(cache, client);
 
-			expect(result).toEqual(mockActiveExperiments);
+			expect(result).toEqual(['asd', 'qwe']);
 			expect(cache.readQuery).toHaveBeenCalledWith({ query: experimentIdsQuery });
 			expect(client.query).toHaveBeenCalledTimes(0);
 		});
 
 		it('should get active experiments from client', async () => {
-			const mockActiveExperiments = ['asd'];
 			const cache = {
 				readQuery: jest.fn().mockReturnValue({})
 			};
@@ -73,7 +71,7 @@ describe('experimentUtils.js', () => {
 					data: {
 						general: {
 							activeExperiments: {
-								value: mockActiveExperiments
+								value: '"asd,qwe"'
 							}
 						}
 					}
@@ -82,7 +80,7 @@ describe('experimentUtils.js', () => {
 
 			const result = await getActiveExperiments(cache, client);
 
-			expect(result).toEqual(mockActiveExperiments);
+			expect(result).toEqual(['asd', 'qwe']);
 			expect(cache.readQuery).toHaveBeenCalledWith({ query: experimentIdsQuery });
 			expect(client.query).toHaveBeenCalledWith({ query: experimentIdsQuery });
 		});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1253

- I forgot that the active experiments come back in a JSON string (extra double quotes) - parsing and splitting moved to util method - it meant that the first and last experiment in `active_experiments` was ignored due to extra double quote
- Selected option in `LendCtaExp` couldn't be a computed, since it was bound to a dropdown - an error was being shown locally, and it wasn't adding the right amount to the basket (defaulted to $25) - ported the `watch` code from `LendCta` component, since it should be the same logic needed
- While tracking down the active experiments issue, I went ahead and refactored the $5 notes mixin, since I initially thought it might have to do with timing of assignment (it didn't...), but I kept the refactor in - it makes it so all assignments now happen in `preFetch` for consistency