### PR TITLE
fix: handle pool reinitialization by dev server

### DIFF
--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -175,7 +175,7 @@ app.use(devMiddleware);
 app.use(hotMiddleware);
 
 // load metrics middleware
-app.use(metricsMiddleware)
+app.use(metricsMiddleware);
 
 // Configure session
 app.use('/', sessionRouter(config.server));

--- a/server/vue-worker-pool.js
+++ b/server/vue-worker-pool.js
@@ -5,9 +5,16 @@ const { SHARE_ENV } = require('worker_threads');
 const workerpool = require('workerpool');
 const promClient = require('prom-client');
 
+let pool;
+
 module.exports = function createWorkerPool({ minWorkers, maxWorkers, workerData } = {}) {
+	// Terminate the existing pool if it was created
+	if (pool) {
+		pool.terminate();
+	}
+
 	// Create pool of worker threads for Vue rendering
-	const pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
+	pool = workerpool.pool(path.resolve(__dirname, 'vue-worker.js'), {
 		minWorkers,
 		maxWorkers,
 		workerType: 'thread',
@@ -18,41 +25,51 @@ module.exports = function createWorkerPool({ minWorkers, maxWorkers, workerData 
 	});
 
 	// Track worker pool metrics
-	new promClient.Gauge({
-		name: 'vue_total_workers',
-		help: 'Total number of vue worker threads, both busy and idle',
-		collect() {
-			this.set(pool.stats().totalWorkers);
-		}
-	});
-	new promClient.Gauge({
-		name: 'vue_idle_workers',
-		help: 'Number of idle vue worker threads',
-		collect() {
-			this.set(pool.stats().idleWorkers);
-		}
-	});
-	new promClient.Gauge({
-		name: 'vue_busy_workers',
-		help: 'Number of busy vue worker threads',
-		collect() {
-			this.set(pool.stats().busyWorkers);
-		}
-	});
-	new promClient.Gauge({
-		name: 'vue_pending_tasks',
-		help: 'Total number of pending tasks in the vue worker pool',
-		collect() {
-			this.set(pool.stats().pendingTasks);
-		}
-	});
-	new promClient.Gauge({
-		name: 'vue_active_tasks',
-		help: 'Total number of active tasks in the vue worker pool',
-		collect() {
-			this.set(pool.stats().activeTasks);
-		}
-	});
+	if (!promClient.register.getSingleMetric('vue_total_workers')) {
+		new promClient.Gauge({
+			name: 'vue_total_workers',
+			help: 'Total number of vue worker threads, both busy and idle',
+			collect() {
+				this.set(pool.stats().totalWorkers);
+			}
+		});
+	}
+	if (!promClient.register.getSingleMetric('vue_idle_workers')) {
+		new promClient.Gauge({
+			name: 'vue_idle_workers',
+			help: 'Number of idle vue worker threads',
+			collect() {
+				this.set(pool.stats().idleWorkers);
+			}
+		});
+	}
+	if (!promClient.register.getSingleMetric('vue_busy_workers')) {
+		new promClient.Gauge({
+			name: 'vue_busy_workers',
+			help: 'Number of busy vue worker threads',
+			collect() {
+				this.set(pool.stats().busyWorkers);
+			}
+		});
+	}
+	if (!promClient.register.getSingleMetric('vue_pending_tasks')) {
+		new promClient.Gauge({
+			name: 'vue_pending_tasks',
+			help: 'Total number of pending tasks in the vue worker pool',
+			collect() {
+				this.set(pool.stats().pendingTasks);
+			}
+		});
+	}
+	if (!promClient.register.getSingleMetric('vue_active_tasks')) {
+		new promClient.Gauge({
+			name: 'vue_active_tasks',
+			help: 'Total number of active tasks in the vue worker pool',
+			collect() {
+				this.set(pool.stats().activeTasks);
+			}
+		});
+	}
 
 	return pool;
 };


### PR DESCRIPTION
Avoids errors like `Error: A metric with the name vue_total_workers has already been registered.` which cause server crashes when the dev-server request handler is updated.