### PR TITLE
fix: move mounted logic to prefetch to set query values

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/DepositIncentiveBanner.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/DepositIncentiveBanner.vue
@@ -30,8 +30,13 @@ export default {
 		};
 	},
 	inject: ['apollo', 'cookieStore'],
-	preFetch(config, client) {
-		return client.query({ query: amountToLendQuery });
+	apollo: {
+		query: amountToLendQuery,
+		preFetch: true,
+		result({ data }) {
+			this.amountToLend = data?.my?.depositIncentiveAmountToLend ?? 0;
+			this.isLoggedin = !!data?.my?.id ?? false;
+		},
 	},
 	computed: {
 		promoBannerContent() {
@@ -50,13 +55,5 @@ export default {
 			};
 		}
 	},
-	mounted() {
-		const userInfo = this.apollo.readQuery({
-			query: amountToLendQuery,
-		});
-
-		this.amountToLend = userInfo?.my?.depositIncentiveAmountToLend ?? 0;
-		this.isLoggedin = !!userInfo?.my?.id ?? false;
-	}
 };
 </script>


### PR DESCRIPTION
`readQuery` was returning null, since preFetch returned message was `You must be authenticated to perform the requested operation`. Not sure about the timing issue here.

Handling logic in `apollo` solved the problem.