### PR TITLE
feat: exclude from badge experiments users that has lent before

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -558,7 +558,7 @@ export default {
 
 		this.optedIn = data?.my?.communicationSettings?.lenderNews || this.$route.query?.optedIn === 'true';
 		// Thanks Badges Experiment
-		if (this.optedIn && !this.printableKivaCards.length) {
+		if (this.optedIn && !this.printableKivaCards.length && isFirstLoan) {
 			const { version } = trackExperimentVersion(
 				this.apollo,
 				this.$kvTrackEvent,


### PR DESCRIPTION
This is used for the moment, we need to comeback at this when `AchievementMilestonesForCheckout` is ready