### PR TITLE
feat: comment reporting

### DIFF
--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -10,10 +10,38 @@
 		<h2 class="tw-sr-only">
 			Loan Comments
 		</h2>
-		<div v-if="!loading" class="tw-my-5 md:tw-my-6 lg:tw-my-8">
-			<kv-carousel :multiple-slides-visible="false" :embla-options="{ loop: false }">
+		<div v-if="!loading" class="tw-mt-2 md:tw-mt-3 lg:tw-mt-5 tw-mb-4 md:tw-mb-5 lg:tw-mb-7">
+			<kv-carousel :multiple-slides-visible="false" :embla-options="{ loop: false, draggable: false }">
 				<template v-for="(comment, index) in comments" #[`slide${index}`]>
 					<div :key="index">
+						<button
+							v-if="isLoggedIn"
+							@click.stop="openCommentMenu"
+							class="tw-ml-auto tw-mr-0 tw-block"
+							:style="{visibility: commentMenuShown ? 'hidden' : 'visible'}"
+						>
+							<kv-material-icon
+								class="tw-w-3 tw-h-3 tw-text-secondary"
+								:icon="mdiDotsHorizontalCircle"
+							/>
+						</button>
+						<div
+							v-if="commentMenuShown"
+							v-click-outside="hideCommentsMenu"
+							class="tw-bg-white tw-rounded tw-p-1.5 tw-absolute tw-right-1 tw-top-0"
+							style="box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08); width: 15rem;"
+						>
+							<h4 class="tw-text-h4 tw-text-secondary tw-mb-1">
+								More options
+							</h4>
+							<ul>
+								<li class="tw-text-base">
+									<button @click="openReportModal(comment.id)">
+										Report this comment
+									</button>
+								</li>
+							</ul>
+						</div>
 						<h2>
 							<em>"{{ comment.body }}"</em>
 						</h2>
@@ -22,27 +50,88 @@
 						</h2>
 					</div>
 				</template>
-
 				<why-special data-testid="bp-why-special" :loan-id="loanId" />
 			</kv-carousel>
 		</div>
+		<kv-lightbox
+			:visible="isLightboxVisible"
+			title="Report comment"
+			@lightbox-closed="isLightboxVisible = false"
+		>
+			<template #header>
+				<h2>
+					Report Comment
+				</h2>
+				<h3 class="tw-mt-2">
+					Why are you reporting this comment?
+				</h3>
+			</template>
+
+			<fieldset class="tw-flex tw-flex-col tw-gap-2 tw-mt-1 tw-mb-2">
+				<kv-radio
+					value="I find it offensive"
+					name="reportReason"
+					v-model="selectedReason"
+				>
+					I find it offensive
+				</kv-radio>
+				<kv-radio
+					value="It's spam or misleading"
+					name="reportReason" v-model="selectedReason"
+				>
+					It's spam or misleading
+				</kv-radio>
+				<kv-radio
+					value="It is harmful, violent, or could cause harm"
+					name="reportReason" v-model="selectedReason"
+				>
+					It is harmful, violent, or could cause harm
+				</kv-radio>
+			</fieldset>
+
+			<template #controls>
+				<kv-button
+					variant="secondary"
+					@click="isLightboxVisible = false"
+				>
+					Cancel
+				</kv-button>
+				<kv-button
+					variant="primary"
+					:state="buttonState"
+					@click="reportComment"
+				>
+					Submit report
+				</kv-button>
+			</template>
+		</kv-lightbox>
 	</article>
 </template>
 
 <script>
+import { mdiDotsHorizontalCircle } from '@mdi/js';
 import { gql } from '@apollo/client';
 import { createIntersectionObserver } from '@/util/observerUtils';
+import logFormatter from '@/util/logFormatter';
 import WhySpecial from '@/components/BorrowerProfile/WhySpecial';
+import clickOutside from '@/plugins/click-outside';
 import KvCarousel from '~/@kiva/kv-components/vue/KvCarousel';
-
+import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
+import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
+import KvRadio from '~/@kiva/kv-components/vue/KvRadio';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 export default {
 	name: 'CommentsAndWhySpecial',
 	inject: ['apollo', 'cookieStore'],
 	components: {
+		KvButton,
 		KvCarousel,
+		KvLightbox,
 		KvLoadingPlaceholder,
+		KvMaterialIcon,
+		KvRadio,
 		WhySpecial,
 	},
 	props: {
@@ -50,14 +139,31 @@ export default {
 			type: Number,
 			default: 0,
 		},
+		isLoggedIn: {
+			type: Boolean,
+			default: false,
+		},
 	},
+	mixins: [
+		clickOutside,
+	],
 	data() {
 		return {
+			mdiDotsHorizontalCircle,
 			loading: true,
 			comments: [],
+			commentMenuShown: false,
+			isLightboxVisible: false,
+			selectedReason: '',
+			selectedCommentId: ''
 		};
 	},
 	computed: {
+		buttonState() {
+			if (this.loading) return 'loading';
+			if (!this.selectedReason) return 'disabled';
+			return '';
+		},
 	},
 	apollo: {
 		query: gql`query loanComments($loanId: Int!) {
@@ -133,6 +239,46 @@ export default {
 				this.loading = false;
 			});
 		},
+		openCommentMenu() {
+			this.commentMenuShown = true;
+		},
+		hideCommentsMenu() {
+			this.commentMenuShown = false;
+		},
+		openReportModal(commentId) {
+			this.selectedCommentId = commentId;
+			this.isLightboxVisible = true;
+		},
+		reportComment() {
+			this.loading = true;
+			this.apollo.mutate({
+				mutation: gql`mutation flagLoanComment($id: Int!, $description: String, $commentId: Int!) {
+					loan(id: $id) {
+						flagComment(description: $description, commentId: $commentId)
+					}
+				}`,
+				variables: {
+					id: this.loanId,
+					commentId: this.selectedCommentId,
+					description: this.selectedReason
+				}
+			}).then(({ data, errors }) => {
+				// comment was added successfully
+				if (data.loan.flagComment) {
+					this.$showTipMsg('Thank you for reporting this comment!');
+				} else if (errors[0].message) {
+					this.$showTipMsg(errors[0].message);
+				} else {
+					throw new Error('There was a problem reporting this comment');
+				}
+			}).catch(e => {
+				logFormatter(e, 'error');
+				this.$showTipMsg('There was a problem reporting this comment', 'error');
+			}).finally(() => {
+				this.isLightboxVisible = false;
+				this.loading = false;
+			});
+		}
 	},
 	mounted() {
 		this.createObserver();

--- a/src/components/Thanks/CommentAsk.vue
+++ b/src/components/Thanks/CommentAsk.vue
@@ -167,8 +167,9 @@ export default {
 				if (data.loan.addComment) {
 					this.$showTipMsg(`Thank you for helping ${this.loanName}!`);
 					this.showComments = false;
+				} else {
+					throw new Error('Comment not added');
 				}
-				throw new Error('Comment not added');
 			}).catch(e => {
 				logFormatter(e, 'error');
 				this.$showTipMsg('There was a problem commenting on this loan', 'error');

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -86,7 +86,11 @@
 			</content-container>
 			<div class="tw-bg-primary tw-mb-5 md:tw-mb-6 lg:tw-mb-8" id="bp-comments-jump-link">
 				<content-container>
-					<comments-and-why-special data-testid="bp-comments" :loan-id="loanId" />
+					<comments-and-why-special
+						data-testid="bp-comments"
+						:loan-id="loanId"
+						:is-logged-in="lender.id ? true : false"
+					/>
 				</content-container>
 			</div>
 			<content-container>


### PR DESCRIPTION
* allows logged in users to report a comment for 1 of 3 reasons

ACK-628

Menu should show for logged in users. Use toast to give feedback. If a user reports a comment a second time, the message returned from the API is displayed "You have already submitted feedback"

Screenshots:
![Screen Shot 2023-06-20 at 3 18 49 PM](https://github.com/kiva/ui/assets/4371888/814de214-1adf-4ab0-b45a-f0cbb41bce67)
![Screen Shot 2023-06-20 at 3 18 55 PM](https://github.com/kiva/ui/assets/4371888/e01ae02e-fb6a-4955-a5ee-3ef6257b5b3a)
![Screen Shot 2023-06-20 at 3 19 03 PM](https://github.com/kiva/ui/assets/4371888/136c0b20-1fd4-40c8-b19f-75f0aef3031e)
