### PR TITLE
fix: try rolling back components library for memory leak

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^3.101.2",
+				"@kiva/kv-components": "^3.91.0",
 				"@kiva/kv-shop": "^1.12.8",
 				"@kiva/kv-tokens": "^2.11.1",
 				"@mdi/js": "^7",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
-		"@kiva/kv-components": "^3.101.2",
+		"@kiva/kv-components": "^3.91.0",
 		"@kiva/kv-shop": "^1.12.8",
 		"@kiva/kv-tokens": "^2.11.1",
 		"@mdi/js": "^7",


### PR DESCRIPTION
- Let's try rolling back the package lib
- This is the oldest we can move to without rolling back other files related to charts