### PR TITLE
fix: show old ty page for non-loan purchases

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -21,7 +21,7 @@
 				:user-preferences="userPreferences"
 			/>
 		</template>
-		<template v-else-if="showNewTYPage">
+		<template v-else-if="showNewTYPage && loans.length > 0">
 			<what-is-next-template
 				:selected-loan="selectedLoan"
 				:loans="loans"


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-748

- Take non-loan (for example, gift card) purchases to old TY page