### PR TITLE
feat: implement config based toggle for apollo batch link which remai…

### DIFF
--- a/config/dev-cluster.js
+++ b/config/dev-cluster.js
@@ -2,11 +2,11 @@ const { merge } = require('webpack-merge');
 var base = require('./index.js')
 var devLocal  = require('./dev-local.js')
 
-const apolloBatch = process.env.APOLLO_BATCH || true;
+const apolloBatching = process.env.APOLLO_BATCH !== 'false';
 
 module.exports = merge(base, devLocal, {
 	app: {
-		apolloBatching: false,
+		apolloBatching,
 		host: 'localhost',
 		publicPath: '/',
 		photoPath: 'https://www-dev-kiva-org.freetls.fastly.net/img/',

--- a/config/dev-cluster.js
+++ b/config/dev-cluster.js
@@ -1,0 +1,36 @@
+const { merge } = require('webpack-merge');
+var base = require('./index.js')
+var devLocal  = require('./dev-local.js')
+
+const apolloBatch = process.env.APOLLO_BATCH || true;
+
+module.exports = merge(base, devLocal, {
+	app: {
+		apolloBatching: false,
+		host: 'localhost',
+		publicPath: '/',
+		photoPath: 'https://www-dev-kiva-org.freetls.fastly.net/img/',
+		graphqlUri: 'https://gateway.development.kiva.org/graphql',
+		enableAnalytics: false,
+		enableSnowplow: false,
+		snowplowUri: 'events.fivetran.com/snowplow/v5qt54ocr2nm',
+		enableGA: false,
+		gaId: 'UA-11686022-7', // dev-vm property
+		auth0: {
+			loginRedirectUrls: {
+				xOXldYg02WsLnlnn0D5xoPWI2i3aNsFD: 'https://kiva.development.kiva.org/authenticate?authLevel=recent',
+				KIzjUBQjKZwMRgYSn6NvMxsUwNppwnLH: 'http://localhost:8888/ui-login?force=true',
+				ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF: 'http://localhost:8888/ui-login?force=true',
+			},
+			enable: true,
+			browserCallbackUri: 'http://localhost:8888/process-browser-auth',
+			serverCallbackUri: 'http://localhost:8888/process-ssr-auth',
+		},
+	},
+	server: {
+		graphqlUri: 'https://gateway.development.kiva.org/graphql',
+		sessionUri: 'https://kiva.development.kiva.org/start-ui-session',
+		memcachedEnabled: false,
+		disableCluster: true,
+	}
+})

--- a/config/index.js
+++ b/config/index.js
@@ -2,6 +2,7 @@ var path = require('path')
 
 module.exports = {
 	app: {
+		apolloBatching: true,
 		host: 'www.kiva.org',
 		transport: 'https',
 		publicPath: 'https://www-kiva-org.freetls.fastly.net/ui/',

--- a/config/k8s-local.js
+++ b/config/k8s-local.js
@@ -8,6 +8,7 @@ const apiHostname = process.env.API_HOSTNAME || "api.kiva.local"
 
 module.exports = merge(base, devVm, {
 	app: {
+		apolloBatching: false,
 		host: `${monolithHostname}`,
 		transport: `${transport}`,
 		publicPath: `${transport}://${monolithHostname}/ui/`,
@@ -23,7 +24,7 @@ module.exports = merge(base, devVm, {
 			},
 			browserCallbackUri: `${transport}://${monolithHostname}/process-browser-auth`,
 			serverCallbackUri: `${transport}://${monolithHostname}/process-ssr-auth`,
-		}
+		},
 	},
 	server: {
 		graphqlUri: `${transport}://${apiHostname}/fed/graphql`,

--- a/config/k8s-local.js
+++ b/config/k8s-local.js
@@ -5,10 +5,11 @@ var devVm  = require('./dev-vm.js')
 const transport = process.env.TRANSPORT || "https"
 const monolithHostname = process.env.MONOLITH_HOSTNAME || "monolith.kiva.local"
 const apiHostname = process.env.API_HOSTNAME || "api.kiva.local"
+const apolloBatching = process.env.APOLLO_BATCH !== 'false';
 
 module.exports = merge(base, devVm, {
 	app: {
-		apolloBatching: false,
+		apolloBatching,
 		host: `${monolithHostname}`,
 		transport: `${transport}`,
 		publicPath: `${transport}://${monolithHostname}/ui/`,

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
 		"webpack-svgstore-plugin": "kiva/webpack-svgstore-plugin#develop"
 	},
 	"engines": {
-		"node": "16.15.0",
+		"node": ">= 16.15.0",
 		"npm": ">= 6.0.0"
 	},
 	"browserslist": [

--- a/src/api/HttpLink.js
+++ b/src/api/HttpLink.js
@@ -1,7 +1,13 @@
 import * as Sentry from '@sentry/vue';
 import { BatchHttpLink } from '@apollo/client/link/batch-http';
+import { HttpLink } from '@apollo/client/link/http';
 
-export default ({ kvAuth0, uri = '', fetch }) => {
+export default ({
+	kvAuth0,
+	uri = '',
+	fetch,
+	apolloBatching,
+}) => {
 	const onVm = uri.indexOf('vm') > -1;
 
 	const options = {
@@ -30,6 +36,11 @@ export default ({ kvAuth0, uri = '', fetch }) => {
 	} catch (e) {
 		console.error(e);
 		Sentry.captureException(e);
+	}
+
+	// Use the regular HttpLink if batching is disabled.
+	if (!apolloBatching) {
+		return new HttpLink(options);
 	}
 
 	return new BatchHttpLink(options);

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -44,7 +44,12 @@ export default function createApolloClient({
 			Auth0LinkCreator({ cookieStore, kvAuth0 }),
 			BasketLinkCreator({ cookieStore }),
 			ContentfulPreviewLink({ cookieStore }),
-			HttpLinkCreator({ kvAuth0, uri, fetch }),
+			HttpLinkCreator({
+				kvAuth0,
+				uri,
+				fetch,
+				apolloBatching: appConfig?.apolloBatching ?? true,
+			}),
 		]),
 		cache,
 		resolvers,


### PR DESCRIPTION
…ns on by default

In working on the new dev stack, we're exploring migration to usign Apollo Router for federation but it doesn't currently support batching. This toggle allows us to turn graphql request batching off in the new development off while testing out things.

With this off you'll see every individual graphql request which does increase the number of network calls from both the server and client, so that's something we'll need to consdier and look more closely at.  Overall we're hoping the performance benefits at the federation layer and by folding in request caching can offset the additional number of requests. There would certainly be more work to come before moving this into prod.