### PR TITLE
feat: bp matching component size fixed for tablets

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -298,7 +298,7 @@
 							'md:tw-relative': !isSticky,
 							'md:tw-bottom-0': !isSticky,
 							'md:tw-order-none': !isSticky,
-							'md:tw-px-3': !isSticky,
+							'lg:tw-px-3': !isSticky,
 							'md:tw-px-4': isSticky,
 							'tw-px-2.5 tw-absolute': isSticky
 						},
@@ -324,7 +324,6 @@
 							{
 								'tw-relative': isSticky,
 								'md:tw-mb-0': !isSticky,
-								'md:tw-col-start-6 md:tw-col-span-7': !isSticky,
 								'md:tw-col-start-5 md:tw-col-span-6': isSticky,
 								'md:tw-hidden': isSticky,
 							},


### PR DESCRIPTION
- 'XX Matched Loan' component updated to full width for tablets on borrower profile

<img width="627" alt="Screenshot 2024-06-28 at 1 36 35 p m" src="https://github.com/kiva/ui/assets/94026278/1bc29aaf-d332-4d79-a2b8-87b9f4e20466">
