### PR TITLE
fix: auto lending advance settings incorrectly displays partners

### DIFF
--- a/src/graphql/query/autolending/autoLendingSelected.graphql
+++ b/src/graphql/query/autolending/autoLendingSelected.graphql
@@ -1,0 +1,13 @@
+query autoLendingSelected {
+	autolending @client {
+		id
+		currentProfile {
+			id
+			loanSearchCriteria {
+				filters {
+					partner
+				}
+			}
+		}
+	}
+}

--- a/src/graphql/query/autolending/partnerList.graphql
+++ b/src/graphql/query/autolending/partnerList.graphql
@@ -1,17 +1,7 @@
-query partnerList {
-	autolending @client {
-		id
-		currentProfile {
-			id
-			loanSearchCriteria {
-				filters {
-					partner
-				}
-			}
-		}
-	}
+query partnerList($offset: Int = 0) {
 	general {
-		partners(limit:1000, filters:{status:active}) {
+		partners(offset: $offset, limit: 100, filters: { status: active }) {
+			totalCount
 			values {
 				id
 				name

--- a/src/pages/Autolending/PartnerFilter.vue
+++ b/src/pages/Autolending/PartnerFilter.vue
@@ -17,12 +17,11 @@
 </template>
 
 <script>
-import _get from 'lodash/get';
 import _map from 'lodash/map';
-import _sortBy from 'lodash/sortBy';
 import { gql } from '@apollo/client';
-import partnerListQuery from '@/graphql/query/autolending/partnerList.graphql';
 import anyOrSelectedAutolendingFilter from '@/plugins/any-or-selected-autolending-filter-mixin';
+import autoLendingSelectedQuery from '@/graphql/query/autolending/autoLendingSelected.graphql';
+import { queryAllPartners } from '@/util/autoLendingUtils';
 import CheckList from './CheckList';
 
 export default {
@@ -41,16 +40,14 @@ export default {
 		};
 	},
 	apollo: {
-		query: partnerListQuery,
+		query: autoLendingSelectedQuery,
 		preFetch: true,
 		result({ data }) {
-			// Filter out the "N/A direct to ..." non-partners and sort by name
-			const allPartners = _get(data, 'general.partners.values') || [];
-			const nonDirectPartners = allPartners.filter(partner => partner.name.indexOf('direct to') === -1);
-
-			this.partnersToDisplay = _sortBy(nonDirectPartners, 'name');
-			this.currentPartnerIds = _get(data, 'autolending.currentProfile.loanSearchCriteria.filters.partner') || [];
+			this.currentPartnerIds = data?.autolending?.currentProfile?.loanSearchCriteria?.filters?.partner ?? [];
 		},
+	},
+	async mounted() {
+		this.partnersToDisplay = await queryAllPartners(this.apollo);
 	},
 	computed: {
 		partnersWithSelected() {

--- a/src/pages/Autolending/PartnerRadios.vue
+++ b/src/pages/Autolending/PartnerRadios.vue
@@ -33,12 +33,11 @@
 </template>
 
 <script>
-import _get from 'lodash/get';
-
-import partnerListQuery from '@/graphql/query/autolending/partnerList.graphql';
 import KvIcon from '@/components/Kv/KvIcon';
 import KvRadio from '@/components/Kv/KvRadio';
 import anyOrSelectedAutolendingRadio from '@/plugins/any-or-selected-autolending-radio-mixin';
+import autoLendingSelectedQuery from '@/graphql/query/autolending/autoLendingSelected.graphql';
+import { queryAllPartners } from '@/util/autoLendingUtils';
 
 export default {
 	name: 'PartnerRadios',
@@ -57,13 +56,10 @@ export default {
 		};
 	},
 	apollo: {
-		query: partnerListQuery,
+		query: autoLendingSelectedQuery,
 		preFetch: true,
 		result({ data }) {
-			this.allPartners = _get(data, 'general.partners.values') || [];
-			this.currentFilterValues = _get(
-				data, 'autolending.currentProfile.loanSearchCriteria.filters.partner'
-			) || [];
+			this.currentFilterValues = data?.autolending?.currentProfile?.loanSearchCriteria?.filters?.partner ?? [];
 
 			if (this.currentFilterValues.length) {
 				this.radio = 'some';
@@ -71,6 +67,9 @@ export default {
 				this.radio = 'all';
 			}
 		},
+	},
+	async mounted() {
+		this.allPartners = await queryAllPartners(this.apollo);
 	},
 	computed: {
 		selectedPartners() {

--- a/src/util/autoLendingUtils.js
+++ b/src/util/autoLendingUtils.js
@@ -1,0 +1,54 @@
+/* eslint-disable import/prefer-default-export */
+import logReadQueryError from '@/util/logReadQueryError';
+import partnerListQuery from '@/graphql/query/autolending/partnerList.graphql';
+import _sortBy from 'lodash/sortBy';
+
+/**
+ * Queries both the available and selected partner IDs
+ *
+ * @param apollo The Apollo Client to use
+ * @returns The available and selected partner IDs
+ */
+export const queryAllPartners = async apollo => {
+	let allPartners = [];
+
+	const queryPartners = (offset = 0) => {
+		return apollo.query({ query: partnerListQuery, variables: { offset } });
+	};
+
+	const addFilteredPartners = partners => {
+		// Filter out the "N/A direct to ..." non-partners and sort by name
+		const nonDirectPartners = partners.filter(p => p?.name?.toLowerCase()?.indexOf('direct to') === -1);
+		allPartners.push(...nonDirectPartners);
+	};
+
+	try {
+		let offset = 0;
+		// Monolith globally limited to returning 100 items
+		const step = 100;
+
+		const initialData = await queryPartners();
+		const totalCount = initialData?.data?.general?.partners?.totalCount ?? [];
+		addFilteredPartners(initialData?.data?.general?.partners?.values ?? []);
+
+		offset += step;
+
+		if (totalCount > offset) {
+			const remainingData = await Promise.all(
+				[...Array(Math.ceil(totalCount / step) - 1)].map(() => {
+					const dataPromise = queryPartners(offset);
+					offset += 100;
+					return dataPromise;
+				})
+			);
+
+			remainingData.forEach(d => addFilteredPartners(d?.data?.general?.partners?.values ?? []));
+		}
+
+		allPartners = _sortBy(allPartners, 'name');
+	} catch (e) {
+		logReadQueryError(e, 'queryAllPartners partnerListQuery');
+	}
+
+	return allPartners;
+};

--- a/src/util/autoLendingUtils.js
+++ b/src/util/autoLendingUtils.js
@@ -4,10 +4,10 @@ import partnerListQuery from '@/graphql/query/autolending/partnerList.graphql';
 import _sortBy from 'lodash/sortBy';
 
 /**
- * Queries both the available and selected partner IDs
+ * Queries the available partner IDs
  *
  * @param apollo The Apollo Client to use
- * @returns The available and selected partner IDs
+ * @returns The IDs of the available partners
  */
 export const queryAllPartners = async apollo => {
 	let allPartners = [];
@@ -17,7 +17,7 @@ export const queryAllPartners = async apollo => {
 	};
 
 	const addFilteredPartners = partners => {
-		// Filter out the "N/A direct to ..." non-partners and sort by name
+		// Filter out the "N/A direct to ..." non-partners
 		const nonDirectPartners = partners.filter(p => p?.name?.toLowerCase()?.indexOf('direct to') === -1);
 		allPartners.push(...nonDirectPartners);
 	};

--- a/test/unit/specs/util/autoLendingUtils.spec.js
+++ b/test/unit/specs/util/autoLendingUtils.spec.js
@@ -1,0 +1,80 @@
+import { queryAllPartners } from '@/util/autoLendingUtils';
+import _sortBy from 'lodash/sortBy';
+
+const createResult = count => (Array.from({ length: count }, (_, i) => ({ name: `${i}` })));
+
+describe('autoLendingUtils.js', () => {
+	describe('queryAllPartners', () => {
+		it('should make only one call if under 100 results and return sorted', async () => {
+			const apollo = {
+				query: jest.fn().mockReturnValue(
+					new Promise(resolve => {
+						resolve({
+							data: {
+								general: {
+									partners: {
+										totalCount: 50,
+										values: createResult(50),
+									}
+								}
+							}
+						});
+					})
+				)
+			};
+
+			const result = await queryAllPartners(apollo);
+
+			expect(result).toEqual(_sortBy(createResult(50), 'name'));
+			expect(apollo.query).toBeCalledTimes(1);
+		});
+
+		it('should make only more calls if over 100 results', async () => {
+			const apollo = {
+				query: jest.fn().mockReturnValue(
+					new Promise(resolve => {
+						resolve({
+							data: {
+								general: {
+									partners: {
+										totalCount: 250,
+										values: createResult(100),
+									}
+								}
+							}
+						});
+					})
+				)
+			};
+
+			const result = await queryAllPartners(apollo);
+
+			expect(result.length).toBe(300);
+			expect(apollo.query).toBeCalledTimes(3);
+		});
+
+		it('should make only more calls if over 100 results and exactly an increment of 100', async () => {
+			const apollo = {
+				query: jest.fn().mockReturnValue(
+					new Promise(resolve => {
+						resolve({
+							data: {
+								general: {
+									partners: {
+										totalCount: 300,
+										values: createResult(100),
+									}
+								}
+							}
+						});
+					})
+				)
+			};
+
+			const result = await queryAllPartners(apollo);
+
+			expect(result.length).toBe(300);
+			expect(apollo.query).toBeCalledTimes(3);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-276

- The partners shown were limited to the 100 returned by default from the monolith -> this must have been a bug since that limitation was added to the monolith endpoints
- Now all non-direct partners are shown in the autolending settings modal
![image](https://github.com/user-attachments/assets/d102789d-2277-4dcd-8fdd-66a69862a16d)
