### PR TITLE
fix: the ATB error can be singular

### DIFF
--- a/src/util/basketUtils.js
+++ b/src/util/basketUtils.js
@@ -68,7 +68,7 @@ export function setLendAmount({ amount, apollo, loanId }) {
 				resolve();
 			}
 		}).catch(errors => {
-			errors.forEach(error => {
+			(Array.isArray(errors) ? errors : [errors]).forEach(error => {
 				logSetLendAmountError(loanId, error);
 			});
 			reject(errors);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1397

- There were internal reports of issues with ATB - the theory was that the invalid basket handling would fail
- I noticed that we get a relatively large number of unhandled exceptions in Sentry related to the error handling in ATB logic, including in the last 24 hours (linked below)
- We explicitly changed the catch to handle arrays 2 years ago, so I made sure we now handle both situations, arrays and non-arrays

https://kiva.sentry.io/issues/2576987672/?project=1201288&query=is%3Aunresolved+basketutils&referrer=issue-stream&statsPeriod=14d&stream_index=0