### PR TITLE
feat: loan card clickable callouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.12.1",
-				"@kiva/kv-components": "^3.75.1",
+				"@kiva/kv-components": "^3.75.2",
 				"@kiva/kv-shop": "^1.8.1",
 				"@kiva/kv-tokens": "^2.11.0",
 				"@mdi/js": "^7",
@@ -4422,9 +4422,9 @@
 			"integrity": "sha512-1lNM7toQpiHWWdKrBmoXPudNLgFscU8rnk4nyBQQhbnlhSLzbjbsCcWWnA+IqXkgOCVysSpI7yEi7fuU6uLMYg=="
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.75.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.75.1.tgz",
-			"integrity": "sha512-LIZpWqM5Ea9JmVEAVCeXyX69agzNItSGujXOVnwBIDSL5HzaZzIpPk3dYG9iDCIIO1ph8jBo5UBNRpIUw5RykA==",
+			"version": "3.75.2",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.75.2.tgz",
+			"integrity": "sha512-s6vn7YZ34ps0sHFKHxdnPVFOGXjuaFGDq17ZRdx5gtqCpbrSBK4O1Y0HoNqCnsJQ2ALCl1eMowLjWDEvaxJEgA==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^2.11.1",
 				"@mdi/js": "^5.9.55",
@@ -47552,9 +47552,9 @@
 			"integrity": "sha512-1lNM7toQpiHWWdKrBmoXPudNLgFscU8rnk4nyBQQhbnlhSLzbjbsCcWWnA+IqXkgOCVysSpI7yEi7fuU6uLMYg=="
 		},
 		"@kiva/kv-components": {
-			"version": "3.75.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.75.1.tgz",
-			"integrity": "sha512-LIZpWqM5Ea9JmVEAVCeXyX69agzNItSGujXOVnwBIDSL5HzaZzIpPk3dYG9iDCIIO1ph8jBo5UBNRpIUw5RykA==",
+			"version": "3.75.2",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.75.2.tgz",
+			"integrity": "sha512-s6vn7YZ34ps0sHFKHxdnPVFOGXjuaFGDq17ZRdx5gtqCpbrSBK4O1Y0HoNqCnsJQ2ALCl1eMowLjWDEvaxJEgA==",
 			"requires": {
 				"@kiva/kv-tokens": "^2.11.1",
 				"@mdi/js": "^5.9.55",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.12.1",
-				"@kiva/kv-components": "^3.74.0",
+				"@kiva/kv-components": "^3.75.1",
 				"@kiva/kv-shop": "^1.8.1",
 				"@kiva/kv-tokens": "^2.11.0",
 				"@mdi/js": "^7",
@@ -4417,11 +4417,11 @@
 			"integrity": "sha512-1lNM7toQpiHWWdKrBmoXPudNLgFscU8rnk4nyBQQhbnlhSLzbjbsCcWWnA+IqXkgOCVysSpI7yEi7fuU6uLMYg=="
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.74.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.74.0.tgz",
-			"integrity": "sha512-G7kE6+tr4KxcDl8doDOwlTQKQuRNa4gKRGrYm33C5m/1232nCON/oZyt0As75zB7SSIrEDlg3vN4wy9AYgiXVw==",
+			"version": "3.75.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.75.1.tgz",
+			"integrity": "sha512-LIZpWqM5Ea9JmVEAVCeXyX69agzNItSGujXOVnwBIDSL5HzaZzIpPk3dYG9iDCIIO1ph8jBo5UBNRpIUw5RykA==",
 			"dependencies": {
-				"@kiva/kv-tokens": "^2.11.0",
+				"@kiva/kv-tokens": "^2.11.1",
 				"@mdi/js": "^5.9.55",
 				"@vueuse/integrations": "^7.6.0",
 				"aria-hidden": "^1.1.3",
@@ -4523,9 +4523,9 @@
 			}
 		},
 		"node_modules/@kiva/kv-tokens": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-2.11.0.tgz",
-			"integrity": "sha512-n+siz5ZeI91jKGB6fMlIgoHmmKsdkgsrSbSKcizdWCnOewDZfmDL7q403AOAEe76cKpFztxavtqb4W9Noh3xNA==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-2.11.1.tgz",
+			"integrity": "sha512-/giaaSjnM6yQrNsb+iURENzyqqEapD+UgaklQ/y/LeNzQUD77evM8SvR+hm+erfaUd99PgeyUQvje1/5nQLSww==",
 			"dependencies": {
 				"@tailwindcss/line-clamp": "^0.4.0",
 				"@tailwindcss/typography": "^0.5.1",
@@ -47508,11 +47508,11 @@
 			"integrity": "sha512-1lNM7toQpiHWWdKrBmoXPudNLgFscU8rnk4nyBQQhbnlhSLzbjbsCcWWnA+IqXkgOCVysSpI7yEi7fuU6uLMYg=="
 		},
 		"@kiva/kv-components": {
-			"version": "3.74.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.74.0.tgz",
-			"integrity": "sha512-G7kE6+tr4KxcDl8doDOwlTQKQuRNa4gKRGrYm33C5m/1232nCON/oZyt0As75zB7SSIrEDlg3vN4wy9AYgiXVw==",
+			"version": "3.75.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.75.1.tgz",
+			"integrity": "sha512-LIZpWqM5Ea9JmVEAVCeXyX69agzNItSGujXOVnwBIDSL5HzaZzIpPk3dYG9iDCIIO1ph8jBo5UBNRpIUw5RykA==",
 			"requires": {
-				"@kiva/kv-tokens": "^2.11.0",
+				"@kiva/kv-tokens": "^2.11.1",
 				"@mdi/js": "^5.9.55",
 				"@vueuse/integrations": "^7.6.0",
 				"aria-hidden": "^1.1.3",
@@ -47562,9 +47562,9 @@
 			}
 		},
 		"@kiva/kv-tokens": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-2.11.0.tgz",
-			"integrity": "sha512-n+siz5ZeI91jKGB6fMlIgoHmmKsdkgsrSbSKcizdWCnOewDZfmDL7q403AOAEe76cKpFztxavtqb4W9Noh3xNA==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-tokens/-/kv-tokens-2.11.1.tgz",
+			"integrity": "sha512-/giaaSjnM6yQrNsb+iURENzyqqEapD+UgaklQ/y/LeNzQUD77evM8SvR+hm+erfaUd99PgeyUQvje1/5nQLSww==",
 			"requires": {
 				"@tailwindcss/line-clamp": "^0.4.0",
 				"@tailwindcss/typography": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.12.1",
-		"@kiva/kv-components": "^3.75.1",
+		"@kiva/kv-components": "^3.75.2",
 		"@kiva/kv-shop": "^1.8.1",
 		"@kiva/kv-tokens": "^2.11.0",
 		"@mdi/js": "^7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.12.1",
-		"@kiva/kv-components": "^3.74.0",
+		"@kiva/kv-components": "^3.75.1",
 		"@kiva/kv-shop": "^1.8.1",
 		"@kiva/kv-tokens": "^2.11.0",
 		"@mdi/js": "^7",

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -154,6 +154,7 @@
 						:is-team-pick="showTeamPicks"
 						:show-loans-activity-feed="showLoansActivityFeed"
 						:enable-huge-amount="enableHugeAmount"
+						:enable-clickable-tags="enableClickableTags"
 						@add-to-basket="addToBasket"
 					/>
 				</div>
@@ -256,6 +257,10 @@ export default {
 		teamName: {
 			type: String,
 			default: () => '',
+		},
+		enableClickableTags: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/components/LoanCards/KvClassicLoanCardContainer.vue
+++ b/src/components/LoanCards/KvClassicLoanCardContainer.vue
@@ -46,6 +46,7 @@ import { createIntersectionObserver } from '@/util/observerUtils';
 import percentRaisedMixin from '@/plugins/loan/percent-raised-mixin';
 import loanCardFieldsExtendedFragment from '@/graphql/fragments/loanCardFieldsExtended.graphql';
 import loanActivitiesQuery from '@/graphql/query/loanActivities.graphql';
+import _isEqual from 'lodash/isEqual';
 import KvClassicLoanCard from '~/@kiva/kv-components/vue/KvClassicLoanCard';
 
 const PHOTO_PATH = 'https://www-kiva-org.freetls.fastly.net/img/';
@@ -231,15 +232,15 @@ export default {
 				this.isBookmarked = result.data.lend.loan?.userProperties?.favorited ?? false;
 			}
 
-			// Getting tags and themes data
-			const { tags, themes } = this.loan || [];
+			// Getting tags and themes data for clickable pills
+			const { tags, themes } = this.loan || {};
 			const tagList = result.data?.lend?.tag || [];
 			const themeList = result.data?.lend?.loanThemeFilter || [];
 			const tagsData = tagList.filter(tag => {
-				return tags.includes(tag.name);
+				return tags?.includes(tag.name);
 			});
 			const themesData = themeList.filter(theme => {
-				return themes.includes(theme.name);
+				return themes?.includes(theme.name);
 			});
 			this.loan = {
 				...this.loan,
@@ -387,14 +388,16 @@ export default {
 				this.$kvTrackEvent('Lending', 'loan-card', 'Failed to fetch loan activity data.');
 			});
 		},
-		jumpFilterPage(tag) {
-			this.$kvTrackEvent('Lending', 'loan-card', 'clicked-tag');
+		jumpFilterPage(filter) {
+			this.$kvTrackEvent('Lending', 'loan-card', 'clicked-tag', filter.type, filter.id.toString());
 			const query = {};
-			query[tag.type] = tag.id;
-			this.$router.push({
-				path: '/lend/filter',
-				query,
-			});
+			query[filter.type] = filter.id.toString();
+			if (!_isEqual(this.$route.query, query)) {
+				this.$router.push({
+					path: '/lend/filter',
+					query,
+				});
+			}
 		},
 	},
 	mounted() {

--- a/src/components/LoanCards/KvClassicLoanCardContainer.vue
+++ b/src/components/LoanCards/KvClassicLoanCardContainer.vue
@@ -27,7 +27,9 @@
 			:combined-activities="combinedActivities"
 			:error-msg="errorMsg"
 			:enable-huge-amount="enableHugeAmount"
+			:enable-clickable-tags="enableClickableTags"
 			@toggle-bookmark="toggleBookmark"
+			@jump-filter-page="jumpFilterPage"
 			@add-to-basket="addToBasket"
 		/>
 	</div>
@@ -141,6 +143,10 @@ export default {
 			default: false,
 		},
 		enableHugeAmount: {
+			type: Boolean,
+			default: false,
+		},
+		enableClickableTags: {
 			type: Boolean,
 			default: false,
 		},
@@ -379,6 +385,15 @@ export default {
 				logFormatter(e, 'error');
 
 				this.$kvTrackEvent('Lending', 'loan-card', 'Failed to fetch loan activity data.');
+			});
+		},
+		jumpFilterPage(tag) {
+			this.$kvTrackEvent('Lending', 'loan-card', 'clicked-tag');
+			const query = {};
+			query[tag.type] = tag.id;
+			this.$router.push({
+				path: '/lend/filter',
+				query,
 			});
 		},
 	},

--- a/src/pages/Lend/LoanSearchPage.vue
+++ b/src/pages/Lend/LoanSearchPage.vue
@@ -54,6 +54,7 @@
 					:challenge-data="challengeData"
 					:show-loans-activity-feed="showLoansActivityFeed"
 					:enable-huge-amount="enableHugeLendAmount"
+					:enable-clickable-tags="enableClickableTags"
 					@add-to-basket="addToBasketCallback"
 					:team-name="teamName"
 				/>
@@ -76,6 +77,7 @@ import teamsGoalsQuery from '@/graphql/query/teamsGoals.graphql';
 import myTeamsQuery from '@/graphql/query/myTeams.graphql';
 import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '@/plugins/five-dollars-test-mixin';
 import hugeLendAmount from '@/plugins/huge-lend-amount-mixin';
+import clickableTags from '@/plugins/clickable-tags-mixin';
 import goalParticipationForLoanQuery from '@/graphql/query/goalParticipationForLoan.graphql';
 import myPublicLenderInfoQuery from '@/graphql/query/myPublicLenderInfo.graphql';
 import ChallengeCallout from '@/components/Lend/LoanSearch/ChallengeCallout';
@@ -144,7 +146,7 @@ export default {
 			hideChallengeCallout: false,
 		};
 	},
-	mixins: [fiveDollarsTest, hugeLendAmount],
+	mixins: [fiveDollarsTest, hugeLendAmount, clickableTags],
 	inject: ['apollo', 'cookieStore'],
 	apollo: {
 		preFetch(config, client, args) {
@@ -381,6 +383,9 @@ export default {
 			SHOW_LOANS_ACTIVITY_FEED_EXP,
 			'EXP-ACK-1098-May2024',
 		);
+
+		// Enable clickable tags test
+		this.initializeLoanCardClickableTags();
 	},
 };
 </script>

--- a/src/plugins/clickable-tags-mixin.js
+++ b/src/plugins/clickable-tags-mixin.js
@@ -1,0 +1,23 @@
+import { trackExperimentVersion } from '@/util/experiment/experimentUtils';
+
+export const CLICKABLE_TAGS_EXP = 'enable_clickable_tags';
+
+export default {
+	data() {
+		return {
+			enableClickableTags: false
+		};
+	},
+	methods: {
+		initializeLoanCardClickableTags() {
+			const { version } = trackExperimentVersion(
+				this.apollo,
+				this.$kvTrackEvent,
+				'Lending',
+				CLICKABLE_TAGS_EXP,
+				'EXP-MP-170-May2024'
+			);
+			this.enableClickableTags = version === 'b';
+		},
+	},
+};


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-170

- Loan card callouts on the `/lend/filter` page are now clickable
- Takes the user to `lend/filter/` with the filter from the callout applied
- Works for tags, themes, and sectors
- Activities are not clickable currently since they are not an active filter on `lend/filter`

![image](https://github.com/kiva/ui/assets/16867161/cb99432a-13f1-48e1-b8bb-8638b24ecb6e)
