### PR TITLE
build: ensure image build happens if github release was published

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -56,7 +56,7 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     needs: create-release
-    if: needs.create-release.outputs.published == 'true'
+    if: ${{ !cancelled() && needs.create-release.outputs.published == 'true' }}
     env:
       GITHUB_PAT: "${{ secrets.KIVA_ROBOT_GITHUB_PAT }}"
       AWS_REGION: "us-west-2"


### PR DESCRIPTION
Because there are additional steps (like notify slack) in the semantic-release action after the actual semantic release process runs, the image build step can end up being skipped when those additional steps fail, even though a tag was created and a github release was created. This is because a "default status check of success() is applied unless you include one of" the [status check functions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#status-check-functions). This adds a `!cancelled()` check to the build image step so that it will happen as long as a release was published, even if the previous step failed overall.