### PR TITLE
fix: prevent failed reciept query thanks

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,52 @@ The Kiva UI project is bound by a [Code of Conduct](code_of_conduct.md).
 
 Kiva welcomes outside contributions to our UI repository. If you have any ideas for a feature or improvement, create an issue and we can discuss whether it makes sense to create a pull request. Thanks for the help!
 
-## Build Setup for localhost (outside of a Kiva VM or Server)
+# Local Development Setup with Caddy
+
+> IMPORTANT NOTE: Turn off Docker if it's running! We have a perpetually running network related to Tilt that will prevent Caddy from starting. I did consider using Tilt and docker-compose but it would require rewriting alot of the Monolith TiltVM setup so this just bypasses it all.
+
+### Required Dependencies
+
+1. Add `127.0.0.1 kiva-ui.local` to your `/etc/hosts` file on your mac
+	- Auth0 configs are already in place to support this domain in the dev tenant
+
+2. Install Caddy
+
+	 `brew install caddy`
+
+3. Start Caddy from the root of the ui repo
+
+	`caddy start` to run in the background or `caddy run` keep the terminal live for additional monitoring
+
+4. In a separate terminal at the root of the ui repo
+``` bash
+# Set you node version using nvm
+$ nvm use
+
+# install dependencies
+$ npm ci
+
+# install husky git hooks (NOTE: This step only needs to be done once on first setup and powers pre-commit linting)
+$ npx husky install
+
+$ npm run dev -- --config=dev-custom-host
+
+# The local dev URL is now: https://kiva-ui.local/, but make sure to access a page actually run by UI, for example https://kiva-ui.local/lend-by-category/women
+
+```
+
+5. To stop Caddy when you're done
+
+	`caddy stop`
+
+
+## Build Setup for localhost develoment (outside of a Tilt or Server environments)
 
 ``` bash
 # DEV MODE
 
 # install dependencies
-$ npm install
+$ npm ci
 
 # install husky git hooks (powers pre-commit linting)
 $ npx husky install

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -255,6 +255,10 @@ export default {
 
 			// Check if transactionId is null, resolve the promise if missing
 			if (!transactionId) {
+				logFormatter(
+					'Thanks page preFetch skipped due to missing transaction_id.',
+					'warning',
+				);
 				return Promise.resolve();
 			}
 
@@ -400,6 +404,10 @@ export default {
 
 		// Check if transactionId is null, exit if missing
 		if (!transactionId) {
+			logFormatter(
+				'Thanks page readQuery skipped due to missing transaction_id.',
+				'warning',
+			);
 			return false;
 		}
 

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -45,17 +45,6 @@
 								We've emailed your order confirmation to you.
 							</p>
 						</template>
-
-						<template v-else>
-							<h1 class="tw-mb-4">
-								Please log in to see your receipt.
-							</h1>
-							<kv-button
-								:href="`/ui-login?force=true&doneUrl=${encodeURIComponent(this.$route.fullPath)}`"
-							>
-								Log in to continue
-							</kv-button>
-						</template>
 					</div>
 				</div>
 				<thanks-layout-v2
@@ -96,6 +85,22 @@
 					</template>
 				</thanks-layout-v2>
 			</div>
+			<template v-else>
+				<div class="page-content tw-flex tw-flex-col tw-items-center tw-text-center">
+					<h2 class="tw-m-4">
+						Please log in to see your receipt.
+					</h2>
+					<kv-button
+						:href="`/ui-login?force=true&doneUrl=${
+							(this.$route.query.kiva_transaction_id && this.$route.query.kiva_transaction_id !== null)
+								? encodeURIComponent(this.$route.fullPath)
+								: encodeURIComponent('/portfolio')
+						}`"
+					>
+						Log in to continue
+					</kv-button>
+				</div>
+			</template>
 			<template v-if="showMayChallengeHeader">
 				<div
 					v-if="loans.length > 0"
@@ -248,6 +253,11 @@ export default {
 				? numeral(route.query?.kiva_transaction_id).value()
 				: null;
 
+			// Check if transactionId is null, resolve the promise if missing
+			if (!transactionId) {
+				return Promise.resolve();
+			}
+
 			return client.query({
 				query: thanksPageQuery,
 				variables: {
@@ -387,6 +397,12 @@ export default {
 		const transactionId = this.$route.query?.kiva_transaction_id
 			? numeral(this.$route.query?.kiva_transaction_id).value()
 			: null;
+
+		// Check if transactionId is null, exit if missing
+		if (!transactionId) {
+			return false;
+		}
+
 		this.monthlyDonationAmount = this.$route.query?.monthly_donation_amount ?? null;
 
 		try {


### PR DESCRIPTION
Folks are consistently getting to, or trying to load thanks without a transaction id which spews a mass query failure error for the reciept. This prevents us from executing an unnessesary query and restores the Login link instead of showing an empty page frame.

Also adds notes on dev setup with caddy...