### PR TITLE
feat: show captcha on /register/social page when required MARS-446

### DIFF
--- a/config/dev-vm.js
+++ b/config/dev-vm.js
@@ -20,6 +20,7 @@ module.exports = merge(base, {
 		googleTagmanagerId: 'GTM-PXFRMT',
 		enableGA: false,
 		gaId: 'UA-11686022-7',
+		grecaptchaSitekey: '6LcXENcmAAAAAEC4ygspn1WTm4zP4gLexXDnWuXE',
 		enableSnowplow: true,
 		snowplowUri: 'events.fivetran.com/snowplow/v5qt54ocr2nm',
 		enableHotjar: false,

--- a/config/dev.js
+++ b/config/dev.js
@@ -14,6 +14,7 @@ module.exports = merge(base, {
 		googleTagmanagerId: 'GTM-PXFRMT',
 		enableGA: true,
 		gaId: 'UA-11686022-3',
+		grecaptchaSitekey: '6LcXENcmAAAAAEC4ygspn1WTm4zP4gLexXDnWuXE',
 		enableHotjar: true,
 		hotjarId: '3071239',
 		enableSnowplow: true,

--- a/config/index.js
+++ b/config/index.js
@@ -15,6 +15,7 @@ module.exports = {
 		googleTagmanagerId: 'GTM-PX6FDG',
 		enableGA: true,
 		gaId: 'UA-175897-4',
+		grecaptchaSitekey: '6LfAq7UiAAAAAOaRj9Wvv2uDN0WEwlfbEPntrVLD',
 		enableSnowplow: true,
 		snowplowUri: 'events.fivetran.com/snowplow/kiva_rules',
 		enableHotjar: true,

--- a/config/qa.js
+++ b/config/qa.js
@@ -14,6 +14,7 @@ module.exports = merge(base, {
 		googleTagmanagerId: 'GTM-WXLS9B',
 		enableGA: true,
 		gaId: 'UA-11686022-4',
+		grecaptchaSitekey: '6LcXENcmAAAAAEC4ygspn1WTm4zP4gLexXDnWuXE',
 		enableSnowplow: true,
 		snowplowUri: 'events.fivetran.com/snowplow/v5qt54ocr2nm',
 		enableHotjar: false,

--- a/config/stage.js
+++ b/config/stage.js
@@ -14,6 +14,7 @@ module.exports = merge(base, {
 		googleTagmanagerId: 'GTM-K6HR28',
 		enableGA: true,
 		gaId: 'UA-11686022-5',
+		grecaptchaSitekey: '6LcXENcmAAAAAEC4ygspn1WTm4zP4gLexXDnWuXE',
 		enableSnowplow: true,
 		snowplowUri: 'events.fivetran.com/snowplow/v5qt54ocr2nm',
 		enableHotjar: false,

--- a/config/test.js
+++ b/config/test.js
@@ -14,6 +14,7 @@ module.exports = merge(base, {
 		googleTagmanagerId: 'GTM-WKWZ7WZ',
 		enableGA: false,
 		gaId: 'UA-11686022-3',
+		grecaptchaSitekey: '6LcXENcmAAAAAEC4ygspn1WTm4zP4gLexXDnWuXE',
 		enableSnowplow: true,
 		snowplowUri: 'events.fivetran.com/snowplow/v5qt54ocr2nm',
 		enableHotjar: false,

--- a/src/components/Forms/ReCaptchaEnterprise.vue
+++ b/src/components/Forms/ReCaptchaEnterprise.vue
@@ -1,0 +1,87 @@
+<template>
+	<div v-show="required">
+		<div
+			class="tw-flex tw-pb-3 tw-justify-center"
+			ref="captcha"
+			data-testid="captcha-container"
+		></div>
+		<input type="hidden" name="captcha">
+	</div>
+</template>
+
+<script>
+if (typeof window !== 'undefined') {
+	window.recaptchaLoaded = new Promise(resolve => {
+		window.recaptchaOnloadCallback = () => {
+			resolve(true);
+		};
+	});
+}
+
+export default {
+	name: 'ReCaptchaEnterprise',
+	props: {
+		required: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			instanceId: null,
+			captchaValue: '',
+		};
+	},
+	metaInfo: {
+		script: [
+			{
+				src: 'https://www.google.com/recaptcha/enterprise.js?onload=recaptchaOnloadCallback&render=explicit',
+				async: true,
+				defer: true,
+			},
+		],
+	},
+	methods: {
+		async loadRecaptcha() {
+			if (typeof window !== 'undefined') {
+				await window.recaptchaLoaded;
+				const setValue = value => {
+					this.captchaValue = value || '';
+					this.$emit('update', this.captchaValue);
+				};
+				this.instanceId = window.grecaptcha?.enterprise?.render(this.$refs.captcha, {
+					sitekey: this.$appConfig.grecaptchaSitekey,
+					callback: setValue,
+					'error-callback': () => setValue(),
+					'expired-callback': () => setValue(),
+				});
+			}
+		},
+		reset() {
+			if (this.instanceId !== null && typeof window !== 'undefined') {
+				window.grecaptcha?.enterprise?.reset(this.instanceId);
+			}
+		},
+		getResponse() {
+			if (this.instanceId !== null && typeof window !== 'undefined') {
+				return window.grecaptcha?.enterprise?.getResponse(this.instanceId);
+			}
+			return null;
+		},
+	},
+	mounted() {
+		if (this.required) {
+			this.loadRecaptcha();
+		}
+	},
+	watch: {
+		required: {
+			handler(value) {
+				if (value && this.instanceId === null) {
+					this.loadRecaptcha();
+				}
+			},
+		},
+	},
+};
+</script>

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -10,8 +10,8 @@
 			<form
 				id="registerSocialTermsForm"
 				class="promptForm tw-text-left"
-				action="."
-				@submit.prevent.stop="postRegisterSocialForm"
+				:action="`https://${$appConfig.auth0.domain}/continue?state=${$route.query.state}`"
+				@submit="postRegisterSocialForm"
 			>
 				<kv-base-input
 					name="firstName"
@@ -64,6 +64,16 @@
 				>
 					I want to receive updates about my loans, Kiva news, and promotions in my inbox
 				</kv-base-input>
+				<re-captcha-enterprise
+					:requried="needsCaptcha"
+					@update="captcha = $event"
+				/>
+				<p
+					class="tw-text-danger tw-text-small tw-font-medium tw-mt-1 tw-mb-2"
+					v-if="$v.captcha.$error"
+				>
+					Please complete the captcha.
+				</p>
 				<p v-if="showSsoTerms" class="tw-text-tertiary tw-text-small tw-mb-4">
 					Kiva will share your name and email address with the organization you are
 					registering with to let them know you've redeemed your credits.
@@ -91,6 +101,7 @@
 import { validationMixin } from 'vuelidate';
 import { required } from 'vuelidate/lib/validators';
 import KvBaseInput from '@/components/Kv/KvBaseInput';
+import ReCaptchaEnterprise from '@/components/Forms/ReCaptchaEnterprise';
 import SystemPage from '@/components/SystemFrame/SystemPage';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 
@@ -104,6 +115,7 @@ export default {
 	components: {
 		KvBaseInput,
 		KvButton,
+		ReCaptchaEnterprise,
 		SystemPage,
 	},
 	mixins: [
@@ -111,8 +123,10 @@ export default {
 	],
 	data() {
 		return {
+			captcha: '',
 			firstName: '',
 			lastName: '',
+			needsCaptcha: false,
 			needsTerms: false,
 			needsNames: false,
 			needsNews: false,
@@ -125,16 +139,27 @@ export default {
 		registrationMessage() {
 			const parts = [];
 			if (this.needsNames) {
-				parts.push('enter your first and last name below');
+				parts.push('enter your first and last name');
 			}
 			if (this.needsTerms) {
 				parts.push('agree to the Terms of Use and Privacy Policy');
 			}
-			return parts.length ? `To finish creating your account, please ${parts.join(' and ')}.` : '';
+			if (this.needsCaptcha) {
+				parts.push('complete the captcha');
+			}
+			if (parts.length === 0) {
+				return '';
+			}
+			const last = parts.pop();
+			const inner = parts.length ? `${parts.join(', ')} and ${last}` : last;
+			return `To finish creating your account, please ${inner} below.`;
 		},
 	},
 	validations() {
 		const validations = {};
+		if (this.needsCaptcha) {
+			validations.captcha = { required };
+		}
 		if (this.needsNames) {
 			validations.firstName = { required };
 			validations.lastName = { required };
@@ -147,6 +172,9 @@ export default {
 		return validations;
 	},
 	created() {
+		if (this.$route.query.captcha) {
+			this.needsCaptcha = true;
+		}
 		if (this.$route.query.terms) {
 			this.needsTerms = true;
 		}
@@ -160,26 +188,25 @@ export default {
 			this.showSsoTerms = true;
 		}
 		// Support legacy behavior of this page, which was to show the terms checkbox only
-		if (!this.$route.query.terms && !this.$route.query.names && !this.$route.query.news) {
+		if (!this.$route.query.terms
+			&& !this.$route.query.names
+			&& !this.$route.query.news
+			&& !this.$route.query.captcha
+		) {
 			this.needsTerms = true;
 			this.needsNews = true;
 		}
 	},
 	methods: {
-		postRegisterSocialForm() {
+		postRegisterSocialForm(event) {
 			this.$kvTrackEvent('Register', 'click-register-social-cta', 'Complete registration');
 			this.$v.$touch();
 
 			if (!this.$v.$invalid) {
-				this.$kvTrackEvent('Register', 'register-social-success', undefined, undefined, undefined, () => {
-					window.location = `https://${this.$appConfig.auth0.domain}/continue`
-					+ '?agree=yes'
-					+ `&newsConsent=${this.newsConsent ? 'yes' : 'no'}`
-					+ `&firstName=${this.firstName}`
-					+ `&lastName=${this.lastName}`
-					+ `&state=${this.$route.query.state}`;
-				});
+				this.$kvTrackEvent('Register', 'register-social-success');
 			} else {
+				event.preventDefault();
+				event.stopPropagation();
 				this.$kvTrackEvent('Register', 'error-register-social-form-invalid-input');
 			}
 		},

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -65,7 +65,8 @@
 					I want to receive updates about my loans, Kiva news, and promotions in my inbox
 				</kv-base-input>
 				<p v-if="showSsoTerms" class="tw-text-tertiary tw-text-small tw-mb-4">
-					{{ ssoTerms }}
+					Kiva will share your name and email address with the organization you are
+					registering with to let them know you've redeemed your credits.
 				</p>
 				<kv-button
 					class="register-button tw-w-full tw-mb-2"
@@ -131,10 +132,6 @@ export default {
 			}
 			return parts.length ? `To finish creating your account, please ${parts.join(' and ')}.` : '';
 		},
-		ssoTerms() {
-			return 'Kiva will share your name and email address with the organization you are '
-				+ 'registering with to let them know you\'ve redeemed your credits.';
-		}
 	},
 	validations() {
 		const validations = {};

--- a/test/e2e/specs/RegisterSocial.cy.js
+++ b/test/e2e/specs/RegisterSocial.cy.js
@@ -1,6 +1,20 @@
 describe('RegisterSocial', () => {
 	const registerSocialPath = '/register/social';
 
+	function completeCaptcha() {
+		return cy.get('[data-testid="captcha-container"] iframe')
+			.first()
+			.then($iframe => {
+				const $body = $iframe.contents().find('body');
+				cy.wrap($body)
+					.find('.recaptcha-checkbox-border')
+					.should('be.visible')
+					.click();
+				cy.wrap($body)
+					.find('.recaptcha-checkbox-checked');
+			});
+	}
+
 	describe('Form usage', () => {
 		it('requires first and last names when names are needed', () => {
 			// Visit to RegisterSocial page requesting names be returned (names=1)
@@ -11,6 +25,7 @@ describe('RegisterSocial', () => {
 			cy.contains('Last name').should('be.visible');
 			cy.contains('I have read and agree').should('not.be.visible');
 			cy.contains('I want to receive').should('not.be.visible');
+			cy.get('[data-testid="captcha-container"]').should('not.be.visible');
 
 			// Submit the form without entering anything
 			cy.contains('Complete registration').click();
@@ -40,6 +55,7 @@ describe('RegisterSocial', () => {
 			cy.contains('First name').should('not.be.visible');
 			cy.contains('Last name').should('not.be.visible');
 			cy.contains('I want to receive').should('not.be.visible');
+			cy.get('[data-testid="captcha-container"]').should('not.be.visible');
 
 			// Submit the form without entering anything
 			cy.contains('Complete registration').click();
@@ -66,6 +82,34 @@ describe('RegisterSocial', () => {
 			cy.contains('First name').should('not.be.visible');
 			cy.contains('Last name').should('not.be.visible');
 			cy.contains('I have read and agree').should('not.be.visible');
+			cy.get('[data-testid="captcha-container"]').should('not.be.visible');
+		});
+
+		it('requires a completed captcha when a captcha is required', () => {
+			// Visit to RegisterSocial page requesting a valid captcha be returned (captcha=1)
+			cy.visit(`${registerSocialPath}?state=abc&captcha=1`);
+
+			// Expect only the captcha to be displayed
+			cy.get('[data-testid="captcha-container"]').should('be.visible');
+			cy.contains('First name').should('not.be.visible');
+			cy.contains('Last name').should('not.be.visible');
+			cy.contains('I have read and agree').should('not.be.visible');
+			cy.contains('I want to receive').should('not.be.visible');
+
+			// Submit the form without entering anything
+			cy.contains('Complete registration').click();
+
+			// Expect this error message to be displayed
+			cy.contains('Please complete the captcha.');
+
+			// Expect the url to not change
+			cy.location('pathname').should('eq', registerSocialPath);
+
+			// Complete the captcha
+			completeCaptcha();
+
+			// Expect the error messages not to be present
+			cy.contains('Please complete the captcha.').should('not.exist');
 		});
 
 		it('displays news consent and requires terms agreement and names when all are needed', () => {
@@ -77,6 +121,7 @@ describe('RegisterSocial', () => {
 			cy.contains('Last name').should('be.visible');
 			cy.contains('I have read and agree').should('be.visible');
 			cy.contains('I want to receive').should('be.visible');
+			cy.get('[data-testid="captcha-container"]').should('be.visible');
 
 			// Submit the form without entering anything
 			cy.contains('Complete registration').click();
@@ -85,19 +130,22 @@ describe('RegisterSocial', () => {
 			cy.contains('Enter first name.');
 			cy.contains('Enter last name.');
 			cy.contains('You must agree to the Kiva Terms of Use and Privacy Policy.');
+			cy.contains('Please complete the captcha.');
 
 			// Expect the url to not change
 			cy.location('pathname').should('eq', registerSocialPath);
 
-			// Check the terms checkbox
+			// Fill out the form
 			cy.findByLabelText('First name', { exact: false }).type('Test');
 			cy.findByLabelText('Last name', { exact: false }).type('Tester');
 			cy.findByText('I have read and agree', { exact: false }).click();
+			completeCaptcha();
 
 			// Expect the error messages not to be present
 			cy.contains('Enter first name.').should('not.exist');
 			cy.contains('Enter last name.').should('not.exist');
 			cy.contains('You must agree to the Kiva Terms of Use and Privacy Policy.').should('not.exist');
+			cy.contains('Please complete the captcha.').should('not.exist');
 		});
 	});
 });


### PR DESCRIPTION
Add support for requiring a captcha at login/registration. Because captcha values can be large, I changed the form to submit a POST request with form encoded data instead of redirecting with GET query parameters. Support for the data coming in a POST request was added in kiva/auth0#338.