### PR TITLE
feat: prevent loading state while waiting for the post

### DIFF
--- a/src/pages/Portfolio/ImpactDashboard/EducationModule.vue
+++ b/src/pages/Portfolio/ImpactDashboard/EducationModule.vue
@@ -1,5 +1,5 @@
 <template>
-	<async-portfolio-section @visible="whenVisible" data-testid="education-module">
+	<async-portfolio-section data-testid="education-module">
 		<kv-grid class="tw-grid-cols-12 tw-items-center">
 			<div
 				class="tw-col-span-12 lg:tw-col-span-5 xl:tw-col-span-6 md:tw-items-start
@@ -17,14 +17,13 @@
 				</p>
 			</div>
 			<div class="tw-col-span-12 lg:tw-col-span-7 xl:tw-col-span-6">
-				<education-post :post="post" :loading="loading" />
+				<education-post :post="post" />
 			</div>
 		</kv-grid>
 	</async-portfolio-section>
 </template>
 
 <script>
-import { gql } from '@apollo/client';
 import AsyncPortfolioSection from './AsyncPortfolioSection';
 import KvGrid from '~/@kiva/kv-components/vue/KvGrid';
 import EducationPost from './EducationPost';
@@ -33,7 +32,12 @@ const imageRequire = require.context('@/assets/images/', true);
 
 export default {
 	name: 'EducationModule',
-	inject: ['apollo'],
+	props: {
+		post: {
+			type: Object,
+			default: null,
+		},
+	},
 	components: {
 		AsyncPortfolioSection,
 		EducationPost,
@@ -41,39 +45,8 @@ export default {
 	},
 	data() {
 		return {
-			loading: true,
-			loadingPromise: null,
-			post: null,
 			imageRequire,
 		};
-	},
-	methods: {
-		fetchAsyncData() {
-			if (this.loading && !this.loadingPromise) {
-				this.loadingPromise = this.apollo.query({
-					query: gql`query ContentfulBlogPosts (
-						$customFields: String,
-						$limit: Int
-					) {
-						contentful {
-							blogPosts: entries(contentType:"blogPost", customFields:$customFields, limit:$limit)
-						}
-					}`,
-					variables: {
-						customFields: 'metadata.tags.sys.id[in]=impact-page|order=-fields.originalPublishDate'
-					},
-				}).then(({ data }) => {
-					this.loading = false;
-					this.post = data?.contentful?.blogPosts?.items?.[0]?.fields ?? null;
-					this.$emit('hide-module', this.post === null);
-				}).finally(() => {
-					this.loadingPromise = null;
-				});
-			}
-		},
-		whenVisible() {
-			this.fetchAsyncData();
-		}
 	},
 };
 </script>

--- a/src/pages/Portfolio/ImpactDashboard/EducationPost.vue
+++ b/src/pages/Portfolio/ImpactDashboard/EducationPost.vue
@@ -1,7 +1,6 @@
 <template>
 	<div class="card-container">
 		<a
-			v-if="!loading"
 			:href="url"
 			class="card-container-link-image"
 			@click="trackEvent('blog-image')"
@@ -15,9 +14,7 @@
 				fallback-format="jpg"
 			/>
 		</a>
-		<kv-loading-placeholder v-else class="placeholder" :style="{ height: '16rem' }" />
 		<a
-			v-if="!loading"
 			:href="url"
 			@click="trackEvent('blog-headline')"
 			class="tw-text-h3 text-overflow tw-decoration-white tw-cursor-pointer"
@@ -25,36 +22,28 @@
 		>
 			{{ headline }}
 		</a>
-		<kv-loading-placeholder v-else class="placeholder" :style="{ height: '2rem' }" />
 		<p
-			v-if="!loading" class="text-overflow tw-mt-0.5"
+			class="text-overflow tw-mt-0.5"
 			:class="{ 'tw-line-clamp-3 md:tw-line-clamp-4' : truncateSummary }"
 		>
 			{{ summary }}
 		</p>
-		<kv-loading-placeholder v-else class="placeholder" :style="{ height: '2rem' }" />
 	</div>
 </template>
 
 <script>
 import KvContentfulImg from '~/@kiva/kv-components/vue/KvContentfulImg';
-import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
 
 export default {
 	name: 'EducationPost',
 	components: {
 		KvContentfulImg,
-		KvLoadingPlaceholder
 	},
 	props: {
 		post: {
 			type: Object,
 			default: () => {}
 		},
-		loading: {
-			type: Boolean,
-			default: false,
-		}
 	},
 	data() {
 		return {
@@ -145,9 +134,5 @@ export default {
 
 .text-overflow {
 	@apply tw-text-white tw-overflow-hidden tw-text-ellipsis;
-}
-
-.placeholder {
-	@apply tw-w-full tw-mb-2;
 }
 </style>


### PR DESCRIPTION
In the past implementation, the module was still appearing while fetching the post and then disappeared if no posts were found. 

With this implementation the page will decide to show or not the whole education module, instead of the module.

The downside of this is that we will have to make an api call even if the module is not visible.