### PR TITLE
fix: hide share challenge if no attributed team

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -108,6 +108,7 @@
 					</template>
 				</div>
 				<share-challenge
+					v-if="teamPublicId"
 					:goal="goal"
 					:loan="challengeLoan"
 					:team-public-id="teamPublicId"


### PR DESCRIPTION
Same logic for hiding the challenge header