### PR TITLE
fix: bottom position fixed

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -289,8 +289,11 @@
 					:class="[
 						'tw-grid-cols-12',
 						'tw-order-first',
-						'tw-bottom-8',
 						'tw-w-full',
+						{
+							'tw-bottom-14': freeCreditWarning || allSharesReserved,
+							'tw-bottom-8': !freeCreditWarning && !allSharesReserved,
+						},
 						{
 							'md:tw-relative': !isSticky,
 							'md:tw-bottom-0': !isSticky,


### PR DESCRIPTION
- bottom position fixed for sticky lend cta when having an extra label

bug:
<img width="475" alt="Screenshot 2024-06-27 at 2 35 22 p m" src="https://github.com/kiva/ui/assets/94026278/02e39b99-8722-4309-ad33-8f60696c7e49">
