### PR TITLE
fix: slide width in badge experiment

### DIFF
--- a/src/components/Thanks/Badges/DetailSection.vue
+++ b/src/components/Thanks/Badges/DetailSection.vue
@@ -198,6 +198,10 @@ export default {
 
 <style lang="postcss" scoped>
 
+.slide-container {
+	width: 164px;
+}
+
 .no-border :deep(span) {
 	@apply tw-bg-transparent tw-border-0;
 }


### PR DESCRIPTION
Needed to set width for image container.

Before:
![image](https://github.com/user-attachments/assets/cbce3a63-61b2-4ba9-9648-95985bce0886)

After:
<img width="501" alt="image" src="https://github.com/user-attachments/assets/8dd6cf94-5fa3-4a28-9d1d-1298f0f20565">
