### PR TITLE
feat: aggregate and filter the activity feed

### DIFF
--- a/src/graphql/query/IwdActions.graphql
+++ b/src/graphql/query/IwdActions.graphql
@@ -3,6 +3,7 @@ query IwdActions {
     campaignActions(
         campaignKey: "iwd2024",
         filters: { gender: female },
+		limit: 12,
     ) {
       totalCount
       values {

--- a/src/graphql/query/IwdActions.graphql
+++ b/src/graphql/query/IwdActions.graphql
@@ -3,7 +3,6 @@ query IwdActions {
     campaignActions(
         campaignKey: "iwd2024",
         filters: { gender: female },
-		limit: 6,
     ) {
       totalCount
       values {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1785
https://kiva.atlassian.net/browse/CORE-1786

- Aggregate/sum amounts for lenders who lend to more than one loan quickly
- Exclude some known corporate accounts that were clogging the feed
- Increased the amount of activity feed data to allow enough displayed items after aggregation and filter
- The default limit of `campaignActions` is 20, so just removing `limit` is safe enough
- Monolith work will likely filter the corporate accounts in the future
- This will be part of a hotfix

At the moment on dev, anonymous has lent a bunch, so they only show up once:
![image](https://github.com/kiva/ui/assets/16867161/8ae72dc6-b8fd-4789-b97f-dbbf6a959274)
