### PR TITLE
feat: restart upload process with new action changes MP-226

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -81,4 +81,4 @@ jobs:
         with:
           dockerfile_target: "release"
           push: true
-          # upload_source_dir: "ui/dist/static"
+          upload_source_dir: "ui/dist"


### PR DESCRIPTION
Note: This will also upload the client manifest and server bundle to s3, but that on't harm anything except the upload time for now. Once we confirm that the action is working, we can come back and exclude those files.