### PR TITLE
feat: adding v-else for matchingCampaign type [CIT-160]

### DIFF
--- a/src/components/Contentful/CampaignLoanWrapper.vue
+++ b/src/components/Contentful/CampaignLoanWrapper.vue
@@ -17,6 +17,7 @@
 				/>
 
 				<campaign-progress-bar
+					:is-matching-campaign="componentProps.isMatchingCampaign"
 					:promo-amount="componentProps.promoAmount"
 					:upc-credit-remaining="componentProps.upcCreditRemaining"
 					:basket-loans="componentProps.basketLoans"

--- a/src/components/CorporateCampaign/CampaignProgressBar.vue
+++ b/src/components/CorporateCampaign/CampaignProgressBar.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		v-if="promoAmount && promoAmount > 0"
+		v-if="(promoAmount && promoAmount > 0) && isMatchingCampaign"
 		class="
 			tw-rounded
 			tw-bg-brand-50
@@ -42,6 +42,32 @@
 			<kv-ui-button
 				v-show="basketLoans.length > 0"
 				@click="$emit('show-basket')"
+			>
+				Checkout now
+			</kv-ui-button>
+		</div>
+	</div>
+	<div
+		v-else
+		class="
+			tw-rounded
+			tw-bg-brand-50
+			tw-w-full
+			tw-py-2
+			tw-px-1
+			tw-mb-2
+			tw-flex-col
+			tw-flex
+			tw-justify-start
+			lg:tw-justify-between
+			lg:tw-align-center
+			"
+	>
+		<div class="lg:tw-mr-1 lg:tw-ml-0 tw-ml-1 lg:tw-pt-1">
+			<kv-ui-button
+				v-show="basketLoans.length > 0"
+				@click="$emit('show-basket')"
+				class="tw-w-full"
 			>
 				Checkout now
 			</kv-ui-button>

--- a/src/components/CorporateCampaign/CampaignProgressBar.vue
+++ b/src/components/CorporateCampaign/CampaignProgressBar.vue
@@ -1,5 +1,54 @@
 <template>
 	<div
+		v-if="(promoAmount && promoAmount > 0) && !isMatchingCorporateCampaign"
+		class="
+			tw-rounded
+			tw-bg-brand-50
+			tw-w-full
+			tw-py-3
+			tw-px-1
+			tw-mb-2
+			tw-flex-col
+			tw-flex
+			lg:tw-flex-row
+			tw-justify-start
+			lg:tw-justify-between
+			lg:tw-align-center
+			"
+	>
+		<div class="tw-flex-grow">
+			<h4 v-if="creditLeft === promoAmount" class="tw-mb-1 tw-px-3">
+				Let's Get Started
+			</h4>
+			<h4 v-else-if="creditLeft > 0" class="tw-mb-1 tw-px-3">
+				Keep Going!
+			</h4>
+			<h4 v-else-if="creditLeft === 0" class="tw-mb-1 tw-px-3">
+				You Did It!
+			</h4>
+			<h3 class="tw-mb-2 tw-px-3">
+				You have ${{ creditLeft }} in credit left
+				<span v-if="campaignPartnerName"> from {{ campaignPartnerName }} </span>
+			</h3>
+			<kv-grid class="tw-grid-cols-2">
+				<kv-progress-bar
+					:value="percentageLeft"
+					class="tw-mb-1.5 lg:tw-mb-1 tw-ml-3 tw-col-span-1"
+					:aria-label="`You have $${ creditLeft } in credit left`"
+				/>
+			</kv-grid>
+		</div>
+		<div class="lg:tw-mr-3 lg:tw-ml-0 tw-ml-3 lg:tw-pt-3">
+			<kv-ui-button
+				v-show="basketLoans.length > 0"
+				@click="$emit('show-basket')"
+			>
+				Checkout now
+			</kv-ui-button>
+		</div>
+	</div>
+	<div
+		v-else-if="basketLoans.length > 0"
 		class="
 			tw-rounded
 			tw-bg-brand-50
@@ -14,58 +63,7 @@
 			lg:tw-align-center
 			"
 	>
-		<!-- Progress bar appears as long as there is promo credit -->
 		<div
-			v-if="(promoAmount && promoAmount > 0) && (isMatchingCorporateCampaign || !isMatchingCorporateCampaign)"
-			class="
-			tw-rounded
-			tw-bg-brand-50
-			tw-w-full
-			tw-py-3
-			tw-px-1
-			tw-mb-2
-			tw-flex-col
-			tw-flex
-			lg:tw-flex-row
-			tw-justify-start
-			lg:tw-justify-between
-			lg:tw-align-center
-			"
-		>
-			<div class="tw-flex-grow">
-				<h4 v-if="creditLeft === promoAmount" class="tw-mb-1 tw-px-3">
-					Let's Get Started
-				</h4>
-				<h4 v-else-if="creditLeft > 0" class="tw-mb-1 tw-px-3">
-					Keep Going!
-				</h4>
-				<h4 v-else-if="creditLeft === 0" class="tw-mb-1 tw-px-3">
-					You Did It!
-				</h4>
-				<h3 class="tw-mb-2 tw-px-3">
-					You have ${{ creditLeft }} in credit left
-					<span v-if="campaignPartnerName"> from {{ campaignPartnerName }} </span>
-				</h3>
-				<kv-grid class="tw-grid-cols-2">
-					<kv-progress-bar
-						:value="percentageLeft"
-						class="tw-mb-1.5 lg:tw-mb-1 tw-ml-3 tw-col-span-1"
-						:aria-label="`You have $${ creditLeft } in credit left`"
-					/>
-				</kv-grid>
-			</div>
-			<div class="lg:tw-mr-3 lg:tw-ml-0 tw-ml-3 lg:tw-pt-3">
-				<kv-ui-button
-					v-show="basketLoans.length > 0"
-					@click="$emit('show-basket')"
-				>
-					Checkout now
-				</kv-ui-button>
-			</div>
-		</div>
-		<!--  Progress bar is hidden as long as there is no promo credit   -->
-		<div
-			v-else
 			class="
 				lg:tw-mr-1
 				lg:tw-ml-0 tw-ml-1
@@ -76,7 +74,6 @@
 				"
 		>
 			<kv-ui-button
-				v-show="basketLoans.length > 0"
 				@click="$emit('show-basket')"
 			>
 				Checkout now
@@ -114,6 +111,10 @@ export default {
 			type: Array,
 			default: () => []
 		},
+		isMatchingCampaign: {
+			type: Boolean,
+			default: false
+		},
 	},
 	computed: {
 		campaignPartnerName() {
@@ -121,9 +122,6 @@ export default {
 				return this.pageSettingData?.matchingAccountName ?? null;
 			}
 			return this.promoData?.promoFund?.displayName ?? null;
-		},
-		isMatchingCorporateCampaign() {
-			return this.isMatchingCampaign;
 		},
 		creditLeft() {
 			return this.upcCreditRemaining > 0 ? this.upcCreditRemaining : 0;

--- a/src/components/CorporateCampaign/CampaignProgressBar.vue
+++ b/src/components/CorporateCampaign/CampaignProgressBar.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		v-if="(promoAmount && promoAmount > 0) && !isMatchingCorporateCampaign"
+		v-if="(promoAmount && promoAmount > 0) && !isMatchingCampaign"
 		class="
 			tw-rounded
 			tw-bg-brand-50

--- a/src/components/CorporateCampaign/CampaignProgressBar.vue
+++ b/src/components/CorporateCampaign/CampaignProgressBar.vue
@@ -1,54 +1,5 @@
 <template>
 	<div
-		v-if="(promoAmount && promoAmount > 0) && isMatchingCampaign"
-		class="
-			tw-rounded
-			tw-bg-brand-50
-			tw-w-full
-			tw-py-3
-			tw-px-1
-			tw-mb-2
-			tw-flex-col
-			tw-flex
-			lg:tw-flex-row
-			tw-justify-start
-			lg:tw-justify-between
-			lg:tw-align-center
-			"
-	>
-		<div class="tw-flex-grow">
-			<h4 v-if="creditLeft === promoAmount" class="tw-mb-1 tw-px-3">
-				Let's Get Started
-			</h4>
-			<h4 v-else-if="creditLeft > 0" class="tw-mb-1 tw-px-3">
-				Keep Going!
-			</h4>
-			<h4 v-else-if="creditLeft === 0" class="tw-mb-1 tw-px-3">
-				You Did It!
-			</h4>
-			<h3 class="tw-mb-2 tw-px-3">
-				You have ${{ creditLeft }} in credit left
-				<span v-if="campaignPartnerName"> from {{ campaignPartnerName }} </span>
-			</h3>
-			<kv-grid class="tw-grid-cols-2">
-				<kv-progress-bar
-					:value="percentageLeft"
-					class="tw-mb-1.5 lg:tw-mb-1 tw-ml-3 tw-col-span-1"
-					:aria-label="`You have $${ creditLeft } in credit left`"
-				/>
-			</kv-grid>
-		</div>
-		<div class="lg:tw-mr-3 lg:tw-ml-0 tw-ml-3 lg:tw-pt-3">
-			<kv-ui-button
-				v-show="basketLoans.length > 0"
-				@click="$emit('show-basket')"
-			>
-				Checkout now
-			</kv-ui-button>
-		</div>
-	</div>
-	<div
-		v-else
 		class="
 			tw-rounded
 			tw-bg-brand-50
@@ -63,11 +14,70 @@
 			lg:tw-align-center
 			"
 	>
-		<div class="lg:tw-mr-1 lg:tw-ml-0 tw-ml-1 lg:tw-pt-1">
+		<!-- Progress bar appears when there is a corporate campaign with promo credit -->
+		<div
+			v-if="(promoAmount && promoAmount > 0) && !isMatchingCampaign"
+			class="
+			tw-rounded
+			tw-bg-brand-50
+			tw-w-full
+			tw-py-3
+			tw-px-1
+			tw-mb-2
+			tw-flex-col
+			tw-flex
+			lg:tw-flex-row
+			tw-justify-start
+			lg:tw-justify-between
+			lg:tw-align-center
+			"
+		>
+			<div class="tw-flex-grow">
+				<h4 v-if="creditLeft === promoAmount" class="tw-mb-1 tw-px-3">
+					Let's Get Started
+				</h4>
+				<h4 v-else-if="creditLeft > 0" class="tw-mb-1 tw-px-3">
+					Keep Going!
+				</h4>
+				<h4 v-else-if="creditLeft === 0" class="tw-mb-1 tw-px-3">
+					You Did It!
+				</h4>
+				<h3 class="tw-mb-2 tw-px-3">
+					You have ${{ creditLeft }} in credit left
+					<span v-if="campaignPartnerName"> from {{ campaignPartnerName }} </span>
+				</h3>
+				<kv-grid class="tw-grid-cols-2">
+					<kv-progress-bar
+						:value="percentageLeft"
+						class="tw-mb-1.5 lg:tw-mb-1 tw-ml-3 tw-col-span-1"
+						:aria-label="`You have $${ creditLeft } in credit left`"
+					/>
+				</kv-grid>
+			</div>
+			<div class="lg:tw-mr-3 lg:tw-ml-0 tw-ml-3 lg:tw-pt-3">
+				<kv-ui-button
+					v-show="basketLoans.length > 0"
+					@click="$emit('show-basket')"
+				>
+					Checkout now
+				</kv-ui-button>
+			</div>
+		</div>
+		<!-- Only checkout button appears when there is a matching campaign with no promo credit -->
+		<div
+			v-else
+			class="
+				lg:tw-mr-1
+				lg:tw-ml-0 tw-ml-1
+				lg:tw-pt-1
+				tw-flex
+				tw-justify-center
+				tw-align-center
+				"
+		>
 			<kv-ui-button
 				v-show="basketLoans.length > 0"
 				@click="$emit('show-basket')"
-				class="tw-w-full"
 			>
 				Checkout now
 			</kv-ui-button>
@@ -111,6 +121,9 @@ export default {
 				return this.pageSettingData?.matchingAccountName ?? null;
 			}
 			return this.promoData?.promoFund?.displayName ?? null;
+		},
+		isMatchingCampaign() {
+			return this.pageSettingData?.matcherAccountId !== undefined;
 		},
 		creditLeft() {
 			return this.upcCreditRemaining > 0 ? this.upcCreditRemaining : 0;

--- a/src/components/CorporateCampaign/CampaignProgressBar.vue
+++ b/src/components/CorporateCampaign/CampaignProgressBar.vue
@@ -14,9 +14,9 @@
 			lg:tw-align-center
 			"
 	>
-		<!-- Progress bar appears when there is a corporate campaign with promo credit -->
+		<!-- Progress bar appears as long as there is promo credit -->
 		<div
-			v-if="(promoAmount && promoAmount > 0) && !isMatchingCampaign"
+			v-if="(promoAmount && promoAmount > 0) && (isMatchingCorporateCampaign || !isMatchingCorporateCampaign)"
 			class="
 			tw-rounded
 			tw-bg-brand-50
@@ -63,7 +63,7 @@
 				</kv-ui-button>
 			</div>
 		</div>
-		<!-- Only checkout button appears when there is a matching campaign with no promo credit -->
+		<!--  Progress bar is hidden as long as there is no promo credit   -->
 		<div
 			v-else
 			class="
@@ -122,8 +122,8 @@ export default {
 			}
 			return this.promoData?.promoFund?.displayName ?? null;
 		},
-		isMatchingCampaign() {
-			return this.pageSettingData?.matcherAccountId !== undefined;
+		isMatchingCorporateCampaign() {
+			return this.isMatchingCampaign;
 		},
 		creditLeft() {
 			return this.upcCreditRemaining > 0 ? this.upcCreditRemaining : 0;

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -790,7 +790,8 @@ export default {
 				basketLoans: this.basketLoans,
 				promoName: this.campaignPartnerName,
 				removeLoanFromBasket: this.removeLoanFromBasket,
-				showBasket: this.showBasket
+				showBasket: this.showBasket,
+				isMatchingCampaign: this.isMatchingCampaign
 			};
 		},
 		pageSettingData() {


### PR DESCRIPTION
For Matching Type Accounts there is no promo credit therefore the UI should not render promo credit meter. Curious if the button length should be reduced?

<img width="1904" alt="Screen Shot 2023-07-18 at 3 27 51 PM" src="https://github.com/kiva/ui/assets/54958840/79acc40c-0f2f-401e-98f9-ff0365dcfdbf">
(How it looks without a filled basket) 

<img width="1904" alt="Screen Shot 2023-07-18 at 3 49 10 PM" src="https://github.com/kiva/ui/assets/54958840/f2c3b1a8-713c-4c39-9164-4deff6eec107">
(With loan in basket)

<img width="814" alt="Screen Shot 2023-07-18 at 3 50 04 PM" src="https://github.com/kiva/ui/assets/54958840/a1e39dda-116b-4fdb-b381-22d4d9a7d8ab">
(Mobile screen)
