### PR TITLE
refactor: remove foundation classes from thanks share

### DIFF
--- a/src/components/Checkout/SocialShareV2.vue
+++ b/src/components/Checkout/SocialShareV2.vue
@@ -9,10 +9,12 @@
 			</p>
 		</div>
 		<div class="share__social social">
-			<a
+			<button
 				data-testid="share-facebook-button"
 				class="social__btn social__btn--facebook"
-				:href="facebookShareUrl({utmCampaign, utmContent})"
+				@click="showSharePopUp(
+					facebookShareUrl({utmCampaign, utmContent}),
+					'Thanks for sharing to Facebook!')"
 				v-kv-track-event="[
 					'post-checkout',
 					'share',
@@ -22,41 +24,39 @@
 			>
 				<kv-icon name="facebook-round" title="Facebook" class="social__icon" />
 				<span>Share</span>
-			</a>
-			<a
+			</button>
+			<button
 				data-testid="share-twitter-button"
 				class="social__btn social__btn--twitter"
-				:href="twitterShareUrl({utmCampaign, utmContent})"
-				target="_blank"
-				rel="noopener"
+				@click="showSharePopUp(
+					twitterShareUrl({utmCampaign, utmContent}),
+					'Thanks for tweeting!')"
 				v-kv-track-event="[
 					'post-checkout',
 					'share',
 					'twitter',
 					utmCampaign,
 					selectedLoanId]"
-				@click="$showTipMsg('Thanks for tweeting!')"
 			>
 				<kv-icon name="twitter" title="Twitter" class="social__icon" />
 				<span>Tweet</span>
-			</a>
-			<a
+			</button>
+			<button
 				data-testid="share-linkedin-button"
 				class="social__btn social__btn--linkedin"
-				:href="linkedInShareUrl({utmCampaign, utmContent})"
-				target="_blank"
-				rel="noopener"
+				@click="showSharePopUp(
+					linkedInShareUrl({utmCampaign, utmContent}),
+					'Thanks for sharing to LinkedIn!')"
 				v-kv-track-event="[
 					'post-checkout',
 					'share',
 					'linkedin',
 					utmCampaign,
 					selectedLoanId]"
-				@click="$showTipMsg('Thanks for sharing to LinkedIn!')"
 			>
 				<kv-icon name="linkedin" title="LinkedIn" class="social__icon" />
 				<span>Share</span>
-			</a>
+			</button>
 			<button
 				data-testid="share-copy-link-button"
 				class="social__btn social__btn--link tw-text-link tw-border-tertiary tw-border"
@@ -475,36 +475,6 @@ $loan-triangle-size: rem-calc(12);
 			.social__icon {
 				fill: $medium-gray;
 				transition: fill 0.25s ease-in;
-			}
-		}
-
-		&--success {
-			background-color: rgb(var(--bg-brand));
-			border-color: rgb(var(--bg-brand));
-		}
-
-		&--error {
-			background-color: rgb(var(--bg-danger));
-			border-color: rgb(var(--bg-danger));
-		}
-
-		&--success,
-		&--error {
-			color: #fff;
-			cursor: default;
-			transition:
-				background-color 0.25s ease-out,
-				border-color 0.25s ease-out,
-				color 0.25s ease-out;
-
-			&:hover {
-				color: #fff;
-				text-decoration: none;
-			}
-
-			.social__icon {
-				transition: fill 0.25s ease-out;
-				fill: #fff;
 			}
 		}
 	}

--- a/src/components/Checkout/SocialShareV2.vue
+++ b/src/components/Checkout/SocialShareV2.vue
@@ -477,36 +477,6 @@ $loan-triangle-size: rem-calc(12);
 				transition: fill 0.25s ease-in;
 			}
 		}
-
-		&--success {
-			background-color: rgb(var(--bg-brand));
-			border-color: rgb(var(--bg-brand));
-		}
-
-		&--error {
-			background-color: rgb(var(--bg-danger));
-			border-color: rgb(var(--bg-danger));
-		}
-
-		&--success,
-		&--error {
-			color: #fff;
-			cursor: default;
-			transition:
-				background-color 0.25s ease-out,
-				border-color 0.25s ease-out,
-				color 0.25s ease-out;
-
-			&:hover {
-				color: #fff;
-				text-decoration: none;
-			}
-
-			.social__icon {
-				transition: fill 0.25s ease-out;
-				fill: #fff;
-			}
-		}
 	}
 }
 

--- a/src/components/Checkout/SocialShareV2.vue
+++ b/src/components/Checkout/SocialShareV2.vue
@@ -477,6 +477,36 @@ $loan-triangle-size: rem-calc(12);
 				transition: fill 0.25s ease-in;
 			}
 		}
+
+		&--success {
+			background-color: rgb(var(--bg-brand));
+			border-color: rgb(var(--bg-brand));
+		}
+
+		&--error {
+			background-color: rgb(var(--bg-danger));
+			border-color: rgb(var(--bg-danger));
+		}
+
+		&--success,
+		&--error {
+			color: #fff;
+			cursor: default;
+			transition:
+				background-color 0.25s ease-out,
+				border-color 0.25s ease-out,
+				color 0.25s ease-out;
+
+			&:hover {
+				color: #fff;
+				text-decoration: none;
+			}
+
+			.social__icon {
+				transition: fill 0.25s ease-out;
+				fill: #fff;
+			}
+		}
 	}
 }
 

--- a/src/components/Thanks/CommentAsk.vue
+++ b/src/components/Thanks/CommentAsk.vue
@@ -1,10 +1,9 @@
 <template>
 	<transition name="kvfade">
 		<div class="tw-bg-secondary" v-if="showComments">
-			<div class="row tw-px-1">
-				<div class="large-2"></div>
-				<div class="small-12 large-8 columns">
-					<div class="tw-mb-4">
+			<kv-page-container>
+				<kv-grid class="tw-grid-cols-12">
+					<div class="tw-col-span-12 lg:tw-col-span-8 lg:tw-col-start-3 tw-pt-2 tw-mb-4">
 						<h1	class="tw-mt-1 tw-mb-3 tw-text-left">
 							Tell others why you love this loan to {{ loanName }}.
 						</h1>
@@ -12,38 +11,36 @@
 							Your comments can really help {{ loanName }} fully fund their loan.
 						</p>
 
-						<div class="row tw-mt-3">
-							<div class="small-12 columns tw-text-center">
-								<div class="tw-relative">
-									<textarea
-										class="tw-w-full tw-border tw-border-secondary tw-rounded tw-h-7 tw-p-2"
-										style="height: 10rem;"
-										v-model="defaultComment"
-									>
-									</textarea>
-									<kv-material-icon
-										class="tw-w-2.5 tw-h-2.5 tw-absolute tw-bottom-2 tw-right-2"
-										:icon="mdiPencilOutline"
-									/>
-								</div>
-								<small
-									class="tw-text-left tw-block"
-								>Please follow our <button
-									class="tw-text-action hover:tw-text-action-highlight"
-									v-kv-track-event="['post-checkout', 'show', 'comments-ask', 'guidelines']"
-									@click="showLightbox = true"
-								>community guidelines</button></small>
-								<kv-button
-									class="tw-mt-3"
-									variant="primary"
-									:state="buttonState"
-									aria-label="Comment"
-									@click="submitComment"
-									v-kv-track-event="['post-checkout', 'submit', 'comments-ask', 'comment']"
+						<div class="tw-mt-3 tw-text-center">
+							<div class="tw-relative">
+								<textarea
+									class="tw-w-full tw-border tw-border-secondary tw-rounded tw-h-7 tw-p-2"
+									style="height: 10rem;"
+									v-model="defaultComment"
 								>
-									Comment
-								</kv-button>
+									</textarea>
+								<kv-material-icon
+									class="tw-w-2.5 tw-h-2.5 tw-absolute tw-bottom-2 tw-right-2"
+									:icon="mdiPencilOutline"
+								/>
 							</div>
+							<small
+								class="tw-text-left tw-block"
+							>Please follow our <button
+								class="tw-text-action hover:tw-text-action-highlight"
+								v-kv-track-event="['post-checkout', 'show', 'comments-ask', 'guidelines']"
+								@click="showLightbox = true"
+							>community guidelines</button></small>
+							<kv-button
+								class="tw-mt-3"
+								variant="primary"
+								:state="buttonState"
+								aria-label="Comment"
+								@click="submitComment"
+								v-kv-track-event="['post-checkout', 'submit', 'comments-ask', 'comment']"
+							>
+								Comment
+							</kv-button>
 						</div>
 						<button
 							class="tw-block tw-mx-auto tw-text-action
@@ -53,52 +50,51 @@
 						>
 							No thanks, maybe later
 						</button>
-					</div>
-				</div>
-				<div class="large-2"></div>
-			</div>
-			<kv-lightbox
-				:visible="showLightbox"
-				title="Kiva Community Guidelines"
-				@lightbox-closed="showLightbox = false"
-			>
-				<!-- eslint-disable max-len -->
-				<div class="tw-prose">
-					<p>
-						Kiva is about connecting people to alleviate poverty. Please show respect for each other and our borrowers. Your comments are often passed to borrowers to give them a confidence boost.
-					</p>
-					<h3>Do</h3>
-					<ul class="tw-mt-0">
-						<li>Share why you supported a particular borrower, or lending partner.</li>
-						<li>
-							Tell the borrower the reasons they should believe in themselves.
-						</li><li>
-							Chime in on a comment another lender has written.
-						</li>
-					</ul>
-					<h3>Don't</h3>
-					<ul class="tw-mt-0">
-						<li>Don't write comments about Kiva itself. Don't write comments about issues relating to historical repayments from the lending partner. Keep it on topic.</li>
-						<li>
-							Don't attack, harass or threaten anyone.
-						</li><li>
-							Don't spam our lenders.
-						</li>
-					</ul>
-					<p>
-						Your rights and responsibilities as part of the Kiva community are laid out in the <router-link
-							to="/legal/terms"
-							target="_blank"
+						<kv-lightbox
+							:visible="showLightbox"
+							title="Kiva Community Guidelines"
+							@lightbox-closed="showLightbox = false"
 						>
-							Terms of Use
-						</router-link> and the following guidelines, which apply to lending teams, comments, conversation tab posts, private messages, profiles and any other content posted on Kiva or Kiva's social media properties.
-					</p>
-					<p>
-						The Kiva team reserves the right to remove posts and messages at our sole discretion. Frequent guideline violations may also lead to the loss of posting privileges. If you have any questions, concerns or grievances related to these guidelines, please write to our team at <a href="mailto:contactus@kiva.org">contactus@kiva.org</a>.
-					</p>
-				<!-- eslint-enable max-len -->
-				</div>
-			</kv-lightbox>
+							<!-- eslint-disable max-len -->
+							<div class="tw-prose">
+								<p>
+									Kiva is about connecting people to alleviate poverty. Please show respect for each other and our borrowers. Your comments are often passed to borrowers to give them a confidence boost.
+								</p>
+								<h3>Do</h3>
+								<ul class="tw-mt-0">
+									<li>Share why you supported a particular borrower, or lending partner.</li>
+									<li>
+										Tell the borrower the reasons they should believe in themselves.
+									</li><li>
+										Chime in on a comment another lender has written.
+									</li>
+								</ul>
+								<h3>Don't</h3>
+								<ul class="tw-mt-0">
+									<li>Don't write comments about Kiva itself. Don't write comments about issues relating to historical repayments from the lending partner. Keep it on topic.</li>
+									<li>
+										Don't attack, harass or threaten anyone.
+									</li><li>
+										Don't spam our lenders.
+									</li>
+								</ul>
+								<p>
+									Your rights and responsibilities as part of the Kiva community are laid out in the <router-link
+										to="/legal/terms"
+										target="_blank"
+									>
+										Terms of Use
+									</router-link> and the following guidelines, which apply to lending teams, comments, conversation tab posts, private messages, profiles and any other content posted on Kiva or Kiva's social media properties.
+								</p>
+								<p>
+									The Kiva team reserves the right to remove posts and messages at our sole discretion. Frequent guideline violations may also lead to the loss of posting privileges. If you have any questions, concerns or grievances related to these guidelines, please write to our team at <a href="mailto:contactus@kiva.org">contactus@kiva.org</a>.
+								</p>
+								<!-- eslint-enable max-len -->
+							</div>
+						</kv-lightbox>
+					</div>
+				</kv-grid>
+			</kv-page-container>
 		</div>
 	</transition>
 </template>
@@ -110,6 +106,8 @@ import { mdiPencilOutline } from '@mdi/js';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
+import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 
 export default {
 	name: 'CommentAsk',
@@ -118,6 +116,8 @@ export default {
 		KvMaterialIcon,
 		KvButton,
 		KvLightbox,
+		KvGrid,
+		KvPageContainer,
 	},
 	props: {
 		loanName: {
@@ -171,10 +171,4 @@ export default {
 		},
 	},
 };
-
 </script>
-
-<style lang="scss" scoped>
-@import 'settings';
-@import "foundation";
-</style>

--- a/src/components/Thanks/ThanksPageCommentAndShare.vue
+++ b/src/components/Thanks/ThanksPageCommentAndShare.vue
@@ -104,7 +104,7 @@
 						<div class="social tw-mt-4 tw-max-w-sm tw-mx-auto">
 							<button
 								data-testid="share-facebook-button"
-								class="social__btn social__btn--facebook tw-w-full"
+								class="social__btn social__btn--facebook"
 								@click="showSharePopUp(
 									facebookShareUrl({utmCampaign, utmContent}),
 									'Thanks for sharing to Facebook!')"
@@ -117,7 +117,7 @@
 							<button
 								data-testid="share-copy-link-button"
 								class="social__btn social__btn--link
-								tw-text-link tw-border-tertiary tw-border tw-w-full"
+									tw-border-action tw-border"
 								:class="copyStatus.class"
 								:disabled="copyStatus.disabled"
 								v-kv-track-event="
@@ -133,7 +133,7 @@
 							</button>
 							<button
 								data-testid="share-twitter-button"
-								class="social__btn social__btn--twitter tw-w-full"
+								class="social__btn social__btn--twitter"
 								v-kv-track-event="
 									['post-checkout', 'share', 'twitter', utmCampaign, loanId]"
 								@click="showSharePopUp(
@@ -145,7 +145,7 @@
 							</button>
 							<button
 								data-testid="share-linkedin-button"
-								class="social__btn social__btn--linkedin tw-w-full"
+								class="social__btn social__btn--linkedin"
 								v-kv-track-event="
 									['post-checkout', 'share', 'linkedin', utmCampaign, loanId]"
 								@click="showSharePopUp(
@@ -159,7 +159,7 @@
 						<div class="tw-text-center tw-mt-2">
 							<button
 								class="tw-block tw-mx-auto tw-text-action
-								tw-underline hover:tw-text-action-highlight "
+								tw-underline hover:tw-text-action-highlight"
 								@click="emitGuestCreateAccount"
 								v-if="isGuest"
 								v-kv-track-event="['Thanks','click-create-account','Create my account']"
@@ -336,6 +336,16 @@ export default {
 
 </script>
 
+<style lang="postcss" scoped>
+.social__btn {
+	@apply tw-w-full tw-rounded tw-flex tw-items-center tw-justify-center tw-mb-2 tw-p-1.5 tw-font-medium;
+}
+
+.social__icon {
+	@apply tw-h-3 tw-w-3 tw-mr-1 tw-shrink-0;
+}
+</style>
+
 <style lang="scss" scoped>
 @import 'settings';
 @import "foundation";
@@ -344,50 +354,18 @@ $color-facebook: #3b5998;
 $color-twitter: #08a0e9;
 $color-linkedin: #0077b5;
 $color-copy-link: #2B7C5F;
-$color-text: #212121;
 
 .social {
-	&__icon {
-		width: rem-calc(24);
-		height: rem-calc(24);
-		flex-shrink: 0;
-		margin-right: rem-calc(9);
-		fill: #fff;
-	}
-
 	&__btn {
-		align-items: center;
-		margin: 0 0 1rem 0;
-		padding: 1rem rem-calc(9) 1rem 1rem;
-		font-weight: $button-font-weight;
-		line-height: 1;
-		flex-shrink: 0;
+		&--facebook {
+			@include button-style($color-facebook, auto, #fff);
 
-		&:nth-child(2n) {
-			margin-right: 0;
-		}
-
-		@include breakpoint(large) {
-			width: 100%;
-			margin-right: 0;
-
-			&:last-child {
-				margin-bottom: 0;
+			.social__icon {
+				fill: #fff;
 			}
 		}
 
-		&--facebook {
-			display: flex;
-			justify-content: center;
-			border-radius: 15px;
-			@include button-style($color-facebook, auto, #fff);
-		}
-
 		&--twitter {
-			display: flex;
-			justify-content: center;
-			border-radius: 15px;
-			color: $color-text;
 			border: 1px solid $color-twitter;
 
 			.social__icon {
@@ -396,10 +374,6 @@ $color-text: #212121;
 		}
 
 		&--linkedin {
-			display: flex;
-			justify-content: center;
-			border-radius: 15px;
-			color: $color-text;
 			border: 1px solid $color-linkedin;
 
 			.social__icon {
@@ -408,50 +382,8 @@ $color-text: #212121;
 		}
 
 		&--link {
-			display: flex;
-			justify-content: center;
-			border-radius: 15px;
-			color: $color-text;
-			border: 1px solid $color-copy-link;
-			width: 100%;
-			transition:
-				background-color 0.25s ease-in,
-				border-color 0.25s ease-in,
-				color 0.25s ease-in;
-
 			.social__icon {
 				color: $color-copy-link;
-				transition: fill 0.25s ease-in;
-			}
-		}
-
-		&--success {
-			background-color: rgb(var(--bg-brand));
-			border-color: rgb(var(--bg-brand));
-		}
-
-		&--error {
-			background-color: rgb(var(--bg-danger));
-			border-color: rgb(var(--bg-danger));
-		}
-
-		&--success,
-		&--error {
-			color: #fff;
-			cursor: default;
-			transition:
-				background-color 0.25s ease-out,
-				border-color 0.25s ease-out,
-				color 0.25s ease-out;
-
-			&:hover {
-				color: #fff;
-				text-decoration: none;
-			}
-
-			.social__icon {
-				transition: fill 0.25s ease-out;
-				fill: #fff;
 			}
 		}
 	}

--- a/src/components/Thanks/ThanksPageCommentAndShare.vue
+++ b/src/components/Thanks/ThanksPageCommentAndShare.vue
@@ -7,10 +7,9 @@
 			:comments-mode="askForComments"
 		/>
 		<!-- Image Section -->
-		<div class="row page-content">
-			<div class="large-2"></div>
-			<div class="small-12 large-8 columns thanks">
-				<div class="hide-for-print">
+		<kv-page-container>
+			<kv-grid class="tw-grid-cols-12">
+				<div class="tw-col-span-12 lg:tw-col-span-8 lg:tw-col-start-3 tw-pt-2 tw-mb-4 hide-for-print">
 					<template v-if="receipt">
 						<div v-if="!calculatePeopleQtyToGoal()">
 							<img :alt="`Fully funded image`" :src="thanksImgRequire(`./kiva-share.png`)">
@@ -42,21 +41,17 @@
 							<figure>
 								<figcaption class="tw-flex progress">
 									<template>
-										<div class="tw-flex-auto tw-text-left">
-											<p
-												class="tw-text-h3 tw-m-0 progress__to-go"
-												data-testid="bp-summary-amount-to-go"
-											>
-												{{ loan.unreservedAmount | numeral('$0,0[.]00') }} TO GO
-											</p>
-										</div>
 										<p
-											class="tw-flex-auto tw-text-right progress__days-remaining"
+											class="tw-flex-auto tw-text-left tw-text-h4 tw-mt-2 tw-mx-0 tw-mb-0.5"
+											data-testid="bp-summary-amount-to-go"
+										>
+											{{ loan.unreservedAmount | numeral('$0,0[.]00') }} TO GO
+										</p>
+										<p
+											class="tw-flex-auto tw-text-right tw-text-h4 tw-mt-2 tw-mx-0 tw-mb-0.5"
 											data-testid="bp-summary-timeleft"
 										>
-											<span lass="tw-text-h3 tw-block tw-m-0">
-												{{ loan.fundraisingTimeLeft }} remaining
-											</span>
+											{{ loan.fundraisingTimeLeft }} remaining
 										</p>
 									</template>
 								</figcaption>
@@ -69,8 +64,8 @@
 						</div>
 					</template>
 				</div>
-			</div>
-		</div>
+			</kv-grid>
+		</kv-page-container>
 		<!-- Comments Section -->
 		<CommentAsk
 			class="hide-for-print"
@@ -79,10 +74,9 @@
 			:loan-id="loan.id"
 		/>
 		<!-- Share Section -->
-		<div class="row page-content">
-			<div class="large-2"></div>
-			<div class="small-12 large-8 columns thanks">
-				<div class="tw-mb-4 hide-for-print">
+		<kv-page-container>
+			<kv-grid class="tw-grid-cols-12">
+				<div class="tw-col-span-12 lg:tw-col-span-8 lg:tw-col-start-3 tw-pt-2 tw-mb-4 hide-for-print">
 					<template v-if="shareAskCopyVersion === null || shareAskCopyVersion === 'a'">
 						<h1	class="tw-mt-1 tw-mb-3 tw-text-left">
 							Get a $25 lending credit by inspiring others.
@@ -107,69 +101,65 @@
 						</p>
 					</template>
 					<template>
-						<div class="row tw-mt-3">
-							<div class="large-2"></div>
-							<div class="small-12 large-8 columns">
-								<div class="share__social social">
-									<a
-										data-testid="share-facebook-button"
-										class="social__btn social__btn--facebook"
-										:href="facebookShareUrl({utmCampaign, utmContent})"
-										v-kv-track-event="
-											['post-checkout', 'share', 'facebook', utmCampaign, loanId]"
-									>
-										<kv-icon name="facebook-round" title="Facebook" class="social__icon" />
-										<span>Share on Facebook</span>
-									</a>
-									<button
-										data-testid="share-copy-link-button"
-										class="social__btn social__btn--link tw-text-link tw-border-tertiary tw-border"
-										:class="copyStatus.class"
-										:disabled="copyStatus.disabled"
-										v-kv-track-event="
-											['post-checkout', 'share', 'copy-link', utmCampaign, loanId]"
-										@click="copyLink({utmCampaign, utmContent}, copyStatus.text)"
-									>
-										<kv-material-icon
-											name="clipboard"
-											class="social__icon"
-											:icon="mdiLink"
-										/>
-										<span>{{ copyStatus.text }}</span>
-									</button>
-									<a
-										data-testid="share-twitter-button"
-										class="social__btn social__btn--twitter"
-										:href="twitterShareUrl({utmCampaign, utmContent})"
-										target="_blank"
-										rel="noopener"
-										v-kv-track-event="
-											['post-checkout', 'share', 'twitter', utmCampaign, loanId]"
-										@click="$showTipMsg('Thanks for tweeting!')"
-									>
-										<kv-icon name="twitter" title="Twitter" class="social__icon" />
-										<span>Tweet your followers</span>
-									</a>
-									<a
-										data-testid="share-linkedin-button"
-										class="social__btn social__btn--linkedin"
-										:href="linkedInShareUrl({utmCampaign, utmContent})"
-										target="_blank"
-										rel="noopener"
-										v-kv-track-event="
-											['post-checkout', 'share', 'linkedin', utmCampaign, loanId]"
-										@click="$showTipMsg('Thanks for sharing to LinkedIn!')"
-									>
-										<kv-icon name="linkedin" title="LinkedIn" class="social__icon" />
-										<span>Share on LinkedIn</span>
-									</a>
-								</div>
-							</div>
-							<div class="large-2"></div>
-						</div>
-						<div class="continue-link">
+						<div class="social tw-mt-4 tw-max-w-sm tw-mx-auto">
 							<button
-								class="tw-text-action tw-underline"
+								data-testid="share-facebook-button"
+								class="social__btn social__btn--facebook tw-w-full"
+								@click="showSharePopUp(
+									facebookShareUrl({utmCampaign, utmContent}),
+									'Thanks for sharing to Facebook!')"
+								v-kv-track-event="
+									['post-checkout', 'share', 'facebook', utmCampaign, loanId]"
+							>
+								<kv-icon name="facebook-round" title="Facebook" class="social__icon" />
+								<span>Share on Facebook</span>
+							</button>
+							<button
+								data-testid="share-copy-link-button"
+								class="social__btn social__btn--link
+								tw-text-link tw-border-tertiary tw-border tw-w-full"
+								:class="copyStatus.class"
+								:disabled="copyStatus.disabled"
+								v-kv-track-event="
+									['post-checkout', 'share', 'copy-link', utmCampaign, loanId]"
+								@click="copyLink({utmCampaign, utmContent}, copyStatus.text)"
+							>
+								<kv-material-icon
+									name="clipboard"
+									class="social__icon"
+									:icon="mdiLink"
+								/>
+								<span>{{ copyStatus.text }}</span>
+							</button>
+							<button
+								data-testid="share-twitter-button"
+								class="social__btn social__btn--twitter tw-w-full"
+								v-kv-track-event="
+									['post-checkout', 'share', 'twitter', utmCampaign, loanId]"
+								@click="showSharePopUp(
+									twitterShareUrl({utmCampaign, utmContent}),
+									'Thanks for tweeting!')"
+							>
+								<kv-icon name="twitter" title="Twitter" class="social__icon" />
+								<span>Tweet your followers</span>
+							</button>
+							<button
+								data-testid="share-linkedin-button"
+								class="social__btn social__btn--linkedin tw-w-full"
+								v-kv-track-event="
+									['post-checkout', 'share', 'linkedin', utmCampaign, loanId]"
+								@click="showSharePopUp(
+									linkedInShareUrl({utmCampaign, utmContent}),
+									'Thanks for sharing to LinkedIn!')"
+							>
+								<kv-icon name="linkedin" title="LinkedIn" class="social__icon" />
+								<span>Share on LinkedIn</span>
+							</button>
+						</div>
+						<div class="tw-text-center tw-mt-2">
+							<button
+								class="tw-block tw-mx-auto tw-text-action
+								tw-underline hover:tw-text-action-highlight "
 								@click="emitGuestCreateAccount"
 								v-if="isGuest"
 								v-kv-track-event="['Thanks','click-create-account','Create my account']"
@@ -177,6 +167,8 @@
 								Create my account
 							</button>
 							<router-link
+								class="tw-block tw-mx-auto tw-text-action
+								tw-underline hover:tw-text-action-highlight"
 								v-else
 								to="/portfolio"
 								v-kv-track-event="['Thanks','click-portfolio-cta','No, continue to my portfolio']"
@@ -186,9 +178,8 @@
 						</div>
 					</template>
 				</div>
-			</div>
-			<div class="large-2"></div>
-		</div>
+			</kv-grid>
+		</kv-page-container>
 	</div>
 </template>
 
@@ -202,6 +193,8 @@ import KvIcon from '@/components/Kv/KvIcon';
 import socialSharingMixin from '@/plugins/social-sharing-mixin';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
+import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
+import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 
 const thanksImgRequire = require.context('@/assets/images/thanks-page', true);
 
@@ -215,6 +208,8 @@ export default {
 		KvIcon,
 		ShareStepper,
 		CommentAsk,
+		KvGrid,
+		KvPageContainer,
 	},
 	props: {
 		receipt: {
@@ -351,90 +346,7 @@ $color-linkedin: #0077b5;
 $color-copy-link: #2B7C5F;
 $color-text: #212121;
 
-$loan-circle-size: rem-calc(70);
-$loan-circle-margin: 1rem;
-$loan-triangle-size: rem-calc(12);
-
-.page-content {
-	padding: 0 10px;
-
-	@media print {
-		padding: 0;
-	}
-}
-
-.message-content {
-	background-color: #F4FBF7;
-	margin-bottom: 15px;
-
-	&__success {
-		color: #1B6E43;
-		float: right;
-		margin-right: 0;
-
-		@include breakpoint(medium) {
-			margin-right: 40px;
-		}
-	}
-
-	&__text {
-		font-size: 15px;
-		margin-top: 15px;
-		padding-left: 15px;
-
-		@include breakpoint(medium) {
-			margin-top: 22px;
-			padding-left: 0;
-		}
-	}
-}
-
-.progress {
-	&__to-go {
-		font-size: 14px;
-		margin-top: 15px;
-		margin-bottom: 5px;
-		color: #212121;
-		font-weight: bold;
-	}
-
-	&__days-remaining {
-		font-size: 14px;
-		margin-top: 15px;
-		margin-bottom: 5px;
-		color: $color-text;
-		text-transform: uppercase;
-		font-weight: bold;
-	}
-}
-
-.thanks {
-	&__social-share {
-		margin-bottom: 0.5rem;
-	}
-}
-
-.share {
-	width: 100%;
-	max-width: rem-calc(600);
-	margin: 0 auto;
-
-	&__social {
-		@include breakpoint(large) {
-			width: rem-calc(135);
-		}
-	}
-}
-
 .social {
-	width: 100%;
-	flex-wrap: wrap;
-	flex-shrink: 0;
-
-	@include breakpoint(large) {
-		flex-direction: column;
-	}
-
 	&__icon {
 		width: rem-calc(24);
 		height: rem-calc(24);
@@ -512,43 +424,6 @@ $loan-triangle-size: rem-calc(12);
 				transition: fill 0.25s ease-in;
 			}
 		}
-
-		&--success {
-			background-color: rgb(var(--bg-brand));
-			border-color: rgb(var(--bg-brand));
-		}
-
-		&--error {
-			background-color: rgb(var(--bg-danger));
-			border-color: rgb(var(--bg-danger));
-		}
-
-		&--success,
-		&--error {
-			color: #fff;
-			cursor: default;
-			transition:
-				background-color 0.25s ease-out,
-				border-color 0.25s ease-out,
-				color 0.25s ease-out;
-
-			&:hover {
-				color: #fff;
-				text-decoration: none;
-			}
-
-			.social__icon {
-				transition: fill 0.25s ease-out;
-				fill: #fff;
-			}
-		}
 	}
-}
-
-.continue-link {
-	margin-top: 25px;
-	text-align: center;
-	text-decoration: underline;
-	text-underline-offset: 3px;
 }
 </style>

--- a/src/components/Thanks/ThanksPageCommentAndShare.vue
+++ b/src/components/Thanks/ThanksPageCommentAndShare.vue
@@ -424,6 +424,36 @@ $color-text: #212121;
 				transition: fill 0.25s ease-in;
 			}
 		}
+
+		&--success {
+			background-color: rgb(var(--bg-brand));
+			border-color: rgb(var(--bg-brand));
+		}
+
+		&--error {
+			background-color: rgb(var(--bg-danger));
+			border-color: rgb(var(--bg-danger));
+		}
+
+		&--success,
+		&--error {
+			color: #fff;
+			cursor: default;
+			transition:
+				background-color 0.25s ease-out,
+				border-color 0.25s ease-out,
+				color 0.25s ease-out;
+
+			&:hover {
+				color: #fff;
+				text-decoration: none;
+			}
+
+			.social__icon {
+				transition: fill 0.25s ease-out;
+				fill: #fff;
+			}
+		}
 	}
 }
 </style>

--- a/src/plugins/social-sharing-mixin.js
+++ b/src/plugins/social-sharing-mixin.js
@@ -107,7 +107,7 @@ export default {
 				await clipboardCopy(`${this.shareMessage} ${url}`);
 				if (this.copyStatus) {
 					this.copyStatus = {
-						class: 'social__btn--success',
+						class: 'tw-transition-colors tw-border-action-highlight tw-text-action-highlight',
 						disabled: true,
 						text: 'Copied!'
 					};
@@ -115,7 +115,7 @@ export default {
 			} catch (err) {
 				if (this.copyStatus) {
 					this.copyStatus = {
-						class: 'social__btn--error',
+						class: 'tw-transition-colors tw-border-danger-highlight tw-text-danger-highlight',
 						disabled: true,
 						text: 'Error'
 					};


### PR DESCRIPTION
* Also standardize share button interactions -- make them buttons and enable small share pop up window on click and working toast messages

ACK-637

The result looks basically the same, the main content area is slightly wider because of the grid differences:

![screencapture-localhost-8888-checkout-thanks-2023-05-23-11_46_56](https://github.com/kiva/ui/assets/4371888/9dbaf854-345d-4098-b15d-049753dc898f)
