### PR TITLE
fix: autolending dev mode lbc null

### DIFF
--- a/src/components/Kv/KvRadio.vue
+++ b/src/components/Kv/KvRadio.vue
@@ -47,7 +47,17 @@ export default {
 		isChecked() {
 			return this.radioValue === this.modelValue;
 		}
-	}
+	},
+	watch: {
+		modelValue: {
+			immediate: true,
+			handler(value) {
+				if (value !== this.inputValue) {
+					this.inputValue = value;
+				}
+			}
+		},
+	},
 };
 
 </script>

--- a/src/pages/Autolending/AutolendingStatus.vue
+++ b/src/pages/Autolending/AutolendingStatus.vue
@@ -151,14 +151,6 @@ export default {
 	mounted() {
 		// After initial value is loaded, setup watch
 		this.$watch('autolendingStatus', this.watchAutolendingStatus);
-		this.$watch('showLightbox', next => {
-			if (next) {
-				this.autolendingStatus = this.setAutolendingStatus({
-					isEnabled: this.isEnabled,
-					pauseUntil: this.pauseUntil
-				});
-			}
-		});
 	},
 	methods: {
 		watchAutolendingStatus() {

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -433,7 +433,7 @@ export default {
 		const cachedRecommendedLoans = this.apollo.readQuery({
 			query: flssLoansQueryExtended,
 			variables: prefetchedRecommendedLoansVariables
-		})?.fundraisingLoans?.values ?? [];
+		})?.fundraisingLoans?.values?.filter(loan => loan !== null) ?? [];
 
 		this.initializeFiveDollarsNotes();
 

--- a/src/util/loanSearch/dataUtils.js
+++ b/src/util/loanSearch/dataUtils.js
@@ -50,7 +50,7 @@ export async function runLoansQuery(apollo, loanSearchState, origin) {
 		origin,
 	);
 
-	return { loans: flssData?.values ?? [], totalCount: flssData?.totalCount ?? 0 };
+	return { loans: flssData?.values?.filter(loan => loan !== null) ?? [], totalCount: flssData?.totalCount ?? 0 };
 }
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,6 +32,9 @@ export default defineConfig({
 		'**/*.bin',
 		'**/*.wasm',
 	],
+	// Force all assets/vite calls through /static in dev mode, compiled mode is covered by the build config below
+	base: isProd ? '/' : '/static/',
+	// Use /static for all assets in prod mode
 	build: {
 		assetsDir: 'static',
 		assetsInlineLimit: (filePath, content) => {


### PR DESCRIPTION
A few things:

- Changes vite config to load all assets and other vite urls behind the `/static` path instead of various direct references such as `/src/`, `@vite` and others... This will help fix Ui in Tilt where we don't have all the new possible vite hmr locations setup
- Updates the KvRadio component to set the initial `inputValue`, this was a similar fix to some we made in our global components. Removes the previous hack watcher which didn't work once deployed to dev.
- Filters out `null` entries in loan queries used in LBC