### PR TITLE
fix: ensure icons are compressed and skip font compression MARS-288

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -5,7 +5,6 @@ const VueLoaderPlugin = require('vue-loader').VueLoaderPlugin;
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const FilterWarningsPlugin = require('webpack-filter-warnings-plugin');
 const webpack = require('webpack');
-const CompressionPlugin = require('compression-webpack-plugin');
 const GitRevisionPlugin = require('git-revision-webpack-plugin');
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin-fixed-hashbug');
 const gitRevisionPlugin = new GitRevisionPlugin({
@@ -332,19 +331,5 @@ module.exports = {
 				sizeThreshold: 500 * 1024 * 1024
 			}
 		})]),
-		...(isProd ? [
-			// gzip compression
-			new CompressionPlugin({
-				// Compress all assets for upload
-				minRatio: Infinity,
-			}),
-			// brotli compression
-			new CompressionPlugin({
-				filename: "[path][base].br",
-				algorithm: "brotliCompress",
-				// Compress all assets for upload
-				minRatio: Infinity,
-			}),
-		] : []),
 	]
 };

--- a/build/webpack.client.base.conf.js
+++ b/build/webpack.client.base.conf.js
@@ -1,11 +1,19 @@
 const { merge } = require('webpack-merge');
 var assetsPath = require('./assets-path');
 var baseWebpackConfig = require('./webpack.base.conf');
+var CompressionPlugin = require('compression-webpack-plugin');
 var SvgStorePlugin = require('webpack-svgstore-plugin');
 var VueSSRClientPlugin = require('vue-server-renderer/client-plugin');
 
 const HardSourceWebpackPlugin = require('hard-source-webpack-plugin-fixed-hashbug')
 const isProd = process.env.NODE_ENV === 'production';
+
+const compressionOptions = {
+	// Compress all assets for upload
+	minRatio: Infinity,
+	// Ignore fonts because they are already compressed
+	exclude: /\.woff|\.woff2|\.ttf|\.eot/,
+};
 
 module.exports = merge(baseWebpackConfig, {
 	entry: {
@@ -34,6 +42,19 @@ module.exports = merge(baseWebpackConfig, {
 			},
 			prefix: 'icon-',
 		}),
+		// file compression
+		...(isProd ? [
+			// gzip compression
+			new CompressionPlugin({
+				...compressionOptions,
+			}),
+			// brotli compression
+			new CompressionPlugin({
+				...compressionOptions,
+				filename: "[path][base].br",
+				algorithm: "brotliCompress",
+			}),
+		] : []),
 		...(isProd ? [] : [new HardSourceWebpackPlugin.ExcludeModulePlugin([
 			// Due to how some loaders emit assets, certain assets are not emitted
 			// on repeated builds with those loaders and hard-source together.


### PR DESCRIPTION
Moving the compression to after the svg plugin in client base so that it runs on the icons file as well, and runs a little faster b/c it's not compressing the files for the server build. I also found that the font files were *larger* after compression, so I'm excluding those.