### PR TITLE
fix: copyUrl calling getFullUrl twice and mixing up different params

### DIFF
--- a/src/util/urlUtils.js
+++ b/src/util/urlUtils.js
@@ -56,8 +56,11 @@ export function getFullUrl(base, args) {
 
 	// remove hash portion of url if present
 	const baseUrlWithoutHash = base.split('#')[0];
+	// remove params portion of url if present
+	const baseUrl = baseUrlWithoutHash.split('?')[0];
 	const hashParams = base.split('#')[1] ? `#${base.split('#')[1]}` : '';
-	const querystring = Object.keys(args)
+	const baseParams = base.split('?')[1] ? base.split('?')[1] : '';
+	let querystring = Object.keys(args)
 		.filter(key => {
 			return !!args[key];
 		})
@@ -65,7 +68,12 @@ export function getFullUrl(base, args) {
 			return `${key}=${encodeURIComponent(args[key])}`;
 		})
 		.join('&');
-	return `${baseUrlWithoutHash}${querystring ? `?${querystring}` : ''}${hashParams}`;
+
+	// append base params if present
+	if (baseParams) {
+		querystring += `&${baseParams}`;
+	}
+	return `${baseUrl}${querystring ? `?${querystring}` : ''}${hashParams}`;
 }
 
 /**

--- a/test/unit/specs/util/urlUtils.spec.js
+++ b/test/unit/specs/util/urlUtils.spec.js
@@ -62,6 +62,13 @@ describe('urlUtils.js', () => {
 		it('return a valid url if missing args but present hash', () => {
 			expect(getFullUrl('https://www.twitter.com/#update')).toBe('https://www.twitter.com/#update');
 		});
+		it('return a valid url, rearranging base url params', () => {
+			const newParam = {
+				a: 'a'
+			};
+			expect(getFullUrl('https://www.kiva.org/lend/filter?b=b&c=c', newParam))
+				.toBe('https://www.kiva.org/lend/filter?a=a&b=b&c=c');
+		});
 	});
 
 	describe('isCCPage', () => {


### PR DESCRIPTION
Currently, with `social-share-mixin` and `shareLink` computed definition, `getFullUrl` is being called twice and making some of the `shareLink` arguments invalid (Browser doesn't recognize them).

For instance, in `ShareChallenge` component when you hit the `Copy Link` button the value is: `https://www.development.kiva.org/lend/filter?team=aplus&lender=christian78848470?utm_source=social_share_link&utm_medium=referral&utm_campaign=teamschallenge&utm_content=christian78848470`. When you visit this link, it should show a callout at the top of the page due to lender param, but it only show the challenge header because of the double `?`.