### PR TITLE
build: use main branch of marketplace-web-ui-ci

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -38,7 +38,7 @@ jobs:
           repository: kiva/marketplace-web-ui-ci
           token: ${{ env.GITHUB_PAT }}
           path: .docker
-          ref: use-existing-assets
+          ref: main
           patterns: |
               resources/org/kiva/marketplaceWebUiCi/ui
       - name: move files
@@ -74,7 +74,7 @@ jobs:
           repository: kiva/marketplace-web-ui-ci
           token: ${{ env.GITHUB_PAT }}
           path: .docker
-          ref: use-existing-assets
+          ref: main
           patterns: |
             resources/org/kiva/marketplaceWebUiCi/ui
       - name: move files

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -74,7 +74,7 @@ jobs:
           repository: kiva/marketplace-web-ui-ci
           token: ${{ env.GITHUB_PAT }}
           path: .docker
-          ref: use-existing-assets
+          ref: main
           patterns: |
             resources/org/kiva/marketplaceWebUiCi/ui
       - name: move files


### PR DESCRIPTION
The `use-existing-assets` branch of marketplace-web-ui-ci has [been merged into `main`](https://github.com/kiva/marketplace-web-ui-ci/pull/100), so we can switch back to using `main`.