### PR TITLE
feat: there was an edge case where a loan could be cleared

### DIFF
--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -458,12 +458,15 @@ export default {
 
 			this.isVisitor = !result.data?.my?.userAccount?.id ?? true;
 
-			this.loan = result.data?.lend?.loan || null;
+			// Some pages initially show loading cards without loan IDs
+			if (result.data?.lend?.loan) {
+				this.loan = result.data.lend.loan;
 
-			// Set client-side to prevent call outs from changing on page load due to random selections
-			this.getLoanCallouts();
+				// Set client-side to prevent call outs from changing on page load due to random selections
+				this.getLoanCallouts();
 
-			if (this.loan) this.isLoading = false;
+				this.isLoading = false;
+			}
 
 			this.basketItems = result.data?.shop?.basket?.items?.values || null;
 		},


### PR DESCRIPTION
- While testing relending exp, I would occasionally get a couple loan cards with blank data in the second row
- Looks like the initial load of the second row provides loan IDs of `0` due to lazy loading
- There seems to have been a race condition between the initial request and the one triggered by watching the loan ID