### PR TITLE
fix: add classes for finding and accessing loan cards from kiva-tests

### DIFF
--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseRecommendations.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseRecommendations.vue
@@ -45,6 +45,7 @@
 			/>
 			<loan-card-controller
 				v-else
+				class="loan-card-container"
 				style="margin-top: 0 !important; min-height: 283px;"
 				:items-in-basket="itemsInBasket"
 				:is-visitor="isVisitor"

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
@@ -41,6 +41,7 @@
 		<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-mb-2 tw-gap-4 tw-px-1">
 			<kv-classic-loan-card-container
 				v-for="(loan, index) in remainingLoans"
+				class="loan-card-container"
 				:key="`new-card-${loan.id}-${index}`"
 				:loan-id="loan.id"
 				:use-full-width="true"

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -73,6 +73,7 @@
 					<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4 tw-px-1">
 						<kv-classic-loan-card-container
 							v-for="(loan, index) in loans"
+							class="loan-card-container"
 							:key="`new-card-${loan.id}-${index}`"
 							:loan-id="loan.id"
 							:use-full-width="true"
@@ -104,6 +105,7 @@
 					<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4 tw-px-1">
 						<kv-classic-loan-card-container
 							v-for="(loan, index) in firstLoan"
+							class="loan-card-container"
 							:key="`new-card-${loan.id}-${index}`"
 							:loan-id="loan.id"
 							:use-full-width="true"
@@ -122,6 +124,7 @@
 
 						<kv-classic-loan-card-container
 							v-for="(loan, index) in remainingLoans"
+							class="loan-card-container"
 							:key="`new-card-${loan.id}-${index}`"
 							:loan-id="loan.id"
 							:use-full-width="true"


### PR DESCRIPTION
We used to have the `grid-loan-card` class on all ui loan cards but those were lost when moving to our new components. This adds a generic default class for use in [kiva-tests](https://github.com/kiva/kiva-tests/pull/38).