### PR TITLE
chore: update verbiage on lending stats page to lending partner

### DIFF
--- a/src/pages/Portfolio/LendingStats/LendingStatsPage.vue
+++ b/src/pages/Portfolio/LendingStats/LendingStatsPage.vue
@@ -62,8 +62,8 @@
 					/>
 					<hr class="tw-border-tertiary tw-my-4">
 					<stats-section
-						title="Field Partners*"
-						noun="Field Partner"
+						title="Lending Partners*"
+						noun="Lending Partner"
 						:not-lent-to="partnersNotLentTo"
 						:lent-to="partnersLentTo"
 						:total="totalPartners"
@@ -75,7 +75,7 @@
 					<hr class="tw-border-tertiary tw-my-4">
 					<p>
 						* Please note, Kiva is continually adding and ending partnerships as we deem necessary.
-						This means, you may end up supporting a loan in a country or through a Field Partner that
+						This means, you may end up supporting a loan in a country or through a Lending Partner that
 						is no longer active and therefore not included in the total number of countries or partners
 						noted on this page. For this reason, it is possible to see discrepancies between the number
 						you've supported and the number to go.


### PR DESCRIPTION
Updates verbiage on lending stats page from field partner to lending partner in accordance with guidance from the Inclusion Committee. 

I wasn't able to validate this locally, so your support in that if you've already got your machine set up to do so would be greatly appreciated!  This updates the bottom section and paragraph of `/portfolio/lending-stats` 