### PR TITLE
fix: use experiment key instead of name

### DIFF
--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -83,7 +83,7 @@ export default ({ cookieStore, route }) => {
 							id,
 							version: currentAssignment.queryForced
 								? currentAssignment.version
-								: assignVersionForLoginId(experimentSetting, getLoginId(cookieStore)),
+								: assignVersionForLoginId(id, experimentSetting, getLoginId(cookieStore)),
 							hash,
 							population,
 							queryForced: currentAssignment.queryForced,

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -159,20 +159,20 @@ export function serializeExpCookie(assignments) {
  *     "population": 0.5,
  * }
  *
- * @param {string} param0.name The name of the experiment
- * @param {Object} param0.distribution An object of the variant weights, where each key is the
+ * @param {string} experimentKey The key of the experiment
+ * @param {Object} param1.distribution An object of the variant weights, where each key is the
  * variant ID and the value is the weight of the variant. The weight must be a number between 0 and 1.
- * @param {number} param0.population A number between 0 and 1 representing the fraction of the population
+ * @param {number} param1.population A number between 0 and 1 representing the fraction of the population
  * that should be included in the experiment.
  * @param {string|number} loginId The login ID of the current user. This ID can be the user or visitor ID.
  * @returns {string|number} Returns a variant ID of the experiment
  */
-export function assignVersionForLoginId({ name, distribution, population = 1 }, loginId) {
-	if (!name || !distribution || !loginId) return;
+export function assignVersionForLoginId(experimentKey, { distribution, population = 1 }, loginId) {
+	if (!experimentKey || !distribution || !loginId) return;
 
-	// Seed the pseudo random number generator with the experiment name and login ID
+	// Seed the pseudo random number generator with the experiment key and login ID
 	// The seed ensures that the same number is generated for this experiment and login ID combination
-	const marker = Alea(name, loginId)();
+	const marker = Alea(experimentKey, loginId)();
 
 	let cutoff = 0;
 

--- a/test/unit/specs/util/experiment/experimentUtils.spec.js
+++ b/test/unit/specs/util/experiment/experimentUtils.spec.js
@@ -506,9 +506,9 @@ describe('experimentUtils.js', () => {
 	});
 
 	describe('assignVersionForLoginId', () => {
+		const key = 'asd';
 		const loginId = 'ac4abedd-b9fd-487b-8d83-6fb73794e33e';
 		const experiment = {
-			name: 'asd',
 			distribution: {
 				control: 0.5,
 				variant: 0.5,
@@ -525,9 +525,9 @@ describe('experimentUtils.js', () => {
 			afterEach(jest.restoreAllMocks);
 
 			it('should return undefined when experiment props missing', () => {
-				expect(assignVersionForLoginId({}, loginId)).toBe(undefined);
-				expect(assignVersionForLoginId({ name: 'a', distribution: 'b' })).toBe(undefined);
-				expect(assignVersionForLoginId({ name: 'a', distribution: 'b' }, '')).toBe(undefined);
+				expect(assignVersionForLoginId(undefined, {}, loginId)).toBe(undefined);
+				expect(assignVersionForLoginId(key, { distribution: 'b' })).toBe(undefined);
+				expect(assignVersionForLoginId(key, { distribution: 'b' }, '')).toBe(undefined);
 			});
 
 			it('should return undefined when dice roll lands outside population level', () => {
@@ -535,45 +535,45 @@ describe('experimentUtils.js', () => {
 
 				spyAlea.mockReturnValueOnce(() => 0.5);
 				data.population = 0.5;
-				expect(assignVersionForLoginId(data, loginId)).toBe('variant');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('variant');
 				expect(spyAlea).toHaveBeenCalledTimes(1);
 
 				spyAlea.mockReturnValueOnce(() => 0.51);
 				data.population = 0.5;
-				expect(assignVersionForLoginId(data, loginId)).toBe(undefined);
+				expect(assignVersionForLoginId(key, data, loginId)).toBe(undefined);
 				expect(spyAlea).toHaveBeenCalledTimes(2);
 
 				spyAlea.mockReturnValueOnce(() => 0.9);
 				data.population = 0.5;
-				expect(assignVersionForLoginId(data, loginId)).toBe(undefined);
+				expect(assignVersionForLoginId(key, data, loginId)).toBe(undefined);
 				expect(spyAlea).toHaveBeenCalledTimes(3);
 			});
 
 			it('should return "control" when dice roll lands in the control distribution', () => {
 				spyAlea.mockReturnValueOnce(() => 0);
-				expect(assignVersionForLoginId(experiment, loginId)).toBe('control');
+				expect(assignVersionForLoginId(key, experiment, loginId)).toBe('control');
 				expect(spyAlea).toHaveBeenCalledTimes(1);
 
 				spyAlea.mockReturnValueOnce(() => 0.25);
-				expect(assignVersionForLoginId(experiment, loginId)).toBe('control');
+				expect(assignVersionForLoginId(key, experiment, loginId)).toBe('control');
 				expect(spyAlea).toHaveBeenCalledTimes(2);
 
 				spyAlea.mockReturnValueOnce(() => 0.5);
-				expect(assignVersionForLoginId(experiment, loginId)).toBe('control');
+				expect(assignVersionForLoginId(key, experiment, loginId)).toBe('control');
 				expect(spyAlea).toHaveBeenCalledTimes(3);
 			});
 
 			it('should return "variant" when dice roll lands in the variant distribution', () => {
 				spyAlea.mockReturnValueOnce(() => 0.51);
-				expect(assignVersionForLoginId(experiment, loginId)).toBe('variant');
+				expect(assignVersionForLoginId(key, experiment, loginId)).toBe('variant');
 				expect(spyAlea).toHaveBeenCalledTimes(1);
 
 				spyAlea.mockReturnValueOnce(() => 0.75);
-				expect(assignVersionForLoginId(experiment, loginId)).toBe('variant');
+				expect(assignVersionForLoginId(key, experiment, loginId)).toBe('variant');
 				expect(spyAlea).toHaveBeenCalledTimes(2);
 
 				spyAlea.mockReturnValueOnce(() => 0.99);
-				expect(assignVersionForLoginId(experiment, loginId)).toBe('variant');
+				expect(assignVersionForLoginId(key, experiment, loginId)).toBe('variant');
 				expect(spyAlea).toHaveBeenCalledTimes(3);
 			});
 
@@ -581,41 +581,41 @@ describe('experimentUtils.js', () => {
 				const data = { ...experiment, distribution: { a: 0.5, b: 0.25, c: 0.25 } };
 
 				spyAlea.mockReturnValueOnce(() => 0);
-				expect(assignVersionForLoginId(data, loginId)).toBe('a');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('a');
 				expect(spyAlea).toHaveBeenCalledTimes(1);
 
 				spyAlea.mockReturnValueOnce(() => 0.5);
-				expect(assignVersionForLoginId(data, loginId)).toBe('a');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('a');
 				expect(spyAlea).toHaveBeenCalledTimes(2);
 
 				spyAlea.mockReturnValueOnce(() => 0.51);
-				expect(assignVersionForLoginId(data, loginId)).toBe('b');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('b');
 				expect(spyAlea).toHaveBeenCalledTimes(3);
 
 				spyAlea.mockReturnValueOnce(() => 0.75);
-				expect(assignVersionForLoginId(data, loginId)).toBe('b');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('b');
 				expect(spyAlea).toHaveBeenCalledTimes(4);
 
 				spyAlea.mockReturnValueOnce(() => 0.76);
-				expect(assignVersionForLoginId(data, loginId)).toBe('c');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('c');
 				expect(spyAlea).toHaveBeenCalledTimes(5);
 
 				spyAlea.mockReturnValueOnce(() => 0.99);
-				expect(assignVersionForLoginId(data, loginId)).toBe('c');
+				expect(assignVersionForLoginId(key, data, loginId)).toBe('c');
 				expect(spyAlea).toHaveBeenCalledTimes(6);
 			});
 
 			it('should return a version when the population is undefined', () => {
 				const data = { ...experiment };
 				delete data.population;
-				expect(['control', 'variant']).toContain(assignVersionForLoginId(data, loginId));
+				expect(['control', 'variant']).toContain(assignVersionForLoginId(key, data, loginId));
 				expect(spyAlea).toHaveBeenCalledTimes(1);
 			});
 		});
 
 		describe('original pseudo random number generator', () => {
 			it('should return same variation over many runs', () => {
-				runManyTimesAndCompare(() => assignVersionForLoginId(experiment, loginId));
+				runManyTimesAndCompare(() => assignVersionForLoginId(key, experiment, loginId));
 			});
 		});
 	});


### PR DESCRIPTION
- Use experiment key instead of name for assignment to match BE