### PR TITLE
fix: extract async checkout error object with primary format

### DIFF
--- a/src/plugins/braintree-dropin-error-mixin.js
+++ b/src/plugins/braintree-dropin-error-mixin.js
@@ -4,7 +4,7 @@ export default {
 	methods: {
 		processBraintreeDropInError(trackCategory, kivaBraintreeResponse) {
 			// extract error response
-			const errorObj = kivaBraintreeResponse?.[0] ?? kivaBraintreeResponse.errors?.[0] ?? kivaBraintreeResponse;
+			const errorObj = kivaBraintreeResponse?.[0] ?? kivaBraintreeResponse?.errors?.[0] ?? kivaBraintreeResponse;
 			// extract error code and message
 			const errorCode = errorObj?.extensions?.code ?? errorObj?.error ?? 'UNKNOWN_ERROR_CODE';
 			const errorMessage = errorObj?.message ?? JSON.stringify(kivaBraintreeResponse);

--- a/src/plugins/braintree-dropin-error-mixin.js
+++ b/src/plugins/braintree-dropin-error-mixin.js
@@ -3,9 +3,11 @@ import * as Sentry from '@sentry/vue';
 export default {
 	methods: {
 		processBraintreeDropInError(trackCategory, kivaBraintreeResponse) {
-			// eslint-disable-next-line max-len
-			const errorCode = kivaBraintreeResponse.errors?.[0]?.extensions?.code ?? kivaBraintreeResponse.errors?.[0]?.error ?? 'UNKNOWN_ERROR_CODE';
-			const errorMessage = kivaBraintreeResponse.errors?.[0]?.message ?? JSON.stringify(kivaBraintreeResponse);
+			// extract error response
+			const errorObj = kivaBraintreeResponse?.[0] ?? kivaBraintreeResponse.errors?.[0] ?? kivaBraintreeResponse;
+			// extract error code and message
+			const errorCode = errorObj?.extensions?.code ?? errorObj?.error ?? 'UNKNOWN_ERROR_CODE';
+			const errorMessage = errorObj?.message ?? JSON.stringify(kivaBraintreeResponse);
 			// eslint-disable-next-line max-len
 			const standardError = 'There was an error processing your payment. Please confirm your payment details and try again or contact our support team at <a href="mailto:contactus@kiva.org">contactus@kiva.org</a>.';
 
@@ -15,7 +17,7 @@ export default {
 			this.$kvTrackEvent(trackCategory, 'DropIn Payment Error', `${errorCode}: ${errorMessage}`);
 
 			// Log validation errors
-			Sentry.captureException(`${errorCode}:${errorMessage}`);
+			Sentry.captureException(`${errorCode}: ${errorMessage}`);
 		},
 	},
 };


### PR DESCRIPTION
With the release yesterday we started to see the format of some of the unhandled errors. This update handles the formatted error response from async checkout more directly.

Example error surfaced in sentry: `UNKNOWN_ERROR_CODE:[{"error":"SALE_REJECTED","message":"Sale was rejected, Status: CHARGE_TRANSIENT_PAYMENT_METHOD_FAILED"}]`