### PR TITLE
fix: add no wrap class only when there are goal participants and borr…

### DIFF
--- a/src/components/Lend/LoanSearch/ChallengeCallout.vue
+++ b/src/components/Lend/LoanSearch/ChallengeCallout.vue
@@ -146,7 +146,7 @@ export default {
 <style scoped lang="postcss">
 .info {
 	@apply tw-bg-white tw-flex tw-items-center tw-justify-center tw-gap-2 tw-shadow-lg tw-py-1
-		md:tw-rounded-lg tw-rounded-b tw-px-4;
+		md:tw-rounded-lg tw-rounded-b tw-px-2.5 md:tw-px-4;
 }
 
 .container {


### PR DESCRIPTION
…owerName exists

Before:
<img width="327" alt="image" src="https://github.com/kiva/ui/assets/56947778/a794b478-31ac-427a-ae62-29d09b1bf340">

after:
<img width="320" alt="image" src="https://github.com/kiva/ui/assets/56947778/bc3b3b79-4779-4640-bbdd-629afe620085">

