### PR TITLE
feat: introspection queries passed to a new query file

### DIFF
--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -328,7 +328,7 @@ export default {
 		resetFilters() {
 			this.$emit('reset-filters');
 			this.selectedCategory = 0;
-			this.selectedGender = '';
+			this.selectedGender = 'all';
 			this.selectedGenders = ['all'];
 			this.sortBy = this.defaultSort;
 			this.updateLocation([]);

--- a/src/graphql/query/loanEnumsQuery.graphql
+++ b/src/graphql/query/loanEnumsQuery.graphql
@@ -1,0 +1,22 @@
+query loanEnums {
+	genderOptions: __type(name: "GenderEnum") {
+		enumValues {
+			name
+		}
+	}
+	standardSorts: __type(name: "LoanSearchSortByEnum") {
+		enumValues {
+			name
+		}
+	}
+	flssSorts: __type(name: "SortEnum") {
+		enumValues {
+			name
+		}
+	}
+	distributionModelOptions: __type(name: "LoanDistributionModelEnum") {
+		enumValues {
+			name
+		}
+	}
+}

--- a/src/graphql/query/loanFacetsQuery.graphql
+++ b/src/graphql/query/loanFacetsQuery.graphql
@@ -32,24 +32,4 @@ query loanFacets {
 			}
 		}
 	}
-	genderOptions: __type(name: "GenderEnum") {
-		enumValues {
-			name
-		}
-	}
-	standardSorts: __type(name: "LoanSearchSortByEnum") {
-		enumValues {
-			name
-		}
-	}
-	flssSorts: __type(name: "SortEnum") {
-		enumValues {
-			name
-		}
-	}
-	distributionModelOptions: __type(name: "LoanDistributionModelEnum") {
-		enumValues {
-			name
-		}
-	}
 }

--- a/src/util/loanSearch/dataUtils.js
+++ b/src/util/loanSearch/dataUtils.js
@@ -1,4 +1,5 @@
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
+import loanEnumsQuery from '@/graphql/query/loanEnumsQuery.graphql';
 import {
 	fetchFacets,
 	fetchLoans,
@@ -61,13 +62,14 @@ export async function runLoansQuery(apollo, loanSearchState, origin) {
 export async function fetchLoanFacets(apollo) {
 	try {
 		const result = await apollo.query({ query: loanFacetsQuery, fetchPolicy: 'network-only' });
+		const resultEnums = await apollo.query({ query: loanEnumsQuery, fetchPolicy: 'network-only' });
 
 		const countryFacets = result.data?.lend?.countryFacets ?? [];
 		const sectorFacets = result.data?.lend?.sector ?? [];
 		const themeFacets = result.data?.lend?.loanThemeFilter ?? [];
 		const tagFacets = result.data?.lend?.tag ?? [];
-		const genderFacets = result.data?.genderOptions?.enumValues ?? [];
-		const distributionModelFacets = result.data?.distributionModelOptions?.enumValues ?? [];
+		const genderFacets = resultEnums.data?.genderOptions?.enumValues ?? [];
+		const distributionModelFacets = resultEnums.data?.distributionModelOptions?.enumValues ?? [];
 		const partnerFacets = result.data?.general?.partners?.values ?? [];
 
 		return {
@@ -85,8 +87,8 @@ export async function fetchLoanFacets(apollo) {
 			tagNames: tagFacets.map(t => t.name.toUpperCase()),
 			genderFacets,
 			genders: genderFacets.map(g => g.name.toUpperCase()),
-			flssSorts: result.data?.flssSorts?.enumValues ?? [],
-			standardSorts: result.data?.standardSorts?.enumValues ?? [],
+			flssSorts: resultEnums.data?.flssSorts?.enumValues ?? [],
+			standardSorts: resultEnums.data?.standardSorts?.enumValues ?? [],
 			distributionModelFacets,
 			distributionModels: distributionModelFacets.map(d => d.name.toUpperCase()),
 			partnerFacets,

--- a/src/util/loanSearch/dataUtils.js
+++ b/src/util/loanSearch/dataUtils.js
@@ -61,16 +61,18 @@ export async function runLoansQuery(apollo, loanSearchState, origin) {
  */
 export async function fetchLoanFacets(apollo) {
 	try {
-		const result = await apollo.query({ query: loanFacetsQuery, fetchPolicy: 'network-only' });
-		const resultEnums = await apollo.query({ query: loanEnumsQuery, fetchPolicy: 'network-only' });
+		const [resultFacets, resultEnums] = await Promise.all([
+			apollo.query({ query: loanFacetsQuery, fetchPolicy: 'network-only' }),
+			apollo.query({ query: loanEnumsQuery, fetchPolicy: 'network-only' })
+		]);
 
-		const countryFacets = result.data?.lend?.countryFacets ?? [];
-		const sectorFacets = result.data?.lend?.sector ?? [];
-		const themeFacets = result.data?.lend?.loanThemeFilter ?? [];
-		const tagFacets = result.data?.lend?.tag ?? [];
+		const countryFacets = resultFacets.data?.lend?.countryFacets ?? [];
+		const sectorFacets = resultFacets.data?.lend?.sector ?? [];
+		const themeFacets = resultFacets.data?.lend?.loanThemeFilter ?? [];
+		const tagFacets = resultFacets.data?.lend?.tag ?? [];
 		const genderFacets = resultEnums.data?.genderOptions?.enumValues ?? [];
 		const distributionModelFacets = resultEnums.data?.distributionModelOptions?.enumValues ?? [];
-		const partnerFacets = result.data?.general?.partners?.values ?? [];
+		const partnerFacets = resultFacets.data?.general?.partners?.values ?? [];
 
 		return {
 			countryFacets,

--- a/test/unit/specs/util/loanSearch/dataUtils.spec.js
+++ b/test/unit/specs/util/loanSearch/dataUtils.spec.js
@@ -1,6 +1,7 @@
 import { runFacetsQueries, runLoansQuery, fetchLoanFacets } from '@/util/loanSearch/dataUtils';
 import * as flssUtils from '@/util/flssUtils';
 import loanFacetsQuery from '@/graphql/query/loanFacetsQuery.graphql';
+import loanEnumsQuery from '@/graphql/query/loanEnumsQuery.graphql';
 import { getFlssFilters, FLSS_ORIGIN_NOT_SPECIFIED } from '@/util/flssUtils';
 import { mockState } from '../../../fixtures/mockLoanSearchData';
 
@@ -144,6 +145,8 @@ describe('dataUtils.js', () => {
 			await fetchLoanFacets(apollo);
 			const apolloVariables = { query: loanFacetsQuery, fetchPolicy: 'network-only' };
 			expect(apollo.query).toHaveBeenCalledWith(apolloVariables);
+			const apolloEnumsVariables = { query: loanEnumsQuery, fetchPolicy: 'network-only' };
+			expect(apollo.query).toHaveBeenCalledWith(apolloEnumsVariables);
 		});
 
 		it('should handle undefined', async () => {


### PR DESCRIPTION
- Introspection queries passed to a new query file for filtering options.
- Genders bug fixed in quick filters when resetting selected filters. We are currently showing no option selected in gender dropdown after resetting the filters.
- Updates tested in `/lend/filter`, `/lend-by-category` and `/lend-by-category/*` pages

<img width="196" alt="Screenshot 2023-10-10 at 12 27 47" src="https://github.com/kiva/ui/assets/94026278/3bcaf2a2-0e15-4943-9266-f0d7742042eb">
