### PR TITLE
fix: state is in hash and show error page for error conditions MP-479

### DIFF
--- a/src/pages/ProcessBrowserAuth.vue
+++ b/src/pages/ProcessBrowserAuth.vue
@@ -9,7 +9,9 @@ export default {
 	name: 'ProcessBrowserAuth',
 	inject: ['kvAuth0'],
 	mounted() {
-		const { state } = this.$route.query;
+		const { hash } = window.location;
+		const state = new URLSearchParams(hash?.substring(1) ?? '').get('state');
+
 		if (state) {
 			const auth0State = store2.session('auth0.state');
 			if (auth0State === state) {
@@ -18,9 +20,24 @@ export default {
 				store2.session.remove('auth0.state');
 				store2.session.remove('auth0.redirect');
 
-				this.$router.push(`${redirect}${window.location.hash}`);
+				this.$router.push(`${redirect}${hash}`);
+			} else {
+				this.goToErrorPage('state_mismatch');
 			}
+		} else {
+			this.goToErrorPage('missing_state');
 		}
+	},
+	methods: {
+		goToErrorPage(error) {
+			this.$router.push({
+				path: '/error',
+				query: {
+					error,
+					error_description: 'You may have clicked on an old or invalid link. Please try again.',
+				},
+			});
+		},
 	},
 };
 </script>


### PR DESCRIPTION
I found that the state param is actually sent over in the hash. I initially got only a blank page though, so I also added a push to the error page to handle those cases more gracefully.