### PR TITLE
fix: radio button was not displayed and validation issues

### DIFF
--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -151,7 +151,7 @@
 
 <script>
 import { validationMixin } from 'vuelidate';
-import { requiredIf } from 'vuelidate/lib/validators';
+import { required, requiredIf } from 'vuelidate/lib/validators';
 import logReadQueryError from '@/util/logReadQueryError';
 import KvBaseInput from '@/components/Kv/KvBaseInput';
 import ReCaptchaEnterprise from '@/components/Forms/ReCaptchaEnterprise';


### PR DESCRIPTION
Seems like timing issue with $v, it was not adding a validation for `selectedComms` and that was causing 500 server error on userUpdates component. As a workaround, setting the flag to true as default so it can be added to validations and then if it's not the radio button experiment, remove that validation.

Still looking some ways to do this without the needsComms flag.