### PR TITLE
Core 1180 solution for loan card tags that are truncated

### DIFF
--- a/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
+++ b/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
@@ -89,3 +89,7 @@ export const LargerImage = story({
 	loanId: loan.id,
 	perRow: 2
 });
+
+export const LongCallouts = story({
+	loanId: loan.id,
+}, false, { activity: { id: 1, name: 'Longer activity name test that will be longer than 50% of the card' } });

--- a/.storybook/stories/PortfolioKivaCreditStats.stories.js
+++ b/.storybook/stories/PortfolioKivaCreditStats.stories.js
@@ -1,6 +1,6 @@
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
-import KivaCreditStats from '@/pages/Portfolio/KivaCreditStats';
+import KivaCreditStats from '@/pages/Portfolio/ImpactDashboard/KivaCreditStats';
 
 import apolloStoryMixin from '../mixins/apollo-story-mixin';
 import cookieStoreStoryMixin from '../mixins/cookie-store-story-mixin';

--- a/src/components/LoanCards/LoanTags/LoanCallouts.vue
+++ b/src/components/LoanCards/LoanTags/LoanCallouts.vue
@@ -45,7 +45,6 @@ export default {
 
 <style scoped>
 .loan-callout {
-	max-width: 50%;
 	background: #f1f1f1;
 }
 </style>


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1180

- Turns out that removing the 50% limitation fixes this issue in most cases
- Fixed issue preventing storybook from loading due to folder structure change for portfolio

![image](https://user-images.githubusercontent.com/16867161/230951270-5f8ff2c8-3a72-4796-81f5-33c8b2d7e07a.png)
