### PR TITLE
fix: calling undefined func on borrower profile added by mistake

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -542,7 +542,6 @@ export default {
 		this.determineIfMobile();
 
 		window.addEventListener('resize', _throttle(() => {
-			this.initStickyBehavior();
 			this.determineIfMobile();
 		}, 200));
 
@@ -554,7 +553,6 @@ export default {
 		},
 	},
 	beforeDestroy() {
-		this.destroyWrapperObserver();
 		window.removeEventListener('resize', _throttle(() => {
 			this.determineIfMobile();
 		}, 200));


### PR DESCRIPTION
Two methods were added by mistake that weren't defined on the component causing errors to appear