### PR TITLE
feat: support inviter param and recruitment on team process page

### DIFF
--- a/src/pages/ProcessJoinTeam.vue
+++ b/src/pages/ProcessJoinTeam.vue
@@ -162,8 +162,9 @@ export default {
 					mutation: joinTeam,
 					variables: {
 						team_id: this.teamId,
-						team_recruitment_id: this.recruitmentIdMutationVariable,
-						promo_id: this.promoId
+						...(this.recruitmentIdMutationVariable
+							&& { team_recruitment_id: this.recruitmentIdMutationVariable }),
+						...(this.promoId && { promo_id: this.promoId }),
 					}
 				});
 				// get updated team membership status to determine if joined or pending

--- a/src/pages/ProcessJoinTeam.vue
+++ b/src/pages/ProcessJoinTeam.vue
@@ -1,7 +1,7 @@
 <template>
 	<www-page>
 		<kv-page-container>
-			<kv-grid class="tw-grid-cols-12 tw-pt-3 md:tw-pt-5 lg:tw-pt-7 tw-mb-4 md:tw-mb-6">
+			<kv-grid class="tw-grid-cols-12 tw-pt-5 md:tw-pt-7 lg:tw-pt-9 tw-mb-4 md:tw-mb-6">
 				<div
 					class="tw-col-span-12 md:tw-col-start-3 md:tw-col-span-8"
 				>
@@ -11,7 +11,7 @@
 							<kv-loading-spinner class="tw-mt-2" />
 						</div>
 					</div>
-					<div v-else>
+					<div v-else class="tw-text-center">
 						<h2 v-if="isPending">
 							Your request to join the {{ teamName }} team is pending. Please check back later.
 						</h2>
@@ -42,11 +42,11 @@ import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import KvLoadingSpinner from '~/@kiva/kv-components/vue/KvLoadingSpinner';
 
-const userTeamMembership = gql`query userTeamMembership( $teamPublicId: String!) {
+const userTeamMembership = gql`query userTeamMembership( $teamPublicId: String!, $publicId: String!) {
 	my {
 		id
 		userAccount {
-		id
+			id
 		}
 	}
 	community {
@@ -56,6 +56,11 @@ const userTeamMembership = gql`query userTeamMembership( $teamPublicId: String!)
 				membershipStatus
 			}
 			name
+		}
+		lender(publicId: $publicId) {
+			id
+			name
+			publicId
 		}
 	}
 }`;
@@ -79,6 +84,11 @@ export default {
 			type: Number,
 			default: null
 		},
+		// the public name of the inviter user in the route query
+		inviter: {
+			type: String,
+			default: ''
+		},
 	},
 	components: {
 		KvLoadingSpinner,
@@ -93,17 +103,20 @@ export default {
 		preFetchVariables({ route }) {
 			return {
 				teamPublicId: route.query.teamPublicId,
+				publicId: route.query.inviter ?? '',
 			};
 		},
 		variables() {
 			return {
 				teamPublicId: this.teamPublicId,
+				publicId: this.inviter ?? '',
 			};
 		},
 		result({ data }) {
 			this.userMembershipStatus = data?.community?.team?.userProperties?.membershipStatus ?? 'none';
 			this.teamName = data?.community?.team?.name ?? '';
 			this.teamId = data?.community?.team?.id ?? 0;
+			this.inviterRecruitmentId = data?.community?.lender?.id ?? null;
 		}
 	},
 	data() {
@@ -111,6 +124,7 @@ export default {
 			userMembershipStatus: 'none',
 			isLoading: true,
 			teamName: '',
+			inviterRecruitmentId: null
 		};
 	},
 	computed: {
@@ -125,6 +139,16 @@ export default {
 			|| this.userMembershipStatus === 'recruited'
 			|| this.userMembershipStatus === 'recruitedByPromo';
 		},
+		recruitmentIdMutationVariable() {
+			// if teamRecruitmentId in the route query, use that value,
+			// otherwise, use the value we got from the apollo query
+			if (this.teamRecruitmentId) {
+				return this.teamRecruitmentId;
+			} if (this.inviter) {
+				return this.inviterRecruitmentId;
+			}
+			return null;
+		}
 	},
 	methods: {
 		memberRedirect() {
@@ -138,7 +162,7 @@ export default {
 					mutation: joinTeam,
 					variables: {
 						team_id: this.teamId,
-						team_recruitment_id: this.teamRecruitmentId,
+						team_recruitment_id: this.recruitmentIdMutationVariable,
 						promo_id: this.promoId
 					}
 				});
@@ -147,6 +171,7 @@ export default {
 					query: userTeamMembership,
 					variables: {
 						teamPublicId: this.teamPublicId,
+						publicId: this.inviter ?? '',
 					},
 					fetchPolicy: 'network-only'
 				});
@@ -176,6 +201,7 @@ export default {
 			this.handleJoinTeam();
 		} else {
 			// is member, redirect to doneUrl or team page
+			this.$showTipMsg('You are already a member of this team');
 			this.memberRedirect();
 		}
 	}

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -514,6 +514,7 @@ module.exports = [
 			teamRecruitmentId: Number(route.query.teamRecruitmentId),
 			teamPublicId: route.query.teamPublicId,
 			promoId: Number(route.query.promoId),
+			inviter: route.query.inviter
 		})
 	},
 	{


### PR DESCRIPTION
We can't generate an recruitmentId if the user is not logged in, so this page needs to also support the inviter query param. 

This allows us to go from un authenticated page > auth0 > team process page (with inviter param) 
Then we can use the inviter param to get the inviter id and pass that to the join team mutation as the recruitment id. 