### PR TITLE
fix(KvDropdown): skip dropdown init and log error when controller missing

### DIFF
--- a/src/components/Kv/KvDropdown.vue
+++ b/src/components/Kv/KvDropdown.vue
@@ -59,7 +59,11 @@ export default {
 		},
 	},
 	mounted() {
-		this.makeDropdown();
+		if (this.reference) {
+			this.makeDropdown();
+		} else {
+			console.error(`KvDropdown: Controller element with id ${this.controller} not found in document.`);
+		}
 	},
 	updated() {
 		if (this.popper) {

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -373,7 +373,7 @@
 
 							<!-- Log in Link -->
 							<router-link
-								v-if="isVisitor"
+								v-show="isVisitor"
 								class="header__button tw-bg-white tw-whitespace-nowrap"
 								:to="loginUrl"
 								data-testid="header-log-in"
@@ -384,7 +384,7 @@
 
 							<!-- Logged in Profile -->
 							<router-link
-								v-else
+								v-show="!isVisitor"
 								:id="myKivaMenuId"
 								data-testid="header-portfolio"
 								to="/portfolio"


### PR DESCRIPTION
Fixes recent errors like `Cannot read properties of null (reading 'addEventListener')`