### PR TITLE
fix: set donation tip to 0 when just 1 dollar donation modal is closed

### DIFF
--- a/src/components/Checkout/DonationNudge/DonationNudgeLightbox.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeLightbox.vue
@@ -4,7 +4,7 @@
 		:no-padding-sides="true"
 		:no-padding-bottom="true"
 		:no-padding-top="true"
-		@lightbox-closed="closeZeroUpsell(0)"
+		@lightbox-closed="closeLightbox"
 		:title="title"
 	>
 		<template #header>
@@ -184,6 +184,12 @@ export default {
 		closeZeroUpsell(amount) {
 			this.setDonationAndClose(amount, 'Zero Donation Upsell');
 			this.zeroUpsellVisible = false;
+		},
+		closeLightbox() {
+			if (this.zeroUpsellVisible) {
+				return this.closeZeroUpsell(0);
+			}
+			return this.closeNudgeLightbox();
 		}
 	},
 };


### PR DESCRIPTION
Closing out donation modal wasn't updating the tip to $0, instead the value remained the same. This pr updates the tip to $0 when this modal is closed.

<img width="968" alt="image" src="https://github.com/kiva/ui/assets/56947778/e33b942e-c1ff-442d-abe4-267f177aabd0">
