### PR TITLE
chore: allow input of optional ci build branch

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -10,6 +10,11 @@ on:
           - staging
           - production
         required: true
+      ci-branch:
+        type: string
+        description: 'The branch to run the CI on.'
+        default: 'main'
+        required: false
   push:
     branches:
       - staging
@@ -74,7 +79,7 @@ jobs:
           repository: kiva/marketplace-web-ui-ci
           token: ${{ env.GITHUB_PAT }}
           path: .docker
-          ref: main
+          ref: ${{ github.event.inputs.ci-branch }}
           patterns: |
             resources/org/kiva/marketplaceWebUiCi/ui
       - name: move files


### PR DESCRIPTION
I think we'll need this option to kick off a semantic release using an alternal `marketplace-web-ui-ci` branch