### PR TITLE
fix: missing newAcctTerms and newsConsent form values for opt-in-comms exp MP-535

### DIFF
--- a/src/components/Checkout/UserUpdatesPreference.vue
+++ b/src/components/Checkout/UserUpdatesPreference.vue
@@ -5,9 +5,9 @@
 			class="tw-flex tw-flex-col tw-gap-2 tw-mt-1 tw-mb-2 tw-text-small"
 		>
 			<kv-radio
-				value="1"
+				value="on"
 				v-model="selectedComms"
-				name="reportComms"
+				name="newsConsent"
 				v-kv-track-event="[
 					trackingCategory,
 					'click',
@@ -21,8 +21,8 @@
 				Send me updates from people I've funded, my impact, and other ways I can help.
 			</kv-radio>
 			<kv-radio
-				value="0"
-				name="reportComms"
+				value="off"
+				name="newsConsent"
 				v-model="selectedComms"
 				:class="{'radio-error': $v.selectedComms.$error}"
 				v-kv-track-event="[

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -70,6 +70,12 @@
 					tracking-category="authentication"
 					@update:modelValue="selectedComms = $event"
 				/>
+				<input
+					v-if="enableRadioBtnExperiment"
+					type="hidden"
+					name="newAcctTerms"
+					value="on"
+				>
 				<template v-else>
 					<kv-base-input
 						name="newAcctTerms"


### PR DESCRIPTION
The terms agreement was missing for version c (radio buttons), causing redirect errors, and the marketing email consent didn't have the right name in versions b & c, so if anyone opted into marketing emails it wasn't saved on their account.