### PR TITLE
feat: ensure loader is hidden on validation error

### DIFF
--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -304,6 +304,7 @@ export default {
 					}
 				})
 				.catch(btSubmitError => {
+					this.$emit('updating-totals', false);
 					console.error(btSubmitError);
 					// Fire specific exception to Sentry/Raven
 					Sentry.withScope(scope => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1444

- An internal user ran into an infinite checkout spinner when a bad CC was used
- No one else could repro -> I guess it was an unusual situation where the user got a replacement card
- I identified which spinner on the page and found in code a user path where an error could have encountered and spinner not hidden
- Other usages of `requestPaymentMethod` hide the loading indicator in the `catch` like in this changeset
- Hopefully this resolves the issue moving forward