### PR TITLE
feat: ability to attribute a loan to a team from cookie value

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -225,6 +225,13 @@ export default {
 					this.forceTeamId = loan.teamId;
 				}
 			});
+			// Remove this loan from the cookie object after we've used it
+			teamChallengeLoanData.splice(
+				teamChallengeLoanData.findIndex(loan => loan.loanId === this.loan.id),
+				1
+			);
+			// overwrite the cookie with the new data
+			this.cookieStore.set(teamChallengeCookieName, JSON.stringify(teamChallengeLoanData));
 		}
 	}
 };


### PR DESCRIPTION
We want the ability for a guest or logged in user to attribute a loan to a team from the challenge page. They may not be part of that team, and they may or may not be logged in at the time they add the loan to their basket

1. User goes to team challenge page, adds a loan to basket, cookie is created (Not in this PR, this will be on cps)
2. User eventually arrives at checkout. 
3. Read cookie 
4. Set the teamId on the loan reservation by calling the `updateLoanReservationTeam` mutation. 
5. If the user is not part of the team, append the team name and id to the drop down, user can manually change the attribution at this point. 
6. Checkout --> user will attribute loan to team and contribute to the challenge even if they are not part of the team. 

I have verified that you can in fact checkout with a loan attributed to a team you do not belong to. 