### PR TITLE
feat: use FLSS for live loan image filter searches when supported MP-732

### DIFF
--- a/server/util/live-loan/live-loan-fetch.js
+++ b/server/util/live-loan/live-loan-fetch.js
@@ -244,7 +244,7 @@ const findFilterOption = (options, name, value) => {
 
 // Takes a string like: "sort_expiringSoon,gender_female"
 // and extracts the sort option, e.g. "expiringSoon"
-async function parseSortString(sortString, sortOptions) {
+function parseSortString(sortString, sortOptions) {
 	let sort = null;
 
 	// only try parsing if the input is valid
@@ -330,7 +330,7 @@ const parseFilterStringFLSS = async filterString => {
 async function fetchRecommendationsByFilter(filterString) {
 	const filters = await parseFilterStringFLSS(filterString);
 	const sortOptions = await fetchFLSSSorts();
-	const sortBy = await parseSortString(filterString, sortOptions);
+	const sortBy = parseSortString(filterString, sortOptions);
 	return fetchLoansFromGraphQL(
 		{
 			query: `query($filters: [FundraisingLoanSearchFilterInput!], $sortBy: SortEnum) {
@@ -426,11 +426,11 @@ async function parseFilterStringLegacy(filterString) {
 
 // Get loans from legacy lend search matching a set of filters
 async function fetchRecommendationsByLegacyFilter(filterString) {
-	const sortOptions = await fetchSorts();
-	const [filters, sort] = await Promise.all([
+	const [filters, sortOptions] = await Promise.all([
 		parseFilterStringLegacy(filterString),
-		parseSortString(filterString, sortOptions),
+		fetchSorts(),
 	]);
+	const sort = parseSortString(filterString, sortOptions);
 	return fetchLoansFromGraphQL(
 		{
 			query: `query($filters: LoanSearchFiltersInput, $sort: LoanSearchSortByEnum) {
@@ -477,8 +477,8 @@ const shouldUseFLSS = async filterString => {
 
 	// Check which sort options are used in the filter string
 	const [legacySorts, flssSorts] = await Promise.all([fetchSorts(), fetchFLSSSorts()]);
-	const legacySort = await parseSortString(filterString, legacySorts);
-	const FLSSSort = await parseSortString(filterString, flssSorts);
+	const legacySort = parseSortString(filterString, legacySorts);
+	const FLSSSort = parseSortString(filterString, flssSorts);
 	const usingLegacySort = !!legacySort;
 	const usingFLSSSort = !!FLSSSort;
 

--- a/server/util/live-loan/live-loan-fetch.js
+++ b/server/util/live-loan/live-loan-fetch.js
@@ -60,7 +60,27 @@ async function fetchLoansFromGraphQL(request, resultPath) {
 }
 
 // Get per-user recommended loans from the ML service
-async function fetchRecommendationsByLoginId(id) {
+async function fetchRecommendationsByLoginId(id, flss = false) {
+	if (flss) {
+		return fetchLoansFromGraphQL(
+			{
+				query: `query($userId: Int) {
+					fundraisingLoans(
+						pageNumber: 0,
+						limit: ${loanCount},
+						userId: $userId,
+						origin: "email:live-loans"
+					) {
+						${loanValues}
+					}
+				}`,
+				variables: {
+					userId: Number(id),
+				}
+			},
+			'data.fundraisingLoans.values'
+		);
+	}
 	return fetchLoansFromGraphQL(
 		{
 			query: `{
@@ -142,6 +162,22 @@ async function fetchSorts() {
 	]);
 }
 
+async function fetchFLSSSorts() {
+	return Promise.resolve([
+		'amountHighToLow',
+		'amountLeft',
+		'amountLowToHigh',
+		'expiringSoon',
+		'mostRecent',
+		'personalized',
+		'personalizedAutolending',
+		'personalizedFallback',
+		'popularityScore',
+		'repaymentTerm',
+		'researchScore'
+	]);
+}
+
 // Get possible themes
 async function fetchThemes() {
 	// If needed, these could be fetched async from legacy api, though be sure to cache results!
@@ -197,12 +233,47 @@ const getFilterArrays = filterString => {
 	return [...matches].map(match => [match[1], match[2]]);
 };
 
+// Helper function to find possible filter options from a given list
+const findFilterOption = (options, name, value) => {
+	const option = options.find(o => o?.name?.toLowerCase() === value);
+	if (!option) {
+		warn(`Unknown ${name} "${value}"`);
+	}
+	return option;
+};
+
+// Takes a string like: "sort_expiringSoon,gender_female"
+// and extracts the sort option, e.g. "expiringSoon"
+async function parseSortString(sortString, sortOptions) {
+	let sort = null;
+
+	// only try parsing if the input is valid
+	if (sortString && typeof sortString === 'string') {
+		// start pasring the string
+		getFilterArrays(sortString)
+			// remove any filter that isn't "sort"
+			.filter(([name]) => name === 'sort')
+			// return just the value of the sort option
+			.map(array => array?.[1])
+			// if the sort option value is valid, set it as the sort to be returned
+			.forEach(value => {
+				const sortOption = sortOptions.find(o => o?.toLowerCase() === value);
+				if (sortOption) {
+					sort = sortOption;
+				}
+			});
+	}
+	return sort;
+}
+
 // Only returns true for supported FLSS loan search filters
 const supportedFilterFLSS = name => {
 	switch (name) {
 		case 'country':
 		case 'gender':
 		case 'sector':
+		case 'theme':
+		case 'tag':
 			return true;
 		default:
 			warn(`Unsupported FLSS filter "${name}"`);
@@ -212,41 +283,70 @@ const supportedFilterFLSS = name => {
 
 // Takes a string like: "gender_female,sector_education"
 // and returns an array of objects like: [ { gender: { eq: 'female' } }, { sector: { eq: 'education' } } ]
-const parseFilterStringFLSS = filterString => {
+const parseFilterStringFLSS = async filterString => {
 	// If the filter string is not valid, return an empty array
 	if (!filterString || typeof filterString !== 'string') {
-		return [];
+		return null;
 	}
-	return getFilterArrays(filterString)
+
+	const filters = {};
+
+	// Helper function to add to a value to an array filter
+	const addArrayFilterValue = (name, value) => {
+		// Make sure existing value is an array if it isn't already
+		filters[name] = filters[name] || { [name]: { any: [] } };
+		// Add the new value to the existing array
+		filters[name][name].any.push(value);
+	};
+
+	// Fetch possible filter options
+	const tags = await fetchTags();
+
+	// Start parsing the filter string
+	getFilterArrays(filterString)
+		.filter(([name]) => name !== 'sort')
 		.filter(([name]) => supportedFilterFLSS(name))
-		.map(([name, value]) => {
-			// FLSS uses 'countryIsoCode' for the country filter
+		.forEach(([name, value]) => {
 			if (name === 'country') {
-				return { countryIsoCode: { eq: value } };
+				// FLSS uses 'countryIsoCode' for the country filter
+				addArrayFilterValue('countryIsoCode', value);
+			} else if (name === 'tag') {
+				// FLSS uses 'tagId' for the tag filter
+				const tag = findFilterOption(tags, name, value);
+				if (tag) {
+					addArrayFilterValue('tagId', tag.id);
+				}
+			} else {
+				// Other filters can be passed through directly
+				addArrayFilterValue(name, value);
 			}
-			// Other filters can be passed through directly
-			return { [name]: { eq: value } };
 		});
+
+	const filterValues = Object.values(filters);
+	return filterValues.length ? filterValues : null;
 };
 
 // Get loans from the Fundraising Loan Search Service matching a set of filters
-async function fetchRecommendationsByFilter(userId, filterString) {
+async function fetchRecommendationsByFilter(filterString) {
+	const filters = await parseFilterStringFLSS(filterString);
+	const sortOptions = await fetchFLSSSorts();
+	const sortBy = await parseSortString(filterString, sortOptions);
 	return fetchLoansFromGraphQL(
 		{
-			query: `query($userId: Int, $filters: [FundraisingLoanSearchFilterInput!]) {
+			query: `query($filters: [FundraisingLoanSearchFilterInput!], $sortBy: SortEnum) {
 				fundraisingLoans(
-					pageNumber:0,
+					pageNumber: 0,
 					limit: ${loanCount},
 					filters: $filters,
-					userId: $userId,
+					sortBy: $sortBy,
 					origin: "email:live-loans"
 				) {
 					${loanValues}
 				}
 			}`,
 			variables: {
-				userId: Number(userId),
-				filters: parseFilterStringFLSS(filterString),
+				filters,
+				sortBy,
 			}
 		},
 		'data.fundraisingLoans.values'
@@ -286,14 +386,6 @@ async function parseFilterStringLegacy(filterString) {
 		// Add the new value to the existing array
 		filters[name].push(value);
 	};
-	// Helper function to find possible filter options from a given list
-	const findFilterOption = (options, name, value) => {
-		const option = options.find(o => o?.name?.toLowerCase() === value);
-		if (!option) {
-			warn(`Unknown ${name} "${value}"`);
-		}
-		return option;
-	};
 
 	// only try parsing if the input is valid
 	if (filterString && typeof filterString === 'string') {
@@ -332,38 +424,12 @@ async function parseFilterStringLegacy(filterString) {
 	return filters;
 }
 
-// Takes a string like: "sort_expiringSoon,gender_female"
-// and extracts the sort option, e.g. "expiringSoon"
-async function parseSortStringLegacy(sortString) {
-	let sort = null;
-
-	// only try parsing if th einput is valid
-	if (sortString && typeof sortString === 'string') {
-		// get possible sorts
-		const sortOptions = await fetchSorts();
-
-		// start pasring the string
-		getFilterArrays(sortString)
-			// remove any filter that isn't "sort"
-			.filter(([name]) => name === 'sort')
-			// return just the value of the sort option
-			.map(array => array?.[1])
-			// if the sort option value is valid, set it as the sort to be returned
-			.forEach(value => {
-				const sortOption = sortOptions.find(o => o?.toLowerCase() === value);
-				if (sortOption) {
-					sort = sortOption;
-				}
-			});
-	}
-	return sort;
-}
-
 // Get loans from legacy lend search matching a set of filters
 async function fetchRecommendationsByLegacyFilter(filterString) {
+	const sortOptions = await fetchSorts();
 	const [filters, sort] = await Promise.all([
 		parseFilterStringLegacy(filterString),
-		parseSortStringLegacy(filterString)
+		parseSortString(filterString, sortOptions),
 	]);
 	return fetchLoansFromGraphQL(
 		{
@@ -401,15 +467,44 @@ async function fetchLoanById(loanId) {
 		'data.lend.loan'
 	);
 }
+
+// Check if the filter string contains any FLSS filters
+const shouldUseFLSS = async filterString => {
+	// input needs to be a string
+	if (!filterString || typeof filterString !== 'string') {
+		return false;
+	}
+
+	// Check which sort options are used in the filter string
+	const [legacySorts, flssSorts] = await Promise.all([fetchSorts(), fetchFLSSSorts()]);
+	const legacySort = await parseSortString(filterString, legacySorts);
+	const FLSSSort = await parseSortString(filterString, flssSorts);
+	const usingLegacySort = !!legacySort;
+	const usingFLSSSort = !!FLSSSort;
+
+	// If the filter string contains a sort option that is only supported by one of the services, use that service
+	if (usingFLSSSort && !usingLegacySort) {
+		return true;
+	}
+	if (usingLegacySort && !usingFLSSSort) {
+		return false;
+	}
+
+	// Use FLSS by default
+	return true;
+};
+
 // Export a function that will fetch loans by live-loan type and id
 module.exports = async function fetchLoansByType(type, id, flss = false) {
 	if (type === 'user') {
-		return flss ? fetchRecommendationsByFilter(id) : fetchRecommendationsByLoginId(id);
+		return fetchRecommendationsByLoginId(id, flss);
 	} if (type === 'loan') {
 		return fetchRecommendationsByLoanId(id);
 	} if (type === 'filter') {
-		// Swap which line below is commented out to switch between FLSS and legacy (monolith) lend search
-		// return fetchRecommendationsByFilter(id);
+		if (await shouldUseFLSS(id)) {
+			return fetchRecommendationsByFilter(id);
+		}
+		warn(`Using legacy loan search for filter "${id}"`);
 		return fetchRecommendationsByLegacyFilter(id);
 	}
 	if (type === 'loanid') {

--- a/server/util/live-loan/live-loan-fetch.js
+++ b/server/util/live-loan/live-loan-fetch.js
@@ -472,7 +472,7 @@ async function fetchLoanById(loanId) {
 const shouldUseFLSS = async filterString => {
 	// input needs to be a string
 	if (!filterString || typeof filterString !== 'string') {
-		return false;
+		return true; // Returning true so that FLSS is the default
 	}
 
 	// Check which sort options are used in the filter string

--- a/test/unit/specs/server/live-loan-fetch.spec.js
+++ b/test/unit/specs/server/live-loan-fetch.spec.js
@@ -10,7 +10,7 @@ jest.mock('../../../../server/util/argv', () => {
 });
 
 describe('live-loan-fetch', () => {
-	describe('fetchRecommendationsByLegacyFilter', () => {
+	describe('fetchRecommendationsByFilter', () => {
 		// Extract the variables used in the graphql query performed by fetchLoansByType when given inputString
 		async function readParsedVariable(inputString) {
 			// Reset fetch mock and make it return a resolved promise when called
@@ -32,65 +32,99 @@ describe('live-loan-fetch', () => {
 		}
 
 		// Test that expectedSort is used for the graphql query that's based on the inputString
-		async function testSortParsing(inputString, expectedSort) {
+		async function testSortParsingLegacy(inputString, expectedSort) {
 			const { sort } = await readParsedVariable(inputString);
 			expect(sort).toEqual(expectedSort);
 		}
+		async function testSortParsing(inputString, expectedSort) {
+			const { sortBy } = await readParsedVariable(inputString);
+			expect(sortBy).toEqual(expectedSort);
+		}
 
 		it('converts input strings to valid LoanSearchFiltersInput objects', async () => {
-			await testFilterParsing('gender_male,sector_education', { gender: 'male', sector: [15] });
-			await testFilterParsing('sector_retail', { sector: [7] });
-			await testFilterParsing('gender_female', { gender: 'female' });
-			await testFilterParsing('country_us,country_pr', { country: ['us', 'pr'] });
-			await testFilterParsing('country_co,country_ke', { country: ['co', 'ke'] });
-			await testFilterParsing('gender_female,country_us', { gender: 'female', country: ['us'] });
-			await testFilterParsing('gender_male,sector_arts,sector_agriculture', { gender: 'male', sector: [9, 1] });
-			await testFilterParsing('sector_personal use', { sector: [16] });
-			await testFilterParsing('sort_expiringSoon,gender_female', { gender: 'female' });
-			await testFilterParsing('theme_green', { theme: ['Green'] });
-			await testFilterParsing('theme_disaster recovery', { theme: ['Disaster recovery'] });
-			await testFilterParsing('theme_refugees/displaced', { theme: ['Refugees/Displaced'] });
-			await testFilterParsing('theme_start-up', { theme: ['Start-Up'] });
-			await testFilterParsing('theme_youth,theme_green', { theme: ['Youth', 'Green'] });
-			await testFilterParsing('tag_u.s. black-owned businesses', { loanTags: [43] });
-			await testFilterParsing('tag_u.s. black-owned businesses,theme_green',
+			// Using sort_random forces using the legacy loan search
+			await testFilterParsing('sort_random,gender_male,sector_education', { gender: 'male', sector: [15] });
+			await testFilterParsing('sort_random,sector_retail', { sector: [7] });
+			await testFilterParsing('sort_random,gender_female', { gender: 'female' });
+			await testFilterParsing('sort_random,country_us,country_pr', { country: ['us', 'pr'] });
+			await testFilterParsing('sort_random,country_co,country_ke', { country: ['co', 'ke'] });
+			await testFilterParsing('sort_random,gender_female,country_us', { gender: 'female', country: ['us'] });
+			await testFilterParsing('sort_random,gender_male,sector_arts,sector_agriculture',
+				{ gender: 'male', sector: [9, 1] });
+			await testFilterParsing('sort_random,sector_personal use', { sector: [16] });
+			await testFilterParsing('sort_random,gender_female', { gender: 'female' });
+			await testFilterParsing('sort_random,theme_green', { theme: ['Green'] });
+			await testFilterParsing('sort_random,theme_disaster recovery', { theme: ['Disaster recovery'] });
+			await testFilterParsing('sort_random,theme_refugees/displaced', { theme: ['Refugees/Displaced'] });
+			await testFilterParsing('sort_random,theme_start-up', { theme: ['Start-Up'] });
+			await testFilterParsing('sort_random,theme_youth,theme_green', { theme: ['Youth', 'Green'] });
+			await testFilterParsing('sort_random,tag_u.s. black-owned businesses', { loanTags: [43] });
+			await testFilterParsing('sort_random,tag_u.s. black-owned businesses,theme_green',
 				{ loanTags: [43], theme: ['Green'] });
-			await testFilterParsing('tag_latinx/hispanic owned business,tag_u.s. black-owned businesses',
+			await testFilterParsing('sort_random,tag_latinx/hispanic owned business,tag_u.s. black-owned businesses',
 				{ loanTags: [45, 43] });
-			await testFilterParsing('notafilter_value', {});
-			await testFilterParsing('sector_notasector', {});
-			await testFilterParsing('theme_notatheme', {});
-			await testFilterParsing('', {});
-			await testFilterParsing('1234', {});
+			await testFilterParsing('sort_random,notafilter_value', {});
+			await testFilterParsing('sort_random,sector_notasector', {});
+			await testFilterParsing('sort_random,theme_notatheme', {});
+			await testFilterParsing('sort_random,tag_notatag', {});
+			await testFilterParsing('sort_random', {});
+			await testFilterParsing('sort_random,1234', {});
 		});
 
 		it('converts input strings to valid LoanSearchSortByEnum values', async () => {
-			await testSortParsing('sort_newest', 'newest');
-			await testSortParsing('sort_expiringSoon,gender_female', 'expiringSoon');
+			await testSortParsingLegacy('sort_random', 'random');
+			await testSortParsingLegacy('sort_random,gender_female', 'random');
+		});
+
+		it('converts input strings to valid [FundraisingLoanSearchFilterInput!] arrays', async () => {
+			await testFilterParsing('gender_male,sector_education',
+				[{ gender: { any: ['male'] } }, { sector: { any: ['education'] } }]);
+			await testFilterParsing('sector_retail', [{ sector: { any: ['retail'] } }]);
+			await testFilterParsing('gender_female', [{ gender: { any: ['female'] } }]);
+			await testFilterParsing('country_us,country_pr', [{ countryIsoCode: { any: ['us', 'pr'] } }]);
+			await testFilterParsing('country_co,country_ke', [{ countryIsoCode: { any: ['co', 'ke'] } }]);
+			await testFilterParsing('gender_female,country_us',
+				[{ gender: { any: ['female'] } }, { countryIsoCode: { any: ['us'] } }]);
+			await testFilterParsing('gender_male,sector_arts,sector_agriculture',
+				[{ gender: { any: ['male'] } }, { sector: { any: ['arts', 'agriculture'] } }]);
+			await testFilterParsing('sector_personal use', [{ sector: { any: ['personal use'] } }]);
+			await testFilterParsing('sort_expiringSoon,gender_female', [{ gender: { any: ['female'] } }]);
+			await testFilterParsing('theme_green', [{ theme: { any: ['green'] } }]);
+			await testFilterParsing('theme_disaster recovery', [{ theme: { any: ['disaster recovery'] } }]);
+			await testFilterParsing('theme_refugees/displaced', [{ theme: { any: ['refugees/displaced'] } }]);
+			await testFilterParsing('theme_start-up', [{ theme: { any: ['start-up'] } }]);
+			await testFilterParsing('theme_youth,theme_green', [{ theme: { any: ['youth', 'green'] } }]);
+			await testFilterParsing('tag_u.s. black-owned businesses', [{ tagId: { any: [43] } }]);
+			await testFilterParsing('tag_u.s. black-owned businesses,theme_green',
+				[{ tagId: { any: [43] } }, { theme: { any: ['green'] } }]);
+			await testFilterParsing('tag_latinx/hispanic owned business,tag_u.s. black-owned businesses',
+				[{ tagId: { any: [45, 43] } }]);
+
+			await testFilterParsing('gender_male,sector_education', [
+				{ gender: { any: ['male'] } },
+				{ sector: { any: ['education'] } }
+			]);
+			await testFilterParsing('sector_retail', [
+				{ sector: { any: ['retail'] } }
+			]);
+			await testFilterParsing('country_us,country_pr', [
+				{ countryIsoCode: { any: ['us', 'pr'] } },
+			]);
+			await testFilterParsing('notafilter_value', null);
+			await testFilterParsing('tag_notatag', null);
+			await testFilterParsing('', null);
+			await testFilterParsing('1234', null);
+		});
+
+		it('converts input strings to valid SortEnum values', async () => {
+			await testSortParsing('sort_expiringSoon', 'expiringSoon');
+			await testSortParsing('sort_mostRecent,gender_female', 'mostRecent');
+			await testSortParsing('sort_researchScore', 'researchScore');
 
 			await testSortParsing('sort_notasort', null);
 			await testSortParsing('gender_female', null);
 			await testSortParsing('', null);
 			await testSortParsing('1234', null);
-		});
-
-		// TODO: activate this test (by removing .skip) once FLSS is used for live loan searching
-		it.skip('converts input strings to valid [FundraisingLoanSearchFilterInput!] arrays', async () => {
-			await testFilterParsing('gender_male,sector_education', [
-				{ gender: { eq: 'male' } },
-				{ sector: { eq: 'education' } }
-			]);
-			await testFilterParsing('sector_retail', [
-				{ sector: { eq: 'retail' } }
-			]);
-			await testFilterParsing('country_us,country_pr', [
-				{ countryIsoCode: { eq: 'us' } },
-				{ countryIsoCode: { eq: 'pr' } }
-			]);
-
-			await testFilterParsing('notafilter_value', []);
-			await testFilterParsing('', []);
-			await testFilterParsing('1234', []);
 		});
 	});
 


### PR DESCRIPTION
Use FLSS for all filter searches that it supports, with a fallback to the legacy loan search if using a sort option that only works there.