### PR TITLE
fix: mfa api token auth requires using authorize call, not checkSession MP-479

### DIFF
--- a/src/pages/ProcessBrowserAuth.vue
+++ b/src/pages/ProcessBrowserAuth.vue
@@ -5,42 +5,21 @@
 <script>
 import store2 from 'store2';
 
-function checkHashSuccess(hash) {
-	if (hash.indexOf('error') > -1) {
-		return false;
-	}
-	if (hash.indexOf('access_token') === -1
-		&& hash.indexOf('id_token') === -1
-		&& hash.indexOf('refresh_token') === -1) {
-		return false;
-	}
-	return true;
-}
-
 export default {
 	name: 'ProcessBrowserAuth',
 	inject: ['kvAuth0'],
 	mounted() {
-		const hashKey = 'auth0.browser_hash';
+		const { state } = this.$route.query;
+		if (state) {
+			const auth0State = store2.session('auth0.state');
+			if (auth0State === state) {
+				const redirect = store2.session('auth0.redirect');
 
-		if (window.location.hash) {
-			const { hash } = window.location;
+				store2.session.remove('auth0.state');
+				store2.session.remove('auth0.redirect');
 
-			if (checkHashSuccess(hash)) {
-				// store hash for after post-auth redirect
-				store2.session(hashKey, hash);
-				// post-auth redirect
-				window.location = '/authenticate/ui?doneUrl=/process-browser-auth';
-			} else {
-				// some problem occured, so close the window and let normal error handling take over
-				this.kvAuth0.popupCallback({ hash });
+				this.$router.push(`${redirect}${window.location.hash}`);
 			}
-		} else {
-			// fetch & erase stored hash
-			const hash = store2.session(hashKey);
-			store2.session.remove(hashKey);
-			// final callback
-			this.kvAuth0.popupCallback({ hash });
 		}
 	},
 };

--- a/src/util/KvAuth0.js
+++ b/src/util/KvAuth0.js
@@ -286,7 +286,8 @@ export default class KvAuth0 {
 						// Ensure browser clock is correct before fetching the token
 						syncDate().then(() => {
 							// Store the current URL in session storage to redirect back to it after MFA
-							const state = storeRedirectState();
+							return storeRedirectState();
+						}).then(state => {
 							this.webAuth.authorize({
 								state,
 								audience: this.mfaAudience,


### PR DESCRIPTION
Auth0 will require MFA authentication via redirect after Aug 30 for MFA API tokens, so silent auth calls like checkSession need to be replaced. Since it's a redirect for an implicit grant, we need to parse the token from the hash on an approved callback url (like /process-browser-auth). /process-browser-auth wasn't being used anymore (previously only used for popup window auth) so I repurposed that to redirect to a destination after confirming state.

Depends on https://github.com/kiva/kiva/pull/12870