### PR TITLE
feat: add banner link back to impact dash if user came from impact dash

### DIFF
--- a/src/components/WwwFrame/PromotionalBanner/Banners/PromoCreditBanner.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/PromoCreditBanner.vue
@@ -1,7 +1,25 @@
-<!-- eslint-disable vue/no-useless-template-attributes -->
 <template>
 	<div
-		v-if="lendingRewardOffered"
+		v-if="isFromImpactDashboard"
+		class="tw-bg-brand tw-text-white tw-text-center tw-py-1 md:tw-py-1.5 tw-px-2"
+		data-testid="lending-reward-banner-impact-dashboard"
+	>
+		<a
+			:href="impactDashboardLink"
+			class="
+					tw-text-white
+					hover:tw-no-underline hover:tw-text-white
+					active:tw-text-white visited:tw-text-white focus:tw-text-white"
+			data-testid="impact-dashboard-promo-banner"
+			v-kv-track-event="['TopNav','click-Promo','Lending Reward Banner']"
+		>
+			<span class="tw-underline">
+				Go back to the other tab to make your selection!
+			</span>
+		</a>
+	</div>
+	<div
+		v-else-if="lendingRewardOffered"
 		class="tw-bg-brand tw-text-white tw-text-center tw-py-1 md:tw-py-1.5 tw-px-2"
 		data-testid="lending-reward-banner"
 	>
@@ -22,7 +40,6 @@
 		</template>
 		<template
 			v-else
-			v-kv-track-event="['TopNav','click-Promo','Lending Reward Banner']"
 		>
 			Make a Kiva loan <br class="sm:tw-inline md:tw-hidden">and receive a $25 free credit to lend again.
 		</template>
@@ -136,6 +153,17 @@ export default {
 		this.fetchManagedAccountCampaign();
 	},
 	computed: {
+		impactDashboardLink() {
+			// return the impact dashboard link
+			// get all query params and remove the fromContext
+			const queryParams = { ...this.$route.query };
+			delete queryParams.fromContext;
+			// return the impact dashboard link with additional query params
+			return `${this.$route.query?.fromContext}?${new URLSearchParams(queryParams).toString()}`;
+		},
+		isFromImpactDashboard() {
+			return this.$route.query?.fromContext?.startsWith('/impact-dashboard') ?? false;
+		},
 		priorityBasketCredit() {
 			// get credits list
 			const basketCredits = this.basketState?.shop?.basket?.credits?.values ?? [];


### PR DESCRIPTION
When a user arrives to the BP with a query param like: `fromContext=/impact-dashboard/hitachi` Generate banner with link back to `/impact-dashboard/hitachi`

This banner state should trump all other states. 

Waiting on copy confirmation in ticket, so there could be a copy  update here