### PR TITLE
feat: bp activity feed hidden for sticky cta

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -256,15 +256,9 @@
 							data-testid="bp-lend-cta-jump-links"
 						/>
 					</div>
-					<div v-if="!!activities">
+					<div v-if="!!activities && !isSticky">
 						<hr
-							class="lg:tw-block tw-border-tertiary tw-w-full tw-my-2"
-							:class="[
-								{
-									'tw-hidden': isSticky,
-									'tw-block': !isSticky,
-								}
-							]"
+							class="tw-block tw-border-tertiary tw-w-full tw-my-2"
 						>
 						<supported-by-lenders
 							:participants="participants"


### PR DESCRIPTION
- Activity feed hidden for sticky CTA in borrower profile page