### PR TITLE
fix: minor issues with comments on bp

### DIFF
--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -45,7 +45,7 @@
 						</div>
 						<!-- comment -->
 						<h2>
-							<em>"{{ comment.body }}"</em>
+							<em class="tw-break-words">"{{ comment.body }}"</em>
 						</h2>
 						<!-- author -->
 						<div class="tw-float-right tw-flex tw-align-center tw-mt-1.5">
@@ -301,7 +301,7 @@ export default {
 										teams
 										lender {
 											id
-											teams {
+											teams(limit: 100) { #arbitrary limit for lenders that have a lot of teams
 												values {
 													id
 													name


### PR DESCRIPTION
There was a bug with displaying the team name if a user is in many teams and the default limit of 20 is not enough. Added artificial limit of 100 

Also added word wrapping as some users are putting in very long urls in the comment