### PR TITLE
test: ensure teams are loaded on Checkout Page to get forceTeamId

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -191,6 +191,11 @@ export default {
 			return this.loan.team ? this.loan.team.id : 0;
 		}
 	},
+	watch: {
+		teams() {
+			this.forceTeamId = getForcedTeamId(this.cookieStore, this.loan.id, this.combinedTeams, this.appendedTeams);
+		}
+	},
 	methods: {
 		onLoanUpdate($event) {
 			this.$emit('refreshtotals', $event);
@@ -206,8 +211,5 @@ export default {
 			this.$emit('validateprecheckout');
 		}
 	},
-	mounted() {
-		this.forceTeamId = getForcedTeamId(this.cookieStore, this.loan.id, this.combinedTeams, this.appendedTeams);
-	}
 };
 </script>


### PR DESCRIPTION
Problem: I've been seeing duplicated teams in Teams dropdown because teams are not assigned at the moment forceTeamId is requested. With this change the component will wait until teams changes to call forceTeamId.

I'm still trying to fix the initial problem but this seems to be related.