### PR TITLE
fix: ensure prefetched channel data is correctly pulled from apollo cache

### DIFF
--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -529,7 +529,6 @@ export default {
 			this.targetedLoanChannelURL,
 			this.loanQueryVars,
 		);
-		console.log(baseData);
 		if (baseData) this.loading = false;
 
 		// Assign our initial view data

--- a/src/util/flssUtils.js
+++ b/src/util/flssUtils.js
@@ -135,7 +135,7 @@ export function getLoanChannelVariables(queryMapFLSS, loanQueryVars) {
 	return {
 		ids: [...loanQueryVars.ids],
 		filterObject: getFlssFilters({ ...queryMapFLSS, ...loanQueryVars }),
-		sortBy: loanQueryVars.sortBy || queryMapFLSS.sortBy,
+		sortBy: loanQueryVars.sortBy || queryMapFLSS.sortBy || null,
 		pageNumber: loanQueryVars.offset / loanQueryVars.limit,
 		pageLimit: loanQueryVars.limit,
 		basketId: loanQueryVars.basketId,


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CORE-1783

- We were getting an apollo cache miss due to using `undefined` as the fallback sort enum value