### PR TITLE
fix: count month days for teams challenge days left

### DIFF
--- a/src/components/Kv/KvProgressCampaign.vue
+++ b/src/components/Kv/KvProgressCampaign.vue
@@ -2,7 +2,7 @@
 	<figure class="tw-grow">
 		<div class="tw-flex tw-items-center tw-justify-between">
 			<p>
-				{{ daysLeft }} days remaining
+				{{ daysLeft }} remaining
 			</p>
 			<p v-if="!minimalStats">
 				{{ numeral(amountLeft).format('$0,0') }} to go
@@ -48,8 +48,8 @@ export default {
 			required: true,
 		},
 		daysLeft: {
-			type: Number,
-			default: 0,
+			type: String,
+			default: '',
 		},
 		minimalStats: {
 			type: Boolean,

--- a/src/components/Thanks/ChallengeHeader.vue
+++ b/src/components/Thanks/ChallengeHeader.vue
@@ -35,7 +35,7 @@
 							</div>
 						</div>
 						<p class="tw-text-right tw-font-medium">
-							{{ daysLeft }} days remaining
+							{{ daysLeft }} remaining
 						</p>
 					</div>
 					<div class="tw-mt-2 tw-mb-6">

--- a/src/plugins/team-goal-mixin.js
+++ b/src/plugins/team-goal-mixin.js
@@ -1,4 +1,4 @@
-import { differenceInCalendarDays } from 'date-fns';
+import { formatDistanceToNowStrict } from 'date-fns';
 
 export default {
 	props: {
@@ -46,11 +46,13 @@ export default {
 			return this.goal?.targets?.values?.[0]?.targetLendAmount ?? 0;
 		},
 		daysLeft() {
-			const start = this.goal?.startDate ? new Date(this.goal?.startDate) : new Date();
 			const end = this.goal?.endDate ? new Date(this.goal?.endDate) : new Date();
-			return differenceInCalendarDays(
+			return formatDistanceToNowStrict(
 				end,
-				start,
+				{
+					unit: 'day',
+					roundingMethod: 'ceil'
+				}
 			);
 		},
 		challengeDescription() {

--- a/test/unit/specs/components/Kv/KvProgressCampaign.spec.js
+++ b/test/unit/specs/components/Kv/KvProgressCampaign.spec.js
@@ -5,7 +5,7 @@ import numeral from 'numeral';
 describe('KvProgressCampaign', () => {
 	it('should display default values', () => {
 		const props = {
-			daysLeft: 29, totalAmount: 4000, fundedAmount: 462,
+			daysLeft: '29 days', totalAmount: 4000, fundedAmount: 462,
 		};
 		const { getByText } = render(KvProgressCampaign, {
 			props,
@@ -14,12 +14,12 @@ describe('KvProgressCampaign', () => {
 		const amountLeft = numeral(props.totalAmount - props.fundedAmount).format('$0,0');
 
 		getByText(`${amountLeft} to go`);
-		getByText(`${props.daysLeft} days remaining`);
+		getByText(`${props.daysLeft} remaining`);
 	});
 
 	it('should not display negative value on loans to go!', () => {
 		const props = {
-			daysLeft: 29, totalAmount: 4000, fundedAmount: 5000,
+			daysLeft: '29 days', totalAmount: 4000, fundedAmount: 5000,
 		};
 		const { getByText } = render(KvProgressCampaign, {
 			props,


### PR DESCRIPTION
`IntervalToDuration` method returns an interval object with ({years, months, days}) we were just getting the days between two dates causing an issue if the difference between them is 1 month at least.

Note: I'm assuming challenge's days are less than 1 year for this fix

Given these dates:
Start: today
End: `2024-07-17T15:37:46.711Z`

## Issue
<img width="757" alt="image" src="https://github.com/kiva/ui/assets/56947778/1ab2538e-3be7-49b5-9404-2a87e5bc89c4">

## Fix:
<img width="748" alt="image" src="https://github.com/kiva/ui/assets/56947778/92ad4845-b979-4629-8393-241376cc2187">
