### PR TITLE
feat: team query params added to filtering query params

### DIFF
--- a/src/util/loanSearch/queryParamUtils.js
+++ b/src/util/loanSearch/queryParamUtils.js
@@ -49,11 +49,15 @@ export function convertQueryToFilters(query, allFacets, queryType, pageLimit) {
 export function updateQueryParams(loanSearchState, router, queryType) {
 	const oldParamKeys = Object.keys(router.currentRoute.query);
 
-	// Preserve UTM params
+	// Preserve UTM params and team query params
 	const utmParams = {};
+	const teamParams = {};
 	oldParamKeys.forEach(key => {
 		if (key.includes('utm_')) {
 			utmParams[key] = router.currentRoute.query[key];
+		}
+		if (key.includes('team')) {
+			teamParams[key] = router.currentRoute.query[key];
 		}
 	});
 
@@ -63,6 +67,7 @@ export function updateQueryParams(loanSearchState, router, queryType) {
 			return { ...prev, ...filterConfig.config[key].getQueryFromFilter(loanSearchState, queryType) };
 		}, {}),
 		...utmParams,
+		...teamParams,
 	};
 
 	const newParamKeys = Object.keys(newParams);


### PR DESCRIPTION
- team query params added to filtering query params

As we don't have filters for `team` and the logic for this query is in the page side, we just need to preserve the team query param like utm cases.