### PR TITLE
fix: unused var removed in saved search component

### DIFF
--- a/src/components/Settings/SaveSearchItem.vue
+++ b/src/components/Settings/SaveSearchItem.vue
@@ -59,7 +59,6 @@ export default {
 	},
 	data() {
 		return {
-			availableLoanCount: 0,
 			showAlerts: this.savedSearch?.isAlert,
 		};
 	},


### PR DESCRIPTION
- var removed as is no longer being used