### PR TITLE
fix: disable tooltip for team links on mobile

### DIFF
--- a/src/components/BorrowerProfile/SupporterDetails.vue
+++ b/src/components/BorrowerProfile/SupporterDetails.vue
@@ -97,7 +97,7 @@
 			:controller="toolTipId"
 			:data-testid="`tooltip-id-${toolTipId}`"
 			theme="dark"
-			v-if="teamTooltipData"
+			v-if="teamTooltipData && !this.isMobile"
 		>
 			{{ teamTooltipData.category }}<br>
 			{{ teamTooltipData.lendersForTeamMessage }}

--- a/src/components/Kv/KvPopper.vue
+++ b/src/components/Kv/KvPopper.vue
@@ -23,7 +23,7 @@ export default {
 	props: {
 		controller: {
 			validator(value) {
-				if (value instanceof String) return true;
+				if (typeof value === 'string') return true;
 				if (typeof window === 'object'
 					&& 'HTMLElement' in window
 					&& value instanceof HTMLElement) return true;

--- a/src/components/Kv/KvTooltip.vue
+++ b/src/components/Kv/KvTooltip.vue
@@ -38,7 +38,7 @@ export default {
 	props: {
 		controller: {
 			validator(value) {
-				if (value instanceof String) return true;
+				if (typeof value === 'string') return true;
 				if (typeof window !== 'undefined'
 					&& 'HTMLElement' in window
 					&& value instanceof HTMLElement) return true;


### PR DESCRIPTION
ACK-621

On mobile currently, you cannot click the contributing teams name or image to go to the team page, this is because KvPopper/KvTooltip is using the touchend to display the information pop up. Our priority is to allow users to navigate to the team pages from here, so this fix removes kvTooltip if mobile, allowing the link to work. 

Also fixes this error:
![Screen Shot 2023-06-07 at 2 46 41 PM](https://github.com/kiva/ui/assets/4371888/f07447f2-bcd5-4b3a-9d48-88b4523d22bb)

It turns out that typeof is not the same as instance of

