### PR TITLE
fix: ensure all assets get compressed before upload MARS-288

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -334,11 +334,16 @@ module.exports = {
 		})]),
 		...(isProd ? [
 			// gzip compression
-			new CompressionPlugin(),
+			new CompressionPlugin({
+				// Compress all assets for upload
+				minRatio: Infinity,
+			}),
 			// brotli compression
 			new CompressionPlugin({
 				filename: "[path][base].br",
 				algorithm: "brotliCompress",
+				// Compress all assets for upload
+				minRatio: Infinity,
 			}),
 		] : []),
 	]


### PR DESCRIPTION
Gzip version of some files was not being generated, which caused a 403/404 when trying to request them.

I discovered this in the description of [the `minRatio` option](https://webpack.js.org/plugins/compression-webpack-plugin/#minratio):

> Use a value of `Infinity` to process all assets even if they are larger than the original size or their original size is `0` bytes (**useful when you are pre-zipping all assets for AWS**).