### PR TITLE
feat: contentful comments component base in cps

### DIFF
--- a/.storybook/stories/CommentsContainer.stories.js
+++ b/.storybook/stories/CommentsContainer.stories.js
@@ -1,0 +1,29 @@
+import CommentsContainer from '@/components/Contentful/CommentsContainer';
+
+export default {
+	title: 'Components/Contentful/CommentsContainer',
+	component: CommentsContainer,
+};
+
+const story = (args) => {
+	const template = (templateArgs, { argTypes }) => ({
+		props: Object.keys(argTypes),
+		components: { CommentsContainer },
+		setup() { return { args: templateArgs }; },
+		template: `
+      		<CommentsContainer v-bind="args" />
+    	`,
+	});
+	template.args = args;
+	return template;
+};
+
+const props = (dataObject = {}) => ({
+	content: {
+		dataObject,
+	},
+});
+
+export const Default = story({});
+
+export const Activity = story(props({ activityId: 'asd' }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.12.1",
-				"@kiva/kv-components": "^3.47.0",
+				"@kiva/kv-components": "^3.51.0",
 				"@kiva/kv-tokens": "^2.7.0",
 				"@mdi/js": "^7",
 				"@opentelemetry/api": "^1.7.0",
@@ -4368,9 +4368,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.47.0.tgz",
-			"integrity": "sha512-JX7MfhjKD4cF8QH2Ey0MTXBt42GlrdvIA3J+QmXAD/xtXIxef1y/mRFlepb0Ep0ayZW9Az+osMOrM8WBDrFCzQ==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.51.0.tgz",
+			"integrity": "sha512-MTjS6pgl5AwSn7LuaoY65Ki1iDgvQPzVnx064vpfbw5BhEE02ZTB6VMaKqrlCpVY+J97LWe6SbE6gq3APfoHDg==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^2.10.0",
 				"@mdi/js": "^5.9.55",
@@ -44875,9 +44875,9 @@
 			}
 		},
 		"@kiva/kv-components": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.47.0.tgz",
-			"integrity": "sha512-JX7MfhjKD4cF8QH2Ey0MTXBt42GlrdvIA3J+QmXAD/xtXIxef1y/mRFlepb0Ep0ayZW9Az+osMOrM8WBDrFCzQ==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.51.0.tgz",
+			"integrity": "sha512-MTjS6pgl5AwSn7LuaoY65Ki1iDgvQPzVnx064vpfbw5BhEE02ZTB6VMaKqrlCpVY+J97LWe6SbE6gq3APfoHDg==",
 			"requires": {
 				"@kiva/kv-tokens": "^2.10.0",
 				"@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.12.1",
-		"@kiva/kv-components": "^3.47.0",
+		"@kiva/kv-components": "^3.51.0",
 		"@kiva/kv-tokens": "^2.7.0",
 		"@mdi/js": "^7",
 		"@opentelemetry/api": "^1.7.0",

--- a/src/components/Contentful/CommentsContainer.vue
+++ b/src/components/Contentful/CommentsContainer.vue
@@ -1,0 +1,28 @@
+<template>
+	<kv-comments-container :activity-id="activityId" />
+</template>
+
+<script>
+import KvCommentsContainer from '~/@kiva/kv-components/vue/KvCommentsContainer';
+
+export default {
+	name: 'CommentsContainer',
+	components: {
+		KvCommentsContainer
+	},
+	props: {
+		/**
+		 * Contentful content object
+		 */
+		content: {
+			type: Object,
+			default: () => ({}),
+		},
+	},
+	computed: {
+		activityId() {
+			return this.content?.dataObject?.activityId;
+		},
+	},
+};
+</script>

--- a/src/components/Contentful/DynamicRichText.vue
+++ b/src/components/Contentful/DynamicRichText.vue
@@ -22,7 +22,8 @@ export default {
 				components: {
 					KvFrequentlyAskedQuestions: () => import('@/components/Kv/KvFrequentlyAskedQuestions'),
 					KvContentfulImg: () => import('~/@kiva/kv-components/vue/KvContentfulImg'),
-					ButtonWrapper: () => import('@/components/Contentful/ButtonWrapper')
+					ButtonWrapper: () => import('@/components/Contentful/ButtonWrapper'),
+					CommentsContainer: () => import('@/components/Contentful/CommentsContainer')
 				},
 				props: {
 				},

--- a/src/components/Contentful/DynamicRichText.vue
+++ b/src/components/Contentful/DynamicRichText.vue
@@ -22,8 +22,7 @@ export default {
 				components: {
 					KvFrequentlyAskedQuestions: () => import('@/components/Kv/KvFrequentlyAskedQuestions'),
 					KvContentfulImg: () => import('~/@kiva/kv-components/vue/KvContentfulImg'),
-					ButtonWrapper: () => import('@/components/Contentful/ButtonWrapper'),
-					CommentsContainer: () => import('@/components/Contentful/CommentsContainer')
+					ButtonWrapper: () => import('@/components/Contentful/ButtonWrapper')
 				},
 				props: {
 				},

--- a/test/unit/specs/components/Contentful/CommentsContainer.spec.js
+++ b/test/unit/specs/components/Contentful/CommentsContainer.spec.js
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/vue';
+import CommentsContainer from '@/components/Contentful/CommentsContainer';
+
+const withContentProp = (dataObject = {}) => ({
+	props: {
+		content: {
+			dataObject,
+		},
+	},
+});
+
+const renderContainer = (dataObject = {}) => {
+	return render(CommentsContainer, withContentProp(dataObject));
+};
+
+describe('CommentsContainer', () => {
+	it('should render without activity ID', async () => {
+		const component = renderContainer();
+		component.getByText('Activity ID missing');
+	});
+
+	it('should render with activity ID', async () => {
+		const component = renderContainer({ activityId: 'asd' });
+		component.getByText('Comment functionality coming soon!');
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/ACK-919

- Added basic Contentful wrapper for `CommentsContainer`
- Unlike the recent CPS PR, I didn't add this new component to the `ui` rich text component -> `ui` has a slightly different collection of rich text components, and I think it makes sense to identify the use case before adding this new Contentful component to the wrong parent(s)

![image](https://github.com/kiva/ui/assets/16867161/974037ad-8a7d-4542-a0a1-dbac02f7a241)

![image](https://github.com/kiva/ui/assets/16867161/f66b9775-b602-49c0-8bb0-a65d6ffae5be)
