### PR TITLE
fix: mp 877 client auth guard

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -175,8 +175,9 @@ function setupClientRouting({
 				route: to,
 			});
 			next();
-		} catch {
-			next();
+		} catch (error) {
+			// pass error through next to ensure redirect to login
+			next(error);
 		}
 	});
 

--- a/src/util/authenticationGuard.js
+++ b/src/util/authenticationGuard.js
@@ -1,4 +1,3 @@
-import _get from 'lodash/get';
 import * as Sentry from '@sentry/vue';
 import authenticationQuery from '#src/graphql/query/authenticationQuery.graphql';
 
@@ -97,7 +96,7 @@ export function authenticationGuard({ route, apolloClient, kvAuth0 }) {
 					throw new Error('recentLoginRequired');
 				}
 				// Route requires multi factor authentication or email verification
-				if (mfaRequired && !kvAuth0.isMfaAuthenticated() && !_get(data, 'my.emailVerifiedRecently')) {
+				if (mfaRequired && !kvAuth0.isMfaAuthenticated() && !data?.my?.emailVerifiedRecently) {
 					throw new Error('verificationRequired');
 				}
 				resolve();


### PR DESCRIPTION
Without this, the auth guard redirect was not being observed during client side navigation. This ensures the redirect occurs based on the route contained in the error.