### PR TITLE
fix: borrower applicant cookie setting location

### DIFF
--- a/server/util/getSessionCookies.js
+++ b/server/util/getSessionCookies.js
@@ -18,14 +18,7 @@ const decodeCookieValue = value => {
 
 function getSessionCookies(url = '', requestCookies = {}) {
 	return new Promise((resolve, reject) => {
-		if (url.length
-			&& (
-				!requestCookies.kv
-				|| !requestCookies.kvis
-				|| !requestCookies.kvbskt
-				|| !requestCookies.kvborrowerapplicant
-			)
-		) {
+		if (url.length && (!requestCookies.kv || !requestCookies.kvis || !requestCookies.kvbskt)) {
 			fetch(url, {
 				headers: {
 					Cookie: getCookieString(requestCookies),

--- a/server/util/getSessionCookies.js
+++ b/server/util/getSessionCookies.js
@@ -23,8 +23,7 @@ function getSessionCookies(url = '', requestCookies = {}) {
 				!requestCookies.kv
 				|| !requestCookies.kvis
 				|| !requestCookies.kvbskt
-				// TODO: always return the new cookie from the monolith start session endpoint
-				// || !requestCookies.kvborrowerapplicant
+				|| !requestCookies.kvborrowerapplicant
 			)
 		) {
 			fetch(url, {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-237

- Cookie now being set on monolith applicant form page: https://github.com/kiva/kiva/pull/12547