### PR TITLE
fix: add watcher to update state when lightbox opens, remove deprecat…

### DIFF
--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -66,7 +66,7 @@
 						data-test="status-save-button"
 						class="smaller button"
 						v-if="!isSaving"
-						@click.native="save"
+						@click="save"
 						:disabled="!isChanged"
 					>
 						Save
@@ -151,6 +151,14 @@ export default {
 	mounted() {
 		// After initial value is loaded, setup watch
 		this.$watch('autolendingStatus', this.watchAutolendingStatus);
+		this.$watch('showLightbox', next => {
+			if (next) {
+				this.autolendingStatus = this.setAutolendingStatus({
+					isEnabled: this.isEnabled,
+					pauseUntil: this.pauseUntil
+				});
+			}
+		});
 	},
 	methods: {
 		watchAutolendingStatus() {


### PR DESCRIPTION
…ed click attribute.

This component really needs to be refactored to use kv-components but in the meantime as nesting our older ui components within newer kv-components seems a bit problematic. I'm just trying to force update the value when the lightbox opens for now.