### PR TITLE
fix: mp 517 paypal credit update config

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -353,9 +353,8 @@ export default {
 						'basket',
 						'Update Donation',
 						'Update Success',
-						// pass raw donation amount to property field
-						numeral(this.amount).format('0,0.00'),
-						// pass donation amount as whole number in value field
+						// pass donation amount as whole number
+						numeral(this.amount).value() * 100,
 						numeral(this.amount).value() * 100
 					);
 					this.amount = numeral(this.amount).format('$0,0.00');

--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -353,8 +353,9 @@ export default {
 						'basket',
 						'Update Donation',
 						'Update Success',
-						// pass donation amount as whole number
-						numeral(this.amount).value() * 100,
+						// pass raw donation amount to property field
+						numeral(this.amount).format('0,0.00'),
+						// pass donation amount as whole number in value field
 						numeral(this.amount).value() * 100
 					);
 					this.amount = numeral(this.amount).format('$0,0.00');

--- a/src/components/Payment/BraintreeDropInInterface.vue
+++ b/src/components/Payment/BraintreeDropInInterface.vue
@@ -104,17 +104,26 @@ export default {
 		}
 	},
 	watch: {
-		amount(next, prev) {
-			if (next !== prev) {
-				this.btDropinInstance?.updateConfiguration?.('paypal', 'amount', this.formattedAmount);
-				this.btDropinInstance?.updateConfiguration?.(
-					'googlePay',
-					'transactionInfo',
-					this.googleTransactionInfo
-				);
-				this.btDropinInstance?.updateConfiguration?.('applePay', 'paymentRequest', this.applePaymentRequest);
-			}
-		}
+		// Watch the amount property for changes and update each payment method configuration to ensure correct amount.
+		amount: {
+			handler(next, prev) {
+				if (next !== prev) {
+					this.btDropinInstance?.updateConfiguration?.('paypal', 'amount', this.formattedAmount);
+					this.btDropinInstance?.updateConfiguration?.('paypalCredit', 'amount', this.formattedAmount);
+					this.btDropinInstance?.updateConfiguration?.(
+						'googlePay',
+						'transactionInfo',
+						this.googleTransactionInfo
+					);
+					this.btDropinInstance?.updateConfiguration?.(
+						'applePay',
+						'paymentRequest',
+						this.applePaymentRequest
+					);
+				}
+			},
+			immediate: true,
+		},
 	},
 	methods: {
 		setUpdatingPaymentWrapper(state) {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -940,9 +940,8 @@ export default {
 				if (hasFreeCredits && refreshEvent === 'kiva-card-applied') {
 					this.disableGuestCheckout();
 				}
-				const overlayTimeout = setTimeout(() => {
+				setTimeout(() => {
 					this.setUpdatingTotals(false);
-					clearTimeout(overlayTimeout);
 				}, 2500);
 			}).catch(response => {
 				console.error(`failed to update totals: ${response}`);

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -940,7 +940,10 @@ export default {
 				if (hasFreeCredits && refreshEvent === 'kiva-card-applied') {
 					this.disableGuestCheckout();
 				}
-				this.setUpdatingTotals(false);
+				const overlayTimeout = setTimeout(() => {
+					this.setUpdatingTotals(false);
+					clearTimeout(overlayTimeout);
+				}, 2500);
 			}).catch(response => {
 				console.error(`failed to update totals: ${response}`);
 				this.setUpdatingTotals(false);


### PR DESCRIPTION
- ensures we update the config for paypalCredit like we do for paypal, google and applepay
- makes the amount watcher use the immediate flag
- extend the overlay visibility so the braintree widget is covered until it gets the updated values