### PR TITLE
feat: team picks switch added for team challenges on filters page

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -40,6 +40,9 @@
 						<template #header>
 							{{ null }} <!-- Hide title text -->
 						</template>
+						<team-picks-switch
+							v-if="showChallengeHeader"
+						/>
 						<loan-search-filter
 							style="min-width: 285px;"
 							:extend-flss-filters="extendFlssFilters"
@@ -79,6 +82,10 @@
 			</div>
 			<div class="tw-flex tw-mr-4">
 				<div class="tw-hidden lg:tw-block" style="width: 285px;">
+					<team-picks-switch
+						v-if="showChallengeHeader"
+						class="tw-mb-2"
+					/>
 					<loan-search-filter
 						:extend-flss-filters="extendFlssFilters"
 						:loading="!initialLoadComplete"
@@ -160,6 +167,7 @@
 import itemsInBasketQuery from '@/graphql/query/basketItems.graphql';
 import loanSearchStateQuery from '@/graphql/query/loanSearchState.graphql';
 import LoanSearchFilter from '@/components/Lend/LoanSearch/LoanSearchFilter';
+import TeamPicksSwitch from '@/components/Lend/LoanSearch/TeamPicksSwitch';
 import { FLSS_QUERY_TYPE } from '@/util/loanSearch/filterUtils';
 import { FLSS_ORIGIN_LEND_FILTER } from '@/util/flssUtils';
 import { runFacetsQueries, runLoansQuery, fetchLoanFacets } from '@/util/loanSearch/dataUtils';
@@ -205,7 +213,8 @@ export default {
 		KvPagination,
 		KvResultsPerPage,
 		LoanSearchSavedSearch,
-		KvClassicLoanCardContainer
+		KvClassicLoanCardContainer,
+		TeamPicksSwitch,
 	},
 	props: {
 		extendFlssFilters: {

--- a/src/components/Lend/LoanSearch/TeamPicksSwitch.vue
+++ b/src/components/Lend/LoanSearch/TeamPicksSwitch.vue
@@ -1,0 +1,41 @@
+<template>
+	<div class="tw-bg-white tw-rounded tw-p-3 lg:tw-shadow-lg">
+		<div class="tw-flex tw-flex-col">
+			<kv-switch
+				v-model="showTeamPicks"
+			>
+				<div class="tw-flex tw-items-center tw-gap-0.5">
+					<img v-if="HandOrangeIcon" :src="HandOrangeIcon" class="tw-w-4">
+					<span>Team Picks</span>
+				</div>
+			</kv-switch>
+			<p class="tw-text-small">
+				Loans handpicked for your team, by your team. On by default for team challenges.
+			</p>
+		</div>
+		<hr class="tw-border-tertiary tw-mt-3 lg:tw-hidden">
+	</div>
+</template>
+
+<script>
+import HandOrangeIcon from '@/assets/images/hand_orange.svg';
+import KvSwitch from '~/@kiva/kv-components/vue/KvSwitch';
+
+export default {
+	name: 'TeamPicksSwitch',
+	components: {
+		KvSwitch
+	},
+	data() {
+		return {
+			showTeamPicks: true,
+			HandOrangeIcon
+		};
+	},
+	watch: {
+		showTeamPicks(val) {
+			this.$emit('showTeamPicks', val);
+		}
+	}
+};
+</script>

--- a/src/components/Lend/LoanSearch/TeamPicksSwitch.vue
+++ b/src/components/Lend/LoanSearch/TeamPicksSwitch.vue
@@ -3,9 +3,10 @@
 		<div class="tw-flex tw-flex-col">
 			<kv-switch
 				v-model="showTeamPicks"
+				@update:modelValue="$emit('showTeamPicks', $event)"
 			>
 				<div class="tw-flex tw-items-center tw-gap-0.5">
-					<img v-if="HandOrangeIcon" :src="HandOrangeIcon" class="tw-w-4">
+					<img :src="HandOrangeIcon" class="tw-w-4">
 					<span>Team Picks</span>
 				</div>
 			</kv-switch>
@@ -32,10 +33,5 @@ export default {
 			HandOrangeIcon
 		};
 	},
-	watch: {
-		showTeamPicks(val) {
-			this.$emit('showTeamPicks', val);
-		}
-	}
 };
 </script>


### PR DESCRIPTION
- team picks switch added for team challenges on filters page

Note: There is some work left to match the switch logic with loans display as the BE stuff is done

<img width="371" alt="Screenshot 2024-03-14 at 12 53 15" src="https://github.com/kiva/ui/assets/94026278/b6c10754-a366-43d5-a260-8095c923a509">
<img width="527" alt="Screenshot 2024-03-14 at 12 53 30" src="https://github.com/kiva/ui/assets/94026278/3610c859-1ad9-4b91-9a9d-41d5f6ca2df6">
