### PR TITLE
feat: requests comments from guests on thank you page

### DIFF
--- a/src/components/Checkout/GuestUpsell.vue
+++ b/src/components/Checkout/GuestUpsell.vue
@@ -6,82 +6,19 @@
 		<p class="guest-account-upsell__subhead tw-mb-4">
 			{{ borrowerUpdateText }}
 		</p>
-		<form id="guestUpsellForm" action="." @submit.prevent.stop="submit">
-			<kv-base-input
-				name="firstName"
-				class="data-hj-suppress tw-mb-2"
-				type="text"
-				v-model.trim="firstName"
-				:validation="$v.firstName"
-			>
-				First name
-				<template #required>
-					Enter first name.
-				</template>
-			</kv-base-input>
-			<kv-base-input
-				name="lastName"
-				class="data-hj-suppress tw-mb-2"
-				type="text"
-				v-model.trim="lastName"
-				:validation="$v.lastName"
-			>
-				Last name
-				<template #required>
-					Enter last name.
-				</template>
-			</kv-base-input>
-			<p
-				v-if="serverError"
-				class="guest-account-upsell__server-error tw-text-danger tw-text-small tw-font-medium tw-mb-2"
-			>
-				There was a problem when trying to create your account, please try again later.
-			</p>
-			<kv-button class="guest-account-upsell__claim-button tw-w-full" type="submit">
-				Create my account
-			</kv-button>
-		</form>
+		<guest-account-creation />
 	</section>
 </template>
 
 <script>
-import { gql } from '@apollo/client';
-import * as Sentry from '@sentry/vue';
-import { validationMixin } from 'vuelidate';
-import { required } from 'vuelidate/lib/validators';
-import KvBaseInput from '@/components/Kv/KvBaseInput';
-import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
 export default {
 	name: 'GuestUpsell',
-	components: {
-		KvButton,
-		KvBaseInput,
-	},
-	inject: ['apollo', 'cookieStore'],
-	mixins: [
-		validationMixin,
-	],
-	validations: {
-		firstName: {
-			required,
-		},
-		lastName: {
-			required,
-		},
-	},
 	props: {
 		loans: {
 			type: Array,
 			default: () => [],
 		},
-	},
-	data() {
-		return {
-			firstName: '',
-			lastName: '',
-			serverError: false,
-		};
 	},
 	computed: {
 		borrowerName() {
@@ -93,59 +30,7 @@ export default {
 		}
 	},
 	mounted() {
-		this.$kvTrackEvent('Thanks', 'view-register-upsell', this.borrowerUpdateText);
-	},
-	methods: {
-		submit() {
-			this.serverError = false;
-			this.$v.$touch();
-			if (!this.$v.$invalid) {
-				this.$kvTrackEvent('Thanks', 'click-register-upsell-name-cta', 'Create my account');
-
-				// will end up redirecting to password reset page.
-				this.apollo.mutate({
-					mutation: gql`mutation startGuestAccountClaim(
-						$firstName: String!,
-						$lastName: String!,
-						$visitorId: String!
-					) {
-						general {
-							startGuestAccountClaim(firstName: $firstName, lastName: $lastName, visitorId: $visitorId)
-						}
-					}`,
-					variables: {
-						firstName: this.firstName,
-						lastName: this.lastName,
-						visitorId: this.cookieStore.get('uiv') || ''
-					},
-				}).then(result => {
-					if (result?.errors?.length > 0) {
-						throw result.errors;
-					}
-					const resetUrl = result?.data?.general?.startGuestAccountClaim;
-					if (!resetUrl) {
-						throw new Error('Missing reset url');
-					}
-					window.location = resetUrl;
-				}).catch(err => {
-					this.serverError = true;
-					const errors = Array.isArray(err) ? err : [err];
-					this.$kvTrackEvent('Thanks', 'error-register-upsell-name-cta', errors.toString());
-					errors.forEach(error => {
-						console.error(error);
-						try {
-							Sentry.withScope(scope => {
-								scope.setTag('guest_checkout', true);
-								scope.setTag('visitor_id', this.cookieStore.get('uiv') || 'none');
-								Sentry.captureException(error);
-							});
-						} catch (e) {
-							// no-op
-						}
-					});
-				});
-			}
-		}
-	},
+		this.$kvTrackEvent('post-checkout', 'show', 'register-upsell', this.borrowerUpdateText);
+	}
 };
 </script>

--- a/src/components/Forms/GuestAccountCreation.vue
+++ b/src/components/Forms/GuestAccountCreation.vue
@@ -1,0 +1,133 @@
+<template>
+	<form
+		id="guestUpsellForm"
+		@submit.prevent.stop="submit"
+	>
+		<kv-base-input
+			name="firstName"
+			class="data-hj-suppress tw-mb-2"
+			type="text"
+			v-model.trim="firstName"
+			:validation="$v.firstName"
+		>
+			First name
+			<template #required>
+				Enter first name.
+			</template>
+		</kv-base-input>
+		<kv-base-input
+			name="lastName"
+			class="data-hj-suppress tw-mb-2"
+			type="text"
+			v-model.trim="lastName"
+			:validation="$v.lastName"
+		>
+			Last name
+			<template #required>
+				Enter last name.
+			</template>
+		</kv-base-input>
+		<p
+			v-if="serverError"
+			class="tw-text-danger tw-text-small tw-font-medium tw-mb-2"
+		>
+			There was a problem when trying to create your account, please try again later.
+		</p>
+		<kv-button class="tw-w-full" type="submit">
+			Create my account
+		</kv-button>
+	</form>
+</template>
+
+<script>
+import { gql } from '@apollo/client';
+import * as Sentry from '@sentry/vue';
+import { validationMixin } from 'vuelidate';
+import { required } from 'vuelidate/lib/validators';
+import KvBaseInput from '@/components/Kv/KvBaseInput';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+
+export default {
+	name: 'GuestAccountCreation',
+	components: {
+		KvButton,
+		KvBaseInput,
+	},
+	inject: ['apollo', 'cookieStore'],
+	mixins: [
+		validationMixin,
+	],
+	validations: {
+		firstName: {
+			required,
+		},
+		lastName: {
+			required,
+		},
+	},
+	props: {
+		loans: {
+			type: Array,
+			default: () => [],
+		},
+	},
+	data() {
+		return {
+			firstName: '',
+			lastName: '',
+			serverError: false,
+		};
+	},
+	methods: {
+		submit() {
+			this.serverError = false;
+			this.$v.$touch();
+			if (!this.$v.$invalid) {
+				this.$kvTrackEvent('post-checkout', 'click', 'create-guest-account');
+
+				// will end up redirecting to password reset page.
+				this.apollo.mutate({
+					mutation: gql`mutation startGuestAccountClaim(
+						$firstName: String!,
+						$lastName: String!,
+						$visitorId: String!
+					) {
+						general {
+							startGuestAccountClaim(firstName: $firstName, lastName: $lastName, visitorId: $visitorId)
+						}
+					}`,
+					variables: {
+						firstName: this.firstName,
+						lastName: this.lastName,
+						visitorId: this.cookieStore.get('uiv') || ''
+					},
+				}).then(result => {
+					if (result?.errors?.length > 0) {
+						throw result.errors;
+					}
+					const resetUrl = result?.data?.general?.startGuestAccountClaim;
+					if (!resetUrl) {
+						throw new Error('Missing reset url');
+					}
+					window.location = resetUrl;
+				}).catch(err => {
+					this.serverError = true;
+					const errors = Array.isArray(err) ? err : [err];
+					this.$kvTrackEvent('post-checkout', 'fail', 'guest-account-claim', errors.toString());
+					errors.forEach(error => {
+						try {
+							Sentry.withScope(scope => {
+								scope.setTag('guest_checkout', true);
+								scope.setTag('visitor_id', this.cookieStore.get('uiv') || 'none');
+								Sentry.captureException(error);
+							});
+						} catch (e) {
+							// no-op
+						}
+					});
+				});
+			}
+		}
+	},
+};
+</script>

--- a/src/components/Thanks/ThanksPageCommentAndShare.vue
+++ b/src/components/Thanks/ThanksPageCommentAndShare.vue
@@ -72,6 +72,7 @@
 			v-if="askForComments"
 			:loan-name="loan.name"
 			:loan-id="loan.id"
+			:is-guest="isGuest"
 		/>
 		<!-- Share Section -->
 		<kv-page-container>

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -147,6 +147,7 @@ import { gql } from '@apollo/client';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
+import guestComment from '@/plugins/guest-comment-mixin';
 import {
 	trackExperimentVersion
 } from '@/util/experiment/experimentUtils';
@@ -419,7 +420,7 @@ export default {
 			state: ''
 		};
 	},
-	mixins: [fiveDollarsTest],
+	mixins: [fiveDollarsTest, guestComment],
 	apollo: {
 		query: preFetchQuery,
 		preFetch(config, client, { route, cookieStore }) {

--- a/src/pages/LoginAndRegister/GuestAccountRedirect.vue
+++ b/src/pages/LoginAndRegister/GuestAccountRedirect.vue
@@ -4,11 +4,12 @@
 
 <script>
 import { gql } from '@apollo/client';
+import { GUEST_COMMENT_COMMENT, GUEST_COMMENT_LOANID } from '@/plugins/guest-comment-mixin';
 
 export default {
 	name: 'GuestAccountRedirect',
 	apollo: {
-		preFetch(config, client) {
+		preFetch(config, client, { cookieStore }) {
 			return client.query({
 				query: gql`query guestRedirect($basketId: String) {
 					shop (basketId: $basketId) {
@@ -23,10 +24,21 @@ export default {
 					}
 				}`,
 			}).then(({ data }) => {
-				// Redirect to /checkout if there are items in the basket, otherwise /portfolio
-				const path = data?.shop?.nonTrivialItemCount > 0 ? '/checkout' : '/portfolio';
 				// Add claimed=1 to the url to show a confirmation tip message on the page
 				const query = { claimed: 1 };
+
+				// Redirect to /checkout if there are items in the basket
+				// Redirect to loan page if there is a pending guest comment
+				// Otherwise /portfolio
+				let path = '';
+				if (data?.shop?.nonTrivialItemCount > 0) {
+					path = '/checkout';
+				} else if (cookieStore.get(GUEST_COMMENT_COMMENT) && cookieStore.get(GUEST_COMMENT_LOANID)) {
+					path = `/lend/${cookieStore.get(GUEST_COMMENT_LOANID)}`;
+				} else {
+					path = '/portfolio';
+				}
+
 				const queryString = Object.keys(query)
 					.map(key => `${key}=${query[key]}`)
 					.join('&');

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -190,7 +190,7 @@ export default {
 		askForComments() {
 			// comments ask should be displayed for logged in users
 			// checking out with a PFP loan or a loan that is attributed to a team.
-			return (this.hasPfpLoan || this.hasTeamAttributedPartnerLoan) && !this.isGuest;
+			return this.hasPfpLoan || this.hasTeamAttributedPartnerLoan;
 		},
 		selectedLoan() {
 			/**  We should select a loan if we are going to ask for comments for it.

--- a/src/plugins/guest-comment-mixin.js
+++ b/src/plugins/guest-comment-mixin.js
@@ -1,0 +1,52 @@
+/**
+ * This mixin is used to submit a comment on a loan that
+ * was left as a guest before they created their account.
+ * If the cookie values are present, and the user is logged in,
+ * we can now leave the comment and remove the cookiies
+ */
+import { gql } from '@apollo/client';
+import logFormatter from '@/util/logFormatter';
+
+export const GUEST_COMMENT_COMMENT = 'guestCommentComment';
+export const GUEST_COMMENT_LOANID = 'guestCommentLoanId';
+
+export default {
+	mounted() {
+		const guestCommentComment = this.cookieStore.get(GUEST_COMMENT_COMMENT);
+		const guestCommentLoanId = this.cookieStore.get(GUEST_COMMENT_LOANID);
+		const currentLoanId = this.$route?.params?.id;
+		const isTargetBorrowerProfile = currentLoanId.toString() === guestCommentLoanId.toString();
+		if (isTargetBorrowerProfile && guestCommentComment) {
+			this.submitComment();
+		}
+	},
+	methods: {
+		submitComment() {
+			this.apollo.mutate({
+				mutation: gql`mutation commentOnLoan($id: Int!, $body: String) {
+					loan(id: $id) {
+						addComment(body: $body)
+					}
+				}`,
+				variables: {
+					id: Number(this.$route?.params?.id ?? 0),
+					body: this.cookieStore.get(GUEST_COMMENT_COMMENT)
+				}
+			}).then(({ data }) => {
+				// comment was added successfully
+				if (data.loan.addComment) {
+					this.$showTipMsg('Thank you for leaving a comment!');
+					// remove cookie values so we don't post the comment again
+					this.cookieStore.remove(GUEST_COMMENT_COMMENT);
+					this.cookieStore.remove(GUEST_COMMENT_LOANID);
+				} else {
+					throw new Error('Comment not added');
+				}
+			}).catch(e => {
+				logFormatter(e, 'error');
+				this.$showTipMsg('There was a problem commenting on this loan', 'error');
+			});
+		}
+	},
+
+};


### PR DESCRIPTION
Ask for comments from guests as well, since they are a large portion of Kiva US Checkout.

The flow for guests is: 
1. On thank you page ask for comment
2. Save comment to cookie, inform user that they have to finish creating an account to post their comment. 
3. Display account claim form (first Name, last name)
4. Follow account claim steps: auth0 password creation, redirect to `/register/guest-redirect`
5. If comment in progress cookies are found by `/register/guest-redirect` redirect to login with destination URL borrower profile with query params.
6. User lands on borrower profile. Mix-in checks for comment cookies, and submits comment and deletes cookies if successful.   
 
Refactors: 

- Refactored guest account creation form so we can use it in multiple places (normal upsell an this new comments upsell)
- Refactored some events to match new event analytics (post-checkout category, etc)