### PR TITLE
fix: remove unnecessary package, reduce origins to only our domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@kiva/kv-components": "^3.47.0",
 				"@kiva/kv-tokens": "^2.7.0",
 				"@mdi/js": "^7",
-				"@sentry/browser": "^7.87.0",
 				"@sentry/vue": "^7.87.0",
 				"@vue/composition-api": "^1.4.6",
 				"algoliasearch": "^3.34.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
 		"@kiva/kv-components": "^3.47.0",
 		"@kiva/kv-tokens": "^2.7.0",
 		"@mdi/js": "^7",
-		"@sentry/browser": "^7.87.0",
 		"@sentry/vue": "^7.87.0",
 		"@vue/composition-api": "^1.4.6",
 		"algoliasearch": "^3.34.0",

--- a/src/main.js
+++ b/src/main.js
@@ -3,7 +3,6 @@
 import Vue from 'vue';
 import VueCompositionAPI from '@vue/composition-api';
 import * as Sentry from '@sentry/vue';
-import { BrowserTracing } from '@sentry/browser';
 import Meta from 'vue-meta';
 import VueProgressBar from 'vue-progressbar';
 import Vue2TouchEvents from 'vue2-touch-events';
@@ -71,9 +70,9 @@ export default function createApp({
 			trackComponents: true,
 			dsn: appConfig.sentryURI,
 			integrations: [
-				new BrowserTracing({
+				new Sentry.BrowserTracing({
 					routingInstrumentation: Sentry.vueRouterInstrumentation(router),
-					tracingOrigins: ['localhost', appConfig.host, /^\//],
+					tracingOrigins: [appConfig.host],
 				}),
 			],
 			release: UI_TAG,


### PR DESCRIPTION
Verified the library update is working in Dev, webvitals emanate from Tracing and there are now some in the dashboard.

Minor tweaks
- increase sampling span to 25% which will cascade to prod in the next release, I'll also add these to flux and plan to turn dev up to 100%
- remove localhost and regex match on host
- remove unnecessary package!