### PR TITLE
feat: use worker threads for vue app and sitemap rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,8 @@
 				"web-vitals": "^2.1.4",
 				"webpack-merge": "^5.8.0",
 				"whatwg-fetch": "^3.6.2",
-				"winston": "^3.3.3"
+				"winston": "^3.3.3",
+				"workerpool": "^9.0.4"
 			},
 			"devDependencies": {
 				"@babel/core": "^7.15.5",
@@ -29035,6 +29036,13 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/mocha/node_modules/workerpool": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+			"integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/mocha/node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -41183,11 +41191,9 @@
 			}
 		},
 		"node_modules/workerpool": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-			"integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-			"dev": true,
-			"peer": true
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.0.4.tgz",
+			"integrity": "sha512-EDeF5re9hGJ88HH2vYDuvG0rV3+I0hlP+9lLQYYzXykW0kjDGyuw21vR1rRWUqNy9x+o5yPlqmyzpHvELzhyeQ=="
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
@@ -63875,6 +63881,13 @@
 						"has-flag": "^4.0.0"
 					}
 				},
+				"workerpool": {
+					"version": "6.2.1",
+					"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+					"integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+					"dev": true,
+					"peer": true
+				},
 				"y18n": {
 					"version": "5.0.8",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -73323,11 +73336,9 @@
 			}
 		},
 		"workerpool": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-			"integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-			"dev": true,
-			"peer": true
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.0.4.tgz",
+			"integrity": "sha512-EDeF5re9hGJ88HH2vYDuvG0rV3+I0hlP+9lLQYYzXykW0kjDGyuw21vR1rRWUqNy9x+o5yPlqmyzpHvELzhyeQ=="
 		},
 		"wrap-ansi": {
 			"version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
 		"web-vitals": "^2.1.4",
 		"webpack-merge": "^5.8.0",
 		"whatwg-fetch": "^3.6.2",
-		"winston": "^3.3.3"
+		"winston": "^3.3.3",
+		"workerpool": "^9.0.4"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.15.5",

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -14,13 +14,14 @@ const webpack = require('webpack');
 const webpackDevMiddleware = require('webpack-dev-middleware');
 const webpackHotMiddleware = require('webpack-hot-middleware');
 const threadLoader = require('thread-loader');
-const promBundle = require("express-prom-bundle");
+const promBundle = require('express-prom-bundle');
+
 const metricsMiddleware = promBundle({
-    includeMethod: true,
-    includePath: true,
-    includeStatusCode: true,
-    includeUp: true,
-    promClient: {
+	includeMethod: true,
+	includePath: true,
+	includeStatusCode: true,
+	includeUp: true,
+	promClient: {
 		collectDefaultMetrics: {}
 	}
 });
@@ -40,7 +41,7 @@ const config = require('../config/selectConfig')(argv.config || 'local');
 const initCache = require('./util/initCache');
 const logger = require('./util/errorLogger');
 
-// Initialize a Cache instance, Should Only be called once!
+// Initialize a Cache instance
 const cache = initCache(config.server);
 
 // app init
@@ -112,7 +113,6 @@ const updateHandler = () => {
 			clientManifest,
 			serverBundle,
 			config,
-			cache,
 		});
 		resolveHandlerReady();
 	}
@@ -162,7 +162,7 @@ app.use(locale(config.app.locale.supported, config.app.locale.default));
 app.use('/ui-routes', serverRoutes);
 
 // Apply sitemap middleware to expose routes we want search engine crawlers to see
-app.use('/sitemaps/ui.xml', sitemapMiddleware(config.app, cache));
+app.use('/sitemaps/ui.xml', sitemapMiddleware(config.app, config.server));
 
 // Handle time sychronization requests
 app.use('/', timesyncRouter());

--- a/server/index.js
+++ b/server/index.js
@@ -34,7 +34,7 @@ const metricsMiddleware = promBundle({
 // Initialize tracing
 require('./util/ddTrace');
 
-// Initialize a Cache instance, Should Only be called once!
+// Initialize a Cache instance
 const cache = initCache(config.server);
 
 const app = express();
@@ -83,7 +83,7 @@ app.use(locale(config.app.locale.supported, config.app.locale.default));
 app.use('/ui-routes', serverRoutes);
 
 // Apply sitemap middleware to expose routes we want search engine crawlers to see
-app.use('/sitemaps/ui.xml', sitemapMiddleware(config.app, cache));
+app.use('/sitemaps/ui.xml', sitemapMiddleware(config.app, config.server));
 
 // Handle time sychronization requests
 app.use('/', timesyncRouter());
@@ -103,7 +103,6 @@ app.use(vueMiddleware({
 	serverBundle,
 	clientManifest,
 	config,
-	cache,
 }));
 
 // Setup Request Error Logger

--- a/server/sitemap/middleware.js
+++ b/server/sitemap/middleware.js
@@ -1,68 +1,42 @@
-const memJsUtils = require('../util/memJsUtils');
+const path = require('path');
+const { Worker } = require('worker_threads');
 const { info } = require('../util/log');
-const generators = require('./generators');
 
 // Length of time that sitemap is cached in memcache, CDNs, and browsers
 const CACHE_TTL = 60 * 60; // 1 hour (seconds)
 
-// Generate route list from scratch by invoking all generators in ./generators
-async function generateRoutes() {
-	// invoke all generators
-	const invokedGenerators = Object.keys(generators).map(name => {
-		info(`Sitemap: invoking ${name} generator`);
-		return generators[name]();
-	});
-	// wait for generators to complete
-	const results = await Promise.all(invokedGenerators);
-	// remove duplicate routes
-	const uniqueResults = [...new Set(results.flat())];
-	// return sorted routes
-	return uniqueResults.sort();
-}
-
-// Create sitemap, using <host> for all url hostnames
-async function createSitemap(host) {
-	// include xml sitemap header
-	let sitemap = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-
-	// add absolute URL for each route to the sitemap
-	const routes = await generateRoutes();
-	routes.forEach(route => {
-		sitemap += `<url><loc>https://${host}${route}</loc></url>`;
-	});
-
-	// include sitemap footer
-	sitemap += '</urlset>';
-
-	return sitemap;
-}
-
-// Get the sitemap for a given <config>
-async function getSitemap(appConfig, cache) {
-	const { host } = appConfig;
-
-	// check for & return cached version
-	const cacheKey = `ui-xml-sitemap-${host}`;
-	const sitemapFromCache = await memJsUtils.getFromCache(cacheKey, cache);
-	if (sitemapFromCache) {
-		info(`Sitemap: returning cached sitemap ${cacheKey}`, { sitemapFromCache });
-		return sitemapFromCache;
-	}
-
-	// otherwise create sitemap and cache it
-	const sitemap = await createSitemap(host);
-	info(`Sitemap: caching sitemap ${cacheKey}`, { sitemap });
-	await memJsUtils.setToCache(cacheKey, sitemap, CACHE_TTL, cache);
-	return sitemap;
-}
-
 // Sitemap middleware
-module.exports = function sitemapMiddleware(appConfig, cache) {
+module.exports = function sitemapMiddleware(appConfig, serverConfig) {
 	return (req, res, next) => {
-		getSitemap(appConfig, cache).then(sitemap => {
+		// Create worker thread to generate sitemap
+		const worker = new Worker(path.resolve(__dirname, 'worker.js'), {
+			workerData: {
+				appConfig,
+				serverConfig,
+				CACHE_TTL
+			},
+		});
+
+		// Send error or sitemap to client
+		worker.on('message', ({ error, sitemap }) => {
+			if (error) {
+				return next(error);
+			}
 			res.setHeader('Content-Type', 'application/xml');
 			res.setHeader('Cache-Control', `public, max-age=${CACHE_TTL};`);
 			res.send(sitemap);
-		}).catch(err => next(err));
+		});
+
+		// Handle errors from worker
+		worker.on('error', err => {
+			next(err);
+		});
+
+		// Handle worker exit
+		worker.on('exit', code => {
+			if (code !== 0) {
+				info(`Sitemap: worker stopped with exit code ${code}`);
+			}
+		});
 	};
 };

--- a/server/sitemap/worker.js
+++ b/server/sitemap/worker.js
@@ -1,0 +1,67 @@
+const { parentPort, workerData } = require('worker_threads');
+const initCache = require('../util/initCache');
+const { info } = require('../util/log');
+const memJsUtils = require('../util/memJsUtils');
+const generators = require('./generators');
+
+const {
+	appConfig,
+	serverConfig,
+	CACHE_TTL,
+} = workerData;
+
+const cache = initCache(serverConfig);
+
+// Generate route list from scratch by invoking all generators in ./generators
+async function generateRoutes() {
+	// invoke all generators
+	const invokedGenerators = Object.keys(generators).map(name => {
+		info(`Sitemap: invoking ${name} generator`);
+		return generators[name]();
+	});
+	// wait for generators to complete
+	const results = await Promise.all(invokedGenerators);
+	// remove duplicate routes
+	const uniqueResults = [...new Set(results.flat())];
+	// return sorted routes
+	return uniqueResults.sort();
+}
+
+// Create sitemap, using <host> for all url hostnames
+async function createSitemap(host) {
+	// include xml sitemap header
+	let sitemap = '<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+
+	// add absolute URL for each route to the sitemap
+	const routes = await generateRoutes();
+	routes.forEach(route => {
+		sitemap += `<url><loc>https://${host}${route}</loc></url>`;
+	});
+
+	// include sitemap footer
+	sitemap += '</urlset>';
+
+	return sitemap;
+}
+
+// Get the sitemap for a given <config>
+async function getSitemap() {
+	const { host } = appConfig;
+
+	// check for & return cached version
+	const cacheKey = `ui-xml-sitemap-${host}`;
+	const sitemapFromCache = await memJsUtils.getFromCache(cacheKey, cache);
+	if (sitemapFromCache) {
+		info(`Sitemap: returning cached sitemap ${cacheKey}`, { sitemapFromCache });
+		parentPort.postMessage({ sitemap: sitemapFromCache });
+		return;
+	}
+
+	// otherwise create sitemap and cache it
+	const sitemap = await createSitemap(host);
+	info(`Sitemap: caching sitemap ${cacheKey}`, { sitemap });
+	await memJsUtils.setToCache(cacheKey, sitemap, CACHE_TTL, cache);
+	parentPort.postMessage({ sitemap });
+}
+
+getSitemap();

--- a/server/util/initCache.js
+++ b/server/util/initCache.js
@@ -31,18 +31,27 @@ function FakeMemcached(options) {
 	return lru;
 }
 
+let cache;
+
 module.exports = function initCache(config) {
+	// Return existing cache if already initialized
+	if (cache) {
+		return cache;
+	}
+
 	if (config.memcachedEnabled && config.memcachedServers.length) {
 		// Create a memcached connection
 		// eslint-disable-next-line new-cap
-		return new memjs.Client.create(config.memcachedServers, {
+		cache = new memjs.Client.create(config.memcachedServers, {
 			failover: true,
 			timeout: 1,
 			keepAlive: true,
 		});
+		return cache;
 	}
 	// Create a simple local-memory cache
-	return FakeMemcached({
+	cache = FakeMemcached({
 		max: 1000
 	});
+	return cache;
 };

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const { SHARE_ENV } = require('worker_threads');
-const workerpool = require('workerpool');
 const Bowser = require('bowser');
 const cookie = require('cookie');
+const vueWorkerPool = require('./vue-worker-pool.js');
 const protectedRoutes = require('./util/protectedRoutes.js');
 const tracer = require('./util/ddTrace');
 
@@ -41,17 +40,11 @@ module.exports = function createMiddleware({
 	clientManifest.publicPath = config.app.publicPath || '/';
 
 	// Create a worker pool to render the app
-	const pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
-		workerType: 'thread',
-		workerThreadOpts: {
-			workerData: {
-				clientManifest,
-				serverBundle,
-				serverConfig: config.server,
-				template,
-			},
-			env: SHARE_ENV,
-		},
+	const pool = vueWorkerPool({
+		clientManifest,
+		serverBundle,
+		serverConfig: config.server,
+		template,
 	});
 
 	function middleware(req, res, next) {

--- a/server/vue-worker-pool.js
+++ b/server/vue-worker-pool.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-new */
+
+const path = require('path');
+const { SHARE_ENV } = require('worker_threads');
+const workerpool = require('workerpool');
+const promClient = require('prom-client');
+
+module.exports = function createWorkerPool(workerData) {
+	// Create pool of worker threads for Vue rendering
+	const pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
+		workerType: 'thread',
+		workerThreadOpts: {
+			workerData,
+			env: SHARE_ENV,
+		},
+	});
+
+	// Track worker pool metrics
+	new promClient.Gauge({
+		name: 'vue_total_workers',
+		help: 'Total number of vue worker threads, both busy and idle',
+		collect() {
+			this.set(pool.stats().totalWorkers);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_idle_workers',
+		help: 'Number of idle vue worker threads',
+		collect() {
+			this.set(pool.stats().idleWorkers);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_busy_workers',
+		help: 'Number of busy vue worker threads',
+		collect() {
+			this.set(pool.stats().busyWorkers);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_pending_tasks',
+		help: 'Total number of pending tasks in the vue worker pool',
+		collect() {
+			this.set(pool.stats().pendingTasks);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_active_tasks',
+		help: 'Total number of active tasks in the vue worker pool',
+		collect() {
+			this.set(pool.stats().activeTasks);
+		}
+	});
+
+	return pool;
+};

--- a/server/vue-worker.js
+++ b/server/vue-worker.js
@@ -1,5 +1,6 @@
-const { parentPort, workerData } = require('worker_threads');
 const { createBundleRenderer } = require('vue-server-renderer');
+const { workerData } = require('worker_threads');
+const workerpool = require('workerpool');
 const initCache = require('./util/initCache');
 const log = require('./util/log');
 const vueSsrCache = require('./util/vueSsrCache');
@@ -8,14 +9,12 @@ const getSessionCookies = require('./util/getSessionCookies');
 
 const {
 	clientManifest,
-	context,
 	serverBundle,
 	serverConfig,
 	template,
 } = workerData;
 
 const isProd = process.env.NODE_ENV === 'production';
-const s = Date.now();
 const cache = initCache(serverConfig);
 
 // create a new renderer instance
@@ -29,52 +28,64 @@ const renderer = createBundleRenderer(serverBundle, {
 	shouldPrefetch: () => false,
 });
 
-// get graphql api possible types for the graphql client
-const typesPromise = getGqlPossibleTypes(serverConfig.graphqlUri, cache)
-	.finally(() => {
-		if (!isProd) {
-			log.info(`fragment fetch: ${Date.now() - s}ms`);
-		}
-	});
+async function render(context) {
+	const s = Date.now();
 
-// fetch initial session cookies in case starting session with this request
-const cookiePromise = getSessionCookies(serverConfig.sessionUri, context.cookies)
-	.finally(() => {
-		if (!isProd) {
-			log.info(`session fetch: ${Date.now() - s}ms`);
-		}
-	});
-
-const setCookies = [];
-
-Promise.all([typesPromise, cookiePromise])
-	.then(([types, cookieInfo]) => {
-		// add fetched types to rendering context
-		context.config.graphqlPossibleTypes = types;
-		// update cookies in the rendering context with any newly fetched session cookies
-		context.cookies = Object.assign(context.cookies, cookieInfo.cookies);
-		// forward any newly fetched 'Set-Cookie' headers
-		context.setCookies = [...cookieInfo.setCookies];
-		// render the app
-		return renderer.renderToString(context);
-	}).then(html => {
-		// collect any cookies created during the app render
-		setCookies.concat(context.setCookies);
-		// send the final rendered html
-		parentPort.postMessage({
-			html,
-			setCookies,
+	// get graphql api possible types for the graphql client
+	const typesPromise = getGqlPossibleTypes(serverConfig.graphqlUri, cache)
+		.finally(() => {
+			if (!isProd) {
+				log.info(`fragment fetch: ${Date.now() - s}ms`);
+			}
 		});
-		if (!isProd) {
-			log.info(`whole request: ${Date.now() - s}ms`);
-		}
-	}).catch(err => {
-		// collect any cookies created during the app render
-		setCookies.concat(context.setCookies);
-		// send the error
-		parentPort.postMessage({
-			error: err,
-			// only send cookies if there is a redirect url
-			setCookies: err.url ? setCookies : [],
+
+	// fetch initial session cookies in case starting session with this request
+	const cookiePromise = getSessionCookies(serverConfig.sessionUri, context.cookies)
+		.finally(() => {
+			if (!isProd) {
+				log.info(`session fetch: ${Date.now() - s}ms`);
+			}
 		});
-	});
+
+	const setCookies = [];
+
+	return Promise.all([typesPromise, cookiePromise])
+		.then(([types, cookieInfo]) => {
+			// add fetched types to rendering context
+			context.config.graphqlPossibleTypes = types;
+			// update cookies in the rendering context with any newly fetched session cookies
+			context.cookies = Object.assign(context.cookies, cookieInfo.cookies);
+			// forward any newly fetched 'Set-Cookie' headers
+			context.setCookies = [...cookieInfo.setCookies];
+			// render the app
+			return renderer.renderToString(context);
+		})
+		.then(html => {
+			// collect any cookies created during the app render
+			setCookies.concat(context.setCookies);
+			// send the final rendered html
+			return {
+				html,
+				setCookies,
+			};
+		})
+		.catch(err => {
+			// collect any cookies created during the app render
+			setCookies.concat(context.setCookies);
+			// send the error
+			return {
+				error: err,
+				// only send cookies if there is a redirect url
+				setCookies: err.url ? setCookies : [],
+			};
+		})
+		.finally(() => {
+			if (!isProd) {
+				log.info(`whole request: ${Date.now() - s}ms`);
+			}
+		});
+}
+
+workerpool.worker({
+	render,
+});

--- a/server/vue-worker.js
+++ b/server/vue-worker.js
@@ -1,0 +1,80 @@
+const { parentPort, workerData } = require('worker_threads');
+const { createBundleRenderer } = require('vue-server-renderer');
+const initCache = require('./util/initCache');
+const log = require('./util/log');
+const vueSsrCache = require('./util/vueSsrCache');
+const getGqlPossibleTypes = require('./util/getGqlPossibleTypes');
+const getSessionCookies = require('./util/getSessionCookies');
+
+const {
+	clientManifest,
+	context,
+	serverBundle,
+	serverConfig,
+	template,
+} = workerData;
+
+const isProd = process.env.NODE_ENV === 'production';
+const s = Date.now();
+const cache = initCache(serverConfig);
+
+// create a new renderer instance
+const renderer = createBundleRenderer(serverBundle, {
+	cache: vueSsrCache(cache),
+	template,
+	clientManifest,
+	runInNewContext: false,
+	inject: false,
+	// don't prefetch anything
+	shouldPrefetch: () => false,
+});
+
+// get graphql api possible types for the graphql client
+const typesPromise = getGqlPossibleTypes(serverConfig.graphqlUri, cache)
+	.finally(() => {
+		if (!isProd) {
+			log.info(`fragment fetch: ${Date.now() - s}ms`);
+		}
+	});
+
+// fetch initial session cookies in case starting session with this request
+const cookiePromise = getSessionCookies(serverConfig.sessionUri, context.cookies)
+	.finally(() => {
+		if (!isProd) {
+			log.info(`session fetch: ${Date.now() - s}ms`);
+		}
+	});
+
+const setCookies = [];
+
+Promise.all([typesPromise, cookiePromise])
+	.then(([types, cookieInfo]) => {
+		// add fetched types to rendering context
+		context.config.graphqlPossibleTypes = types;
+		// update cookies in the rendering context with any newly fetched session cookies
+		context.cookies = Object.assign(context.cookies, cookieInfo.cookies);
+		// forward any newly fetched 'Set-Cookie' headers
+		context.setCookies = [...cookieInfo.setCookies];
+		// render the app
+		return renderer.renderToString(context);
+	}).then(html => {
+		// collect any cookies created during the app render
+		setCookies.concat(context.setCookies);
+		// send the final rendered html
+		parentPort.postMessage({
+			html,
+			setCookies,
+		});
+		if (!isProd) {
+			log.info(`whole request: ${Date.now() - s}ms`);
+		}
+	}).catch(err => {
+		// collect any cookies created during the app render
+		setCookies.concat(context.setCookies);
+		// send the error
+		parentPort.postMessage({
+			error: err,
+			// only send cookies if there is a redirect url
+			setCookies: err.url ? setCookies : [],
+		});
+	});

--- a/src/util/KvAuth0.js
+++ b/src/util/KvAuth0.js
@@ -142,7 +142,7 @@ export default class KvAuth0 {
 	}
 
 	getFakeAuthCookieValue() {
-		if (!this.checkFakeAuth) return;
+		if (!this.fakeAuthAllowed()) return;
 
 		const cookieValue = this.cookieStore.get(FAKE_AUTH_NAME) ?? '';
 


### PR DESCRIPTION
This is a quick first pass at using worker threads for ui server requests.

I didn't find a way to share the vue bundle renderer between threads (functions can't be passed, as far as I can tell from the errors), so I just initialized one for each request. Not sure how that will affect performance, but I think threading will likely more than make up for it.

I setup a worker for live loans as well, but ran into issues with font registration. It sounds like node-canvas doesn't play nice with threads (according to https://github.com/Automattic/node-canvas/issues/1694) because of having to communicate between native C code and the nodejs process. I think it would be better to spin off live loans into their own service anyway, or maybe set it up as a lambda function.