### PR TITLE
fix: padding on callout container

### DIFF
--- a/src/components/Lend/LoanSearch/ChallengeCallout.vue
+++ b/src/components/Lend/LoanSearch/ChallengeCallout.vue
@@ -66,6 +66,6 @@ export default {
 }
 
 .container {
-	@apply md:tw-my-4 tw-px-0 md:tw-px-4 lg:tw-px-8;
+	@apply md:tw-pt-3 tw-px-0 md:tw-px-4 lg:tw-px-8;
 }
 </style>


### PR DESCRIPTION
Margin was not necessary, we just needed to care about the space between the top of the page and the component.