### PR TITLE
feat: bring back synchronous add all to basket and checkout state to button

### DIFF
--- a/src/components/LoanCards/Buttons/MultipleAtcButton.vue
+++ b/src/components/LoanCards/Buttons/MultipleAtcButton.vue
@@ -12,11 +12,15 @@
 				tw-rounded
 			"
 			:disabled="isAdding"
-			@click="$emit('add-multiple')"
+			@click="$emit(showCheckout ? 'checkout' : 'add-multiple')"
 		>
 			${{ amount }}
 			<div
-				class="tw-ml-1.5 tw-bg-marigold"
+				class="tw-ml-1.5"
+				:class="{
+					'tw-bg-marigold': !showCheckout,
+					'tw-bg-white': showCheckout
+				}"
 				style="border-radius: 0 14px 14px 0; padding: 12px 18px; font-weight: 621;"
 			>
 				{{ buttonCopy }}
@@ -41,10 +45,15 @@ export default {
 			type: Boolean,
 			default: false
 		},
+		showCheckout: {
+			type: Boolean,
+			default: false
+		},
 	},
 	computed: {
 		buttonCopy() {
 			if (this.isAdding) return 'Adding to basket';
+			if (this.showCheckout) return 'Checkout now';
 			if (this.loansNumber > 2) return `Add all ${this.loansNumber} cart`;
 			return 'Add both to cart';
 		}

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -17,7 +17,9 @@
 					:amount="multipleAmount"
 					:loans-number="totalLoans"
 					:is-adding="isAddingMultiple"
+					:show-checkout="hasMultipleBeenAdded"
 					@add-multiple="addMultipleLoans"
+					@checkout="checkout"
 				/>
 			</div>
 			<kv-carousel
@@ -114,7 +116,8 @@ export default {
 	},
 	data() {
 		return {
-			isAddingMultiple: false
+			isAddingMultiple: false,
+			hasMultipleBeenAdded: false,
 		};
 	},
 	computed: {
@@ -186,7 +189,7 @@ export default {
 					try {
 						// Ensure the reservations happen synchronously to prevent race conditions with the basket
 						// eslint-disable-next-line no-await-in-loop
-						this.$refs[key][0].addToBasket(amount);
+						await this.$refs[key][0].addToBasket(amount);
 					} catch {
 						// no-op
 					}
@@ -201,11 +204,17 @@ export default {
 				multipleAmount
 			);
 
+			this.isAddingMultiple = false;
+			this.hasMultipleBeenAdded = true;
+		},
+		checkout() {
+			this.$kvTrackEvent('loan-card', 'checkout', 'relending-lending-home-add-all');
+
 			this.$router.push({ path: '/checkout' });
 		},
 		loanCardKey(index) {
 			return `loan-card-${index}`;
-		}
+		},
 	},
 };
 </script>


### PR DESCRIPTION
- It appears that adding all at once can still potentially encounter a race condition resulting in multiple donation lines in the basket
- Now the loans are added in order
- This time there's also a "Checkout now" state to the new "add all" button