### PR TITLE
fix: add text to time left in pfp

### DIFF
--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -70,7 +70,7 @@
 			<template v-else-if="loanStatus === 'pfp'">
 				<p class="tw-flex-auto" data-testid="bp-summary-timeleft">
 					<span class="tw-text-h3 tw-block tw-m-0">
-						{{ timeLeft }}
+						{{ timeLeft }} left
 					</span>
 
 					<span class="tw-text-h4 tw-text-secondary tw-block">


### PR DESCRIPTION
ACK-635

We think the text "1 day in private fundraising" is confusing, changed it to "1 day left in private fundraising"

Before:
![Screen Shot 2023-05-19 at 8 59 11 AM](https://github.com/kiva/ui/assets/4371888/170b834e-66c0-4999-bd06-7a3a3a115fc9)

After:
![Screen Shot 2023-05-19 at 10 13 31 AM](https://github.com/kiva/ui/assets/4371888/44d5f842-2445-414a-ba15-fe7b4aafb824)
