### PR TITLE
fix: attempt retry after network error before logging the error MP-857

### DIFF
--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -39,16 +39,16 @@ export default function createApolloClient({
 
 	const client = new ApolloClient({
 		link: ApolloLink.from([
-			NetworkErrorRetryLink({
-				activateRetry: appConfig?.apolloNetworkErrorRetryActive,
-				attemptsMax: appConfig?.apolloNetworkErrorRetryAttempts,
-			}),
-			NetworkErrorLoggingLink(),
 			SnowplowSessionLink({ cookieStore }),
 			ExperimentIdLink({ cookieStore }),
 			Auth0LinkCreator({ cookieStore, kvAuth0 }),
 			BasketLinkCreator({ cookieStore }),
 			ContentfulPreviewLink({ cookieStore }),
+			NetworkErrorLoggingLink(),
+			NetworkErrorRetryLink({
+				activateRetry: appConfig?.apolloNetworkErrorRetryActive,
+				attemptsMax: appConfig?.apolloNetworkErrorRetryAttempts,
+			}),
 			HttpLinkCreator({
 				uri,
 				fetch,


### PR DESCRIPTION
Because responses from the server are handled in reverse order (requests start at the top of the link chain and responses are sent back up from the terminating link), network errors are being logged as errors even when the retry is happening successfully. This PR change the link order so that the network error retry link is the first one to process the server response, followed by the network error logging link. This should make it so that we only log network errors when the retries fail.