### PR TITLE
fix: firstLoan variable was not considering if the user was a guest

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -559,7 +559,8 @@ export default {
 
 		this.optedIn = data?.my?.communicationSettings?.lenderNews || this.$route.query?.optedIn === 'true';
 		// Thanks Badges Experiment
-		if (this.optedIn && !this.printableKivaCards.length && isFirstLoan) {
+		const enableExperiment = this.optedIn && !this.printableKivaCards.length && (isFirstLoan || this.isGuest);
+		if (enableExperiment) {
 			const { version } = trackExperimentVersion(
 				this.apollo,
 				this.$kvTrackEvent,


### PR DESCRIPTION
TY badge experiment was not showing for guests because `firstLoan` was evaluating user's account information