### PR TITLE
feat: don't save new filter to saved search

### DIFF
--- a/src/util/loanSearch/filters/flexibleFundraisingEnabled.js
+++ b/src/util/loanSearch/filters/flexibleFundraisingEnabled.js
@@ -73,11 +73,7 @@ export default {
 		return [];
 	},
 	getRemovedFacet: () => ({ flexibleFundraisingEnabled: null }),
-	getSavedSearch: loanSearchState => ({
-		flexibleFundraisingEnabled: loanSearchState?.flexibleFundraisingEnabled !== null
-			? loanSearchState.flexibleFundraisingEnabled
-			: null,
-	}),
+	getSavedSearch: () => ({}),
 	getFlssFilter: loanSearchState => ({
 		...(typeof loanSearchState?.flexibleFundraisingEnabled !== 'undefined'
 			&& loanSearchState.flexibleFundraisingEnabled !== null

--- a/test/unit/specs/util/loanSearch/filters/flexibleFundraisingEnabled.spec.js
+++ b/test/unit/specs/util/loanSearch/filters/flexibleFundraisingEnabled.spec.js
@@ -50,8 +50,8 @@ describe('flexibleFundraisingEnabled.js', () => {
 
 		describe('getSavedSearch', () => {
 			it('should get saved search', () => {
-				expect(flexibleFundraisingEnabled.getSavedSearch({ [facetsKey]: null })).toEqual({ [facetsKey]: null });
-				expect(flexibleFundraisingEnabled.getSavedSearch({ [facetsKey]: true })).toEqual({ [facetsKey]: true });
+				expect(flexibleFundraisingEnabled.getSavedSearch()).toEqual({});
+				expect(flexibleFundraisingEnabled.getSavedSearch()).toEqual({});
 			});
 		});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1717

- We were trying to save a new FLSS filter that isn't supported by saved-search/monolith