### PR TITLE
fix: reduce checkout query complexity

### DIFF
--- a/config/dev-local.js
+++ b/config/dev-local.js
@@ -7,7 +7,7 @@ module.exports = merge(base, devVm, {
 		apolloBatching: false,
 		host: 'localhost',
 		publicPath: '/',
-		photoPath: 'https://www-dev-kiva-org.freetls.fastly.net/img/',
+		photoPath: 'https://www.development.kiva.org/img/',
 		graphqlUri: 'https://gateway.development.kiva.org/graphql',
 		enableAnalytics: false,
 		enableSnowplow: false,
@@ -23,6 +23,7 @@ module.exports = merge(base, devVm, {
 			enable: true,
 			browserCallbackUri: 'http://localhost:8888/process-browser-auth',
 			serverCallbackUri: 'http://localhost:8888/process-ssr-auth',
+			apiAudience: 'https://api.development.kiva.org/graphql',
 		},
 	},
 	server: {

--- a/src/graphql/query/checkout/checkoutSettings.graphql
+++ b/src/graphql/query/checkout/checkoutSettings.graphql
@@ -4,6 +4,18 @@ query checkoutSettings($basketId: String) {
 			value
 			key
 		}
+		ftd_message_enable: uiConfigSetting(key: "ftd_message_enable") {
+			key
+			value
+		}
+		ftd_message_amount: uiConfigSetting(key: "ftd_message_amount") {
+			key
+			value
+		}
+		ftd_message_valid_date: uiConfigSetting(key: "ftd_message_valid_date") {
+			key
+			value
+		}
 	}
 	shop (basketId: $basketId) {
 		id

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -34,18 +34,6 @@ query initializeCheckout($basketId: String) {
 			value
 			description
 		}
-		ftd_message_enable: uiConfigSetting(key: "ftd_message_enable") {
-			key
-			value
-		}
-		ftd_message_amount: uiConfigSetting(key: "ftd_message_amount") {
-			key
-			value
-		}
-		ftd_message_valid_date: uiConfigSetting(key: "ftd_message_valid_date") {
-			key
-			value
-		}
 	}
 	shop (basketId: $basketId) {
 		id

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -523,6 +523,14 @@ export default {
 		const validationErrors = _get(shopMutationData, 'validatePreCheckout', []);
 		this.showCheckoutError(validationErrors, true);
 
+		// Fire error for empty shop state
+		if (!this.isServer && !this.totals) {
+			Sentry.withScope(scope => {
+				scope.setTag('init_checkout', 'Missing baseline basket information');
+				Sentry.captureMessage(`Missing baseline basket information; totals value is ${this.totals}.`);
+			});
+		}
+
 		// TODO: Implement check against contentful setting
 		// to signify if holiday mode is enabled
 


### PR DESCRIPTION
- Move the new ftd settings to a different query
- Add Sentry log for missing totals data. One key component of critical basket data.
- - Looks like our current apollo prefetch handler is not returning the `errors` out of the collected set of queries so a check at that level will need additional work.