### PR TITLE
feat: loans map added to lender profile

### DIFF
--- a/src/components/Kv/KvMap.vue
+++ b/src/components/Kv/KvMap.vue
@@ -12,6 +12,9 @@
 <script>
 import { createIntersectionObserver } from '@/util/observerUtils';
 import testDelayedGlobalLibrary from '@/util/timeoutUtils';
+import countriesBorders from '@/assets/data/components/LenderProfile/countries-borders.json';
+import { getIntervals, mapColors } from '@/components/LenderProfile/LenderMap';
+import kvTokensPrimitives from '~/@kiva/kv-tokens/primitives.json';
 
 export default {
 	name: 'KvMap',
@@ -124,6 +127,44 @@ export default {
 			type: Number,
 			default: 4
 		},
+		/**
+		 * Show the zoom control
+		 */
+		showZoomControl: {
+			type: Boolean,
+			default: false
+		},
+		/**
+		 * Allow dragging of the map
+		 */
+		allowDragging: {
+			type: Boolean,
+			default: false
+		},
+		/**
+		 * Show labels on the map
+		 * Working for leaflet only
+		 */
+		showLabels: {
+			type: Boolean,
+			default: true
+		},
+		/**
+		 * Lender data for the map
+		 * Working for leaflet only
+		 */
+		countriesData: {
+			type: Array,
+			default: () => ([]),
+		},
+		/**
+		 * Show fundraising loans
+		 * Working for leaflet only
+		 */
+		showFundraisingLoans: {
+			type: Boolean,
+			default: false
+		},
 	},
 	data() {
 		return {
@@ -162,7 +203,13 @@ export default {
 			if (prev === null && this.lat && !this.mapLibreReady && !this.leafletReady) {
 				this.initializeMap();
 			}
-		}
+		},
+		showFundraisingLoans() {
+			if (this.mapInstance) {
+				this.mapInstance.remove();
+				this.initializeLeaflet();
+			}
+		},
 	},
 	mounted() {
 		if (!this.mapLibreReady && !this.leafletReady) {
@@ -260,8 +307,8 @@ export default {
 				center: [this.lat, this.long],
 				zoom: this.initialZoom || this.zoomLevel,
 				// todo make props for the following options
-				dragging: false,
-				zoomControl: false,
+				dragging: this.allowDragging,
+				zoomControl: this.showZoomControl,
 				animate: true,
 				scrollWheelZoom: false,
 				doubleClickZoom: false,
@@ -269,12 +316,55 @@ export default {
 			});
 			/* eslint-disable quotes */
 			// Add our tileset to the mapInstance
-			L.tileLayer('https://api.maptiler.com/maps/bright/{z}/{x}/{y}.png?key=n1Mz5ziX3k6JfdjFe7mx', {
+			let tileLayer = 'https://api.maptiler.com/maps/landscape/{z}/{x}/{y}.png?key=n1Mz5ziX3k6JfdjFe7mx';
+			if (this.showLabels) {
+				tileLayer = 'https://api.maptiler.com/maps/bright/{z}/{x}/{y}.png?key=n1Mz5ziX3k6JfdjFe7mx';
+			}
+			L.tileLayer(tileLayer, {
 				tileSize: 512,
 				zoomOffset: -1,
 				minZoom: 1,
-				crossOrigin: true
+				crossOrigin: true,
 			}).addTo(this.mapInstance);
+
+			if (this.countriesData.length > 0) {
+				const countriesFeatures = countriesBorders.features ?? [];
+
+				countriesFeatures.forEach((country, index) => {
+					const countryData = this.countriesData.find(data => data.isoCode === country.properties.ISO_A2);
+					if (countryData) {
+						countriesFeatures[index].lenderLoans = countryData.value;
+						countriesFeatures[index].numLoansFundraising = countryData.numLoansFundraising;
+					}
+				});
+
+				L.geoJson(
+					countriesBorders,
+					{
+						style: this.countryStyle,
+						onEachFeature: this.onEachCountryFeature
+					}
+				).addTo(this.mapInstance);
+
+				this.countriesData.forEach(country => {
+					if (country.numLoansFundraising > 0 && this.showFundraisingLoans) {
+						const circle = L.circle([country.lat, country.long], {
+							color: kvTokensPrimitives.colors.black,
+							weight: 1,
+							fillColor: kvTokensPrimitives.colors.brand[900],
+							fillOpacity: 1,
+							radius: 130000,
+						}).addTo(this.mapInstance);
+
+						const tooltipText = `Click to see ${country.numLoansFundraising} fundraising loans in ${country.label}`;
+						circle.bindTooltip(tooltipText);
+
+						circle.on('click', () => {
+							this.circleMapClicked(country.isoCode);
+						});
+					}
+				});
+			}
 			/* eslint-enable quotes */
 			/* eslint-enable no-undef, max-len */
 
@@ -294,7 +384,7 @@ export default {
 				center: [this.long, this.lat],
 				zoom: this.initialZoom || this.zoomLevel,
 				attributionControl: false,
-				dragPan: false,
+				dragPan: this.allowDragging,
 				scrollZoom: false,
 				doubleClickZoom: false,
 				dragRotate: false,
@@ -307,6 +397,82 @@ export default {
 			if (this.initialZoom !== null) {
 				this.createWrapperObserver();
 			}
+		},
+		countryStyle(feature) {
+			return {
+				color: kvTokensPrimitives.colors.white,
+				fillColor: this.getCountryColor(feature.lenderLoans),
+				weight: 1,
+				fillOpacity: 1,
+			};
+		},
+		getCountryColor(lenderLoans) {
+			const loanCountsArray = [];
+			this.countriesData.forEach(country => {
+				loanCountsArray.push(country.value);
+			});
+
+			const maxNumLoansToOneCountry = Math.max(...loanCountsArray);
+			const intervals = getIntervals(1, maxNumLoansToOneCountry, 6);
+
+			if (intervals.length === 1) {
+				const [inf, sup] = intervals[0]; // eslint-disable-line no-unused-vars
+
+				for (let i = 0; i < sup; i += 1) {
+					const loansNumber = i + 1;
+
+					if (lenderLoans && lenderLoans >= loansNumber && lenderLoans < loansNumber + 1) {
+						return kvTokensPrimitives.colors.brand[mapColors[i]];
+					}
+				}
+			} else {
+				for (let i = 0; i < intervals.length; i += 1) {
+					const [inf, sup] = intervals[i];
+					if (lenderLoans && lenderLoans >= inf && lenderLoans <= sup) {
+						return kvTokensPrimitives.colors.brand[mapColors[i]];
+					}
+				}
+			}
+
+			return kvTokensPrimitives.colors.gray[300];
+		},
+		onEachCountryFeature(feature, layer) {
+			const loansString = feature.lenderLoans
+				? `${feature.lenderLoans} loan${feature.lenderLoans > 1 ? 's' : ''}`
+				: '0 loans';
+			const countryString = `${feature.properties.ADMIN} <br/> ${loansString}`;
+
+			layer.bindTooltip(countryString, {
+				sticky: true,
+			});
+
+			layer.on({
+				mouseover: this.highlightFeature,
+				mouseout: this.resetHighlight,
+			});
+		},
+		highlightFeature(e) {
+			const layer = e.target;
+
+			layer.setStyle({
+				fillColor: kvTokensPrimitives.colors.gray[500],
+			});
+		},
+		resetHighlight(e) {
+			const layer = e.target;
+			const { feature } = layer;
+
+			layer.setStyle({
+				fillColor: this.getCountryColor(feature.lenderLoans),
+			});
+		},
+		circleMapClicked(countryIso) {
+			this.$router.push({
+				path: '/lend/filter',
+				query: {
+					country: countryIso,
+				},
+			});
 		},
 	},
 	beforeDestroy() {

--- a/src/components/LenderProfile/LenderMap.vue
+++ b/src/components/LenderProfile/LenderMap.vue
@@ -1,0 +1,199 @@
+<template>
+	<section>
+		<h4 class="data-hj-suppress tw-mb-2">
+			{{ lenderMapTitle }}
+		</h4>
+		<kv-map
+			class="
+				tw-rounded
+				tw-overflow-hidden
+				tw-mb-3
+			"
+			:auto-zoom-delay="500"
+			:aspect-ratio="1.8"
+			:lat="30"
+			:long="1"
+			:zoom-level="2"
+			:use-leaflet="true"
+			:show-zoom-control="true"
+			:allow-dragging="true"
+			:show-labels="false"
+			:countries-data="countriesData"
+            :show-fundraising-loans="showFundraisingLoans"
+		/>
+		<div>
+			<p class="tw-mb-1 tw-font-medium">
+				Legend:
+			</p>
+			<div class="tw-grid tw-grid-cols-2 md:tw-grid-cols-3 tw-gap-2">
+				<div
+					v-for="legend in legendData"
+					:key="legend.color"
+					class="tw-flex tw-items-start tw-gap-1"
+				>
+					<span
+						:class="[
+							'tw-w-4',
+							'tw-h-2',
+							'tw-border',
+							legend.color,
+						]"
+					></span>
+					<p class="tw-text-small tw-font-medium">
+						{{ legend.label }}
+					</p>
+				</div>
+			</div>
+			<div class="tw-flex tw-items-center tw-gap-1 tw-mt-2">
+				<span
+					class="tw-w-1 tw-h-1 tw-border tw-rounded-full tw-bg-brand-900"
+				></span>
+				<p class="tw-text-small tw-font-medium">
+					Fundraising loans
+				</p>
+			</div>
+		</div>
+		<div class="tw-mt-3">
+			<p class="tw-mb-1 tw-font-medium">
+				Options:
+			</p>
+			<kv-checkbox
+				class="tw-text-small tw-font-medium custom-checkbox"
+				v-model="showFundraisingLoans"
+			>
+				Show fundraising loans
+			</kv-checkbox>
+		</div>
+	</section>
+</template>
+
+<script>
+import numeral from 'numeral';
+import KvMap from '@/components/Kv/KvMap';
+import KvCheckbox from '~/@kiva/kv-components/vue/KvCheckbox';
+
+export const getIntervals = (min, max, nbIntervals) => {
+	const size = Math.floor((max - min) / nbIntervals);
+	const result = [];
+
+	if (size <= 0) return [[min, max]];
+
+	for (let i = 0; i < nbIntervals; i += 1) {
+		let inf = min + (i * size);
+		let sup = ((inf + size) < max) ? inf + size : max;
+
+		if (i > 0) {
+			inf += (1 * i);
+			sup += (1 * i);
+		}
+
+		if (i > 0 && sup > max) {
+			sup = max;
+		}
+
+		if (i === (nbIntervals - 1)) {
+			if (sup < max || sup > max) sup = max;
+		}
+
+		result.push([inf, sup]);
+
+		if (sup >= max) break;
+	}
+
+	return result;
+};
+
+export const mapColors = [
+	100,
+	300,
+	500,
+	650,
+	800,
+	1000,
+];
+
+export default {
+	name: 'LenderMap',
+	components: {
+		KvMap,
+		KvCheckbox,
+	},
+	props: {
+		lenderInfo: {
+			type: Object,
+			required: true,
+		},
+	},
+	data() {
+		return {
+			showFundraisingLoans: true,
+		};
+	},
+	computed: {
+		lenderMapTitle() {
+			return this.lenderInfo?.name
+				? `${this.lenderInfo.name}'s Lending Activity by Country`
+				: 'Lending Activity by Country';
+		},
+		countriesData() {
+			return (this.lenderInfo?.statsPerCountry?.values ?? []).map(stat => ({
+				label: stat.country?.name ?? '',
+				value: stat.loanCount ?? '',
+				lat: stat.country?.geocode?.latitude ?? 0,
+				long: stat.country?.geocode?.longitude ?? 0,
+				isoCode: stat.country?.isoCode ?? '',
+				numLoansFundraising: stat.country?.numLoansFundraising ?? 0,
+			}));
+		},
+		legendData() {
+			const legendLabels = [];
+			const loanCountsArray = [];
+			this.countriesData.forEach(country => {
+				loanCountsArray.push(country.value);
+			});
+
+			const maxNumLoansToOneCountry = Math.max(...loanCountsArray);
+			const intervals = getIntervals(1, maxNumLoansToOneCountry, 6);
+
+			if (intervals.length === 1) {
+				const [inf, sup] = intervals[0]; // eslint-disable-line no-unused-vars
+
+				for (let i = 0; i < sup; i += 1) {
+					const loansNumber = i + 1;
+					const label = `${loansNumber} loan${loansNumber > 1 ? 's' : ''} made`;
+
+					legendLabels.push({
+						color: `tw-bg-brand-${mapColors[i]}`,
+						label,
+					});
+				}
+			} else {
+				intervals.forEach((interval, index) => {
+					const [inf, sup] = interval;
+					const formattedInf = numeral(inf).format('0,0');
+					const formattedSup = numeral(sup).format('0,0');
+
+					let label = `${formattedInf} - ${formattedSup} loans made`;
+					if (inf === sup) {
+						label = `${formattedInf} loans made`;
+					}
+
+					legendLabels.push({
+						color: `tw-bg-brand-${mapColors[index]}`,
+						label,
+					});
+				});
+			}
+
+			return legendLabels;
+		},
+
+	}
+};
+</script>
+
+<style lang="postcss" scoped>
+.custom-checkbox ::v-deep label > div:first-of-type {
+    @apply tw-w-2 tw-h-2;
+}
+</style>

--- a/src/graphql/query/lenderPublicProfile.graphql
+++ b/src/graphql/query/lenderPublicProfile.graphql
@@ -24,6 +24,12 @@ query LenderPublicProfile ($publicId: String!) {
 					loanCount
 					country {
 						name
+						numLoansFundraising
+						geocode {
+							latitude
+							longitude
+						}
+						isoCode
 					}
 				}
 			}

--- a/src/pages/LenderProfile/LenderProfile.vue
+++ b/src/pages/LenderProfile/LenderProfile.vue
@@ -1,7 +1,7 @@
 <template>
 	<www-page>
 		<kv-page-container
-			class="tw-py-2"
+			class="tw-pt-4 tw-pb-8"
 		>
 			<lender-summary
 				:public-id="publicId"
@@ -37,6 +37,10 @@
 			<lender-stats
 				:lender-info="lenderInfo"
 			/>
+
+			<lender-map
+				:lender-info="lenderInfo"
+			/>
 		</kv-page-container>
 	</www-page>
 </template>
@@ -52,6 +56,7 @@ import LenderTeamsList from '@/components/LenderProfile/LenderTeamsList';
 import LenderBadges from '@/components/LenderProfile/LenderBadges';
 import LenderInviteesList from '@/components/LenderProfile/LenderInviteesList';
 import LenderDedicationsList from '@/components/LenderProfile/LenderDedicationsList';
+import LenderMap from '@/components/LenderProfile/LenderMap';
 import KvPageContainer from '~/@kiva/kv-components/vue/KvPageContainer';
 
 export default {
@@ -67,6 +72,7 @@ export default {
 		LenderBadges,
 		LenderInviteesList,
 		LenderDedicationsList,
+		LenderMap,
 	},
 	metaInfo() {
 		return {


### PR DESCRIPTION
- loans map added to lender profile

Some cases:
<img width="1019" alt="Screenshot 2024-08-12 at 1 53 37 p m" src="https://github.com/user-attachments/assets/75fc68c0-37aa-4828-b369-07ac58e2f570">
<img width="1011" alt="Screenshot 2024-08-12 at 1 53 50 p m" src="https://github.com/user-attachments/assets/f08ad008-e92c-41ad-8e48-ef01346c7d7b">
<img width="1018" alt="Screenshot 2024-08-12 at 1 54 03 p m" src="https://github.com/user-attachments/assets/b7e787c7-e2ba-441b-b3ea-e3610da233fb">
<img width="434" alt="Screenshot 2024-08-12 at 2 04 41 p m" src="https://github.com/user-attachments/assets/dae50aaf-55c0-49da-9a6a-61f44523dc33">


Mouse over country:
<img width="1007" alt="Screenshot 2024-08-12 at 1 54 36 p m" src="https://github.com/user-attachments/assets/6efa0a25-03a7-439c-9004-be768d7f589a">


Mouse over fundraising loans dot:
<img width="993" alt="Screenshot 2024-08-12 at 1 54 46 p m" src="https://github.com/user-attachments/assets/6dec7e0c-29b2-47d3-af66-9d29d0d1a547">

Hidden fundraising loans dots:
<img width="1004" alt="Screenshot 2024-08-12 at 2 00 18 p m" src="https://github.com/user-attachments/assets/17511a8f-8d59-463c-88d4-776a886c993e">

