### PR TITLE
fix: print kiva cards should have more priority on visible section

### DIFF
--- a/src/components/Thanks/ThanksLayoutV2.vue
+++ b/src/components/Thanks/ThanksLayoutV2.vue
@@ -346,11 +346,17 @@ export default {
 		showShare: {
 			type: Boolean,
 			default: true
+		},
+		showReceipt: {
+			type: Boolean,
+			default: false
 		}
 	},
 	data() {
 		let visibleSection = 'receipt';
-		if (this.showGuestUpsell) {
+		if (this.showReceipt) {
+			visibleSection = 'receipt';
+		} else if (this.showGuestUpsell) {
 			visibleSection = 'guest';
 		} else if (this.showShare) {
 			visibleSection = 'share';

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -66,6 +66,7 @@
 					:show-mg-cta="!isMonthlyGoodSubscriber && !isGuest && !hasModernSub"
 					:show-guest-upsell="isGuest"
 					:show-share="loans.length > 0"
+					:show-receipt="this.printableKivaCards.length > 0"
 				>
 					<template #receipt>
 						<checkout-receipt


### PR DESCRIPTION
Page should show order confirmation if they are print cards