### PR TITLE
fix: props and attrs not set correctly on buttons MP-858

### DIFF
--- a/src/components/15Years/15YearsButton.vue
+++ b/src/components/15Years/15YearsButton.vue
@@ -6,15 +6,13 @@ export default {
 	render() {
 		const options = {
 			class: ['fifteen-yr-button', this.variant ? `fifteen-yr-button--${this.variant}` : ''],
-			props: {},
-			attrs: {},
 			on: { click: this.onClick },
 		};
 		if (this.to) {
-			options.props.to = this.to;
+			options.to = this.to;
 		}
 		if (this.href) {
-			options.attrs.href = this.href;
+			options.href = this.href;
 		}
 		return h(this.tag, options, this.$slots.default());
 	},

--- a/src/components/Kv/KvButton.vue
+++ b/src/components/Kv/KvButton.vue
@@ -7,14 +7,12 @@ export default {
 	render() {
 		const options = {
 			class: { button: true },
-			props: {},
-			attrs: {},
 		};
 		if (this.to) {
-			options.props.to = this.to;
+			options.to = this.to;
 		}
 		if (this.href) {
-			options.attrs.href = this.href;
+			options.href = this.href;
 		}
 		return h(this.tag, options, this.$slots.default());
 	},


### PR DESCRIPTION
The render function API changed from Vue 2 to Vue 3 and VNodes now have a flat prop structure. See https://v3-migration.vuejs.org/breaking-changes/render-function-api.html#vnode-props-format for details.