### PR TITLE
Core 1296 enable flss experimentation on lending home

### DIFF
--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -4,7 +4,7 @@ import _set from 'lodash/set';
 // Experiment Ids from setting that will be passed in the X-Experiment Header
 const targetIds = [
 	'EXP-ML-Service-Bandit-LendByCategory',
-	'EXP-FLSS-Lend-Filter'
+	'EXP-FLSS-Ongoing-Sitewide'
 ];
 
 function buildExpHeaders(cookieStore) {

--- a/src/api/ExperimentIdLink.js
+++ b/src/api/ExperimentIdLink.js
@@ -1,55 +1,41 @@
 import { setContext } from '@apollo/client/link/context';
 import _set from 'lodash/set';
+import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 
-// Experiment Ids from setting that will be passed in the X-Experiment Header
+// Experiment assignments that will be passed in the X-Experiment Header
 const targetIds = [
 	'EXP-ML-Service-Bandit-LendByCategory',
 	'EXP-FLSS-Ongoing-Sitewide'
 ];
 
-function buildExpHeaders(cookieStore) {
-	// kiva specific experiment cookie
-	const exps = cookieStore.get('uiab');
-	// handle missing cookie
-	if (typeof exps === 'undefined') {
-		return '';
-	}
-	const expCookieArray = exps.split('|');
-	// filter experiments to only those containing targeted ids
-	const targetExps = expCookieArray.filter(exp => {
-		let matched = false;
-		targetIds.forEach(expId => {
-			if (exp.indexOf(expId) !== -1) {
-				matched = true;
-				return true;
-			}
-		});
-		return matched;
-	});
+function buildExpHeaders(cache) {
+	const experimentAssignments = [];
 
-	// set experiment id:version then concatenate
-	let experimentHeader = '';
-	targetExps.forEach((target, index) => {
-		const expSegments = target.split(':');
-		if (expSegments.length && expSegments.length > 1) {
-			experimentHeader += `${expSegments[0]};${expSegments[1]}`;
-			if (targetExps.length - 1 > index) {
-				experimentHeader += ',';
-			}
+	targetIds.forEach(id => {
+		const exp = cache?.readFragment({
+			id: `Experiment:${id}`,
+			fragment: experimentVersionFragment,
+		}) ?? {};
+
+		if (exp.version) {
+			experimentAssignments.push(`${id};${exp.version}`);
 		}
 	});
-	return experimentHeader;
+
+	return experimentAssignments.join();
 }
 
-export default ({ cookieStore }) => {
+export default () => {
 	return setContext((operation, previousContext) => {
-		// fetch experiment header
-		const experimentHeader = buildExpHeaders(cookieStore);
-		// pass along existing context if no session id exists
+		// Fetch experiment header value
+		const experimentHeader = buildExpHeaders(previousContext?.cache);
+
+		// Pass along existing context if no experiment assignments exists
 		if (experimentHeader === '') {
 			return previousContext;
 		}
-		// add header to existing context and pass along
+
+		// Add header to existing context and pass along
 		return _set(previousContext, 'headers.X-Experiments', experimentHeader);
 	});
 };

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -40,7 +40,7 @@ export default function createApolloClient({
 		link: ApolloLink.from([
 			NetworkErrorLink(),
 			SnowplowSessionLink({ cookieStore }),
-			ExperimentIdLink({ cookieStore }),
+			ExperimentIdLink(),
 			Auth0LinkCreator({ cookieStore, kvAuth0 }),
 			BasketLinkCreator({ cookieStore }),
 			ContentfulPreviewLink({ cookieStore }),

--- a/src/pages/Lend/LendByCategoryPage.vue
+++ b/src/pages/Lend/LendByCategoryPage.vue
@@ -109,6 +109,7 @@ const LOAN_FINDING_EXP_KEY = 'loan_finding_page';
 const ADD_TO_BASKET_V2_EXP = 'add_to_basket_v2';
 const BANDIT_EXP = 'EXP-ML-Service-Bandit-LendByCategory';
 const FLSS_CATEGORY_SERVICE_EXP = 'flss_category_service';
+const FLSS_ONGOING_EXP_KEY = 'EXP-FLSS-Ongoing-Sitewide';
 
 const getHasEverLoggedIn = client => !!(client.readQuery({ query: hasEverLoggedInQuery })?.hasEverLoggedIn);
 
@@ -678,6 +679,7 @@ export default {
 							client.query({ query: experimentQuery, variables: { id: BANDIT_EXP } }),
 							client.query({ query: experimentQuery, variables: { id: FLSS_CATEGORY_SERVICE_EXP } }),
 							client.query({ query: experimentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
+							client.query({ query: experimentQuery, variables: { id: FLSS_ONGOING_EXP_KEY } }),
 						]);
 					});
 			});
@@ -791,6 +793,14 @@ export default {
 				'EXP-CORE-1057-Feb2023'
 			);
 		}
+
+		trackExperimentVersion(
+			this.apollo,
+			this.$kvTrackEvent,
+			'Lending',
+			FLSS_ONGOING_EXP_KEY,
+			'EXP-VUE-FLSS-Ongoing-Sitewide'
+		);
 	},
 	beforeDestroy() {
 		this.destroyViewportObserver();

--- a/src/pages/Lend/LoanChannelCategoryPage.vue
+++ b/src/pages/Lend/LoanChannelCategoryPage.vue
@@ -23,9 +23,6 @@ import AddToBasketInterstitial from '@/components/Lightboxes/AddToBasketIntersti
 import LoanChannelCategoryControl from '@/pages/Lend/LoanChannelCategoryControl';
 import retryAfterExpiredBasket from '@/plugins/retry-after-expired-basket-mixin';
 import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
-import { trackExperimentVersion } from '@/util/experiment/experimentUtils';
-
-const FLSS_ONGOING_EXP_KEY = 'EXP-FLSS-Ongoing-Sitewide';
 
 export default {
 	name: 'LoanChannelCategoryPage',
@@ -55,7 +52,6 @@ export default {
 				client.query({ query: experimentAssignmentQuery, variables: { id: 'new_loan_card' } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: 'filter_pills' } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
-				client.query({ query: experimentAssignmentQuery, variables: { id: FLSS_ONGOING_EXP_KEY } }),
 			]);
 		}
 	},
@@ -77,14 +73,6 @@ export default {
 		this.initializeFilterPillsTest();
 
 		this.initializeFiveDollarsNotes();
-
-		trackExperimentVersion(
-			this.apollo,
-			this.$kvTrackEvent,
-			'Lending',
-			FLSS_ONGOING_EXP_KEY,
-			'EXP-VUE-FLSS-Ongoing-Sitewide'
-		);
 	},
 	methods: {
 		initializeNewLoanCardTest() {

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -76,6 +76,7 @@ const EXP_KEY = 'loan_finding_page';
 const LOAN_CARD_EXP_KEY = 'lh_new_loan_card';
 const CATEGORIES_REDIRECT_EXP_KEY = 'categories_redirect';
 const prefetchedRecommendedLoansVariables = { pageLimit: 2, origin: FLSS_ORIGIN_LENDING_HOME };
+const FLSS_ONGOING_EXP_KEY = 'EXP-FLSS-Ongoing-Sitewide';
 
 export default {
 	name: 'LoanFinding',
@@ -139,6 +140,7 @@ export default {
 				client.query({ query: experimentAssignmentQuery, variables: { id: LOAN_CARD_EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: CATEGORIES_REDIRECT_EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
+				client.query({ query: experimentAssignmentQuery, variables: { id: FLSS_ONGOING_EXP_KEY } }),
 			]);
 		},
 		result({ data }) {
@@ -325,6 +327,14 @@ export default {
 				'EXP-CORE-1057-Feb2023'
 			);
 		}
+
+		trackExperimentVersion(
+			this.apollo,
+			this.$kvTrackEvent,
+			'Lending',
+			FLSS_ONGOING_EXP_KEY,
+			'EXP-VUE-FLSS-Ongoing-Sitewide'
+		);
 	},
 	beforeDestroy() {
 		this.destroySpotlightViewportObserver();

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -124,24 +124,27 @@ export default {
 	apollo: {
 		query: userInfoQuery,
 		preFetch(config, client) {
-			const userInfoPromise = client.query({
-				query: userInfoQuery,
-			});
-
-			const recommendedLoansPromise = client.query({
-				query: flssLoansQueryExtended,
-				variables: prefetchedRecommendedLoansVariables
-			});
-
 			return Promise.all([
-				userInfoPromise,
-				recommendedLoansPromise,
 				client.query({ query: experimentAssignmentQuery, variables: { id: EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: LOAN_CARD_EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: CATEGORIES_REDIRECT_EXP_KEY } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 				client.query({ query: experimentAssignmentQuery, variables: { id: FLSS_ONGOING_EXP_KEY } }),
-			]);
+			]).then(() => {
+				const userInfoPromise = client.query({
+					query: userInfoQuery,
+				});
+
+				const recommendedLoansPromise = client.query({
+					query: flssLoansQueryExtended,
+					variables: prefetchedRecommendedLoansVariables
+				});
+
+				return Promise.all([
+					userInfoPromise,
+					recommendedLoansPromise,
+				]);
+			});
 		},
 		result({ data }) {
 			this.userInfo = data?.my?.userAccount ?? {};


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1296

- Turns out that the recent experimentation refactor broke passing experiment header to gql for new users without an existing `uiab` cookie
- We didn't previously provide the header outside of LBC, and the data team requested it on: /lend/filter, /lending-home, /lend-by-category, and /lend-by-category/*
- The header value and experiment name for tracking were both updated following the data team's request, since this will be an ongoing experimentation setup for the ML backend