### PR TITLE
fix: don't show CTA until progress loaded

### DIFF
--- a/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
+++ b/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
@@ -58,6 +58,10 @@ export const Loading = story({
 	loanId: loan.id,
 }, true);
 
+export const PartialLoading = story({
+	loanId: loan.id,
+}, false, { unreservedAmount: undefined, fundraisingPercent: undefined });
+
 export const UseFullWidth = story({
 	loanId: loan.id,
 	useFullWidth: true

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -137,7 +137,7 @@
 
 			<!-- CTA Button -->
 			<kv-loading-placeholder
-				v-if="isLoading"
+				v-if="!allDataLoaded"
 				class="tw-rounded tw-self-start" :style="{ width: '9rem', height: '3rem' }"
 			/>
 
@@ -323,6 +323,9 @@ export default {
 			// Local resolver values for the progress bar load client-side
 			return typeof this.loan?.unreservedAmount !== 'undefined'
 				&& typeof this.loan?.fundraisingPercent !== 'undefined';
+		},
+		allDataLoaded() {
+			return !this.isLoading && this.hasProgressData;
 		},
 		fundraisingPercent() {
 			return this.loan?.fundraisingPercent ?? 0;


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1129

- CTA now only shown once progress data is loaded client-side

![image](https://user-images.githubusercontent.com/16867161/230954073-65930bad-7ebb-49c0-904c-fd93134432c9.png)
