### PR TITLE
feat: teams page additional features

### DIFF
--- a/src/graphql/query/leaderboardsQuery.graphql
+++ b/src/graphql/query/leaderboardsQuery.graphql
@@ -1,6 +1,6 @@
-query leaderboardsQuery {
+query leaderboardsQuery($category: TeamCategoryEnum) {
 	community {
-		leaderboards {
+		leaderboards(category: $category ) {
 			amountFunded {
 				lastMonth {
 					rank

--- a/src/pages/LendingTeams/TeamLeaderboard.vue
+++ b/src/pages/LendingTeams/TeamLeaderboard.vue
@@ -41,7 +41,17 @@
 					:key="timeFrame"
 					class="tw-border-primary"
 				>
+					<!-- loader and no teams -->
+					<span
+						class="tw-text-center tw-text-secondary tw-mb-2"
+						v-if="!isLoading && teamsToShow(timeFrame).length === 0"
+					>No teams to show</span>
+					<kv-loading-placeholder
+						v-if="isLoading"
+						class="tw-mb-2" :style="{width: '100%', height: '1.6rem'}"
+					/>
 					<div
+						v-else
 						v-for="leaderboardTeam in teamsToShow(timeFrame)"
 						:key="leaderboardTeam.team.id"
 						class="tw-text-small tw-rounded-sm tw-flex tw-flex-row tw-p-1"
@@ -117,10 +127,12 @@ import KvTab from '~/@kiva/kv-components/vue/KvTab';
 import KvTabPanel from '~/@kiva/kv-components/vue/KvTabPanel';
 import KvTabs from '~/@kiva/kv-components/vue/KvTabs';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
+import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 
 export default {
 	name: 'TeamLeaderboard',
 	components: {
+		KvLoadingPlaceholder,
 		KvProgressBar,
 		KvTabs,
 		KvTab,
@@ -132,10 +144,14 @@ export default {
 			teamNoImage,
 			isMobile: false,
 			expandTeams: false,
-			selectedTabIndex: 0
+			selectedTabIndex: 0,
 		};
 	},
 	props: {
+		isLoading: {
+			type: Boolean,
+			default: false,
+		},
 		boardType: {
 			type: String,
 			validator: value => ['memberCount', 'overallLoanedAmount'].includes(value),

--- a/src/pages/LendingTeams/TeamLeaderboards.vue
+++ b/src/pages/LendingTeams/TeamLeaderboards.vue
@@ -1,17 +1,30 @@
 <template>
 	<div class="tw-col-span-12 md:tw-col-span-4">
-		<h3 class="tw-mb-3">
+		<h3 class="tw-mb-0">
 			Team Leaderboards
 		</h3>
-		<team-leaderboard board-type="overallLoanedAmount" :board-teams="funded" />
-		<team-leaderboard board-type="memberCount" :board-teams="members" />
+		<p class="tw-text-small  tw-mb-2">
+			For {{ teamCategory ? teamCategoryFriendlyName(teamCategory) : 'all' }} teams
+		</p>
+		<team-leaderboard
+			board-type="overallLoanedAmount"
+			:board-teams="funded"
+			:team-category="teamCategory"
+			:is-loading="isLoading"
+		/>
+		<team-leaderboard
+			board-type="memberCount"
+			:board-teams="members"
+			:team-category="teamCategory"
+			:is-loading="isLoading"
+		/>
 	</div>
 </template>
 
 <script>
 
 import TeamLeaderboard from './TeamLeaderboard';
-import { fetchLeaderboard } from '../../util/teamsUtil';
+import { fetchLeaderboard, teamCategoryFriendlyName } from '../../util/teamsUtil';
 
 export default {
 	name: 'TeamLeaderboards',
@@ -23,13 +36,38 @@ export default {
 		return {
 			funded: {},
 			members: {},
+			teamCategory: '',
+			isLoading: true,
 		};
 	},
+	watch: {
+		'$route.query.teamCategory': {
+			handler(teamCategory) {
+				if (teamCategory !== '') {
+					this.teamCategory = teamCategory;
+					this.getLeaderboards();
+				}
+			},
+			deep: true,
+			immediate: true
+		}
+	},
+	methods: {
+		getLeaderboards() {
+			this.isLoading = true;
+			fetchLeaderboard(this.apollo, this.teamCategory)
+				.then(leaderboards => {
+					this.funded = leaderboards?.amountFunded ?? {};
+					this.members = leaderboards?.newUsers ?? {};
+				})
+				.finally(() => {
+					this.isLoading = false;
+				});
+		},
+		teamCategoryFriendlyName
+	},
 	mounted() {
-		fetchLeaderboard(this.apollo).then(leaderboards => {
-			this.funded = leaderboards?.amountFunded ?? {};
-			this.members = leaderboards?.newUsers ?? {};
-		});
+		this.getLeaderboards();
 	},
 };
 </script>

--- a/src/util/teamsUtil.js
+++ b/src/util/teamsUtil.js
@@ -1,6 +1,85 @@
 import teamsQuery from '@/graphql/query/teamsQuery.graphql';
 import leaderboardsQuery from '@/graphql/query/leaderboardsQuery.graphql';
 
+export const teamCategories = [
+	{
+		value: '',
+		label: '-- All Categories --',
+	},
+	{
+		value: 'AlumniGroups',
+		label: 'Alumni Groups',
+	},
+	{
+		value: 'Businesses',
+		label: 'Businesses',
+	},
+	{
+		value: 'BusinessesInternalGroups',
+		label: 'Business - Internal Groups',
+	},
+	{
+		value: 'Clubs',
+		label: 'Clubs',
+	},
+	{
+		value: 'CollegesUniversities',
+		label: 'Colleges/Universities',
+	},
+	{
+		value: 'CommonInterest',
+		label: 'Common Interest',
+	},
+	{
+		value: 'Events',
+		label: 'Events',
+	},
+	{
+		value: 'Families',
+		label: 'Families',
+	},
+	{
+		value: 'FieldPartnerFans',
+		label: 'Field Partner Fans',
+	},
+	{
+		value: 'Friends',
+		label: 'Friends',
+	},
+	{
+		value: 'LocalArea',
+		label: 'Local Area',
+	},
+	{
+		value: 'Memorials',
+		label: 'Memorials',
+	},
+	{
+		value: 'ReligiousCongregations',
+		label: 'Religious Congregations',
+	},
+	{
+		value: 'Schools',
+		label: 'Schools',
+	},
+	{
+		value: 'SportsGroups',
+		label: 'Sports Groups',
+	},
+	{
+		value: 'YouthGroups',
+		label: 'Youth Groups',
+	},
+	{
+		value: 'Other',
+		label: 'Other',
+	}
+];
+
+export function teamCategoryFriendlyName(categoryValue) {
+	return teamCategories.find(category => category.value === categoryValue)?.label;
+}
+
 /**
 * @param {Object} apollo, sortOption, category, membershipType, queryString, offset, limit
 */
@@ -24,10 +103,13 @@ export async function fetchTeams(apollo, sortOption, category, membershipType, q
 	}
 }
 
-export async function fetchLeaderboard(apollo) {
+export async function fetchLeaderboard(apollo, category) {
 	try {
 		const result = await apollo.query({
 			query: leaderboardsQuery,
+			variables: {
+				category: category || undefined,
+			},
 		});
 		return result.data?.community?.leaderboards;
 	} catch (e) {


### PR DESCRIPTION
Some additional features for the /teams page

* Leaderboards now change to filter on the category 
* Added info line indicating this. 
* Added placeholder loader while leaderboards load. 
* Added no teams to show when leaderboard query is empty
* Fixed some issues with query params not being removed when the "all" value is selected
* Added utility variable of team category values and friendly labels

<img width="1134" alt="Screenshot 2023-10-02 at 5 09 42 PM" src="https://github.com/kiva/ui/assets/4371888/d1fb9bf1-1e1a-44cb-82e8-6d0c1df34ab8">
