### PR TITLE
feat: first IWD thanks page variation

### DIFF
--- a/.storybook/mock-data/thanks-page-data-mock.js
+++ b/.storybook/mock-data/thanks-page-data-mock.js
@@ -226,6 +226,25 @@ export const femaleLoanData = {
 	}
 };
 
+export const femaleLoanDataWithInviter = {
+	"data": {
+		...femaleLoanData.data,
+		"community": {
+			"lender": {
+				"id": 123,
+				"name": "Mary",
+				"image": {
+					"id": 123,
+					"url": "https://www-kiva-org-0.freetls.fastly.net/img/s100/4da4a17c4b35913d22114bf29bb1911b.jpg",
+					"width": 3264,
+					"height": 2448
+				},
+				"publicId": "mary19806605"
+			}
+		}
+	}
+}
+
 export const iwdExperiment = {
 	id: 'Experiment:iwd_header_2024',
 	version: 'b'

--- a/.storybook/stories/ThanksPage.stories.js
+++ b/.storybook/stories/ThanksPage.stories.js
@@ -2,26 +2,46 @@ import ThanksPage from '@/pages/Thanks/ThanksPage';
 import apolloStoryMixin from '../mixins/apollo-story-mixin';
 import cookieStoreStoryMixin from '../mixins/cookie-store-story-mixin';
 import kvAuth0StoryMixin from '../mixins/kv-auth0-story-mixin';
-import { maleLoanData, femaleLoanData, iwdExperiment } from '../mock-data/thanks-page-data-mock';
+import {
+	maleLoanData,
+	femaleLoanData,
+	femaleLoanDataWithInviter,
+	iwdExperiment,
+} from '../mock-data/thanks-page-data-mock';
+import VueRouter from 'vue-router';
+
+const routes = new VueRouter();
 
 export default {
 	title: 'Page/ThanksPage',
 	component: ThanksPage,
+	decorators: [
+		(story, { args }) => {
+			// Ensure story iframe loads with expected query string
+			routes.replace(`/?${args.queryString}`).catch(() => { });
+			return story();
+		}
+	]
 };
 
-const story = (queryResult = {}, fragmentResult = {}) => {
+const story = (queryResult = {}, fragmentResult = {}, queryString = '') => {
 	const template = () => ({
 		components: { ThanksPage },
 		mixins: [cookieStoreStoryMixin(), kvAuth0StoryMixin],
 		// Using provide ensures that apollo is not shared between stories
 		provide: apolloStoryMixin({ queryResult, fragmentResult }).provide,
+		routes,
 		template: '<thanks-page />',
-	})
+	});
+	template.args = { queryString };
 	return template;
 };
 
 export const Default = story(maleLoanData);
 
-export const IWD = story(femaleLoanData, iwdExperiment);
-
 export const IWDNoFemaleLoan = story(maleLoanData, iwdExperiment);
+
+export const IWDInviterKiva = story(femaleLoanData, iwdExperiment, 'valet_inviter=kiva');
+
+export const IWDInviterLender = story(femaleLoanDataWithInviter, iwdExperiment, 'valet_inviter=mary19806605');
+

--- a/src/components/Iwd/IwdThanksPageVariations.vue
+++ b/src/components/Iwd/IwdThanksPageVariations.vue
@@ -54,10 +54,10 @@
 						<!-- eslint-disable-next-line max-len -->
 						<span class="tw-text-brand">{{ iwdBorrowerLocation }}</span><span>, the borrower</span><span class="tw-text-brand"> you just lent to</span><span>! This loan is special because...</span>
 					</div>
-					<div class="iwd-borrower-image tw-basis-auto md:tw-basis-1/2 tw-overflow-hidden">
+					<div class="iwd-borrower-image tw-basis-auto md:tw-basis-1/2">
 						<borrower-image
 							v-if="iwdLoan"
-							class="tw-w-full tw-bg-black data-hj-suppress"
+							class="tw-h-full tw-w-full tw-bg-black data-hj-suppress !tw-p-0 tw-rounded"
 							:alt="iwdBorrowerName"
 							:default-image="{ width: 548 }"
 							:hash="iwdLoanImageHash"

--- a/src/components/Iwd/IwdThanksPageVariations.vue
+++ b/src/components/Iwd/IwdThanksPageVariations.vue
@@ -1,0 +1,178 @@
+<template>
+	<div class="tw-bg-secondary">
+		<div class="row page-content !tw-pt-0">
+			<template v-if="iwdValetInviterId">
+				<div
+					class="
+						tw-flex
+						tw-bg-white
+						tw-shadow-lg
+						tw-mt-0
+						md:tw-mt-2
+						tw-rounded-b
+						md:tw-rounded-t
+						tw-p-1.5
+						tw-gap-1
+						tw-items-center
+					"
+				>
+					<div class="tw-shrink-0">
+						<img :src="iWD2024Badge" alt="IWD Badge" class="tw-w-10 md:tw-w-6">
+					</div>
+					<div class="md:tw-font-medium">
+						<span>Thank you! Your support for </span>
+						<span
+							v-if="iwdValetInviterName"
+							class="data-hj-suppress"
+						>
+							{{ iwdValetInviterName }} &
+						</span>
+						<!-- eslint-disable-next-line max-len -->
+						<span>Kiva is invaluable to our mission and to our borrowers around the world. We’ve sent a receipt to your email.</span>
+					</div>
+				</div>
+				<div
+					class="
+						tw-flex
+						tw-flex-col
+						md:tw-flex-row
+						tw-w-full
+						tw-pt-2
+						md:tw-pt-3
+						tw-gap-1.5
+						md:tw-gap-3.5
+						tw-items-normal
+						md:tw-items-center
+						tw-p-2
+						md:tw-p-0
+					"
+				>
+					<div v-if="iwdBorrowerName && iwdBorrowerLocation" class="tw-font-medium tw-block md:tw-hidden">
+						<span class="tw-text-brand">Meet </span>
+						<span class="tw-text-brand data-hj-suppress">{{ iwdBorrowerName }}</span>
+						<span> from the </span>
+						<!-- eslint-disable-next-line max-len -->
+						<span class="tw-text-brand">{{ iwdBorrowerLocation }}</span><span>, the borrower</span><span class="tw-text-brand"> you just lent to</span><span>! This loan is special because...</span>
+					</div>
+					<div class="iwd-borrower-image tw-basis-auto md:tw-basis-1/2 tw-overflow-hidden">
+						<borrower-image
+							v-if="iwdLoan"
+							class="tw-w-full tw-bg-black data-hj-suppress"
+							:alt="iwdBorrowerName"
+							:default-image="{ width: 548 }"
+							:hash="iwdLoanImageHash"
+							:images="[{ width: 548 }]"
+						/>
+					</div>
+					<div class="tw-flex tw-flex-col tw-basis-auto md:tw-basis-1/2 tw-gap-1.5">
+						<div v-if="iwdBorrowerName && iwdBorrowerLocation" class="tw-font-medium tw-hidden md:tw-block">
+							<span class="tw-text-brand">Meet </span>
+							<span class="tw-text-brand data-hj-suppress">{{ iwdBorrowerName }}</span>
+							<span> from the </span>
+							<!-- eslint-disable-next-line max-len -->
+							<span class="tw-text-brand">{{ iwdBorrowerLocation }}</span><span>, the borrower</span><span class="tw-text-brand"> you just lent to</span><span>! This loan is special because...</span>
+						</div>
+						<div class="tw-flex tw-flex-col md:tw-flex-row tw-gap-1 tw-px-2 md:tw-px-0">
+							<kv-button
+								v-if="iwdLoanId"
+								:href="`/lend/${iwdLoanId}`"
+								v-kv-track-event="['Thanks', 'click-read-borrower-story']"
+							>
+								<span>Read </span>
+								<span v-if="iwdBorrowerName" class="data-hj-suppress">
+									{{ `${iwdBorrowerName}'s ` }}
+								</span>
+								<span>story</span>
+							</kv-button>
+							<kv-button
+								href="/about/how"
+								variant="secondary"
+								v-kv-track-event="['Thanks', 'click-more-about-kiva']"
+							>
+								More about Kiva
+							</kv-button>
+						</div>
+					</div>
+				</div>
+			</template>
+			<template v-else>
+				<!-- TODO: content coming soon -->
+			</template>
+		</div>
+	</div>
+</template>
+
+<script>
+import iWD2024Badge from '@/assets/images/achievements/iwd_2024_badge.png';
+import BorrowerImage from '@/components/BorrowerProfile/BorrowerImage';
+import KvButton from '~/@kiva/kv-components/vue/KvButton';
+
+export const KIVA_INVITER_ID = 'KIVA';
+
+export default {
+	name: 'IwdThanksPageVariations',
+	components: {
+		BorrowerImage,
+		KvButton,
+	},
+	data() {
+		return {
+			iWD2024Badge,
+		};
+	},
+	props: {
+		iwdValetInviterId: {
+			type: String,
+			default: undefined,
+		},
+		iwdValetInviter: {
+			type: Object,
+			default: () => ({}),
+		},
+		iwdLoan: {
+			type: Object,
+			default: () => ({}),
+		},
+	},
+	computed: {
+		iwdValetInviterName() {
+			return this.iwdValetInviter?.name ?? '';
+		},
+		iwdLoanId() {
+			return this.iwdLoan?.id ?? '';
+		},
+		iwdLoanImageHash() {
+			return this.iwdLoan?.image?.hash;
+		},
+		iwdBorrowerName() {
+			return this.iwdLoan?.name ?? '';
+		},
+		iwdBorrowerLocation() {
+			return this.iwdLoan?.geocode?.country?.name ?? '';
+		},
+	},
+};
+
+</script>
+
+<style lang="scss" scoped>
+// Using SCSS allows matching parent ThanksPage.vue component
+@import 'settings';
+
+.iwd-borrower-image {
+	height: 289px;
+
+	@include breakpoint(medium) {
+		height: 420px;
+	}
+
+	::v-deep img {
+		object-fit: cover;
+		height: 289px;
+
+		@include breakpoint(medium) {
+			height: 420px;
+		}
+	}
+}
+</style>

--- a/src/graphql/query/lenderPublicProfile.graphql
+++ b/src/graphql/query/lenderPublicProfile.graphql
@@ -1,0 +1,14 @@
+query LenderPublicProfile ($publicId: String!) {
+	community {
+		lender(publicId: $publicId) {
+			id
+			name
+			image {
+				id
+				url
+				width
+				height
+			}
+		}
+	}
+}

--- a/src/graphql/query/thanksPage.graphql
+++ b/src/graphql/query/thanksPage.graphql
@@ -84,6 +84,7 @@ query checkoutReceipt($checkoutId: Int!, $visitorId: String) {
 							distributionModel
 							unreservedAmount @client
 							inPfp
+							gender
 						}
 						team {
 							id


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1729

- Implemented the first IWD thanks page variation
- This is when a user checks out after being invited by a user
- The query string in this situation will have `valet_inviter` as either `kiva` or the lender public ID
- There is a slight variation on whether the inviter is Kiva, but below is the situation where there's a lender public ID
- Implemented decorator to change a story iframe URL before it gets rendered

![image](https://github.com/kiva/ui/assets/16867161/f86609b5-8c79-440b-89d2-2d6b1327a367)

![image](https://github.com/kiva/ui/assets/16867161/719d224b-6830-47ac-9b0e-f44a9e5a3400)
