### PR TITLE
feat: message lightbox added to lender profile

### DIFF
--- a/src/components/LenderProfile/LenderSummary.vue
+++ b/src/components/LenderProfile/LenderSummary.vue
@@ -72,7 +72,7 @@
 				</p>
 			</template>
 
-			<template v-if="isLoggedIn && loansNumber == 0">
+			<template v-else-if="isLoggedIn && loansNumber == 0">
 				<p>In order to send a message, you will need to make a loan using your own funds first. This helps us prevent spam and unwanted messages.</p>
 				<p class="tw-mt-2">
 					Please
@@ -83,7 +83,7 @@
 				</p>
 			</template>
 
-			<template v-if="isLoggedIn && loansNumber > 0">
+			<template v-else>
 				<div>
 					<p
 						v-if="errorMessage"

--- a/src/components/LenderProfile/LenderSummary.vue
+++ b/src/components/LenderProfile/LenderSummary.vue
@@ -42,7 +42,14 @@
 					</div>
 				</dl>
 
-				<div class="tw-mt-2.5">
+				<div class="tw-mt-2.5 tw-flex tw-flex-col lg:tw-flex-row tw-gap-2">
+					<kv-button
+						class="tw-w-full lg:tw-w-auto"
+						variant="secondary"
+						@click="showMessageLightbox()"
+					>
+						Send message
+					</kv-button>
 					<kv-button
 						class="tw-w-full lg:tw-w-auto"
 						variant="secondary"
@@ -53,20 +60,97 @@
 				</div>
 			</div>
 		</div>
+		<kv-lightbox
+			:visible="lightboxVisible"
+			@lightbox-closed="lightboxClosed"
+			:title="lightboxTitle"
+		>
+			<!-- eslint-disable max-len vue/singleline-html-element-content-newline -->
+			<template v-if="!isLoggedIn">
+				<p>
+					You must be signed in and have made loans on Kiva first to send a Lender Message. This helps us reduce the amount of SPAM and unwanted messages in the system.
+				</p>
+			</template>
+
+			<template v-if="isLoggedIn && loansNumber == 0">
+				<p>In order to send a message, you will need to make a loan using your own funds first. This helps us prevent spam and unwanted messages.</p>
+				<p class="tw-mt-2">
+					Please
+					<router-link to="/lend">
+						make a loan first
+					</router-link>
+					(note that loans made with bonus credit are not eligible) and then try your message again!
+				</p>
+			</template>
+
+			<template v-if="isLoggedIn && loansNumber > 0">
+				<div>
+					<p
+						v-if="errorMessage"
+						class="tw-text-danger tw-text-small tw-mb-1.5"
+					>
+						{{ errorMessage }}
+					</p>
+					<div class="tw-relative">
+						<textarea
+							class="
+								tw-w-full tw-border tw-border-tertiary tw-rounded-sm tw-px-2 tw-py-1 tw-min-h-16 tw-mb-1.5
+								tw-ring-inset tw-appearance-none tw-resize-none
+								focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-action focus:tw-border-transparent
+							"
+							v-model="lenderMessage"
+						>
+					</textarea>
+						<kv-material-icon
+							class="tw-w-2.5 tw-h-2.5 tw-absolute tw-bottom-3 tw-right-1"
+							:icon="mdiPencilOutline"
+						/>
+					</div>
+					<div class="tw-flex tw-flex-col lg:tw-flex-row tw-gap-2">
+						<kv-button
+							class="tw-w-full lg:tw-w-auto"
+							variant="secondary"
+							:state="sendButtonState"
+							@click="sendMessage"
+						>
+							Send message
+						</kv-button>
+						<kv-button
+							class="tw-w-full lg:tw-w-auto"
+							variant="secondary"
+							@click="closeLightbox"
+						>
+							Close
+						</kv-button>
+					</div>
+				</div>
+				<p class="tw-mt-4">
+					Lender messages shouldn't be used for self-promotion, advertising or solicitation. More information can be found in
+					<router-link to="/kiva-community-guidelines">Kiva's community guidelines</router-link>.
+				</p>
+			</template>
+			<!-- eslint-enable max-len -->
+		</kv-lightbox>
 	</div>
 </template>
 
 <script>
 import { format, parseISO } from 'date-fns';
-import { mdiAccountCircle } from '@mdi/js';
+import { mdiAccountCircle, mdiPencilOutline } from '@mdi/js';
+import logReadQueryError from '@/util/logReadQueryError';
+import userInfoQuery from '@/graphql/query/userInfo.graphql';
+import sendLenderMessageMutation from '@/graphql/mutation/sendLenderMessage.graphql';
 import KvMaterialIcon from '~/@kiva/kv-components/vue/KvMaterialIcon';
 import KvButton from '~/@kiva/kv-components/vue/KvButton';
+import KvLightbox from '~/@kiva/kv-components/vue/KvLightbox';
 
 export default {
 	name: 'LenderSummary',
+	inject: ['apollo', 'cookieStore'],
 	components: {
 		KvMaterialIcon,
 		KvButton,
+		KvLightbox,
 	},
 	props: {
 		publicId: {
@@ -81,6 +165,13 @@ export default {
 	data() {
 		return {
 			mdiAccountCircle,
+			mdiPencilOutline,
+			isLoggedIn: false,
+			loansNumber: 0,
+			lightboxVisible: false,
+			lenderMessage: '',
+			sendingMessage: false,
+			errorMessage: '',
 		};
 	},
 	computed: {
@@ -109,6 +200,63 @@ export default {
 					.filter(([_, value]) => value)
 			);
 		},
+		lightboxTitle() {
+			return this.isLoggedIn
+				? `Send a Lender Message to ${this.lenderName}`
+				: 'Not Signed In';
+		},
+		sendButtonState() {
+			if (this.lenderMessage.length < 2 || this.sendingMessage) {
+				return 'disabled';
+			}
+			return '';
+		},
 	},
+	methods: {
+		showMessageLightbox() {
+			this.lightboxVisible = true;
+		},
+		lightboxClosed() {
+			this.lightboxVisible = false;
+		},
+		closeLightbox() {
+			this.lenderMessage = '';
+			this.lightboxClosed();
+		},
+		sendMessage() {
+			this.sendingMessage = true;
+			this.errorMessage = '';
+			try {
+				this.apollo.mutate({
+					mutation: sendLenderMessageMutation,
+					variables: {
+						lenderPublicId: this.publicId,
+						message: this.lenderMessage,
+					},
+				});
+			} catch (e) {
+				this.sendingMessage = false;
+				this.errorMessage = e[0]?.message
+					? e[0].message
+					: 'There was a problem sending your message. Please try again later.';
+			} finally {
+				this.sendingMessage = false;
+				this.closeLightbox();
+				this.$showTipMsg('Your message has been sent!');
+			}
+		},
+	},
+	async mounted() {
+		try {
+			const { data } = await this.apollo.query({
+				query: userInfoQuery,
+			});
+
+			this.isLoggedIn = !!data.my?.userAccount?.id ?? false;
+			this.loansNumber = data.my?.userStats?.number_of_loans ?? 0;
+		} catch (e) {
+			logReadQueryError(e, 'LenderSummary userIdQuery');
+		}
+	}
 };
 </script>

--- a/src/graphql/mutation/sendLenderMessage.graphql
+++ b/src/graphql/mutation/sendLenderMessage.graphql
@@ -1,0 +1,5 @@
+mutation sendLenderMessage($lenderPublicId: ID!, $message: String!) {
+    my {
+        sendMessage(lenderPublicId: $lenderPublicId, message: $message)
+    }
+}

--- a/src/graphql/query/userInfo.graphql
+++ b/src/graphql/query/userInfo.graphql
@@ -8,5 +8,8 @@ query userInfo {
 			lastName
 			balance
 		}
+		userStats {
+			number_of_loans
+		}
 	}
 }


### PR DESCRIPTION
- message lightbox added to lender profile

Not signed:
<img width="960" alt="Screenshot 2024-08-01 at 2 48 23 p m" src="https://github.com/user-attachments/assets/5a5dad92-fb07-49c9-bc72-8019427c4c93">

Signed and no loans:
<img width="837" alt="Screenshot 2024-08-01 at 2 51 37 p m" src="https://github.com/user-attachments/assets/8bfa0dcd-73c4-4c90-bd57-cd0592944980">

Signed with loans:
<img width="988" alt="Screenshot 2024-08-01 at 2 47 25 p m" src="https://github.com/user-attachments/assets/c3af32bc-1d30-4e1e-a952-f3426dcdc912">

