### PR TITLE
feat: only check filesystem for static files when the /static route is requested

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -52,7 +52,7 @@ function setHeaders(res, path) {
 	res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
 }
 
-app.use(express.static('dist', {
+app.use('/static', express.static('dist/static', {
 	setHeaders,
 	maxAge: '1y'
 }));


### PR DESCRIPTION
I noticed a trace for a live loan image that indicated waiting 7 seconds to do the fs.stat() call in express.static. I've seen this call in all our requests for a while now (usually only taking a few milliseconds), but I just realized that we could isolate that filesystem call to only static requests. This should improve server response time, especially in high-traffic situations.