### PR TITLE
feat: improve ui-site-map MP-880

### DIFF
--- a/src/pages/UiSiteMap/RouteListing.vue
+++ b/src/pages/UiSiteMap/RouteListing.vue
@@ -5,11 +5,19 @@
 				Prod Routes
 			</h2>
 			<ul class="tw-list-disc tw-list-inside tw-mb-4">
-				<li v-for="route in prodRoutes" :key="route.path">
-					<router-link :to="route.path">
+				<li v-for="route in prodRoutes" :key="route.path" class="tw-mb-1">
+					<router-link :to="pathWithParams(route)">
 						<!-- eslint-disable-next-line -->
-						{{ route.path.replace('/','') }} <span v-if="route.name !== 'no-name'">({{ route.name }})</span>
+						{{ pathWithParams(route).replace('/','') }} <span v-if="route.name !== 'no-name'">({{ route.name }})</span>
 					</router-link>
+					<input
+						class="tw-ml-1 tw-px-1 tw-border"
+						type="text"
+						v-for="(value, key) in route.params"
+						:key="key"
+						v-model="route.params[key]"
+						:placeholder="`set ${key}`"
+					>
 				</li>
 			</ul>
 		</div>
@@ -18,11 +26,19 @@
 				Dev Routes
 			</h2>
 			<ul class="tw-list-disc tw-list-inside tw-mb-4">
-				<li v-for="route in devRoutes" :key="route.path">
-					<router-link :to="route.path">
+				<li v-for="route in devRoutes" :key="route.path" class="tw-mb-1">
+					<router-link :to="pathWithParams(route)">
 						<!-- eslint-disable-next-line -->
-						{{ route.path.replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
+						{{ pathWithParams(route).replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
 					</router-link>
+					<input
+						class="tw-ml-1 tw-px-1 tw-border"
+						type="text"
+						v-for="(value, key) in route.params"
+						:key="key"
+						v-model="route.params[key]"
+						:placeholder="`set ${key}`"
+					>
 				</li>
 			</ul>
 		</div>
@@ -31,7 +47,7 @@
 				Redirects
 			</h2>
 			<ul class="tw-list-disc tw-list-inside tw-mb-4">
-				<li v-for="route in redirectRoutes" :key="route.path">
+				<li v-for="route in redirectRoutes" :key="route.path" class="tw-mb-1">
 					<router-link :to="route.path">
 						<!-- eslint-disable-next-line -->
 						{{ route.path.replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
@@ -57,6 +73,7 @@ export default {
 			devRoutes: [],
 			prodRoutes: [],
 			redirectRoutes: [],
+			paramRegex: /:\w+/g,
 		};
 	},
 	created() {
@@ -69,7 +86,13 @@ export default {
 		};
 
 		this.$router.options.routes.forEach(route => {
-			const routeWithDefaults = { ...defaults, ...route };
+			const matchesArr = route.path.match(this.paramRegex) ?? [];
+			const params = matchesArr.reduce((matchesObj, match) => ({ ...matchesObj, [match]: null }), {});
+			const routeWithDefaults = {
+				...defaults,
+				...route,
+				params,
+			};
 			if (route.redirect) {
 				return this.redirectRoutes.push(routeWithDefaults);
 			}
@@ -79,6 +102,11 @@ export default {
 
 			this.prodRoutes.push(routeWithDefaults);
 		});
+	},
+	methods: {
+		pathWithParams(route) {
+			return route.path.replace(this.paramRegex, match => route.params[match] || match);
+		}
 	},
 };
 </script>

--- a/src/pages/UiSiteMap/RouteListing.vue
+++ b/src/pages/UiSiteMap/RouteListing.vue
@@ -4,7 +4,7 @@
 			<h2 class="tw-mb-4">
 				Prod Routes
 			</h2>
-			<ul class="tw-list-disc tw-list-inside">
+			<ul class="tw-list-disc tw-list-inside tw-mb-4">
 				<li v-for="route in prodRoutes" :key="route.path">
 					<router-link :to="route.path">
 						<!-- eslint-disable-next-line -->
@@ -17,11 +17,29 @@
 			<h2 class="tw-mb-4">
 				Dev Routes
 			</h2>
-			<ul class="tw-list-disc tw-list-inside">
+			<ul class="tw-list-disc tw-list-inside tw-mb-4">
 				<li v-for="route in devRoutes" :key="route.path">
 					<router-link :to="route.path">
 						<!-- eslint-disable-next-line -->
 						{{ route.path.replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
+					</router-link>
+				</li>
+			</ul>
+		</div>
+		<div v-if="redirectRoutes.length">
+			<h2 class="tw-mb-4">
+				Redirects
+			</h2>
+			<ul class="tw-list-disc tw-list-inside tw-mb-4">
+				<li v-for="route in redirectRoutes" :key="route.path">
+					<router-link :to="route.path">
+						<!-- eslint-disable-next-line -->
+						{{ route.path.replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
+					</router-link>
+					&rarr;
+					<router-link :to="route.redirect">
+						<!-- eslint-disable-next-line -->
+						{{ route.redirect }}
 					</router-link>
 				</li>
 			</ul>
@@ -38,25 +56,28 @@ export default {
 		return {
 			devRoutes: [],
 			prodRoutes: [],
+			redirectRoutes: [],
 		};
 	},
 	created() {
 		this.$router.options.routes = _orderBy(this.$router.options.routes, [route => route.path.toLowerCase()]);
 
+		const defaults = {
+			name: 'no-name',
+			path: 'no-path',
+			status: 'no-status',
+		};
+
 		this.$router.options.routes.forEach(route => {
-			if (route.status === 'dev') {
-				this.devRoutes.push({
-					name: route.name ? route.name : 'no-name',
-					path: route.path ? route.path : 'no-path',
-					status: route.status ? route.status : 'no-status',
-				});
-			} else {
-				this.prodRoutes.push({
-					name: route.name ? route.name : 'no-name',
-					path: route.path ? route.path : 'no-path',
-					status: route.status ? route.status : 'no-status',
-				});
+			const routeWithDefaults = { ...defaults, ...route };
+			if (route.redirect) {
+				return this.redirectRoutes.push(routeWithDefaults);
 			}
+			if (route.status === 'dev') {
+				return this.devRoutes.push(routeWithDefaults);
+			}
+
+			this.prodRoutes.push(routeWithDefaults);
 		});
 	},
 };


### PR DESCRIPTION
This separates the redirect routes into their own list, showing both the original path and the destination.
<img width="627" alt="Screenshot 2024-10-02 at 2 53 16 PM" src="https://github.com/user-attachments/assets/bcafe43f-2a04-4419-9a5b-4810f051495e">

This also extracts and replaces path parameters with values from inputs, allowing clicking on the link with whatever test value you want. However, this doesn't yet work with parameters that have pattern limitations (like `/lend/:id(\d+)`).
<img width="804" alt="Screenshot 2024-10-02 at 2 53 28 PM" src="https://github.com/user-attachments/assets/590b5b50-4e16-4185-bbe7-33f55c32e457">
