### PR TITLE
feat: [CP-477] disabling batching so we can shift traffic to the EKS cluster

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -1,8 +1,11 @@
 const { merge } = require('webpack-merge');
 var base = require('./index.js')
 
+const apolloBatching = process.env.APOLLO_BATCH !== 'false';
+
 module.exports = merge(base, {
 	app: {
+		apolloBatching,
 		host: 'www.dev.kiva.org',
 		publicPath: 'https://www.dev.kiva.org/',
 		photoPath: 'https://www-dev-kiva-org.freetls.fastly.net/img/',


### PR DESCRIPTION
It looks like we're still seeing UI in dev make batched requests, which makes sense if this config is what is used by the ui pods serving `dev.kiva.org`