### PR TITLE
feat: add user avatar to teams page challenge cta

### DIFF
--- a/src/components/Teams/TeamGoal.vue
+++ b/src/components/Teams/TeamGoal.vue
@@ -37,12 +37,39 @@
 			<div class="tw-mt-1">
 				<kv-progress-bar
 					:value="percentageFunded"
+					aria-label="Completion of challenge"
 					class="tw-w-full"
 				/>
 			</div>
 
 			<div class="tw-flex tw-flex-row tw-justify-between tw-mt-1 tw-items-center tw-text-secondary">
-				<span>{{ membersParticipating }} members participating</span>
+				<div class="tw-flex tw-items-center">
+					<div class="tw-shrink-0">
+						<img
+							v-for="(lender, i) in participationLendersDisplayed"
+							:key="lender.id"
+							:src="lender.image.url"
+							alt="Lender photo"
+							class="
+								data-hj-suppress
+								tw-inline-block
+								tw-w-4
+								tw-h-4
+								tw-rounded-full
+								tw-overflow-hidden
+								tw-border
+								tw-border-white
+								tw-object-fill
+								tw-relative
+							"
+							:class="{ 'tw--ml-2': i > 0, 'tw-border-gray-200': lender.isLegacyPlaceholder }"
+							:style="{ 'z-index': participationLendersDisplayed.length - i }"
+						>
+					</div>
+					<span class="tw-whitespace-nowrap tw-text-ellipsis tw-overflow-hidden tw-px-1">
+						{{ participationTotalCount }} members participating
+					</span>
+				</div>
 				<kv-button :to="`/team/challenge/${teamPublicId}`" variant="caution">
 					View
 				</kv-button>
@@ -58,6 +85,7 @@ import {
 	parseISO,
 	differenceInDays,
 } from 'date-fns';
+import { isLegacyPlaceholderAvatar } from '@/util/imageUtils';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
@@ -115,8 +143,14 @@ export default {
 		percentageFunded() {
 			return (this.loansFunded / this.totalLoans) * 100;
 		},
-		membersParticipating() {
+		participationTotalCount() {
 			return this.goal?.participation?.totalCount ?? 0;
+		},
+		participationLendersDisplayed() {
+			return (this.goal?.participation?.values ?? []).map(p => ({
+				...p.lender,
+				isLegacyPlaceholder: isLegacyPlaceholderAvatar(p.lender.image.url.split('/').pop()),
+			})).slice(0, 4);
 		},
 	},
 	methods: {

--- a/src/graphql/query/teamsGoals.graphql
+++ b/src/graphql/query/teamsGoals.graphql
@@ -1,30 +1,35 @@
 query GetGoals {
-  getGoals(filters: { audienceType: TEAM, isActive: true}) {
-    totalCount
-    values {
-      id
-      description
-      name
-      participation {
-        totalCount
-        values {
-          lenderId
-        }
-      }
-      status
-      targets {
-        totalCount
-        values {
-          ... on LoanTarget {
-            loanId
-            status
-          }
-        }
-      }
-      endDate
-	  ... on TeamGoal {
-        teamId
-      }
-    }
-  }
+	getGoals(filters: { audienceType: TEAM, isActive: true}) {
+		totalCount
+		values {
+		id
+		description
+		name
+		participation {
+			totalCount
+			values {
+				lender {
+					id
+					image {
+						url
+					}
+				}
+			}
+		}
+		status
+		targets {
+			totalCount
+			values {
+				... on LoanTarget {
+					loanId
+					status
+				}
+			}
+		}
+		endDate
+		... on TeamGoal {
+			teamId
+		}
+		}
+	}
 }

--- a/src/graphql/query/teamsGoals.graphql
+++ b/src/graphql/query/teamsGoals.graphql
@@ -2,34 +2,34 @@ query GetGoals {
 	getGoals(filters: { audienceType: TEAM, isActive: true}) {
 		totalCount
 		values {
-		id
-		description
-		name
-		participation {
-			totalCount
-			values {
-				lender {
-					id
-					image {
-						url
+			id
+			description
+			name
+			participation {
+				totalCount
+				values {
+					lender {
+						id
+						image {
+							url
+						}
 					}
 				}
 			}
-		}
-		status
-		targets {
-			totalCount
-			values {
-				... on LoanTarget {
-					loanId
-					status
+			status
+			targets {
+				totalCount
+				values {
+					... on LoanTarget {
+						loanId
+						status
+					}
 				}
 			}
-		}
-		endDate
-		... on TeamGoal {
-			teamId
-		}
+			endDate
+			... on TeamGoal {
+				teamId
+			}
 		}
 	}
 }

--- a/src/util/imageUtils.js
+++ b/src/util/imageUtils.js
@@ -78,6 +78,7 @@ export function getKivaImageUrl({
  * The legacy avatars are found exclusively at the following urls:
  * <domain>/img/<size param>/726677.jpg
  * <domain>/img/<size param>/315726.jpg
+ * for images from Fastly, urls, like: <domain>/img/s100/4d844ac2c0b77a8a522741b908ea5c32.jpg
  * @param {String|Number} filename or hash of avatar image
  * @returns {Boolean} full url for the image
  */
@@ -92,6 +93,6 @@ export function isLegacyPlaceholderAvatar(filename) {
 	if (filenameCleaned.indexOf('.') > -1) {
 		[filenameCleaned] = filenameCleaned.split('.');
 	}
-	const defaultProfileIds = ['726677', '315726'];
+	const defaultProfileIds = ['726677', '315726', '4d844ac2c0b77a8a522741b908ea5c32'];
 	return defaultProfileIds.some(id => id === filenameCleaned);
 }

--- a/test/unit/specs/util/imageUtils.spec.js
+++ b/test/unit/specs/util/imageUtils.spec.js
@@ -64,6 +64,7 @@ describe('imageUtils.js', () => {
 			expect(isLegacyPlaceholderAvatar('123abc')).toBe(false);
 			expect(isLegacyPlaceholderAvatar(12344)).toBe(false);
 		});
+
 		it('Returns if legacy placeholder avatar', () => {
 			expect(isLegacyPlaceholderAvatar('726677.jpg')).toBe(true);
 			expect(isLegacyPlaceholderAvatar('315726.jpg')).toBe(true);
@@ -73,6 +74,8 @@ describe('imageUtils.js', () => {
 			expect(isLegacyPlaceholderAvatar('315726')).toBe(true);
 			expect(isLegacyPlaceholderAvatar(726677)).toBe(true);
 			expect(isLegacyPlaceholderAvatar(315726)).toBe(true);
+			expect(isLegacyPlaceholderAvatar('4d844ac2c0b77a8a522741b908ea5c32')).toBe(true);
+			expect(isLegacyPlaceholderAvatar('4d844ac2c0b77a8a522741b908ea5c32.jpg')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/ACK-875

- Added lender image to MVP team activity section
- Note that the lenders in our MVP data mostly have legacy avatars
- Border color switches between white and gray depending on if the avatar is legacy (with white background)
- Added ellipsis overflow for participation count text, since there was wrapping before
- added missing aria label on progress component

![image](https://github.com/kiva/ui/assets/16867161/06a3c9ee-0bba-4ead-905f-9418140dc3a3)
