### PR TITLE
feat: configure min/max vue worker count with env vars

### DIFF
--- a/config/dynamic.js
+++ b/config/dynamic.js
@@ -102,5 +102,7 @@ module.exports = {
 		memcachedServers,
 		port: 8888,
 		sessionUri: `https://www.${baseUrl}/start-ui-session`,
+		minVueWorkers: process.env.MIN_VUE_WORKERS || 1,
+		maxVueWorkers: process.env.MAX_VUE_WORKERS || 3,
 	}
 }

--- a/config/index.js
+++ b/config/index.js
@@ -78,6 +78,8 @@ module.exports = {
 		memcachedEnabled: true,
 		memcachedServers: 'memcached-01:11211,memcached-02:11211',
 		gzipEnabled: false,
+		minVueWorkers: 1,
+		maxVueWorkers: 3,
 	},
 	build: {
 		assetsRoot: path.resolve(__dirname, '../dist'),

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -41,10 +41,14 @@ module.exports = function createMiddleware({
 
 	// Create a worker pool to render the app
 	const pool = vueWorkerPool({
-		clientManifest,
-		serverBundle,
-		serverConfig: config.server,
-		template,
+		minWorkers: config.server.minVueWorkers,
+		maxWorkers: config.server.maxVueWorkers,
+		workerData: {
+			clientManifest,
+			serverBundle,
+			serverConfig: config.server,
+			template,
+		},
 	});
 
 	function middleware(req, res, next) {

--- a/server/vue-worker-pool.js
+++ b/server/vue-worker-pool.js
@@ -5,9 +5,11 @@ const { SHARE_ENV } = require('worker_threads');
 const workerpool = require('workerpool');
 const promClient = require('prom-client');
 
-module.exports = function createWorkerPool(workerData) {
+module.exports = function createWorkerPool({ minWorkers, maxWorkers, workerData } = {}) {
 	// Create pool of worker threads for Vue rendering
 	const pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
+		minWorkers,
+		maxWorkers,
 		workerType: 'thread',
 		workerThreadOpts: {
 			workerData,


### PR DESCRIPTION
Also sets default `minWorkers` to 1 so that there will always be at least 1 worker ready to render requests.