### PR TITLE
feat: fixes needed for relending experiment

### DIFF
--- a/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
+++ b/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
@@ -43,6 +43,8 @@ const story = (args = {}, isLoading = false, extraLoanProps = {}, extraData = {}
 				:use-full-width="useFullWidth"
 				:show-tags="showTags"
 				:large-card="largeCard"
+				:enable-relending-exp="enableRelendingExp"
+				:user-balance="userBalance"
 			/>
 		`,
 	})
@@ -75,11 +77,13 @@ export const ShowTags = story({
 export const Matched = story({
 	loanId: loan.id,
 	showTags: true,
-}, false, { matchingText: 'Matched by Ebay', matchRatio: 1, loanFundraisingInfo: {
-	fundedAmount: '200.00',
-	isExpiringSoon: false,
-	reservedAmount: '0.00'
-} });
+}, false, {
+	matchingText: 'Matched by Ebay', matchRatio: 1, loanFundraisingInfo: {
+		fundedAmount: '200.00',
+		isExpiringSoon: false,
+		reservedAmount: '0.00'
+	}
+});
 
 export const AllSharesReserved = story({
 	loanId: loan.id,
@@ -104,3 +108,27 @@ export const LargeCard = story({
 export const LongCallouts = story({
 	loanId: loan.id,
 }, false, { activity: { id: 1, name: 'Longer activity name test that will be longer than 50% of the card' } });
+
+export const LendAgain = story({
+	loanId: loan.id,
+}, false, { userProperties: { lentTo: true } });
+
+export const LendAgainSmallAmount = story({
+	loanId: loan.id,
+}, false, {
+	userProperties: { lentTo: true },
+	unreservedAmount: '5.00'
+});
+
+export const Relending = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	userBalance: 50,
+}, false);
+
+
+export const RelendingSmallAmount = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	userBalance: 20,
+}, false, { userProperties: { lentTo: true } });

--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -1,15 +1,34 @@
 <template>
 	<div>
-		<form v-if="useFormSubmit" @submit.prevent="addToBasket" class="tw-w-full tw-flex">
+		<form v-if="showAddToBasket" @submit.prevent="addToBasket" class="tw-w-full tw-flex">
 			<fieldset
-				class="tw-w-full tw-flex" :disabled="isAdding"
+				class="tw-w-full tw-flex"
+				:disabled="isAdding"
 				data-testid="bp-lend-cta-select-and-button"
 			>
-				<div class="amountDropdownWrapper">
-					<kv-ui-select
-						v-if="hideShowLendDropdown && !isLessThan25 && !enableRelendingExp"
+				<!-- Adding to basket button -->
+				<kv-button
+					v-if="isAdding"
+					class="tw-inline-flex tw-flex-1"
+				>
+					Adding to basket
+				</kv-button>
+
+				<!-- Stranded loans -->
+				<lend-amount-button
+					v-else-if="showLendAmountButton"
+					class="tw-w-full"
+					:loan-id="loan.id"
+					:show-now="false"
+					:amount-left="amountToLend"
+					@add-to-basket="addToBasket"
+				/>
+
+				<template v-else>
+					<kv-select
+						v-if="showLendDropdown"
 						:id="`LoanAmountDropdown_${loan.id}`"
-						class="tw-min-w-12"
+						class="amountDropdownWrapper tw-min-w-12"
 						v-model="selectedOption"
 						v-kv-track-event="['Lending', 'click-Modify loan amount', 'open dialog', loanId, loanId]"
 						@update:modelValue="trackLendAmountSelection"
@@ -22,56 +41,36 @@
 						>
 							${{ priceOption }}
 						</option>
-					</kv-ui-select>
-				</div>
+					</kv-select>
 
-				<!-- Lend button -->
-				<div :class="{ 'lendButtonWrapper' : hideShowLendDropdown}">
-					<kv-ui-button
-						key="lendButton"
-						v-if="lendButtonVisibility && !isLessThan25 && !enableRelendingExp"
-						class="tw-inline-flex tw-flex-1"
-						data-testid="bp-lend-cta-lend-button"
-						type="submit"
-					>
-						{{ ctaButtonText }}
-					</kv-ui-button>
+					<!-- Lend button -->
+					<div :class="{ 'lend-button-with-dropdown' : showLendDropdown }">
+						<!-- Lend again/lent previously button -->
+						<kv-button
+							v-if="showLendAgain"
+							class="lend-again"
+							data-testid="bp-lend-cta-lend-again-button"
+							type="submit"
+						>
+							Lend again
+						</kv-button>
 
-					<!-- Lend again/lent previously button -->
-					<kv-ui-button
-						key="lendAgainButton"
-						v-if="showLendAgain"
-						class="lend-again"
-						data-testid="bp-lend-cta-lend-again-button"
-						type="submit"
-					>
-						Lend again
-					</kv-ui-button>
-				</div>
-
-				<!-- Stranded loans -->
-				<lend-amount-button
-					class="tw-w-full"
-					:loan-id="loan.id"
-					:show-now="false"
-					:amount-left="amountLeft"
-					@add-to-basket="addToBasket"
-					v-if="isLendAmountButton"
-				/>
-
-				<!-- Adding to basket button -->
-				<kv-ui-button
-					v-if="isAdding"
-					class="tw-inline-flex tw-flex-1"
-				>
-					Adding to basket
-				</kv-ui-button>
+						<kv-button
+							v-else
+							class="tw-inline-flex tw-flex-1"
+							data-testid="bp-lend-cta-lend-button"
+							type="submit"
+						>
+							{{ ctaButtonText }}
+						</kv-button>
+					</div>
+				</template>
 			</fieldset>
 		</form>
 
 		<!-- Continue to checkout button -->
-		<kv-ui-button
-			v-if="this.state === 'basketed'"
+		<kv-button
+			v-else-if="this.state === 'basketed'"
 			variant="secondary"
 			class="tw-inline-flex tw-flex-1"
 			data-testid="bp-lend-cta-checkout-button"
@@ -79,24 +78,24 @@
 			v-kv-track-event="['Lending', 'click-Continue-to-checkout', 'Continue to checkout', loanId, loanId]"
 		>
 			Checkout now
-		</kv-ui-button>
-
-		<!-- Refunded, allSharesReserved button -->
-		<kv-ui-button
-			v-if="showNonActionableLoanButton"
-			class="tw-inline-flex tw-flex-1"
-		>
-			{{ ctaButtonText }}
-		</kv-ui-button>
+		</kv-button>
 
 		<!-- Funded / expired -->
 		<div
-			v-if="isFunded"
+			v-else-if="isFunded"
 			class="tw-w-full tw-text-center tw-rounded tw-p-2"
 			style="background: #f1f1f1;"
 		>
 			This loan was just funded! 🎉
 		</div>
+
+		<!-- Refunded, allSharesReserved button -->
+		<kv-button
+			v-else-if="showNonActionableLoanButton"
+			class="tw-inline-flex tw-flex-1"
+		>
+			{{ ctaButtonText }}
+		</kv-button>
 	</div>
 </template>
 
@@ -108,8 +107,8 @@ import {
 	isBetween25And500
 } from '@/util/loanUtils';
 import LendAmountButton from '@/components/LoanCards/Buttons/LendAmountButton';
-import KvUiSelect from '~/@kiva/kv-components/vue/KvSelect';
-import KvUiButton from '~/@kiva/kv-components/vue/KvButton';
+import KvSelect from '~/@kiva/kv-components/vue/KvSelect';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 export default {
 	name: 'LendCtaExp',
@@ -121,10 +120,6 @@ export default {
 		basketItems: {
 			type: Array,
 			default: () => []
-		},
-		isLoading: {
-			type: Boolean,
-			default: true
 		},
 		isAdding: {
 			type: Boolean,
@@ -145,8 +140,8 @@ export default {
 	},
 	components: {
 		LendAmountButton,
-		KvUiButton,
-		KvUiSelect,
+		KvButton,
+		KvSelect,
 	},
 	data() {
 		return {
@@ -204,34 +199,33 @@ export default {
 		unreservedAmount() {
 			return this.loan?.unreservedAmount ?? '';
 		},
-		amountLeft() {
-			if (this.enableRelendingExp) {
-				if (this.enableFiveDollarsNotes) {
-					if (this.userBalance > 20) return Number(this.unreservedAmount) > 25 ? '25' : this.unreservedAmount;
-					return this.unreservedAmount > 5 ? '5' : this.unreservedAmount;
-				}
-				if (this.unreservedAmount > 25) return Number(this.unreservedAmount) > 25 ? '25' : this.unreservedAmount; // eslint-disable-line max-len
-			}
-			return this.unreservedAmount ?? '';
-		},
 		lentPreviously() {
 			return this.loan?.userProperties?.lentTo ?? false;
 		},
+		amountToLend() {
+			if (this.enableRelendingExp) {
+				if (this.enableFiveDollarsNotes && this.userBalance <= 20) {
+					return Number(this.unreservedAmount) > 5 ? '5' : this.unreservedAmount;
+				}
+				return Number(this.unreservedAmount) > 25 ? '25' : this.unreservedAmount;
+			}
+			return (this.isLessThan25 && !this.enableFiveDollarsNotes) ? this.unreservedAmount : this.selectedOption;
+		},
 		isInBasket() {
-			/* eslint-disable */
-			return this.basketItems?.some(item => item.__typename === 'LoanReservation' && item.id === this.loan.id) ?? false;
-			/* eslint-enable */
+			return this.basketItems
+				// eslint-disable-next-line no-underscore-dangle
+				?.some(item => item.__typename === 'LoanReservation' && item.id === this.loan.id) ?? false;
 		},
 		prices() {
 			// We don't want to open up $5 loan shares for loans with more than $25 at this time
-			// IF we wanted to show this interface on loans with less than 25 remaining they would see the selector
-			const minAmount = parseFloat(this.unreservedAmount < 25 ? this.minNoteSize : 25); // 25_hard_coded
-			// limit price options
+			// If we wanted to show this interface on loans with less than 25 remaining they would see the selector
+			const minAmount = parseFloat(this.unreservedAmount < 25 ? this.minNoteSize : 25);
 			const priceArray = getDropdownPriceArray(this.unreservedAmount, minAmount, this.enableFiveDollarsNotes);
-			// eslint-disable-next-line
+
 			if (this.isCompleteLoanActive && !priceArray.includes(Number(this.unreservedAmount).toFixed())) {
 				priceArray.push(Number(this.unreservedAmount).toFixed());
 			}
+
 			return priceArray;
 		},
 		ctaButtonText() {
@@ -247,20 +241,7 @@ export default {
 					return 'Lend';
 			}
 		},
-		useFormSubmit() {
-			if (this.hideShowLendDropdown
-				|| this.lendButtonVisibility
-				|| this.lendAgainButton
-				|| this.state === 'lent-to'
-				|| this.isAdding) {
-				return true;
-			}
-			return false;
-		},
 		state() {
-			if (this.isLoading) {
-				return 'loading';
-			}
 			if (this.isAdding) {
 				return 'adding';
 			}
@@ -278,47 +259,38 @@ export default {
 			}
 			return 'lend';
 		},
-		lendButtonVisibility() {
-			return this.state === 'lend' || this.state === 'loading';
-		},
-		showNonActionableLoanButton() {
-			return this.state === 'refunded'
-				|| this.state === 'expired';
-		},
-		hideShowLendDropdown() {
-			return this.state === 'lend' || this.state === 'lent-to';
-		},
-		allSharesReserved() {
-			if (parseFloat(this.unreservedAmount) === 0) {
-				return true;
-			}
-			return false;
-		},
-		isLessThan25() {
-			if (this.enableFiveDollarsNotes) return false; // NOTE: for $5 dollars notes we need to show the dropdown
-			return isLessThan25(this.unreservedAmount);
-		},
 		isLentTo() {
 			return this.state === 'lent-to';
 		},
+		isFunded() {
+			return this.state === 'funded' || this.state === 'fully-reserved';
+		},
 		isCompleteLoanActive() {
-			// eslint-disable-next-line
 			return (isLessThan25(this.unreservedAmount) || isBetween25And500(this.unreservedAmount));
 		},
-		isLendAmountButton() {
-			if (this.enableRelendingExp) return (this.lendButtonVisibility || this.state === 'lent-to');
-			// eslint-disable-next-line
-			return (this.lendButtonVisibility || this.state === 'lent-to') && isLessThan25(this.unreservedAmount) && !this.enableFiveDollarsNotes;
+		allSharesReserved() {
+			return parseFloat(this.unreservedAmount) === 0;
 		},
-		isFunded() {
-			return this.state === 'funded'
-				|| this.state === 'fully-reserved';
+		isLessThan25() {
+			return isLessThan25(this.unreservedAmount);
 		},
-		amountToLend() {
-			return this.isLessThan25 ? this.unreservedAmount : this.selectedOption;
+		showAddToBasket() {
+			return this.showLendDropdown || this.showLendAmountButton || this.isAdding;
+		},
+		showLendAmountButton() {
+			return (this.state === 'lend' || this.isLentTo || this.state === 'loading')
+				&& (this.enableRelendingExp || (!this.enableFiveDollarsNotes && isLessThan25(this.unreservedAmount)));
+		},
+		showLendDropdown() {
+			return (this.state === 'lend' || this.isLentTo)
+				&& !this.isLessThan25
+				&& !this.enableRelendingExp;
 		},
 		showLendAgain() {
 			return this.isLentTo && !this.isLessThan25;
+		},
+		showNonActionableLoanButton() {
+			return this.state === 'refunded' || this.state === 'expired';
 		},
 	},
 };
@@ -338,7 +310,7 @@ export default {
 	@apply tw-px-1;
 }
 
-.lendButtonWrapper >>> span:first-child {
+.lend-button-with-dropdown >>> span:first-child {
 	border-radius: 0 14px 14px 0;
 }
 

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -157,7 +157,6 @@
 				v-else
 				:loan="loan"
 				:basket-items="basketItems"
-				:is-loading="isLoading"
 				:is-adding="isAdding"
 				:enable-five-dollars-notes="enableFiveDollarsNotes"
 				:enable-relending-exp="enableRelendingExp"

--- a/src/components/LoanCards/LoanTags/LoanTagV2.vue
+++ b/src/components/LoanCards/LoanTags/LoanTagV2.vue
@@ -24,7 +24,7 @@ export default {
 	props: {
 		loan: {
 			type: Object,
-			required: true,
+			default: null,
 		},
 		amountLeft: {
 			type: Number,

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -21,7 +21,7 @@
 				/>
 			</div>
 			<kv-carousel
-				class="tw-w-full tw-overflow-hidden tw-mt-1"
+				class="tw-w-full tw-overflow-hidden tw-mt-1 tw-pb-2"
 				:class="{ 'tw-px-1 tw-pt-1' : enableLoanCardExp }"
 				id="customizedCarousel"
 				:multiple-slides-visible="true"


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1355

Here are the notes from the ticket:
1. Extra “lend again” button if you lent to a loan that had more than $75 left and it shows up in the carousel again
2. Adding all loans to basket w/ $5 notes ends up adding them all at $5 instead of $25 (when your balance is higher, like $50)
3. Adding single when button says “Lend $5" will add a $25 dollar loan to the basket

Solution:
- Refactored logic around showing different CTA components, since it was somewhat confusing before - helped fix #1 
- Changed what `amountToLend` means - helped fix #2 + #3
- Fixed issue where carousel would cut off card drop shadow when only 2 loans + pager hidden
- Fixed random issue where `null` was passed to loan tags - might just a HMR issue, but it's addressed now