### PR TITLE
fix: avoid zooming bug removing smallest image size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kvue",
-	"version": "2.612.1",
+	"version": "2.619.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kvue",
-			"version": "2.612.1",
+			"version": "2.619.2",
 			"license": "UNLICENSED",
 			"dependencies": {
 				"@apollo/client": "^3.3.21",
@@ -11835,9 +11835,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001442",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-			"integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
+			"version": "1.0.30001512",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+			"integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -11846,6 +11846,10 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			]
 		},
@@ -48419,9 +48423,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001442",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
-			"integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow=="
+			"version": "1.0.30001512",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001512.tgz",
+			"integrity": "sha512-2S9nK0G/mE+jasCUsMPlARhRCts1ebcp2Ji8Y8PWi4NDE1iRdLCnEPHkEfeBrGC45L4isBx5ur3IQ6yTE2mRZw=="
 		},
 		"canvas": {
 			"version": "2.11.2",

--- a/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCardExp.vue
@@ -397,7 +397,6 @@ export default {
 				{ width: 416, viewSize: 480 },
 				{ width: 374, viewSize: 414 },
 				{ width: 335, viewSize: 375 },
-				{ width: 300 },
 			];
 		}
 	},


### PR DESCRIPTION
- removing smallest image size option to avoid image bug in tiny screens and zoomed out desktop version

<img width="528" alt="Screenshot 2023-07-05 at 16 49 36" src="https://github.com/kiva/ui/assets/94026278/9f39b8f3-dd41-4a26-ad16-8a65b3cd7600">
<img width="483" alt="Screenshot 2023-07-05 at 16 50 24" src="https://github.com/kiva/ui/assets/94026278/5ef5a1a4-385b-4fe0-ab08-7e7b981d2d0c">
<img width="406" alt="Screenshot 2023-07-06 at 9 10 36" src="https://github.com/kiva/ui/assets/94026278/a869581d-80c6-4851-bef0-c33c8848f1eb">


Fixed example
<img width="477" alt="Screenshot 2023-07-06 at 9 14 44" src="https://github.com/kiva/ui/assets/94026278/b9c12e69-ef82-47c9-8884-3e0002915eaa">


