### PR TITLE
feat: carousel updated for mobile version in lending home page

### DIFF
--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -1,7 +1,8 @@
 <template>
 	<div class="tw-w-full">
-		<div class="tw-mx-auto tw-px-2.5 md:tw-px-4 lg:tw-px-8" style="max-width: 1200px;">
-			<div class="tw-flex tw-flex-col lg:tw-flex-row tw-justify-between tw-items-end lg:tw-items-center">
+		<div class="tw-mx-auto tw-px-0 md:tw-px-4 lg:tw-px-8" style="max-width: 1200px;">
+			<!-- eslint-disable-next-line max-len -->
+			<div class="tw-flex tw-flex-col lg:tw-flex-row tw-justify-between tw-items-end lg:tw-items-center tw-px-2.5 md:tw-px-0">
 				<div class="tw-w-full lg:tw-w-auto">
 					<h2 v-html="title" class="tw-text-h2 tw-text-primary"></h2>
 					<p
@@ -106,7 +107,7 @@ export default {
 			const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
 			// handle tiny screens
 			if (viewportWidth < 414) {
-				return `${viewportWidth - 80}px`;
+				return '100%';
 			}
 			if (viewportWidth >= 414 && viewportWidth < 768) {
 				return '278px';
@@ -201,10 +202,77 @@ export default {
 
 <style lang="postcss" scoped>
 #customizedCarousel >>> .kv-carousel__controls {
-	justify-content: center;
+	@apply tw-justify-center;
+	@apply tw-w-16;
+	@apply tw-mx-auto;
+	@apply tw-rounded-lg;
+
+	box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.18);
+	-webkit-box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.18);
+	-moz-box-shadow: 0 2px 5px 2px rgba(0, 0, 0, 0.18);
 }
 
 #customizedCarousel >>> .kv-carousel__controls div {
-	visibility: visible;
+	@apply tw-visible;
+}
+
+#customizedCarousel >>> .kv-carousel__controls button {
+	@apply tw-border-0;
+}
+
+#customizedCarousel >>> .kv-carousel__controls button span {
+	@apply tw-invisible;
+}
+
+#customizedCarousel >>> .kv-carousel__controls button:first-child span::after {
+	@apply tw-visible;
+	@apply tw-text-h3;
+	@apply tw-rotate-180;
+
+	content: '\2794';
+}
+
+#customizedCarousel >>> .kv-carousel__controls button:nth-child(3) span::before {
+	@apply tw-visible;
+	@apply tw-text-h3;
+
+	content: '\2794';
+}
+
+#customizedCarousel >>> div:first-child div div div,
+#customizedCarousel >>> div:first-child > div > div.loan-card-active-hover a picture {
+	@apply tw-rounded-none;
+}
+
+@screen md {
+	#customizedCarousel >>> .kv-carousel__controls {
+		@apply tw-w-full;
+		@apply tw-rounded-none;
+
+		box-shadow: none;
+		-webkit-box-shadow: none;
+		-moz-box-shadow: none;
+	}
+
+	#customizedCarousel >>> div:first-child div div div {
+		@apply tw-rounded;
+	}
+
+	#customizedCarousel >>> div:first-child > div > div.loan-card-active-hover a picture {
+		@apply tw-rounded-t;
+	}
+
+	#customizedCarousel >>> .kv-carousel__controls button {
+		@apply tw-border-2;
+	}
+
+	#customizedCarousel >>> .kv-carousel__controls button span {
+		@apply tw-visible;
+	}
+
+	#customizedCarousel >>> .kv-carousel__controls button:first-child span::after,
+	#customizedCarousel >>> .kv-carousel__controls button:nth-child(3) span::before {
+		content: '';
+	}
 }
 </style>

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -97,6 +97,7 @@ export default {
 		return {
 			isAddingMultiple: false,
 			hasMultipleBeenAdded: false,
+			windowWidth: typeof window !== 'undefined' ? window.innerWidth : 1024,
 		};
 	},
 	computed: {
@@ -104,18 +105,13 @@ export default {
 			return this.perStep === 2;
 		},
 		singleSlideWidth() {
-			const viewportWidth = typeof window !== 'undefined' ? window.innerWidth : 1024;
-			// handle tiny screens
-			if (viewportWidth < 414) {
+			if (this.windowWidth <= 733) {
 				return '100%';
 			}
-			if (viewportWidth >= 414 && viewportWidth < 768) {
-				return '278px';
-			}
-			if (viewportWidth >= 768 && viewportWidth < 1024) {
+			if (this.windowWidth > 733 && this.windowWidth < 1024) {
 				return '328px';
 			}
-			if (viewportWidth >= 1024) {
+			if (this.windowWidth >= 1024) {
 				if (this.isLargeCard) {
 					return '512px';
 				}
@@ -196,6 +192,11 @@ export default {
 		loanCardKey(index) {
 			return `loan-card-${index}`;
 		},
+	},
+	mounted() {
+		window.addEventListener('resize', () => {
+			this.windowWidth = window.innerWidth;
+		});
 	},
 };
 </script>

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -51,6 +51,7 @@
 </template>
 
 <script>
+import _throttle from 'lodash/throttle';
 import KvClassicLoanCardContainer from '@/components/LoanCards/KvClassicLoanCardContainer';
 import MultipleAtcButton from '@/components/LoanCards/Buttons/MultipleAtcButton';
 import KvCarousel from '~/@kiva/kv-components/vue/KvCarousel';
@@ -98,6 +99,7 @@ export default {
 			isAddingMultiple: false,
 			hasMultipleBeenAdded: false,
 			windowWidth: typeof window !== 'undefined' ? window.innerWidth : 1024,
+			handleResize: _throttle(this.isWindowWidth, 200)
 		};
 	},
 	computed: {
@@ -192,16 +194,24 @@ export default {
 		loanCardKey(index) {
 			return `loan-card-${index}`;
 		},
+		isWindowWidth() {
+			this.windowWidth = window.innerWidth;
+		}
 	},
 	mounted() {
-		window.addEventListener('resize', () => {
-			this.windowWidth = window.innerWidth;
-		});
+		window.addEventListener('resize', this.handleResize);
 	},
+	beforeDestroy() {
+		window.removeEventListener('resize', this.handleResize);
+	}
 };
 </script>
 
 <style lang="postcss" scoped>
+#customizedCarousel {
+	@apply tw-px-0;
+}
+
 #customizedCarousel >>> .kv-carousel__controls {
 	@apply tw-justify-center;
 	@apply tw-w-16;
@@ -246,6 +256,10 @@ export default {
 }
 
 @screen md {
+	#customizedCarousel {
+		@apply tw-px-1;
+	}
+
 	#customizedCarousel >>> .kv-carousel__controls {
 		@apply tw-w-full;
 		@apply tw-rounded-none;

--- a/src/components/LoanFinding/PartnerSpotlightSection.vue
+++ b/src/components/LoanFinding/PartnerSpotlightSection.vue
@@ -99,7 +99,7 @@ export default {
 <style lang="postcss" scoped>
 
 #mfiCarousel >>> h2 {
-	@apply tw-text-h4 tw-mb-0 tw-text-action tw-ml-2;
+	@apply tw-text-h4 tw-mb-0 tw-text-action;
 }
 
 #mfiCarousel >>> section {


### PR DESCRIPTION
- carousel updated for mobile version in lending home page

New mobile version
<img width="448" alt="Screenshot 2023-07-19 at 15 59 27" src="https://github.com/kiva/ui/assets/94026278/84755e45-53cf-490c-abf5-31cf285ebe24">

Desktop version stills as current
<img width="1104" alt="Screenshot 2023-07-19 at 16 05 01" src="https://github.com/kiva/ui/assets/94026278/0b52c68b-6374-4078-82a6-a67d05b7d071">

