### PR TITLE
fix: ensure exporter is created

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@opentelemetry/api": "^1.7.0",
 				"@opentelemetry/auto-instrumentations-node": "^0.40.2",
 				"@opentelemetry/exporter-metrics-otlp-proto": "^0.46.0",
+				"@opentelemetry/exporter-trace-otlp-grpc": "^0.49.1",
 				"@opentelemetry/exporter-trace-otlp-proto": "^0.46.0",
 				"@opentelemetry/instrumentation": "^0.46.0",
 				"@opentelemetry/instrumentation-express": "^0.34.1",
@@ -5354,22 +5355,137 @@
 			}
 		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
-			"integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
+			"integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "1.19.0",
-				"@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-				"@opentelemetry/otlp-transformer": "0.46.0",
-				"@opentelemetry/resources": "1.19.0",
-				"@opentelemetry/sdk-trace-base": "1.19.0"
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
+				"@opentelemetry/otlp-transformer": "0.49.1",
+				"@opentelemetry/resources": "1.22.0",
+				"@opentelemetry/sdk-trace-base": "1.22.0"
 			},
 			"engines": {
 				"node": ">=14"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/api-logs": {
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+			"integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+			"dependencies": {
+				"@opentelemetry/api": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+			"integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/otlp-transformer": {
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+			"integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+			"dependencies": {
+				"@opentelemetry/api-logs": "0.49.1",
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/resources": "1.22.0",
+				"@opentelemetry/sdk-logs": "0.49.1",
+				"@opentelemetry/sdk-metrics": "1.22.0",
+				"@opentelemetry/sdk-trace-base": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+			"integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+			"dependencies": {
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/semantic-conventions": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-logs": {
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+			"integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+			"dependencies": {
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/resources": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.4.0 <1.9.0",
+				"@opentelemetry/api-logs": ">=0.39.1"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
+			"integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
+			"dependencies": {
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/resources": "1.22.0",
+				"lodash.merge": "^4.6.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.3.0 <1.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+			"integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+			"dependencies": {
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/resources": "1.22.0",
+				"@opentelemetry/semantic-conventions": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+			"integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/exporter-trace-otlp-http": {
@@ -8568,13 +8684,13 @@
 			}
 		},
 		"node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
-			"integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
+			"integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "1.19.0",
-				"@opentelemetry/otlp-exporter-base": "0.46.0",
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/otlp-exporter-base": "0.49.1",
 				"protobufjs": "^7.2.3"
 			},
 			"engines": {
@@ -8582,6 +8698,42 @@
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+			"integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+			"dependencies": {
+				"@opentelemetry/semantic-conventions": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": ">=1.0.0 <1.9.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/otlp-exporter-base": {
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+			"integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+			"dependencies": {
+				"@opentelemetry/core": "1.22.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+			"integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw==",
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/@opentelemetry/otlp-proto-exporter-base": {
@@ -8836,6 +8988,42 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
+			"integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+			"dependencies": {
+				"@grpc/grpc-js": "^1.7.1",
+				"@opentelemetry/core": "1.19.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
+				"@opentelemetry/otlp-transformer": "0.46.0",
+				"@opentelemetry/resources": "1.19.0",
+				"@opentelemetry/sdk-trace-base": "1.19.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.0"
+			}
+		},
+		"node_modules/@opentelemetry/sdk-node/node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+			"version": "0.46.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
+			"integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+			"dependencies": {
+				"@grpc/grpc-js": "^1.7.1",
+				"@opentelemetry/core": "1.19.0",
+				"@opentelemetry/otlp-exporter-base": "0.46.0",
+				"protobufjs": "^7.2.3"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.0.0"
 			}
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
@@ -48157,16 +48345,90 @@
 			}
 		},
 		"@opentelemetry/exporter-trace-otlp-grpc": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
-			"integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.49.1.tgz",
+			"integrity": "sha512-Zbd7f3zF7fI2587MVhBizaW21cO/SordyrZGtMtvhoxU6n4Qb02Gx71X4+PzXH620e0+JX+Pcr9bYb1HTeVyJA==",
 			"requires": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "1.19.0",
-				"@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
-				"@opentelemetry/otlp-transformer": "0.46.0",
-				"@opentelemetry/resources": "1.19.0",
-				"@opentelemetry/sdk-trace-base": "1.19.0"
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/otlp-grpc-exporter-base": "0.49.1",
+				"@opentelemetry/otlp-transformer": "0.49.1",
+				"@opentelemetry/resources": "1.22.0",
+				"@opentelemetry/sdk-trace-base": "1.22.0"
+			},
+			"dependencies": {
+				"@opentelemetry/api-logs": {
+					"version": "0.49.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.49.1.tgz",
+					"integrity": "sha512-kaNl/T7WzyMUQHQlVq7q0oV4Kev6+0xFwqzofryC66jgGMacd0QH5TwfpbUwSTby+SdAdprAe5UKMvBw4tKS5Q==",
+					"requires": {
+						"@opentelemetry/api": "^1.0.0"
+					}
+				},
+				"@opentelemetry/core": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+					"integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.22.0"
+					}
+				},
+				"@opentelemetry/otlp-transformer": {
+					"version": "0.49.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.49.1.tgz",
+					"integrity": "sha512-Z+koA4wp9L9e3jkFacyXTGphSWTbOKjwwXMpb0CxNb0kjTHGUxhYRN8GnkLFsFo5NbZPjP07hwAqeEG/uCratQ==",
+					"requires": {
+						"@opentelemetry/api-logs": "0.49.1",
+						"@opentelemetry/core": "1.22.0",
+						"@opentelemetry/resources": "1.22.0",
+						"@opentelemetry/sdk-logs": "0.49.1",
+						"@opentelemetry/sdk-metrics": "1.22.0",
+						"@opentelemetry/sdk-trace-base": "1.22.0"
+					}
+				},
+				"@opentelemetry/resources": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.22.0.tgz",
+					"integrity": "sha512-+vNeIFPH2hfcNL0AJk/ykJXoUCtR1YaDUZM+p3wZNU4Hq98gzq+7b43xbkXjadD9VhWIUQqEwXyY64q6msPj6A==",
+					"requires": {
+						"@opentelemetry/core": "1.22.0",
+						"@opentelemetry/semantic-conventions": "1.22.0"
+					}
+				},
+				"@opentelemetry/sdk-logs": {
+					"version": "0.49.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.49.1.tgz",
+					"integrity": "sha512-gCzYWsJE0h+3cuh3/cK+9UwlVFyHvj3PReIOCDOmdeXOp90ZjKRoDOJBc3mvk1LL6wyl1RWIivR8Rg9OToyesw==",
+					"requires": {
+						"@opentelemetry/core": "1.22.0",
+						"@opentelemetry/resources": "1.22.0"
+					}
+				},
+				"@opentelemetry/sdk-metrics": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.22.0.tgz",
+					"integrity": "sha512-k6iIx6H3TZ+BVMr2z8M16ri2OxWaljg5h8ihGJxi/KQWcjign6FEaEzuigXt5bK9wVEhqAcWLCfarSftaNWkkg==",
+					"requires": {
+						"@opentelemetry/core": "1.22.0",
+						"@opentelemetry/resources": "1.22.0",
+						"lodash.merge": "^4.6.2"
+					}
+				},
+				"@opentelemetry/sdk-trace-base": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.22.0.tgz",
+					"integrity": "sha512-pfTuSIpCKONC6vkTpv6VmACxD+P1woZf4q0K46nSUvXFvOFqjBYKFaAMkKD3M1mlKUUh0Oajwj35qNjMl80m1Q==",
+					"requires": {
+						"@opentelemetry/core": "1.22.0",
+						"@opentelemetry/resources": "1.22.0",
+						"@opentelemetry/semantic-conventions": "1.22.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+					"integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw=="
+				}
 			}
 		},
 		"@opentelemetry/exporter-trace-otlp-http": {
@@ -50406,14 +50668,37 @@
 			}
 		},
 		"@opentelemetry/otlp-grpc-exporter-base": {
-			"version": "0.46.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
-			"integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+			"version": "0.49.1",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.49.1.tgz",
+			"integrity": "sha512-DNDNUWmOqtKTFJAyOyHHKotVox0NQ/09ETX8fUOeEtyNVHoGekAVtBbvIA3AtK+JflP7LC0PTjlLfruPM3Wy6w==",
 			"requires": {
 				"@grpc/grpc-js": "^1.7.1",
-				"@opentelemetry/core": "1.19.0",
-				"@opentelemetry/otlp-exporter-base": "0.46.0",
+				"@opentelemetry/core": "1.22.0",
+				"@opentelemetry/otlp-exporter-base": "0.49.1",
 				"protobufjs": "^7.2.3"
+			},
+			"dependencies": {
+				"@opentelemetry/core": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.22.0.tgz",
+					"integrity": "sha512-0VoAlT6x+Xzik1v9goJ3pZ2ppi6+xd3aUfg4brfrLkDBHRIVjMP0eBHrKrhB+NKcDyMAg8fAbGL3Npg/F6AwWA==",
+					"requires": {
+						"@opentelemetry/semantic-conventions": "1.22.0"
+					}
+				},
+				"@opentelemetry/otlp-exporter-base": {
+					"version": "0.49.1",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.49.1.tgz",
+					"integrity": "sha512-z6sHliPqDgJU45kQatAettY9/eVF58qVPaTuejw9YWfSRqid9pXPYeegDCSdyS47KAUgAtm+nC28K3pfF27HWg==",
+					"requires": {
+						"@opentelemetry/core": "1.22.0"
+					}
+				},
+				"@opentelemetry/semantic-conventions": {
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.22.0.tgz",
+					"integrity": "sha512-CAOgFOKLybd02uj/GhCdEeeBjOS0yeoDeo/CA7ASBSmenpZHAKGB3iDm/rv3BQLcabb/OprDEsSQ1y0P8A7Siw=="
+				}
 			}
 		},
 		"@opentelemetry/otlp-proto-exporter-base": {
@@ -50577,6 +50862,30 @@
 					"integrity": "sha512-+9BcqfiEDGPXEIo+o3tso/aqGM5dGbGwAkGVp3FPpZ8GlkK1YlaKRd9gMVyPaeRATwvO5wYGGnCsAc/sMMM9Qw==",
 					"requires": {
 						"@opentelemetry/api": "^1.0.0"
+					}
+				},
+				"@opentelemetry/exporter-trace-otlp-grpc": {
+					"version": "0.46.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.46.0.tgz",
+					"integrity": "sha512-kR4kehnfIhv7v/2MuNYfrlh9A/ZtQofwCzurTIplornUjdzhKDGgjui1NkNTqTfM1QkqfCiavGsf5hwocx29bA==",
+					"requires": {
+						"@grpc/grpc-js": "^1.7.1",
+						"@opentelemetry/core": "1.19.0",
+						"@opentelemetry/otlp-grpc-exporter-base": "0.46.0",
+						"@opentelemetry/otlp-transformer": "0.46.0",
+						"@opentelemetry/resources": "1.19.0",
+						"@opentelemetry/sdk-trace-base": "1.19.0"
+					}
+				},
+				"@opentelemetry/otlp-grpc-exporter-base": {
+					"version": "0.46.0",
+					"resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.46.0.tgz",
+					"integrity": "sha512-/KB/xfZZiWIY2JknvCoT/e9paIzQO3QCBN5gR6RyxpXM/AGx3YTAOKvB/Ts9Va19jo5aE74gB7emhFaCNy4Rmw==",
+					"requires": {
+						"@grpc/grpc-js": "^1.7.1",
+						"@opentelemetry/core": "1.19.0",
+						"@opentelemetry/otlp-exporter-base": "0.46.0",
+						"protobufjs": "^7.2.3"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"@opentelemetry/api": "^1.7.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.40.2",
 		"@opentelemetry/exporter-metrics-otlp-proto": "^0.46.0",
+		"@opentelemetry/exporter-trace-otlp-grpc": "^0.49.1",
 		"@opentelemetry/exporter-trace-otlp-proto": "^0.46.0",
 		"@opentelemetry/instrumentation": "^0.46.0",
 		"@opentelemetry/instrumentation-express": "^0.34.1",

--- a/server/util/tracer.js
+++ b/server/util/tracer.js
@@ -2,8 +2,10 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const opentelemetry = require('@opentelemetry/api');
 
 // Not functionally required but gives some insight what happens behind the scenes
-const { diag, DiagConsoleLogger, DiagLogLevel } = opentelemetry;
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+if (process?.env?.OTEL_DEBUG === 'true') {
+	const { diag, DiagConsoleLogger, DiagLogLevel } = opentelemetry;
+	diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+}
 
 const { AlwaysOnSampler, SamplingDecision, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql');

--- a/server/util/tracer.js
+++ b/server/util/tracer.js
@@ -9,7 +9,7 @@ if (process?.env?.OTEL_DEBUG === 'true') {
 
 const { AlwaysOnSampler, SamplingDecision, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql');
-const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto');
+const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
 const { ConsoleSpanExporter, NodeTracerProvider } = require('@opentelemetry/sdk-trace-node');
 const { Resource } = require('@opentelemetry/resources');
 const { WinstonInstrumentation } = require('@opentelemetry/instrumentation-winston');

--- a/server/util/tracer.js
+++ b/server/util/tracer.js
@@ -2,8 +2,8 @@ const { registerInstrumentations } = require('@opentelemetry/instrumentation');
 const opentelemetry = require('@opentelemetry/api');
 
 // Not functionally required but gives some insight what happens behind the scenes
-// const { diag, DiagConsoleLogger, DiagLogLevel } = opentelemetry;
-// diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
+const { diag, DiagConsoleLogger, DiagLogLevel } = opentelemetry;
+diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.INFO);
 
 const { AlwaysOnSampler, SamplingDecision, SimpleSpanProcessor } = require('@opentelemetry/sdk-trace-base');
 const { GraphQLInstrumentation } = require('@opentelemetry/instrumentation-graphql');
@@ -14,7 +14,7 @@ const { WinstonInstrumentation } = require('@opentelemetry/instrumentation-winst
 const { SemanticResourceAttributes } = require('@opentelemetry/semantic-conventions');
 
 // Basic export switch to enable console or OTLP
-const Exporter = (process.env.OPENTELEMETRY_EXPORTER_TYPE || '').toLowerCase().startsWith('c')
+const Exporter = (process?.env?.OPENTELEMETRY_EXPORTER_TYPE ?? 'export')?.toLowerCase().startsWith('c')
 	? ConsoleSpanExporter : OTLPTraceExporter;
 const { ExpressInstrumentation } = require('@opentelemetry/instrumentation-express');
 const { HttpInstrumentation } = require('@opentelemetry/instrumentation-http');


### PR DESCRIPTION
My theory here is that the check for the exporter type if failing with a js error b/c it wasn't set. Trying to fix the values the conditional is operating on first after which I'll also define a better default in flux.

Also wrapped the debug init in a flag I can set in flux if further debugging is needed...