### PR TITLE
fix: change storybook build generated js filenames so they do not sta…

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,5 +14,19 @@ const config = {
   docs: {
     autodocs: "tag",
   },
+  async viteFinal(config) {
+    // Merge custom configuration into the default config
+    const { mergeConfig } = await import('vite');
+
+    return mergeConfig(config, {
+		build: {
+			rollupOptions: {
+				output: {
+					chunkFileNames: 'assets/entry-[name]-[hash:10].js',
+				},
+			},
+		},
+    });
+  },
 };
 export default config;


### PR DESCRIPTION
…rt with underscores.

All storybook js entries are now prefixed with `entry-` so the prior files such as `_baseAssignValue-0CH7BhwL9t.js` now look like `entry-_baseAssignValue-0CH7BhwL9t.js`.