### PR TITLE
feat: add campaign progress bar to category page

### DIFF
--- a/.storybook/mock-data/thanks-page-data-mock.js
+++ b/.storybook/mock-data/thanks-page-data-mock.js
@@ -112,6 +112,9 @@ export const maleLoanData = {
 	}
 }
 
+const futureDate = new Date();
+futureDate.setDate(futureDate.getDate() + 20);
+
 export const femaleLoanData = {
 	"data": {
 		"shop": {
@@ -228,6 +231,15 @@ export const femaleLoanData = {
 				"totalCount": 1
 			}
 		},
+		"general": {
+			"kivaStats": {
+				"campaignStats": {
+					"currentBorrowerCount": 2298,
+					"targetBorrowerCount": 6000,
+					"targetEndDate": futureDate.toISOString(),
+				}
+			}
+		}
 	}
 };
 

--- a/.storybook/stories/KvProgressCampaign.stories.js
+++ b/.storybook/stories/KvProgressCampaign.stories.js
@@ -15,6 +15,7 @@ const story = (args) => {
 					:funded-borrowers="fundedBorrowers"
 					:total-borrowers="totalBorrowers"
 					:days-left="daysLeft"
+					:minimal-stats="minimalStats"
 				/>
 			</div>
 		`,
@@ -25,4 +26,8 @@ const story = (args) => {
 
 export const Default = story({
 	daysLeft: 29, totalBorrowers: 4000, fundedBorrowers: 462,
+});
+
+export const MinimalStats = story({
+	daysLeft: 29, totalBorrowers: 4000, fundedBorrowers: 462, minimalStats: true
 });

--- a/.storybook/stories/KvProgressCampaign.stories.js
+++ b/.storybook/stories/KvProgressCampaign.stories.js
@@ -12,10 +12,9 @@ const story = (args) => {
 		template: `
 			<div>
 				<kv-progress-campaign
-					:funded-loans="fundedLoans"
-					:total-loans="totalLoans"
+					:funded-borrowers="fundedBorrowers"
+					:total-borrowers="totalBorrowers"
 					:days-left="daysLeft"
-					:raised-money="raisedMoney"
 				/>
 			</div>
 		`,
@@ -25,5 +24,5 @@ const story = (args) => {
 };
 
 export const Default = story({
-	raisedMoney: 345900, daysLeft: 29, totalLoans: 4000, fundedLoans: 462,
+	daysLeft: 29, totalBorrowers: 4000, fundedBorrowers: 462,
 });

--- a/src/components/Iwd/ActivityFeed.vue
+++ b/src/components/Iwd/ActivityFeed.vue
@@ -10,7 +10,8 @@
 
 <script>
 import ActivityCard from '@/components/Iwd/ActivityCard';
-import IwdActionsQuery from '@/graphql/query/IwdActions.graphql';
+import iwdActionsQuery from '@/graphql/query/IwdActions.graphql';
+import logReadQueryError from '@/util/logReadQueryError';
 
 export default {
 	name: 'ActivityFeed',
@@ -24,17 +25,17 @@ export default {
 		};
 	},
 	methods: {
-		fetchActivities() {
-			// Fetch activities from API
-			this.apollo.query({
-				query: IwdActionsQuery,
-			}).then(({ data }) => {
-				this.activities = data?.lend?.campaignActions?.values ?? [];
-			});
+		async fetchActivities() {
+			try {
+				const response = await this.apollo.query({ query: iwdActionsQuery });
+				this.activities = response?.data?.lend?.campaignActions?.values ?? [];
+			} catch (e) {
+				logReadQueryError(e, 'ActivityFeed iwdActionsQuery');
+			}
 		},
 	},
-	mounted() {
-		this.fetchActivities();
+	async mounted() {
+		await this.fetchActivities();
 	},
 };
 </script>

--- a/src/components/Iwd/IwdCategoryHeader.vue
+++ b/src/components/Iwd/IwdCategoryHeader.vue
@@ -1,0 +1,47 @@
+<template>
+	<div class="tw-flex tw-flex-col tw-w-full">
+		<div class="tw-flex tw-pt-2 md:tw-gap-6 lg:tw-gap-12">
+			<div>
+				<h1 style="line-height: 1;" class="md:tw-pb-3">
+					Help us fund 4,000 women for Women’s Day!
+				</h1>
+				<div class="tw-flex md:tw-hidden tw-py-0.5 tw-items-center">
+					<img :src="iWD2024Badge" alt="IWD Badge" style="width: 114px;">
+					<iwd-progress-campaign class="tw-pr-2" />
+				</div>
+				<!-- eslint-disable max-len -->
+				<p class="tw-pb-3">
+					To celebrate International Women’s Day, we’re aiming to fund 4,000 women this week. That’s 4,000 more women who could have the resources they need to thrive — and invest in their communities.
+				</p>
+				<p>We need you to make it happen. Help us reach our goal and earn your exclusive International Women’s Day badge!</p>
+				<!-- eslint-enable max-len -->
+			</div>
+			<div class="tw-shrink-0 tw-hidden md:tw-block">
+				<img :src="iWD2024Badge" alt="IWD Badge">
+				<iwd-progress-campaign />
+			</div>
+		</div>
+		<div class="tw-pt-2">
+			<activity-feed />
+		</div>
+	</div>
+</template>
+
+<script>
+import ActivityFeed from '@/components/Iwd/ActivityFeed';
+import iWD2024Badge from '@/assets/images/achievements/iwd_2024_badge.png';
+import IwdProgressCampaign from '@/components/Iwd/IwdProgressCampaign';
+
+export default {
+	name: 'IwdCategoryHeader',
+	components: {
+		ActivityFeed,
+		IwdProgressCampaign,
+	},
+	data() {
+		return {
+			iWD2024Badge,
+		};
+	},
+};
+</script>

--- a/src/components/Iwd/IwdProgressCampaign.vue
+++ b/src/components/Iwd/IwdProgressCampaign.vue
@@ -4,6 +4,7 @@
 		:funded-borrowers="fundedBorrowers"
 		:total-borrowers="totalBorrowers"
 		:days-left="daysLeft"
+		:minimal-stats="minimalStats"
 	/>
 	<kv-loading-placeholder v-else class="tw-w-full tw-h-8" />
 </template>
@@ -22,6 +23,12 @@ export default {
 		KvLoadingPlaceholder,
 	},
 	inject: ['apollo', 'cookieStore'],
+	props: {
+		minimalStats: {
+			type: Boolean,
+			default: false,
+		},
+	},
 	data() {
 		return {
 			fundedBorrowers: undefined,

--- a/src/components/Iwd/IwdProgressCampaign.vue
+++ b/src/components/Iwd/IwdProgressCampaign.vue
@@ -1,0 +1,62 @@
+<template>
+	<kv-progress-campaign
+		v-if="displayProgress"
+		:funded-borrowers="fundedBorrowers"
+		:total-borrowers="totalBorrowers"
+		:days-left="daysLeft"
+	/>
+	<kv-loading-placeholder v-else class="tw-w-full tw-h-8" />
+</template>
+
+<script>
+import KvProgressCampaign from '@/components/Kv/KvProgressCampaign';
+import campaignStatsQuery from '@/graphql/query/campaignStats.graphql';
+import logReadQueryError from '@/util/logReadQueryError';
+import intervalToDuration from 'date-fns/intervalToDuration';
+import KvLoadingPlaceholder from '~/@kiva/kv-components/vue/KvLoadingPlaceholder';
+
+export default {
+	name: 'IwdProgressCampaign',
+	components: {
+		KvProgressCampaign,
+		KvLoadingPlaceholder,
+	},
+	inject: ['apollo', 'cookieStore'],
+	data() {
+		return {
+			fundedBorrowers: undefined,
+			totalBorrowers: undefined,
+			daysLeft: undefined,
+		};
+	},
+	computed: {
+		displayProgress() {
+			return !!(typeof this.fundedBorrowers !== 'undefined'
+				&& typeof this.totalBorrowers !== 'undefined'
+				&& typeof this.daysLeft !== 'undefined');
+		},
+	},
+	async mounted() {
+		try {
+			const response = await this.apollo.query({
+				query: campaignStatsQuery,
+				variables: {
+					campaignKey: 'iwd2024',
+					filters: { gender: 'female' },
+				},
+			});
+			this.fundedBorrowers = response?.data?.general?.kivaStats?.campaignStats?.currentBorrowerCount;
+			this.totalBorrowers = response?.data?.general?.kivaStats?.campaignStats?.targetBorrowerCount;
+			const targetEndDate = response?.data?.general?.kivaStats?.campaignStats?.targetEndDate;
+			if (targetEndDate) {
+				this.daysLeft = intervalToDuration({
+					start: new Date(),
+					end: new Date(targetEndDate)
+				}).days;
+			}
+		} catch (e) {
+			logReadQueryError(e, 'IwdProgressCampaign campaignStatsQuery');
+		}
+	},
+};
+</script>

--- a/src/components/Iwd/IwdThanksPageVariations.vue
+++ b/src/components/Iwd/IwdThanksPageVariations.vue
@@ -19,12 +19,13 @@
 						tw-rounded-b
 						md:tw-rounded-t
 						tw-p-1.5
-						tw-gap-1
+						tw-gap-2
 						tw-items-center
 					"
 				>
-					<div class="tw-shrink-0">
+					<div class="tw-shrink-0 tw-flex tw-flex-col md:tw-flex-row tw-gap-0.5 md:tw-gap-1 tw-items-center">
 						<img :src="iWD2024Badge" alt="IWD Badge" class="tw-w-10 md:tw-w-6">
+						<iwd-progress-campaign :minimal-stats="true" />
 					</div>
 					<div class="md:tw-font-medium">
 						<span>Thank you! Your support for </span>
@@ -122,7 +123,7 @@
 							tw-flex-col
 							md:tw-flex-row
 							tw-gap-1.5
-							md:tw-gap-3
+							md:tw-gap-8
 						"
 					>
 						<div class="tw-flex tw-flex-col tw-basis-auto md:tw-basis-1/2">
@@ -206,8 +207,18 @@
 								</button>
 							</div>
 						</div>
-						<div class="tw-basis-auto md:tw-basis-1/2">
+						<div
+							class="
+								tw-flex
+								md:tw-flex-col
+								tw-basis-auto
+								md:tw-basis-1/2
+								tw-items-center
+								md:tw-items-stretch
+							"
+						>
 							<img id="badge-image" :src="iWD2024Badge" alt="IWD Badge" class="tw-mx-0 md:tw-mx-auto">
+							<iwd-progress-campaign />
 						</div>
 					</div>
 				</div>
@@ -223,6 +234,7 @@ import socialSharingMixin from '@/plugins/social-sharing-mixin';
 import KvIcon from '@/components/Kv/KvIcon';
 import { mdiLink } from '@mdi/js';
 import { getFullUrl } from '@/util/urlUtils';
+import IwdProgressCampaign from '@/components/Iwd/IwdProgressCampaign';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 
@@ -235,6 +247,7 @@ export default {
 		KvButton,
 		KvIcon,
 		KvMaterialIcon,
+		IwdProgressCampaign,
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [socialSharingMixin],

--- a/src/components/Iwd/IwdThanksPageVariations.vue
+++ b/src/components/Iwd/IwdThanksPageVariations.vue
@@ -104,7 +104,7 @@
 			</template>
 			<template v-else>
 				<div class="tw-flex tw-flex-col tw-w-full tw-pb-2">
-					<div class="tw-text-center tw-pt-1.5 tw-pb-2 tw-mx-auto" style="max-width: 685px;">
+					<div class="tw-text-center tw-pt-1.5 tw-px-2 tw-pb-2 tw-mx-auto" style="max-width: 685px;">
 						<h2 class="tw-pb-1.5">
 							Spread the word. Multiply your impact.
 						</h2>

--- a/src/components/Kv/KvProgressCampaign.vue
+++ b/src/components/Kv/KvProgressCampaign.vue
@@ -1,11 +1,11 @@
 <template>
-	<figure>
+	<figure class="tw-grow">
 		<div class="tw-flex tw-items-center tw-justify-between">
 			<p>
-				{{ fundedLoans }} loans funded
+				{{ fundedBorrowers }} funded
 			</p>
 			<p>
-				{{ loansLeft }} to go!
+				{{ borrowersLeft }} to go
 			</p>
 		</div>
 		<kv-progress-bar
@@ -14,19 +14,15 @@
 			:value="progressPercentage"
 			:bg-variant="bgVariant"
 		/>
-		<div class="">
+		<div>
 			<p>
-				{{ numeralRaised }} raised
-			</p>
-			<p>
-				{{ daysRemaining }}
+				{{ daysLeft }} days left
 			</p>
 		</div>
 	</figure>
 </template>
 
 <script>
-import numeral from 'numeral';
 import KvProgressBar from '~/@kiva/kv-components/vue/KvProgressBar';
 
 export default {
@@ -35,19 +31,15 @@ export default {
 		KvProgressBar
 	},
 	props: {
-		fundedLoans: {
+		fundedBorrowers: {
 			type: Number,
 			required: true,
 		},
-		totalLoans: {
+		totalBorrowers: {
 			type: Number,
 			required: true,
 		},
 		daysLeft: {
-			type: Number,
-			required: true,
-		},
-		raisedMoney: {
 			type: Number,
 			required: true,
 		},
@@ -58,19 +50,13 @@ export default {
 		};
 	},
 	computed: {
-		numeralRaised() {
-			return numeral(this.raisedMoney).format('$0,0');
-		},
-		daysRemaining() {
-			return `${this.daysLeft} days remaining`;
-		},
-		loansLeft() {
-			return this.totalLoans - this.fundedLoans > 0
-				? this.totalLoans - this.fundedLoans
+		borrowersLeft() {
+			return this.totalBorrowers - this.fundedBorrowers > 0
+				? this.totalBorrowers - this.fundedBorrowers
 				: 0;
 		},
 		progressPercentage() {
-			return (this.fundedLoans / this.totalLoans) * 100;
+			return (this.fundedBorrowers / this.totalBorrowers) * 100;
 		},
 	},
 };

--- a/src/components/Kv/KvProgressCampaign.vue
+++ b/src/components/Kv/KvProgressCampaign.vue
@@ -4,17 +4,17 @@
 			<p>
 				{{ fundedBorrowers }} funded
 			</p>
-			<p>
+			<p v-if="!minimalStats">
 				{{ borrowersLeft }} to go
 			</p>
 		</div>
 		<kv-progress-bar
-			class="tw-my-1"
+			class="tw-my-0.5"
 			aria-label="Percent the loan has funded"
 			:value="progressPercentage"
 			:bg-variant="bgVariant"
 		/>
-		<div>
+		<div v-if="!minimalStats">
 			<p>
 				{{ daysLeft }} days left
 			</p>
@@ -42,6 +42,10 @@ export default {
 		daysLeft: {
 			type: Number,
 			required: true,
+		},
+		minimalStats: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/graphql/query/IwdActions.graphql
+++ b/src/graphql/query/IwdActions.graphql
@@ -1,8 +1,8 @@
 query IwdActions {
   lend {
     campaignActions(
-        campaignKey: "international_womens_day",
-        filters: {gender: female}
+        campaignKey: "iwd2024",
+        filters: { gender: female }
     ) {
       totalCount
       values {

--- a/src/graphql/query/campaignStats.graphql
+++ b/src/graphql/query/campaignStats.graphql
@@ -1,0 +1,11 @@
+query CampaignStats($campaignKey: String!, $filters: LoanSearchFiltersInput) {
+  general {
+    kivaStats {
+      campaignStats(campaignKey: $campaignKey, filters: $filters) {
+        currentBorrowerCount
+        targetBorrowerCount
+        targetEndDate
+      }
+    }
+  }
+}

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -22,30 +22,7 @@
 					<span class="show-for-large">{{ loanChannelName }}</span>
 				</p>
 				<template v-if="iwdHeaderExpEnabled">
-					<div class="tw-flex tw-flex-col tw-w-full">
-						<div class="tw-flex tw-pt-2 md:tw-gap-6 lg:tw-gap-12">
-							<div>
-								<h1 style="line-height: 1;" class="md:tw-pb-3">
-									Help us fund 4,000 women for Women’s Day!
-								</h1>
-								<div class="tw-flex md:tw-hidden tw-py-0.5">
-									<img :src="iWD2024Badge" alt="IWD Badge" style="width: 114px;">
-								</div>
-								<!-- eslint-disable max-len -->
-								<p class="tw-pb-3">
-									To celebrate International Women’s Day, we’re aiming to fund 4,000 women this week. That’s 4,000 more women who could have the resources they need to thrive — and invest in their communities.
-								</p>
-								<p>We need you to make it happen. Help us reach our goal and earn your exclusive International Women’s Day badge!</p>
-								<!-- eslint-enable max-len -->
-							</div>
-							<div class="tw-shrink-0 tw-hidden md:tw-block">
-								<img :src="iWD2024Badge" alt="IWD Badge">
-							</div>
-						</div>
-						<div class="tw-pt-2">
-							<activity-feed />
-						</div>
-					</div>
+					<iwd-category-header />
 				</template>
 				<template v-else>
 					<h1 class="tw-mb-2">
@@ -205,8 +182,7 @@ import EmptyState from '@/components/LoanFinding/EmptyState';
 import experimentAssignmentQuery from '@/graphql/query/experimentAssignment.graphql';
 import experimentVersionFragment from '@/graphql/fragments/experimentVersion.graphql';
 import { trackExperimentVersion } from '@/util/experiment/experimentUtils';
-import ActivityFeed from '@/components/Iwd/ActivityFeed';
-import iWD2024Badge from '@/assets/images/achievements/iwd_2024_badge.png';
+import IwdCategoryHeader from '@/components/Iwd/IwdCategoryHeader';
 
 const defaultLoansPerPage = 12;
 
@@ -306,7 +282,7 @@ export default {
 		PromoGridLoanCardExp,
 		KvClassicLoanCardContainer,
 		EmptyState,
-		ActivityFeed,
+		IwdCategoryHeader,
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [loanChannelQueryMapMixin],
@@ -349,7 +325,6 @@ export default {
 			helpMeChooseLoans: [],
 			isLoadingHC: true,
 			iwdHeaderExpEnabled: false,
-			iWD2024Badge,
 		};
 	},
 	computed: {

--- a/test/unit/specs/components/Kv/KvProgressCampaign.spec.js
+++ b/test/unit/specs/components/Kv/KvProgressCampaign.spec.js
@@ -4,28 +4,25 @@ import KvProgressCampaign from '@/components/Kv/KvProgressCampaign';
 describe('KvProgressCampaign', () => {
 	it('should display default values', () => {
 		const props = {
-			raisedMoney: 345900, daysLeft: 29, totalLoans: 4000, fundedLoans: 462,
+			daysLeft: 29, totalBorrowers: 4000, fundedBorrowers: 462,
 		};
 		const { getByText } = render(KvProgressCampaign, {
 			props,
 		});
 
-		getByText(`${props.fundedLoans} loans funded`);
-		getByText('$345,900 raised');
-		getByText(`${props.totalLoans - props.fundedLoans} to go!`);
-		getByText(`${props.daysLeft} days remaining`);
+		getByText(`${props.fundedBorrowers} funded`);
+		getByText(`${props.totalBorrowers - props.fundedBorrowers} to go`);
+		getByText(`${props.daysLeft} days left`);
 	});
 
 	it('should not display negative value on loans to go!', () => {
 		const props = {
-			raisedMoney: 345900, daysLeft: 29, totalLoans: 4000, fundedLoans: 5000,
+			daysLeft: 29, totalBorrowers: 4000, fundedBorrowers: 5000,
 		};
 		const { getByText } = render(KvProgressCampaign, {
 			props,
 		});
 
-		getByText(`${props.fundedLoans} loans funded`);
-		getByText('$345,900 raised');
-		getByText('0 to go!');
+		getByText('0 to go');
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1724

- Updated the campaign progress bar to match the updated mocks + data
- Moved the IWD header into its own file
- Created a wrapper component for the shared progress bar usage
- Added the bar to the category page for IWD
- Small fix for padding on thanks page from previous PR

![image](https://github.com/kiva/ui/assets/16867161/f9cae6e7-0b50-4ecb-983b-3d30411a4c24)

![image](https://github.com/kiva/ui/assets/16867161/8fdde768-e466-4b89-b71f-90562ec2e925)

**UPDATE**

- Added the progress bar to the thanks page variations for IWD
- Created minimal version of the progress bar

![image](https://github.com/kiva/ui/assets/16867161/22ed55fd-1a0e-4940-88a8-e4b76048e3ab)

![image](https://github.com/kiva/ui/assets/16867161/cc4e19e6-6fa3-43e6-828f-e388307e95a6)

![image](https://github.com/kiva/ui/assets/16867161/166af56b-d087-4bed-8f87-235bed1881ed)

![image](https://github.com/kiva/ui/assets/16867161/c3d05595-1992-418c-ba4d-3a18c0e3fae4)


