### PR TITLE
fix: filter out unhanded google ads code request errors from sentry

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,12 @@ export default function createApp({
 				// make sentry colleted event easy to compare to
 				const eventAsString = JSON.stringify(event);
 				// match specific 3rd party events for exclusion
+				// Skip sending failed to fetch error caused by unhandled promise rejection in google ads
+				// Sentry Event Link: https://kiva.sentry.io/issues/4413252219/events/726c65f507684f43b748e913d4793518/
+				// This url is unreachable: https://pagead2.googlesyndication.com/pagead/buyside_topics/set/
+				if (eventAsString.indexOf('Failed to fetch') !== -1) {
+					return false;
+				}
 				// Skip sending failed loads of pX
 				// eslint-disable-next-line quotes
 				if (eventAsString.indexOf("Cannot set property 'PX1065' of undefined") !== -1) {

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,8 @@ export default function createApp({
 				// Skip sending failed to fetch error caused by unhandled promise rejection in google ads
 				// Sentry Event Link: https://kiva.sentry.io/issues/4413252219/events/726c65f507684f43b748e913d4793518/
 				// This url is unreachable: https://pagead2.googlesyndication.com/pagead/buyside_topics/set/
-				if (eventAsString.indexOf('Failed to fetch') !== -1) {
+				if (eventAsString.indexOf('Failed to fetch') !== -1
+					&& eventAsString.indexOf('pagead') !== -1) {
 					return false;
 				}
 				// Skip sending failed loads of pX


### PR DESCRIPTION
This should clear up the false alarms for UI checkout errors