### PR TITLE
Fix loan cta again

### DIFF
--- a/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
+++ b/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
@@ -44,6 +44,7 @@ const story = (args = {}, isLoading = false, extraLoanProps = {}, extraData = {}
 				:show-tags="showTags"
 				:large-card="largeCard"
 				:enable-relending-exp="enableRelendingExp"
+				:enable-five-dollars-notes="enableFiveDollarsNotes"
 				:user-balance="userBalance"
 			/>
 		`,
@@ -126,9 +127,18 @@ export const Relending = story({
 	userBalance: 50,
 }, false);
 
-
 export const RelendingSmallAmount = story({
 	loanId: loan.id,
 	enableRelendingExp: true,
 	userBalance: 20,
 }, false, { userProperties: { lentTo: true } });
+
+export const FiveDollarNotes = story({
+	loanId: loan.id,
+	enableFiveDollarsNotes: true,
+});
+
+export const FiveDollarNotesSmallAmount = story({
+	loanId: loan.id,
+	enableFiveDollarsNotes: true,
+}, false, { unreservedAmount: '5.00' });

--- a/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
+++ b/.storybook/stories/KivaClassicBasicLoanCardExp.stories.js
@@ -125,13 +125,53 @@ export const Relending = story({
 	loanId: loan.id,
 	enableRelendingExp: true,
 	userBalance: 50,
-}, false);
+});
 
-export const RelendingSmallAmount = story({
+export const RelendingLendAgain = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	userBalance: 50,
+}, false, { userProperties: { lentTo: true } });
+
+export const RelendingSmallBalance = story({
 	loanId: loan.id,
 	enableRelendingExp: true,
 	userBalance: 20,
+});
+
+export const RelendingSmallBalanceSmallAmount = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	userBalance: 20,
+}, false, { unreservedAmount: '5.00' });
+
+export const RelendingFiveDollarNotes = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	enableFiveDollarsNotes: true,
+	userBalance: 50,
+});
+
+export const RelendingFiveDollarNotesLendAgain = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	enableFiveDollarsNotes: true,
+	userBalance: 50,
 }, false, { userProperties: { lentTo: true } });
+
+export const RelendingFiveDollarNotesSmallBalance = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	enableFiveDollarsNotes: true,
+	userBalance: 20,
+});
+
+export const RelendingFiveDollarNotesSmallBalanceSmallAmount = story({
+	loanId: loan.id,
+	enableRelendingExp: true,
+	enableFiveDollarsNotes: true,
+	userBalance: 20,
+}, false, { unreservedAmount: '5.00' });
 
 export const FiveDollarNotes = story({
 	loanId: loan.id,

--- a/src/components/LoanCards/Buttons/LendCtaExp.vue
+++ b/src/components/LoanCards/Buttons/LendCtaExp.vue
@@ -279,13 +279,11 @@ export default {
 		},
 		showLendAmountButton() {
 			return (this.state === 'lend' || this.isLentTo || this.state === 'loading')
-				&& (this.enableRelendingExp
-					|| this.enableFiveDollarsNotes
-					|| (!this.enableFiveDollarsNotes && isLessThan25(this.unreservedAmount)));
+				&& (this.enableRelendingExp || (!this.enableFiveDollarsNotes && isLessThan25(this.unreservedAmount)));
 		},
 		showLendDropdown() {
 			return (this.state === 'lend' || this.isLentTo)
-				&& !this.isLessThan25
+				&& (this.enableFiveDollarsNotes || !this.isLessThan25)
 				&& !this.enableRelendingExp;
 		},
 		showLendAgain() {


### PR DESCRIPTION
- Noticed that the CTA for $5 notes was incorrect after recent changes, it would show the lend amount button, where $5 notes should have the dropdown for all situations but the relending carousel