### PR TITLE
fix: reposition animated sparkles around borrower image MP-376

### DIFF
--- a/src/components/Thanks/AnimatedSparkles.vue
+++ b/src/components/Thanks/AnimatedSparkles.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable max-len -->
 <template>
-	<svg width="199" height="164" viewBox="0 0 199 164" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+	<svg viewBox="0 0 199 164" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 		<path class="spark spark-1" d="M38.3281 50.8176C33.2656 50.8176 32 46.4392 32 44.25C32 46.4392 30.7344 50.8176 25.6719 50.8176C30.7344 50.8176 32 55.4392 32 57.75C32 55.4392 33.2656 50.8176 38.3281 50.8176Z" fill="white" stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
 		<g class="spark spark-2" clip-path="url(#clip0_8313_593)">
 			<rect x="172.358" y="0.118286" width="24.5106" height="27" fill="url(#pattern0_8313_593)" />

--- a/src/components/Thanks/WhatIsNextTemplate.vue
+++ b/src/components/Thanks/WhatIsNextTemplate.vue
@@ -10,8 +10,8 @@
 				</p>
 
 				<div class="borrower-container">
-					<div class="tw-absolute tw-w-full tw-h-full tw-z-docked" style="width: 240px;">
-						<animated-sparkles />
+					<div class="tw-absolute tw-h-full tw-z-docked tw-left-1/2 -tw-translate-x-1/2">
+						<animated-sparkles class="tw-h-full" />
 					</div>
 
 					<div


### PR DESCRIPTION
I noticed this positioning was not centered due to the svg sizing

### Before
<img width="480" alt="Screenshot 2024-06-20 at 5 42 23 PM" src="https://github.com/kiva/ui/assets/4149025/73a93e20-d98b-49b7-8af9-9a3078331ca0">

### After
<img width="506" alt="Screenshot 2024-06-20 at 5 42 01 PM" src="https://github.com/kiva/ui/assets/4149025/5a9a5e9b-f35b-4677-bd59-8f5589909a94">
