### PR TITLE
feat: support all teams search params to/from url

### DIFF
--- a/src/pages/LendingTeams/TeamSearchBar.vue
+++ b/src/pages/LendingTeams/TeamSearchBar.vue
@@ -33,9 +33,15 @@ export default {
 		KvTextInput,
 	},
 	inject: ['apollo'],
+	props: {
+		initialValue: {
+			type: String,
+			default: ''
+		},
+	},
 	data() {
 		return {
-			queryString: '',
+			queryString: this.initialValue,
 		};
 	},
 	methods: {


### PR DESCRIPTION
Support all team search params to and from the url query for the `/teams-beta` page. Fixes paging and allows the url to hold all the values for a specific teams search

This page is now feature complete