### PR TITLE
fix: use global loan card classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^3.90.0",
+				"@kiva/kv-components": "^3.90.1",
 				"@kiva/kv-shop": "^1.12.8",
 				"@kiva/kv-tokens": "^2.11.1",
 				"@mdi/js": "^7",
@@ -5355,9 +5355,9 @@
 			"integrity": "sha512-1lNM7toQpiHWWdKrBmoXPudNLgFscU8rnk4nyBQQhbnlhSLzbjbsCcWWnA+IqXkgOCVysSpI7yEi7fuU6uLMYg=="
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "3.90.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.90.0.tgz",
-			"integrity": "sha512-/U3cFvlRfIgznARGS2JzQZjqWOG6xWmoS5zl6o8bwObHJR2Jlc3EgAsZ0eWP9X4PuA1P94R3q6X50cQrOxAY5Q==",
+			"version": "3.90.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.90.1.tgz",
+			"integrity": "sha512-GOTadusz5QQb5RJhcRAeTspHO42gEa6g7yw34m8OLFo/RhhY3IY9yv5Dho6sC/+PYk3JLnq+6W1Tygb8y1uhWw==",
 			"dependencies": {
 				"@kiva/kv-tokens": "^2.13.0",
 				"@mdi/js": "^5.9.55",
@@ -48807,9 +48807,9 @@
 			"integrity": "sha512-1lNM7toQpiHWWdKrBmoXPudNLgFscU8rnk4nyBQQhbnlhSLzbjbsCcWWnA+IqXkgOCVysSpI7yEi7fuU6uLMYg=="
 		},
 		"@kiva/kv-components": {
-			"version": "3.90.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.90.0.tgz",
-			"integrity": "sha512-/U3cFvlRfIgznARGS2JzQZjqWOG6xWmoS5zl6o8bwObHJR2Jlc3EgAsZ0eWP9X4PuA1P94R3q6X50cQrOxAY5Q==",
+			"version": "3.90.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-3.90.1.tgz",
+			"integrity": "sha512-GOTadusz5QQb5RJhcRAeTspHO42gEa6g7yw34m8OLFo/RhhY3IY9yv5Dho6sC/+PYk3JLnq+6W1Tygb8y1uhWw==",
 			"requires": {
 				"@kiva/kv-tokens": "^2.13.0",
 				"@mdi/js": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
-		"@kiva/kv-components": "^3.90.0",
+		"@kiva/kv-components": "^3.90.1",
 		"@kiva/kv-shop": "^1.12.8",
 		"@kiva/kv-tokens": "^2.11.1",
 		"@mdi/js": "^7",

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseRecommendations.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseRecommendations.vue
@@ -45,7 +45,6 @@
 			/>
 			<loan-card-controller
 				v-else
-				class="loan-card-container"
 				style="margin-top: 0 !important; min-height: 283px;"
 				:items-in-basket="itemsInBasket"
 				:is-visitor="isVisitor"

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
@@ -41,7 +41,6 @@
 		<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-mb-2 tw-gap-4 tw-px-1">
 			<kv-classic-loan-card-container
 				v-for="(loan, index) in remainingLoans"
-				class="loan-card-container"
 				:key="`new-card-${loan.id}-${index}`"
 				:loan-id="loan.id"
 				:use-full-width="true"

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -73,7 +73,6 @@
 					<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4 tw-px-1">
 						<kv-classic-loan-card-container
 							v-for="(loan, index) in loans"
-							class="loan-card-container"
 							:key="`new-card-${loan.id}-${index}`"
 							:loan-id="loan.id"
 							:use-full-width="true"
@@ -105,7 +104,6 @@
 					<div class="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-4 tw-px-1">
 						<kv-classic-loan-card-container
 							v-for="(loan, index) in firstLoan"
-							class="loan-card-container"
 							:key="`new-card-${loan.id}-${index}`"
 							:loan-id="loan.id"
 							:use-full-width="true"
@@ -124,7 +122,6 @@
 
 						<kv-classic-loan-card-container
 							v-for="(loan, index) in remainingLoans"
-							class="loan-card-container"
 							:key="`new-card-${loan.id}-${index}`"
 							:loan-id="loan.id"
 							:use-full-width="true"


### PR DESCRIPTION
I found more places (lend/filter) that also had no way to easily grab a list of loans followed by drilling into the selected card. Let's go with a global data-testid instead...