### PR TITLE
fix: team attribution is not being assigned on not log in users

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -194,7 +194,9 @@ export default {
 	watch: {
 		teams: {
 			handler() {
-				this.forceTeamId = getForcedTeamId(this.cookieStore, this.loan.id, this.combinedTeams, this.appendedTeams);
+				this.forceTeamId = getForcedTeamId(
+					this.cookieStore, this.loan.id, this.combinedTeams, this.appendedTeams
+				);
 			},
 			immediate: true
 		}


### PR DESCRIPTION
Fix team assignment for users without team or not logged in users