### PR TITLE
fix: ensure scroll handler is called

### DIFF
--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -1456,6 +1456,7 @@ export default {
 		},
 		checkoutLightboxClosed() {
 			this.checkoutVisible = false;
+			this.handleScrollPosition();
 		},
 		handleScrollPosition(y) {
 			if (this.scrollToLoans) {


### PR DESCRIPTION
This was previously in an else statement here but was accidentally removed. We can look later at how to make it more clear that this handles global scroll position changes.