### PR TITLE
feat: [CP-477] disabling batching so we can shift traffic to the EKS cluster

### DIFF
--- a/deploy/dev/values.yaml
+++ b/deploy/dev/values.yaml
@@ -63,3 +63,5 @@ configmap:
     value: "dev"
   - key: NODE_OPTIONS
     value: "--max-old-space-size=460"
+  - key: APOLLO_BATCH
+    value: "false"


### PR DESCRIPTION
Let me know if this is not the right place to change. We're wanting to start proxying requests that are made to `*.dk1.kiva.org` to our EKS dev cluster, but ran into an issue with Apollo Router not supporting operation batching.