### PR TITLE
feat: add most recent loan sort

### DIFF
--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -230,6 +230,10 @@ export default {
 				{
 					title: 'Ending soon',
 					key: 'expiringSoon'
+				},
+				{
+					title: 'Most recent',
+					key: 'mostRecent'
 				}
 			];
 			this.quickFiltersOptions.gender = [

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -800,6 +800,10 @@ export default {
 				{
 					title: 'Ending soon',
 					key: 'expiringSoon'
+				},
+				{
+					title: 'Most recent',
+					key: 'mostRecent'
 				}
 			];
 			this.quickFiltersOptions.gender = [

--- a/src/util/loanSearch/filters/sortOptions.js
+++ b/src/util/loanSearch/filters/sortOptions.js
@@ -18,7 +18,8 @@ export const sortByNameToDisplay = {
 	amountHighToLow: 'Amount: High to Low',
 	amountLowToHigh: 'Amount: Low to High',
 	personalized: 'Recommended',
-	popularityScore: 'Trending now'
+	popularityScore: 'Trending now',
+	mostRecent: 'Most recent'
 };
 
 /**
@@ -31,14 +32,16 @@ const lendToFlssSort = new Map([
 	['loanAmountDesc', 'amountHighToLow'],
 	['loanAmount', 'amountLowToHigh'],
 	['amountLeft', 'amountLeft'],
-	['repaymentTerm', 'repaymentTerm']
+	['repaymentTerm', 'repaymentTerm'],
+	['newest', 'mostRecent']
 ]);
 
 export const visibleFLSSSortOptions = [
 	'expiringSoon',
 	'amountHighToLow',
 	'amountLowToHigh',
-	'personalized',
+	'mostRecent',
+	'personalized'
 ];
 
 const experimentVisibleFLSSSortOptions = [
@@ -49,6 +52,7 @@ const experimentVisibleFLSSSortOptions = [
 	'amountLeft',
 	'popularityScore',
 	'repaymentTerm',
+	'mostRecent'
 ];
 
 /**


### PR DESCRIPTION
Users requested the ability to sort loans by most recent. This adds it to the ui interfaces. There is a companion PR to add it to the loan filters utilities in kv-ui-elements

![Screen Shot 2023-08-22 at 10 36 28 AM](https://github.com/kiva/ui/assets/4371888/313ff4c4-8e06-4580-b24c-64acf3c63fa1)
