### PR TITLE
fix: preference needs to be an string

### DIFF
--- a/src/plugins/badge-goal-mixin.js
+++ b/src/plugins/badge-goal-mixin.js
@@ -28,7 +28,7 @@ export default {
 			checkInjections(this, injections);
 
 			try {
-				const preferences = { ...userPreferences.preferences, goal: badgeName };
+				const preferences = JSON.stringify({ ...userPreferences.preferences, goal: badgeName });
 
 				const updateUserPreferencesMutation = gql`
 					mutation UpdateUserPreferences(


### PR DESCRIPTION
Removed `stringify` by mistake