### PR TITLE
feat: export worker pool metrics to monitor vue rendering

### DIFF
--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -1,9 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const { SHARE_ENV } = require('worker_threads');
-const workerpool = require('workerpool');
 const Bowser = require('bowser');
 const cookie = require('cookie');
+const vueWorkerPool = require('./vue-worker-pool.js');
 const protectedRoutes = require('./util/protectedRoutes.js');
 const tracer = require('./util/ddTrace');
 
@@ -41,17 +40,11 @@ module.exports = function createMiddleware({
 	clientManifest.publicPath = config.app.publicPath || '/';
 
 	// Create a worker pool to render the app
-	const pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
-		workerType: 'thread',
-		workerThreadOpts: {
-			workerData: {
-				clientManifest,
-				serverBundle,
-				serverConfig: config.server,
-				template,
-			},
-			env: SHARE_ENV,
-		},
+	const pool = vueWorkerPool({
+		clientManifest,
+		serverBundle,
+		serverConfig: config.server,
+		template,
 	});
 
 	function middleware(req, res, next) {

--- a/server/vue-worker-pool.js
+++ b/server/vue-worker-pool.js
@@ -1,0 +1,56 @@
+/* eslint-disable no-new */
+
+const path = require('path');
+const { SHARE_ENV } = require('worker_threads');
+const workerpool = require('workerpool');
+const promClient = require('prom-client');
+
+module.exports = function createWorkerPool(workerData) {
+	// Create pool of worker threads for Vue rendering
+	const pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
+		workerType: 'thread',
+		workerThreadOpts: {
+			workerData,
+			env: SHARE_ENV,
+		},
+	});
+
+	// Track worker pool metrics
+	new promClient.Gauge({
+		name: 'vue_total_workers',
+		help: 'Total number of vue worker threads, both busy and idle',
+		collect() {
+			this.set(pool.stats().totalWorkers);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_idle_workers',
+		help: 'Number of idle vue worker threads',
+		collect() {
+			this.set(pool.stats().idleWorkers);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_busy_workers',
+		help: 'Number of busy vue worker threads',
+		collect() {
+			this.set(pool.stats().busyWorkers);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_pending_tasks',
+		help: 'Total number of pending tasks in the vue worker pool',
+		collect() {
+			this.set(pool.stats().pendingTasks);
+		}
+	});
+	new promClient.Gauge({
+		name: 'vue_active_tasks',
+		help: 'Total number of active tasks in the vue worker pool',
+		collect() {
+			this.set(pool.stats().activeTasks);
+		}
+	});
+
+	return pool;
+};


### PR DESCRIPTION
I think it would be useful to have these metrics reported from the start, to monitor for issues. Are these metric names good or could they be better?