### PR TITLE
fix: add surrogate keys for ui assets

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -50,6 +50,7 @@ function setHeaders(res, path) {
 		res.header('Access-Control-Allow-Origin', `https://${config.app.host}`);
 	}
 	res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+	res.header('Surrogate-Key', 'ui-all ui-static all-assets');
 }
 
 app.use('/static', express.static('dist/static', {


### PR DESCRIPTION
Adds surrogate keys for Ui assets along with the `all-assets` key. We don't currently cache pages out of ui but if there are other surrogate keys you think we should add, let me know!