### PR TITLE
feat: display flash messages for visitor in the tip message MARS-448

### DIFF
--- a/src/api/fixtures/FlashMessageTypeEnum.js
+++ b/src/api/fixtures/FlashMessageTypeEnum.js
@@ -1,0 +1,11 @@
+export const TIP = 'tip';
+export const WARNING = 'warning';
+export const ERROR = 'error';
+
+const FlashMessageTypeEnum = {
+	TIP,
+	WARNING,
+	ERROR,
+};
+
+export default FlashMessageTypeEnum;

--- a/src/components/WwwFrame/TheTipMessage.vue
+++ b/src/components/WwwFrame/TheTipMessage.vue
@@ -1,15 +1,52 @@
 <template>
 	<kv-toast
 		ref="tip"
-		@close="$closeTipMsg"
+		@close="closeCurrentMessage"
 		class="tw-fixed tw-top-9 md:tw-top-11 tw-left-0 tw-right-0 tw-z-banner"
 	/>
 </template>
 
 <script>
+import { captureException } from '@sentry/vue';
+import { gql } from '@apollo/client';
 import DOMPurify from 'dompurify';
+import { TIP, WARNING, ERROR } from '@/api/fixtures/FlashMessageTypeEnum';
 import tipMessageData from '@/graphql/query/tipMessage/tipMessageData.graphql';
 import KvToast from '~/@kiva/kv-components/vue/KvToast';
+
+// query for flash messages
+const flashMessageQuery = gql`
+	query flashMessage($visitorId: String!) {
+		tips: flashMessages(messageType: tip, visitorId: $visitorId) {
+			...flashMessage
+		}
+		warnings: flashMessages(messageType: warning, visitorId: $visitorId) {
+			...flashMessage
+		}
+		errors: flashMessages(messageType: error, visitorId: $visitorId) {
+			...flashMessage
+		}
+	}
+	fragment flashMessage on FlashMessage {
+		id
+		messageType
+		message
+	}
+`;
+
+// graphql mutation to clear all flash messages
+const clearFlashMessagesMutation = gql`
+	mutation clearFlashMessages($visitorId: String!) {
+		tips: clearFlashMessages(messageType: tip, visitorId: $visitorId)
+		warnings: clearFlashMessages(messageType: warning, visitorId: $visitorId)
+		errors: clearFlashMessages(messageType: error, visitorId: $visitorId)
+	}
+`;
+
+// order of levels
+const levels = [TIP, WARNING, ERROR];
+// compare levels of message types to determine which is more important to display
+const compareLevels = (a, b) => levels.indexOf(a) >= levels.indexOf(b);
 
 export default {
 	name: 'TheTipMessage',
@@ -21,37 +58,94 @@ export default {
 		query: tipMessageData,
 		preFetch: true,
 		result({ data }) {
-			if (this.$refs.tip) {
-				const showing = data?.tip?.visible ?? false;
-
-				if (showing) {
-					const message = data?.tip?.message ?? '';
-					this.safeMessage = DOMPurify.sanitize(message, { ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a'] });
-					this.messageType = data?.tip?.type ?? '';
-					this.persist = data?.tip?.persist ?? false;
-
-					this.$refs.tip.show(this.safeMessage, this.messageType, this.preventAutoDismiss);
-					this.initialPath = this.$route.path;
-				} else {
-					this.$refs.tip.close();
-				}
-			}
+			const showing = data?.tip?.visible ?? false;
+			this.tipMessage = showing ? data?.tip ?? null : null;
 		}
 	},
 	data() {
 		return {
-			safeMessage: '',
-			messageType: '',
-			persist: false,
-			initialPath: null
+			initialPath: null,
+			flashMessages: [],
+			tipMessage: null,
 		};
 	},
+	created() {
+		this.initialPath = this.$route.path;
+
+		// query for flash messages
+		this.apollo.query({
+			query: flashMessageQuery,
+			variables: {
+				visitorId: this.cookieStore.get('uiv'),
+			},
+		}).then(({ data }) => {
+			const tips = data?.tips ?? [];
+			const warnings = data?.warnings ?? [];
+			const errors = data?.errors ?? [];
+			this.flashMessages = [...errors, ...warnings, ...tips];
+		}).then(() => {
+			// clear all flash messages
+			return this.apollo.mutate({
+				mutation: clearFlashMessagesMutation,
+				variables: {
+					visitorId: this.cookieStore.get('uiv'),
+				},
+			});
+		}).catch(err => {
+			try {
+				console.error(err);
+				captureException(err);
+			} catch (e) {
+				// no-op
+			}
+		});
+	},
 	computed: {
-		preventAutoDismiss() {
-			return this.persist || this.messageType === 'error' || this.messageType === 'warning';
-		}
+		currentMessage() {
+			// return tip message if it's level is higher than first flash message, otherwise return first flash message
+			return this.tipMessage?.type && compareLevels(this.tipMessage.type, this.flashMessages[0]?.messageType)
+				? this.tipMessage
+				: this.flashMessages[0];
+		},
+		persist() {
+			const type = this.currentMessage?.type ?? this.currentMessage?.messageType ?? '';
+			return !!this.currentMessage?.persist || type === TIP || type === WARNING;
+		},
+	},
+	methods: {
+		showCurrentMessage() {
+			const message = this.currentMessage?.message ?? '';
+			const safeMessage = DOMPurify.sanitize(message, { ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a'] });
+			const type = this.currentMessage?.type ?? this.currentMessage?.messageType ?? '';
+			this.$refs.tip?.show(safeMessage, type, this.persist);
+		},
+		closeCurrentMessage() {
+			if (this.currentMessage) {
+				// close current message
+				if (this.currentMessage === this.tipMessage) {
+					this.$closeTipMsg();
+				} else {
+					this.flashMessages?.shift();
+				}
+				// show next message
+				if (this.flashMessages?.length) {
+					this.showCurrentMessage();
+				}
+			}
+		},
 	},
 	watch: {
+		// open and close the toast when the current message changes
+		currentMessage: {
+			handler(message) {
+				if (message) {
+					this.showCurrentMessage();
+				} else {
+					this.$refs.tip?.close();
+				}
+			},
+			immediate: true,
+		},
 		/*
 			Observe $route.path for changes
 			- This enables us to hide the tip message when you navigate to another ui server page
@@ -61,9 +155,9 @@ export default {
 		// eslint-disable-next-line object-shorthand
 		'$route.path'(to) {
 			if (to !== this.initialPath && this.persist !== true) {
-				this.$refs.tip.close();
+				this.$refs.tip?.close();
 			} else if (to === this.initialPath) {
-				this.$refs.tip.show(this.safeMessage, this.messageType, this.preventAutoDismiss);
+				this.showCurrentMessage();
 			}
 		},
 	}

--- a/src/components/WwwFrame/TheTipMessage.vue
+++ b/src/components/WwwFrame/TheTipMessage.vue
@@ -71,7 +71,8 @@ export default {
 	},
 	created() {
 		this.initialPath = this.$route.path;
-
+	},
+	mounted() {
 		// query for flash messages
 		this.apollo.query({
 			query: flashMessageQuery,

--- a/test/unit/specs/components/WwwFrame/TheTipMessage.spec.js
+++ b/test/unit/specs/components/WwwFrame/TheTipMessage.spec.js
@@ -1,0 +1,86 @@
+import { render } from '@testing-library/vue';
+import { TIP, WARNING, ERROR } from '@/api/fixtures/FlashMessageTypeEnum';
+import TheTipMessage from '@/components/WwwFrame/TheTipMessage';
+import CookieStore from '@/util/cookieStore';
+
+function renderTipMessage(tipMessage, flashMessages) {
+	return render(TheTipMessage, {
+		provide: {
+			apollo: {
+				query: () => Promise.resolve({ data: { ...flashMessages } || {} }),
+				mutate: () => Promise.resolve({}),
+			},
+			cookieStore: new CookieStore(),
+		},
+		mocks: {
+			$route: { path: '/' }
+		},
+		stubs: {
+			KvToast: {
+				template: '<div v-html="message"></div>',
+				data() {
+					return { message: '' };
+				},
+				methods: {
+					close: () => {},
+					show(message) {
+						this.message = message;
+					},
+				}
+			}
+		},
+		data: tipMessage ? () => {
+			return {
+				tipMessage: { ...tipMessage }
+			};
+		} : undefined,
+	});
+}
+
+const defaultFlashMessages = {
+	tips: [{ message: 'This is an info message', messageType: TIP }],
+	warnings: [{ message: 'This is a warning message', messageType: WARNING }],
+	errors: [{ message: 'This is an error message', messageType: ERROR }],
+};
+
+describe('TheTipMessage', () => {
+	// it displays the current tip message when there are no flash messages
+	it('displays the current tip message when there are no flash messages', async () => {
+		const tipMessage = { message: 'This is a tip message', type: TIP };
+		const { findByText } = renderTipMessage(tipMessage);
+
+		// Expect the tip message to be displayed
+		await findByText('This is a tip message');
+	});
+
+	// it display the highest priority flash message when there is no tip message
+	it('displays the highest priority flash message when there is no tip message', async () => {
+		const { findByText } = renderTipMessage(null, defaultFlashMessages);
+
+		// Expect the flash message to be displayed
+		await findByText('This is an error message');
+	});
+
+	// it displays nothing when there are no tip messages or flash messages
+	it('displays nothing when there are no tip messages or flash messages', async () => {
+		const { queryByText } = renderTipMessage();
+
+		// Expect nothing to be displayed
+		expect(queryByText('This is a tip message')).toBeNull();
+		expect(queryByText('This is an error message')).toBeNull();
+		expect(queryByText('This is a warning message')).toBeNull();
+		expect(queryByText('This is an info message')).toBeNull();
+	});
+
+	// it displays the highest priority tip or flash message when there are multiple messages and message types
+	it('displays the highest priority message when there are multiple messages and message types', async () => {
+		const tipMessage = { message: 'This is a tip message', type: WARNING };
+		const { findByText, queryByText } = renderTipMessage(tipMessage, defaultFlashMessages);
+
+		// Expect the first flash message to be displayed
+		await findByText('This is an error message');
+		expect(queryByText('This is a warning message')).toBeNull();
+		expect(queryByText('This is an info message')).toBeNull();
+		expect(queryByText('This is a tip message')).toBeNull();
+	});
+});


### PR DESCRIPTION
Checks for FlashMessages from the api while still using the TipMessage from the local resolver. Displays whichever has a higher level first (error being the highest, then warning, then tip), favoring the tipMessage in a tie. Displays the next available message after the current message is closed.