### PR TITLE
chore: update configs for custom domain and dev mode with caddy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+{
+	http_port 8989
+}
+
+kiva-ui.local {
+	reverse_proxy localhost:8888
+}

--- a/config/dev-custom-host.js
+++ b/config/dev-custom-host.js
@@ -5,7 +5,7 @@ var devVm  = require('./dev-vm.js')
 module.exports = merge(base, devVm, {
 	app: {
 		apolloBatching: false,
-		host: 'kiva-ui.local:8888',
+		host: 'kiva-ui.local',
 		publicPath: '/',
 		photoPath: 'https://www.development.kiva.org/img/',
 		graphqlUri: 'https://gateway.development.kiva.org/graphql',
@@ -19,12 +19,12 @@ module.exports = merge(base, devVm, {
 		auth0: {
 			loginRedirectUrls: {
 				xOXldYg02WsLnlnn0D5xoPWI2i3aNsFD: 'https://www.development.kiva.org/authenticate?authLevel=recent',
-				KIzjUBQjKZwMRgYSn6NvMxsUwNppwnLH: 'http://kiva-ui.local:8888/ui-login?force=true',
-				ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF: 'http://kiva-ui.local:8888/ui-login?force=true',
+				KIzjUBQjKZwMRgYSn6NvMxsUwNppwnLH: 'https://kiva-ui.local/ui-login?force=true',
+				ouGKxT4mE4wQEKqpfsHSE96c9rHXQqZF: 'https://kiva-ui.local/ui-login?force=true',
 			},
 			enable: true,
-			browserCallbackUri: 'http://kiva-ui.local:8888/process-browser-auth',
-			serverCallbackUri: 'http://kiva-ui.local:8888/process-ssr-auth',
+			browserCallbackUri: 'https://kiva-ui.local/process-browser-auth',
+			serverCallbackUri: 'https://kiva-ui.local/process-ssr-auth',
 			apiAudience: 'https://gateway.development.kiva.org/graphql',
 		},
 	},


### PR DESCRIPTION
This is an alternate approach to developing UI locally which allows for both login and checkout while on the VPN.

It uses a simple Caddy server to proxy requests to a locally running UI instance targeting our dev environment.

Setup:
- Add `127.0.0.1 kiva-ui.local` to your `/etc/hosts` file
- Auth0 configs are already in place
- `caddy start` from the root of the ui repo
- `npm run dev -- --config=dev-custom-host` in a separate terminal at the root of the ui repo