### PR TITLE
feat: showing old ty page for print-in-yourself kiva card in basket mp-795

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -366,8 +366,8 @@ export default {
 			return this.ctaContentBlock?.primaryCtaText;
 		},
 		showFocusedShareAsk() {
-			// if jumpToGuestUpsell is true, don't show focused share ask;
-			if (this.jumpToGuestUpsell) {
+			// if jumpToGuestUpsell is true or there's print-it-yourself card don't show focused share ask;
+			if (this.jumpToGuestUpsell || this.printableKivaCards.length) {
 				return false;
 			}
 			// Only show focused share ask for non-guest loan purchases or for only US loan purchases from guests


### PR DESCRIPTION
Current behavior was showing the comment and share variant of the thanks page. We want to show the old ty page when a user checkouts with a print-in-yourself card 