### PR TITLE
build: ensure only one release is running at any time

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -15,6 +15,9 @@ on:
       - staging
       - production
 
+concurrency:
+  group: kiva-ui-semantic-release
+
 jobs:
   # Create a release
   create-release:


### PR DESCRIPTION
https://docs.github.com/en/actions/using-jobs/using-concurrency