### PR TITLE
feat: hiding save search for keyword and loan funding type filters

### DIFF
--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -366,10 +366,33 @@ export default {
 
 			return isNumber(storedPageLimit) ? +storedPageLimit : this.loanSearchState.pageLimit;
 		},
-		showSavedSearch() {
+		activeFilters() {
 			return filterConfig.keys.reduce((prev, key) => {
-				return prev || filterConfig.config[key].showSavedSearch(this.loanSearchState);
-			}, false);
+				if (filterConfig.config[key].showSavedSearch(this.loanSearchState)) {
+					prev.push(key);
+				}
+				return prev;
+			}, []);
+		},
+		// MPL-56 - Temporarily hiding save search for new filters
+		unsupportedSaveFilters() {
+			return (
+				this.activeFilters.length === 1
+				&& (
+					this.activeFilters.includes('keywordSearch')
+					|| this.activeFilters.includes('flexibleFundraisingEnabled')
+				)
+			)
+			|| (
+				this.activeFilters.length === 2
+				&& this.activeFilters.includes('keywordSearch')
+				&& this.activeFilters.includes('flexibleFundraisingEnabled'));
+		},
+		showSavedSearch() {
+			return !this.unsupportedSaveFilters
+				&& filterConfig.keys.reduce((prev, key) => {
+					return prev || filterConfig.config[key].showSavedSearch(this.loanSearchState);
+				}, false);
 		},
 	},
 	methods: {


### PR DESCRIPTION
Didn't want to touch current logic for filters, that's why I decided to create two new computed to evaluate showing `Save Search`