### PR TITLE
feat: new categories shouldn't show sort by quick filter

### DIFF
--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -205,6 +205,7 @@ export default {
 				women: false,
 				kivaUs: false,
 				endingSoon: false,
+				amountLeft: false,
 			},
 		};
 	},
@@ -226,6 +227,9 @@ export default {
 			} else if (this.presetFilterActive.endingSoon) {
 				this.resetSortBy();
 				this.presetFilterActive.endingSoon = false;
+			} else if (this.presetFilterActive.amountLeft) {
+				this.resetSortBy();
+				this.presetFilterActive.amountLeft = false;
 			}
 
 			// These categories use location/gender/sort by for FLSS and need
@@ -239,6 +243,9 @@ export default {
 			} else if (catId === 3) { // ending-soon
 				this.sortBy = 'expiringSoon';
 				this.presetFilterActive.endingSoon = true;
+			} else if (catId === 171 || catId === 172) { // featured-projects and basic-needs
+				this.sortBy = 'amountLeft';
+				this.presetFilterActive.amountLeft = true;
 			} else {
 				if (catId === 33 || catId === 96) { // mission-driven-orgs, covid-19
 					// we don't currently have this option for these categories, also irrelevant since
@@ -275,6 +282,9 @@ export default {
 			if (this.presetFilterActive.endingSoon && sortBy !== 'expiringSoon') {
 				this.resetCategory();
 				this.presetFilterActive.endingSoon = false;
+			} else if (this.presetFilterActive.amountLeft && sortBy !== 'amountLeft') {
+				this.resetCategory();
+				this.presetFilterActive.amountLeft = false;
 			}
 			this.$emit('update-filters', { sortBy });
 			this.$kvTrackEvent(

--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -367,7 +367,9 @@ export default {
 			return this.targetedLoanChannelUrl === 'kiva-u-s';
 		},
 		removeSortByDropdown() {
-			return this.targetedLoanChannelUrl === 'ending-soon';
+			return this.targetedLoanChannelUrl === 'ending-soon'
+				|| this.targetedLoanChannelUrl === 'featured-projects'
+				|| this.targetedLoanChannelUrl === 'basic-needs';
 		}
 	},
 };

--- a/src/plugins/loan-channel-query-map.js
+++ b/src/plugins/loan-channel-query-map.js
@@ -1047,6 +1047,23 @@ export default {
 						isMatchable: true
 					},
 				},
+				{
+					id: 171,
+					url: 'featured-projects',
+					flssLoanSearch: {
+						lenderRepaymentTerm: createMinMaxRange(0, 8),
+						sortBy: 'amountLeft',
+					},
+				},
+				{
+					id: 172,
+					url: 'basic-needs',
+					flssLoanSearch: {
+						sectorId: [10],
+						themeId: [8],
+						sortBy: 'amountLeft',
+					},
+				},
 			]
 
 		};


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-513

- Two new home page channels have the `amountLeft` sort
- Updated the category page to handle the new sort -> preselect special casing, hiding sort quick filter, and updating channel map
- The category page is linked to from the home page loans by category component, so this special casing is needed