### PR TITLE
fix: add missing initial click event for braintree type checkout button

### DIFF
--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -156,6 +156,7 @@ export default {
 	},
 	methods: {
 		submit() {
+			this.$kvTrackEvent('basket', 'Braintree Checkout', 'Button Click');
 			if (this.isGuestCheckout) {
 				this.$v.$touch();
 				if (!this.$v.$invalid) {

--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -156,7 +156,7 @@ export default {
 	},
 	methods: {
 		submit() {
-			this.$kvTrackEvent('basket', 'Braintree Checkout', 'Button Click');
+			this.$kvTrackEvent('basket', 'click', 'braintree-checkout-button');
 			if (this.isGuestCheckout) {
 				this.$v.$touch();
 				if (!this.$v.$invalid) {


### PR DESCRIPTION
We currently don't have an initial click event for a braintree checkout. We have several subsequent events for different actions but not this one... It is a sibling [to this](https://github.com/kiva/ui/blob/main/src/components/Checkout/KivaCreditPayment.vue#L29) Kiva Credit button click.