### PR TITLE
fix: [CP-603] Pass kiva-robot token when checking out repo

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          token: ${{ secrets.KIVA_ROBOT_GITHUB_PAT }}
       - name: checkout-actions
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Read the docs more closely and realized it said we should pass the token when checking out the repo 🤦🏻‍♀️ 

https://github.com/stefanzweifel/git-auto-commit-action/tree/v4#commits-made-by-this-action-do-not-trigger-new-workflow-runs