### PR TITLE
fix: declare component events that can be emitted MP-873 MP-901

### DIFF
--- a/src/components/15Years/15YearsButton.vue
+++ b/src/components/15Years/15YearsButton.vue
@@ -16,6 +16,7 @@ export default {
 		}
 		return h(this.tag, options, this.$slots.default());
 	},
+	emits: ['click'],
 	props: {
 		to: {
 			type: String,

--- a/src/components/15Years/15YearsGlobe.vue
+++ b/src/components/15Years/15YearsGlobe.vue
@@ -21,6 +21,7 @@ export default {
 	components: {
 		FifteenYearsGlobeCTA,
 	},
+	emits: ['selectcountry', 'pan'],
 	data() {
 		return {
 			ctaVisible: false,

--- a/src/components/15Years/15YearsIndividualsProfile.vue
+++ b/src/components/15Years/15YearsIndividualsProfile.vue
@@ -141,6 +141,7 @@ export default {
 	components: {
 		FifteenYearsButton,
 	},
+	emits: ['show-full-profile', 'show-next-person'],
 	props: {
 		expanded: {
 			type: Boolean,

--- a/src/components/15Years/15YearsLightbox.vue
+++ b/src/components/15Years/15YearsLightbox.vue
@@ -66,6 +66,7 @@ export default {
 			isShown: false
 		};
 	},
+	emits: ['lightbox-closed'],
 	props: {
 		visible: {
 			type: Boolean,

--- a/src/components/AutoDeposit/AutoDepositDropInPaymentWrapper.vue
+++ b/src/components/AutoDeposit/AutoDepositDropInPaymentWrapper.vue
@@ -52,6 +52,7 @@ export default {
 	},
 	inject: ['apollo'],
 	mixins: [braintreeDropInError],
+	emits: ['complete-transaction', 'no-update'],
 	props: {
 		amount: {
 			type: Number,

--- a/src/components/BorrowerProfile/DescriptionListItem.vue
+++ b/src/components/BorrowerProfile/DescriptionListItem.vue
@@ -17,6 +17,7 @@
 <script>
 export default {
 	name: 'DescriptionListItem',
+	emits: ['show-definition'],
 	props: {
 		term: {
 			type: String,

--- a/src/components/BorrowerProfile/FieldPartnerDetails.vue
+++ b/src/components/BorrowerProfile/FieldPartnerDetails.vue
@@ -141,6 +141,7 @@ export default {
 			mdiStarHalfFull,
 		};
 	},
+	emits: ['show-definition'],
 	props: {
 		partnerId: { // Partner.id
 			type: Number,

--- a/src/components/BorrowerProfile/JournalUpdates.vue
+++ b/src/components/BorrowerProfile/JournalUpdates.vue
@@ -90,6 +90,7 @@ export default {
 		UpdateDetails
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['hide-section'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/BorrowerProfile/LendersAndTeams.vue
+++ b/src/components/BorrowerProfile/LendersAndTeams.vue
@@ -239,6 +239,7 @@ export default {
 		SupporterDetails,
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['hide-section'],
 	props: {
 		displayType: {
 			type: String,

--- a/src/components/BorrowerProfile/LoanDetails.vue
+++ b/src/components/BorrowerProfile/LoanDetails.vue
@@ -78,6 +78,7 @@ export default {
 	components: {
 		DescriptionListItem,
 	},
+	emits: ['show-definition'],
 	props: {
 		partnerName: { // LoanPartner.partnerName
 			type: String,

--- a/src/components/BorrowerProfile/TrusteeDetails.vue
+++ b/src/components/BorrowerProfile/TrusteeDetails.vue
@@ -89,6 +89,7 @@ export default {
 		DescriptionListItem,
 		KvTextLink,
 	},
+	emits: ['show-definition'],
 	props: {
 		borrowerName: {
 			type: String,

--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -138,6 +138,12 @@ export default {
 		TeamAttribution
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: [
+		'refreshtotals',
+		'updating-totals',
+		'jump-to-loans',
+		'validateprecheckout',
+	],
 	props: {
 		disableRedirects: {
 			type: Boolean,

--- a/src/components/Checkout/BasketItemsList.vue
+++ b/src/components/Checkout/BasketItemsList.vue
@@ -57,6 +57,12 @@ import { userUsLoanCheckout } from '#src/util/optimizelyUserMetrics';
 
 export default {
 	name: 'BasketItemsList',
+	emits: [
+		'refreshtotals',
+		'updating-totals',
+		'jump-to-loans',
+		'validateprecheckout',
+	],
 	props: {
 		disableRedirects: {
 			type: Boolean,

--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -172,6 +172,7 @@ export default {
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [checkoutUtils, braintreeDropInError],
+	emits: ['complete-transaction', 'updating-totals', 'refreshtotals', 'opt-in'],
 	props: {
 		amount: {
 			type: String,

--- a/src/components/Checkout/CheckoutHolidayPromo.vue
+++ b/src/components/Checkout/CheckoutHolidayPromo.vue
@@ -23,6 +23,7 @@ export default {
 		KvIcon,
 	},
 	inject: ['apollo'],
+	emits: ['updating-totals'],
 	methods: {
 		addOnePrintKivaCard() {
 			this.$emit('updating-totals', true);

--- a/src/components/Checkout/DepositIncentiveUpsell.vue
+++ b/src/components/Checkout/DepositIncentiveUpsell.vue
@@ -123,6 +123,7 @@ const upsellLoansQuery = gql`query upsellLoansQuery(
 export default {
 	name: 'DepositIncentiveUpsell',
 	inject: ['apollo'],
+	emits: ['adding-loan', 'done-adding'],
 	props: {
 		maxLoans: {
 			type: Number,

--- a/src/components/Checkout/DonateRepaymentsToggle.vue
+++ b/src/components/Checkout/DonateRepaymentsToggle.vue
@@ -74,6 +74,7 @@ export default {
 		KvLightbox,
 	},
 	inject: ['apollo'],
+	emits: ['updating-totals', 'refreshtotals'],
 	data() {
 		return {
 			donateRepayments: false,

--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -239,6 +239,7 @@ export default {
 		HowKivaUsesDonation,
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['refreshtotals', 'updating-totals'],
 	props: {
 		donation: {
 			type: Object,

--- a/src/components/Checkout/EmptyBasketCarousel.vue
+++ b/src/components/Checkout/EmptyBasketCarousel.vue
@@ -55,6 +55,7 @@ export default {
 		KvCarousel,
 		KvClassicLoanCardContainer
 	},
+	emits: ['updating-totals', 'refreshtotals'],
 	props: {
 		enableFiveDollarsNotes: {
 			type: Boolean,

--- a/src/components/Checkout/InContext/InContextCheckout.vue
+++ b/src/components/Checkout/InContext/InContextCheckout.vue
@@ -182,6 +182,12 @@ export default {
 	mixins: [
 		checkoutUtils
 	],
+	emits: [
+		'complete-transaction',
+		'checkout-failure',
+		'refreshtotals',
+		'updating-totals'
+	],
 	props: {
 		isLoggedIn: {
 			type: Boolean,

--- a/src/components/Checkout/KivaCardItem.vue
+++ b/src/components/Checkout/KivaCardItem.vue
@@ -144,6 +144,7 @@ export default {
 		LoanPrice,
 		RemoveBasketItem,
 	},
+	emits: ['refreshtotals', 'updating-totals'],
 	props: {
 		kivaCard: {
 			type: Object,

--- a/src/components/Checkout/KivaCardRedemption.vue
+++ b/src/components/Checkout/KivaCardRedemption.vue
@@ -148,6 +148,7 @@ export default {
 		KvTextInput,
 	},
 	inject: ['apollo'],
+	emits: ['updating-totals', 'refreshtotals'],
 	props: {
 		credits: {
 			type: Array,

--- a/src/components/Checkout/KivaCreditGuestPayment.vue
+++ b/src/components/Checkout/KivaCreditGuestPayment.vue
@@ -105,6 +105,12 @@ export default {
 	mixins: [
 		checkoutUtils,
 	],
+	emits: [
+		'complete-transaction',
+		'checkout-failure',
+		'refreshtotals',
+		'updating-totals',
+	],
 	props: {
 		managedAccountId: {
 			type: String,

--- a/src/components/Checkout/KivaCreditPayment.vue
+++ b/src/components/Checkout/KivaCreditPayment.vue
@@ -25,6 +25,12 @@ export default {
 	mixins: [
 		checkoutUtils
 	],
+	emits: [
+		'complete-transaction',
+		'checkout-failure',
+		'refreshtotals',
+		'updating-totals'
+	],
 	props: {
 		useAsyncCheckout: {
 			type: Boolean,

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -48,6 +48,7 @@ export default {
 		RemoveBasketItem,
 	},
 	inject: ['apollo'],
+	emits: ['refreshtotals', 'updating-totals'],
 	props: {
 		price: {
 			type: String,

--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -241,6 +241,11 @@ export default {
 		KvMaterialIcon
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: [
+		'refreshtotals',
+		'updating-totals',
+		'credit-removed'
+	],
 	props: {
 		totals: {
 			type: Object,

--- a/src/components/Checkout/RemoveBasketItem.vue
+++ b/src/components/Checkout/RemoveBasketItem.vue
@@ -25,6 +25,7 @@ export default {
 		KvMaterialIcon,
 	},
 	inject: ['apollo'],
+	emits: ['updating-totals', 'refreshtotals'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/Checkout/TeamAttribution.vue
+++ b/src/components/Checkout/TeamAttribution.vue
@@ -34,6 +34,7 @@ import KvSelect from '@kiva/kv-components/vue/KvSelect';
 
 export default {
 	name: 'TeamAttribution',
+	emits: ['refresh-totals', 'updating-totals'],
 	props: {
 		teams: {
 			type: Array,

--- a/src/components/Checkout/VerifyRemovePromoCredit.vue
+++ b/src/components/Checkout/VerifyRemovePromoCredit.vue
@@ -46,6 +46,7 @@ export default {
 		KvButton,
 		KvLightbox,
 	},
+	emits: ['credit-removed', 'promo-opt-out-lightbox-closed', 'updating-totals'],
 	props: {
 		activeCreditType: {
 			type: String,

--- a/src/components/CorporateCampaign/CampaignHero.vue
+++ b/src/components/CorporateCampaign/CampaignHero.vue
@@ -70,6 +70,7 @@ export default {
 	components: {
 		KvUiButton,
 	},
+	emits: ['jump-to-loans', 'add-to-basket'],
 	props: {
 		heroAreaContent: {
 			type: Object,

--- a/src/components/CorporateCampaign/CampaignJoinTeamForm.vue
+++ b/src/components/CorporateCampaign/CampaignJoinTeamForm.vue
@@ -77,6 +77,7 @@ export default {
 		KvLightbox,
 		KvLoadingOverlay,
 	},
+	emits: ['team-process-complete'],
 	props: {
 		promoId: {
 			type: Number,

--- a/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
+++ b/src/components/CorporateCampaign/CampaignLoanGridDisplay.vue
@@ -103,6 +103,14 @@ export default {
 		KvPagination,
 		KivaClassicBasicLoanCard,
 	},
+	emits: [
+		'add-to-basket',
+		'remove-loan-from-basket',
+		'reset-loan-filters',
+		'show-basket',
+		'show-loan-details',
+		'update-total-count',
+	],
 	props: {
 		checkoutVisible: {
 			type: Boolean,

--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -82,6 +82,15 @@ export default {
 		KvLoadingSpinner,
 		KivaClassicBasicLoanCard
 	},
+	emits: [
+		'add-to-basket',
+		'remove-loan-from-basket',
+		'reset-loan-filters',
+		'show-basket',
+		'show-loan-details',
+		'update-available-loans',
+		'update-total-count'
+	],
 	props: {
 		filters: {
 			type: Object,

--- a/src/components/CorporateCampaign/CampaignProgressBar.vue
+++ b/src/components/CorporateCampaign/CampaignProgressBar.vue
@@ -94,6 +94,7 @@ export default {
 		KvUiButton,
 		KvGrid
 	},
+	emits: ['show-basket'],
 	props: {
 		promoAmount: {
 			type: String,

--- a/src/components/CorporateCampaign/CampaignVerificationForm.vue
+++ b/src/components/CorporateCampaign/CampaignVerificationForm.vue
@@ -44,6 +44,7 @@ export default {
 		KvLightbox,
 		KvButton,
 	},
+	emits: ['verification-complete', 'campaign-verification-opt-out'],
 	props: {
 		formId: {
 			type: String,

--- a/src/components/CorporateCampaign/LoanSearch/AttributeFilter.vue
+++ b/src/components/CorporateCampaign/LoanSearch/AttributeFilter.vue
@@ -25,6 +25,7 @@ export default {
 	mixins: [
 		anyOrSelectedAutolendingFilter
 	],
+	emits: ['updated-filters'],
 	props: {
 		allAttributes: {
 			type: Array,

--- a/src/components/CorporateCampaign/LoanSearch/GenderFilter.vue
+++ b/src/components/CorporateCampaign/LoanSearch/GenderFilter.vue
@@ -25,6 +25,7 @@ export default {
 	components: {
 		KvRadio
 	},
+	emits: ['gender-updated'],
 	props: {
 		selectedGender: {
 			type: String,

--- a/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
+++ b/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
@@ -305,6 +305,12 @@ export default {
 		SortOrder,
 		TagFilter
 	},
+	emits: [
+		'updated-filters',
+		'updated-sort-by',
+		'reset-loan-filters',
+		'set-loan-display'
+	],
 	props: {
 		activeLoanDisplay: {
 			type: String,

--- a/src/components/CorporateCampaign/LoanSearch/LocationFilter.vue
+++ b/src/components/CorporateCampaign/LoanSearch/LocationFilter.vue
@@ -36,6 +36,7 @@ export default {
 	mixins: [
 		anyOrSelectedAutolendingFilter
 	],
+	emits: ['updated-filters'],
 	props: {
 		allCountries: {
 			type: Array,

--- a/src/components/CorporateCampaign/LoanSearch/SectorFilter.vue
+++ b/src/components/CorporateCampaign/LoanSearch/SectorFilter.vue
@@ -25,6 +25,7 @@ export default {
 	mixins: [
 		anyOrSelectedAutolendingFilter
 	],
+	emits: ['updated-filters'],
 	props: {
 		allSectors: {
 			type: Array,

--- a/src/components/CorporateCampaign/LoanSearch/SortOrder.vue
+++ b/src/components/CorporateCampaign/LoanSearch/SortOrder.vue
@@ -27,6 +27,7 @@ export default {
 	components: {
 		KvRadio
 	},
+	emits: ['sort-order-updated'],
 	props: {
 		selectedSort: {
 			type: String,

--- a/src/components/CorporateCampaign/LoanSearch/TagFilter.vue
+++ b/src/components/CorporateCampaign/LoanSearch/TagFilter.vue
@@ -25,6 +25,7 @@ export default {
 	mixins: [
 		anyOrSelectedAutolendingFilter
 	],
+	emits: ['updated-filters'],
 	props: {
 		allTags: {
 			type: Array,

--- a/src/components/Forms/MonthlyGoodUpdateForm.vue
+++ b/src/components/Forms/MonthlyGoodUpdateForm.vue
@@ -198,6 +198,7 @@ export default {
 		};
 	},
 	setup() { return { v$: useVuelidate() }; },
+	emits: ['form-update'],
 	props: {
 		/**
 		 * Should all inputs on the form be disabled

--- a/src/components/Forms/MultiAmountSelector.vue
+++ b/src/components/Forms/MultiAmountSelector.vue
@@ -55,6 +55,7 @@ export default {
 	components: {
 		KvCurrencyInput
 	},
+	emits: ['pill-toggled', 'custom-amount-updated'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Forms/ReCaptchaEnterprise.vue
+++ b/src/components/Forms/ReCaptchaEnterprise.vue
@@ -12,6 +12,7 @@
 <script>
 export default {
 	name: 'ReCaptchaEnterprise',
+	emits: ['update'],
 	props: {
 		required: {
 			type: Boolean,

--- a/src/components/Kv/KvAccordionItem.vue
+++ b/src/components/Kv/KvAccordionItem.vue
@@ -55,6 +55,7 @@ export default {
 		KvMaterialIcon,
 		KvExpandable,
 	},
+	emits: ['toggle'],
 	props: {
 		/**
 		 * Unique id. used for a11y

--- a/src/components/Kv/KvCarousel.vue
+++ b/src/components/Kv/KvCarousel.vue
@@ -78,6 +78,7 @@ export default {
 	components: {
 		KvIcon,
 	},
+	emits: ['change', 'interact-carousel'],
 	props: {
 		autoplay: {
 			type: Boolean,

--- a/src/components/Kv/KvCauseSelector.vue
+++ b/src/components/Kv/KvCauseSelector.vue
@@ -64,6 +64,7 @@ export default {
 	components: {
 		KvIcon
 	},
+	emits: ['change'],
 	props: {
 		/**
 		 * The cause to display

--- a/src/components/Kv/KvCheckbox.vue
+++ b/src/components/Kv/KvCheckbox.vue
@@ -32,6 +32,7 @@ export default {
 		prop: 'checked',
 		event: 'change'
 	},
+	emits: ['update'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvCheckboxList.vue
+++ b/src/components/Kv/KvCheckboxList.vue
@@ -26,6 +26,7 @@ export default {
 	components: {
 		KvCheckbox,
 	},
+	emits: ['updated'],
 	props: {
 		/**
 		 * Whether to show the select/deselect all link

--- a/src/components/Kv/KvChip.vue
+++ b/src/components/Kv/KvChip.vue
@@ -16,6 +16,7 @@ import KvIcon from '#src/components/Kv/KvIcon';
 export default {
 	name: 'KvChip',
 	components: { KvIcon },
+	emits: ['click-chip'],
 	props: {
 		title: {
 			type: String,

--- a/src/components/Kv/KvChipClassic.vue
+++ b/src/components/Kv/KvChipClassic.vue
@@ -26,6 +26,7 @@ export default {
 	components: {
 		KvMaterialIcon,
 	},
+	emits: ['click'],
 	data() {
 		return {
 			mdiClose,

--- a/src/components/Kv/KvCurrencyInput.vue
+++ b/src/components/Kv/KvCurrencyInput.vue
@@ -20,6 +20,7 @@ export default {
 	components: {
 		KvTextInput
 	},
+	emits: ['input'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvDropdown.vue
+++ b/src/components/Kv/KvDropdown.vue
@@ -20,6 +20,7 @@ import {
 export default {
 	name: 'KvDropdown',
 	inject: ['apollo', 'cookieStore'],
+	emits: ['show', 'hide'],
 	props: {
 		controller: { type: String, required: true },
 		openDelay: { type: Number, default: 0 },

--- a/src/components/Kv/KvExpandableQuestion.vue
+++ b/src/components/Kv/KvExpandableQuestion.vue
@@ -41,6 +41,7 @@ export default {
 		KvExpandable,
 		KvMaterialIcon,
 	},
+	emits: ['toggle'],
 	props: {
 		/**
 		 * Question Title

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -86,6 +86,7 @@ export default {
 			isShown: false
 		};
 	},
+	emits: ['lightbox-closed'],
 	props: {
 		visible: {
 			type: Boolean,

--- a/src/components/Kv/KvLoanActivities.vue
+++ b/src/components/Kv/KvLoanActivities.vue
@@ -77,6 +77,7 @@ export default {
 		KvLightbox,
 		KvLendCta
 	},
+	emits: ['add-to-basket'],
 	props: {
 		/**
 		 * loan object coming from parent component

--- a/src/components/Kv/KvPagination.vue
+++ b/src/components/Kv/KvPagination.vue
@@ -58,6 +58,7 @@ export default {
 	components: {
 		KvMaterialIcon,
 	},
+	emits: ['page-changed'],
 	props: {
 		limit: {
 			type: Number,

--- a/src/components/Kv/KvPhoneInput.vue
+++ b/src/components/Kv/KvPhoneInput.vue
@@ -81,6 +81,7 @@ export default {
 		KvFlag,
 		KvTextInput
 	},
+	emits: ['input', 'validity-changed'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvPillToggle.vue
+++ b/src/components/Kv/KvPillToggle.vue
@@ -27,6 +27,7 @@
 <script>
 export default {
 	name: 'KvPillToggle',
+	emits: ['pill-toggled'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvPopper.vue
+++ b/src/components/Kv/KvPopper.vue
@@ -20,6 +20,7 @@ import {
 
 export default {
 	name: 'KvPopper',
+	emits: ['show', 'hide'],
 	props: {
 		controller: {
 			validator(value) {

--- a/src/components/Kv/KvRangeMinMaxSlider.vue
+++ b/src/components/Kv/KvRangeMinMaxSlider.vue
@@ -32,6 +32,7 @@ import { getDisplayedNumber } from '#src/util/loanSearch/filterUtils';
 
 export default {
 	name: 'KvRangeMinMaxSlider',
+	emits: ['updated'],
 	props: {
 		rangeMin: {
 			type: Number,

--- a/src/components/Kv/KvRangeSlider.vue
+++ b/src/components/Kv/KvRangeSlider.vue
@@ -31,6 +31,7 @@ export default {
 		prop: 'value',
 		event: 'input'
 	},
+	emits: ['input', 'change'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvResultsPerPage.vue
+++ b/src/components/Kv/KvResultsPerPage.vue
@@ -21,6 +21,7 @@ export default {
 	components: {
 		KvSelect,
 	},
+	emits: ['updated'],
 	props: {
 		options: {
 			type: Array,

--- a/src/components/Kv/KvSelectBox.vue
+++ b/src/components/Kv/KvSelectBox.vue
@@ -58,6 +58,7 @@ export default {
 	components: {
 		KvTextInput,
 	},
+	emits: ['selected'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvToggle.vue
+++ b/src/components/Kv/KvToggle.vue
@@ -27,6 +27,7 @@ export default {
 		prop: 'checked',
 		event: 'change'
 	},
+	emits: ['change'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/Kv/KvVerificationCodeInput.vue
+++ b/src/components/Kv/KvVerificationCodeInput.vue
@@ -47,6 +47,7 @@ export default {
 		prop: 'value',
 		event: 'input'
 	},
+	emits: ['input'],
 	props: {
 		maxlength: {
 			type: Number,

--- a/src/components/Lend/LoanSearch/ChallengeCallout.vue
+++ b/src/components/Lend/LoanSearch/ChallengeCallout.vue
@@ -50,6 +50,7 @@ export default {
 		KvToast,
 		SupportedByLenders,
 	},
+	emits: ['close'],
 	props: {
 		currentLender: {
 			type: Object,

--- a/src/components/Lend/LoanSearch/LoanSearchCheckboxListFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchCheckboxListFilter.vue
@@ -15,6 +15,7 @@ export default {
 	components: {
 		KvCheckboxList,
 	},
+	emits: ['updated'],
 	props: {
 		options: {
 			type: Array,

--- a/src/components/Lend/LoanSearch/LoanSearchFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilter.vue
@@ -165,6 +165,7 @@ export default {
 		KvSelectBox,
 		KvRangeMinMaxSlider,
 	},
+	emits: ['reset', 'updated'],
 	props: {
 		extendFlssFilters: {
 			type: Boolean,

--- a/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
@@ -37,6 +37,7 @@ export default {
 		KvChipClassic,
 		KvTextLink,
 	},
+	emits: ['updated', 'reset'],
 	props: {
 		loanSearchState: {
 			type: Object,

--- a/src/components/Lend/LoanSearch/LoanSearchInterface.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchInterface.vue
@@ -232,6 +232,7 @@ export default {
 		TeamPicksSwitch,
 	},
 	mixins: [addToBasketExpMixin],
+	emits: ['add-to-basket', 'show-cart-modal'],
 	props: {
 		extendFlssFilters: {
 			type: Boolean,

--- a/src/components/Lend/LoanSearch/LoanSearchLocationFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchLocationFilter.vue
@@ -41,6 +41,7 @@ export default {
 		KvIcon,
 		KvCheckboxList,
 	},
+	emits: ['updated'],
 	props: {
 		/**
 		 * The regions with countries used to build the checkbox lists. Expected format:

--- a/src/components/Lend/LoanSearch/LoanSearchRadioGroupFilter.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchRadioGroupFilter.vue
@@ -23,6 +23,7 @@ export default {
 	components: {
 		KvRadio,
 	},
+	emits: ['updated'],
 	props: {
 		options: {
 			type: Array,

--- a/src/components/Lend/LoanSearch/LoanSearchSortBy.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSortBy.vue
@@ -33,6 +33,7 @@ export default {
 		KvMaterialIcon,
 		KvRadio,
 	},
+	emits: ['updated'],
 	props: {
 		/**
 		 * allSortOptions contains all sort emuns tagged with their type

--- a/src/components/Lend/LoanSearch/TeamPicksSwitch.vue
+++ b/src/components/Lend/LoanSearch/TeamPicksSwitch.vue
@@ -26,6 +26,7 @@ export default {
 	components: {
 		KvSwitch
 	},
+	emits: ['handle-team-picks'],
 	props: {
 		showPicks: {
 			type: Boolean,

--- a/src/components/LenderProfile/AsyncLenderSection.vue
+++ b/src/components/LenderProfile/AsyncLenderSection.vue
@@ -10,6 +10,7 @@ import delayUntilVisibleMixin from '#src/plugins/delay-until-visible-mixin';
 export default {
 	name: 'AsyncLenderSection',
 	mixins: [delayUntilVisibleMixin],
+	emits: ['visible'],
 	mounted() {
 		this.delayUntilVisible(entry => this.$emit('visible', entry));
 	},

--- a/src/components/LenderProfile/LenderStats.vue
+++ b/src/components/LenderProfile/LenderStats.vue
@@ -36,6 +36,7 @@ import AsyncLenderSection from './AsyncLenderSection';
 
 export default {
 	name: 'LenderStats',
+	emits: ['get-lender-stats'],
 	props: {
 		lenderStats: {
 			type: Object,

--- a/src/components/Lightboxes/AddToBasketInterstitial.vue
+++ b/src/components/Lightboxes/AddToBasketInterstitial.vue
@@ -122,6 +122,7 @@ export default {
 		LYML,
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['add-to-basket', 'processing-add-to-basket'],
 	data() {
 		return {
 			basketInterstitialState: {},

--- a/src/components/Lightboxes/EcoChallengeLightbox.vue
+++ b/src/components/Lightboxes/EcoChallengeLightbox.vue
@@ -129,6 +129,7 @@ export default {
 		KvTextLink,
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['close-lightbox'],
 	props: {
 		visible: {
 			type: Boolean,

--- a/src/components/LoanCards/AdaptiveMicroLoanCard.vue
+++ b/src/components/LoanCards/AdaptiveMicroLoanCard.vue
@@ -64,6 +64,7 @@ export default {
 		FundraisingStatusMeter,
 	},
 	inject: ['apollo'],
+	emits: ['add-to-basket', 'processing-add-to-basket'],
 	props: {
 		itemsInBasket: {
 			type: Array,

--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfo.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfo.vue
@@ -23,6 +23,7 @@ import BorrowerInfoBody from '#src/components/LoanCards/BorrowerInfo/BorrowerInf
 
 export default {
 	name: 'BorrowerInfo',
+	emits: ['track-loan-card-interaction'],
 	props: {
 		use: {
 			type: String,

--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfoBody.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfoBody.vue
@@ -23,6 +23,7 @@
 <script>
 export default {
 	name: 'BorrowerInfoBody',
+	emits: ['track-loan-card-interaction', 'read-more-link'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfoHeader.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfoHeader.vue
@@ -21,6 +21,7 @@ export default {
 	components: {
 		BorrowerInfoName,
 	},
+	emits: ['track-loan-card-interaction'],
 	props: {
 		country: {
 			type: String,

--- a/src/components/LoanCards/BorrowerInfo/BorrowerInfoName.vue
+++ b/src/components/LoanCards/BorrowerInfo/BorrowerInfoName.vue
@@ -15,6 +15,7 @@
 <script>
 export default {
 	name: 'BorrowerInfoName',
+	emits: ['name-click', 'track-loan-card-interaction'],
 	props: {
 		disableLink: {
 			type: Boolean,

--- a/src/components/LoanCards/Buttons/ActionButton.vue
+++ b/src/components/LoanCards/Buttons/ActionButton.vue
@@ -32,6 +32,7 @@ export default {
 		addToBasketInsterstitial
 	],
 	inject: ['apollo'],
+	emits: ['add-to-basket'],
 	props: {
 		disableRedirects: {
 			type: Boolean,

--- a/src/components/LoanCards/Buttons/CheckoutNowButton.vue
+++ b/src/components/LoanCards/Buttons/CheckoutNowButton.vue
@@ -31,6 +31,7 @@ export default {
 			mdiCheckboxMarkedCircleOutline
 		};
 	},
+	emits: ['add-to-basket'],
 	props: {
 		disableRedirects: {
 			type: Boolean,

--- a/src/components/LoanCards/Buttons/Lend25Button.vue
+++ b/src/components/LoanCards/Buttons/Lend25Button.vue
@@ -16,6 +16,7 @@ export default {
 	components: {
 		LendButton,
 	},
+	emits: ['add-to-basket'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/Buttons/LendAgainButton.vue
+++ b/src/components/LoanCards/Buttons/LendAgainButton.vue
@@ -16,6 +16,7 @@ export default {
 	components: {
 		LendButton,
 	},
+	emits: ['add-to-basket'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/Buttons/LendAmountButton.vue
+++ b/src/components/LoanCards/Buttons/LendAmountButton.vue
@@ -16,6 +16,7 @@ export default {
 	components: {
 		LendButton,
 	},
+	emits: ['add-to-basket'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/Buttons/LendButton.vue
+++ b/src/components/LoanCards/Buttons/LendButton.vue
@@ -23,6 +23,7 @@ export default {
 		KvButton,
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['add-to-basket', 'update:loading'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -54,6 +54,7 @@ export default {
 			loading: false,
 		};
 	},
+	emits: ['add-to-basket'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
@@ -88,6 +88,7 @@ import KvIcon from '#src/components/Kv/KvIcon';
 
 export default {
 	name: 'ExpandableLoanCard',
+	emits: ['add-to-basket', 'track-interaction'],
 	props: {
 		enableFiveDollarsNotes: {
 			type: Boolean,

--- a/src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
+++ b/src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
@@ -1,4 +1,5 @@
 export default {
+	emits: ['toggle-favorite', 'track-interaction'],
 	props: {
 		amountLeft: {
 			type: Number,

--- a/src/components/LoanCards/FavoriteStar.vue
+++ b/src/components/LoanCards/FavoriteStar.vue
@@ -43,6 +43,7 @@ export default {
 	components: {
 		KvMaterialIcon,
 	},
+	emits: ['favorite-toggled'],
 	props: {
 		isFavorite: {
 			type: Boolean,

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -92,6 +92,7 @@ export default {
 		LoanTag
 	},
 	inject: ['apollo'],
+	emit: ['track-interaction', 'toggle-favorite'],
 	props: {
 		amountLeft: {
 			type: Number,

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -188,6 +188,7 @@ import TrusteeInfoPanel from './InfoPanels/TrusteeInfoPanel';
 
 export default {
 	name: 'DetailedLoanCard',
+	emits: ['add-to-basket', 'close-detailed-loan-card', 'track-interaction'],
 	props: {
 		loan: {
 			type: Object,

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCard.vue
@@ -65,6 +65,13 @@ export default {
 		HoverLoanCardLarge,
 		KvIcon,
 	},
+	emits: [
+		'add-to-basket',
+		'track-interaction',
+		'update-detailed-loan-index',
+		'update-hover-loan-index',
+		'set-prevent-updating-detailed-card',
+	],
 	props: {
 		cardNumber: {
 			type: Number,

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -106,6 +106,12 @@ export default {
 	mixins: [
 		hoverLoanCardMixin,
 	],
+	emits: [
+		'add-to-basket',
+		'track-interaction',
+		'update-detailed-loan-index',
+		'toggle-favorite',
+	],
 	props: {
 		expiringSoonMessage: {
 			type: String,

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardSmall.vue
@@ -48,6 +48,7 @@ export default {
 	mixins: [
 		hoverLoanCardMixin,
 	],
+	emits: ['update-detailed-loan-index'],
 	props: {
 		expanded: {
 			type: Boolean,

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/BorrowerStoryPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/BorrowerStoryPanel.vue
@@ -44,6 +44,7 @@ export default {
 		KvLoadingSpinner
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['track-interaction'],
 	props: {
 		expandable: {
 			type: Boolean,

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/InfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/InfoPanel.vue
@@ -38,6 +38,7 @@ export default {
 		KvExpandable,
 		KvIcon,
 	},
+	emits: ['track-interaction'],
 	props: {
 		id: {
 			type: String,

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/LoanDetailsPanel.vue
@@ -140,6 +140,7 @@ export default {
 		KvLoadingSpinner
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['track-interaction'],
 	props: {
 		expandable: {
 			type: Boolean,

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/PartnerInfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/PartnerInfoPanel.vue
@@ -104,6 +104,7 @@ export default {
 		KvLoadingSpinner
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['track-interaction'],
 	props: {
 		expandable: {
 			type: Boolean,

--- a/src/components/LoanCards/HoverLoanCard/InfoPanels/TrusteeInfoPanel.vue
+++ b/src/components/LoanCards/HoverLoanCard/InfoPanels/TrusteeInfoPanel.vue
@@ -112,6 +112,7 @@ export default {
 		KvLoadingSpinner,
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['track-interaction'],
 	props: {
 		expandable: {
 			type: Boolean,

--- a/src/components/LoanCards/HoverLoanCard/hoverLoanCardMixin.js
+++ b/src/components/LoanCards/HoverLoanCard/hoverLoanCardMixin.js
@@ -1,4 +1,5 @@
 export default {
+	emits: ['track-interaction'],
 	props: {
 		amountLeft: {
 			type: Number,

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -284,6 +284,7 @@ const loanQuery = gql`
 
 export default {
 	name: 'KivaClassicBasicLoanCard',
+	emits: ['show-loan-details', 'add-to-basket', 'custom-checkout-button-action'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/KvClassicLoanCardContainer.vue
+++ b/src/components/LoanCards/KvClassicLoanCardContainer.vue
@@ -102,6 +102,7 @@ const loanQuery = gql`
 
 export default {
 	name: 'KvClassicLoanCardContainer',
+	emits: ['add-to-basket', 'show-cart-modal', 'updating-totals'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -179,6 +179,7 @@ export default {
 		BorrowerInfoHeader,
 		BorrowerInfoBody,
 	},
+	emits: ['track-interaction', 'toggle-favorite'],
 	props: {
 		isVisitor: {
 			type: Boolean,

--- a/src/components/LoanCards/LoanCardController.vue
+++ b/src/components/LoanCards/LoanCardController.vue
@@ -88,6 +88,19 @@ const ListLoanCard = defineAsyncComponent(() => import('#src/components/LoanCard
 
 export default {
 	name: 'LoanCardController',
+	emits: [
+		'track-interaction',
+		'toggle-favorite',
+		'add-to-basket',
+		'processing-add-to-basket',
+		'image-click',
+		'name-click',
+		'read-more-link',
+		'update-detailed-loan-index',
+		'update-hover-loan-index',
+		'close-detailed-loan-card',
+		'set-prevent-updating-detailed-card',
+	],
 	props: {
 		disableRedirects: {
 			type: Boolean,

--- a/src/components/LoanCards/LoanCardImage.vue
+++ b/src/components/LoanCards/LoanCardImage.vue
@@ -41,6 +41,7 @@ export default {
 	components: {
 		FavoriteStar,
 	},
+	emits: ['favorite-toggled', 'image-click', 'track-loan-card-interaction'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCards/NewHomePageLoanCard.vue
+++ b/src/components/LoanCards/NewHomePageLoanCard.vue
@@ -191,6 +191,7 @@ const loanCardQuery = gql`
 
 export default {
 	name: 'NewHomePageLoanCard',
+	emits: ['dedication-click'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/components/LoanCollections/HomeExp/LoanCategorySelectorHomeExp.vue
+++ b/src/components/LoanCollections/HomeExp/LoanCategorySelectorHomeExp.vue
@@ -43,6 +43,7 @@ export default {
 			categoryPage: '/lend-by-category/',
 		};
 	},
+	emits: ['handle-category-click'],
 	props: {
 		/**
 		 * Array of loan channel data in an object

--- a/src/components/LoanCollections/KivaClassicLoanCategorySelector.vue
+++ b/src/components/LoanCollections/KivaClassicLoanCategorySelector.vue
@@ -22,6 +22,7 @@ export default {
 	components: {
 		KvButton,
 	},
+	emits: ['handle-category-click'],
 	props: {
 		/**
 		 * Array of loan channel data in an object

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -64,6 +64,7 @@ export default {
 		KvClassicLoanCardContainer,
 		ViewMoreCard,
 	},
+	emits: ['add-to-basket'],
 	props: {
 		title: {
 			type: String,

--- a/src/components/LoanFinding/PartnerSpotlightSection.vue
+++ b/src/components/LoanFinding/PartnerSpotlightSection.vue
@@ -50,6 +50,7 @@ export default {
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [addToBasketExpMixin],
+	emits: ['add-to-basket'],
 	props: {
 		spotlightData: {
 			type: Object,

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -93,6 +93,7 @@ export default {
 	},
 	inject: ['apollo'],
 	mixins: [addToBasketExpMixin],
+	emits: ['add-to-basket', 'data-loaded'],
 	props: {
 		enableFiveDollarsNotes: {
 			type: Boolean,

--- a/src/components/LoansByCategory/FeaturedHeroLoan.vue
+++ b/src/components/LoansByCategory/FeaturedHeroLoan.vue
@@ -104,6 +104,7 @@ export default {
 		BorrowerInfoName,
 	},
 	inject: ['apollo'],
+	emits: ['toggle-favorite', 'track-interaction'],
 	props: {
 		amountLeft: {
 			type: Number,

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseBorrowerSelector.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseBorrowerSelector.vue
@@ -29,6 +29,7 @@
 <script>
 export default {
 	name: 'HelpmeChooseBorrowerSelector',
+	emits: ['select'],
 	props: {
 		imageUrl: {
 			type: String,

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseRecommendations.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseRecommendations.vue
@@ -86,6 +86,7 @@ export default {
 		LoanCardController,
 		KvLoadingPlaceholder
 	},
+	emits: ['show-triggers'],
 	props: {
 		loans: {
 			type: Array,

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseTrigger.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseTrigger.vue
@@ -20,6 +20,7 @@ const AppleIcon = shallowRef(defineAsyncComponent(() => import('#src/assets/imag
 
 export default {
 	name: 'HelpmeChooseTrigger',
+	emits: ['update'],
 	props: {
 		variant: {
 			type: String,

--- a/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
+++ b/src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
@@ -63,6 +63,7 @@ import HelpmeChooseRecommendations from './HelpmeChooseRecommendations';
 
 export default {
 	name: 'HelpmeChooseWrapper',
+	emits: ['update'],
 	props: {
 		remainingLoans: {
 			type: Array,

--- a/src/components/LoansByCategory/QuickFilters/CheckboxList.vue
+++ b/src/components/LoansByCategory/QuickFilters/CheckboxList.vue
@@ -40,6 +40,7 @@ export default {
 		KvCheckbox,
 		KvMaterialIcon
 	},
+	emits: ['updated', 'closeRegions'],
 	props: {
 		/**
 		 * The items to display in the checkbox list

--- a/src/components/LoansByCategory/QuickFilters/LocationSelector.vue
+++ b/src/components/LoansByCategory/QuickFilters/LocationSelector.vue
@@ -171,6 +171,7 @@ export default {
 	mixins: [
 		clickOutside,
 	],
+	emits: ['update-location', 'handle-overlay'],
 	props: {
 		regions: {
 			type: Array,

--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -154,6 +154,7 @@ import LocationSelector from './LocationSelector';
 export default {
 	name: 'QuickFilters',
 	inject: ['cookieStore'],
+	emits: ['update-filters', 'reset-filters', 'handle-overlay'],
 	props: {
 		totalLoans: {
 			type: Number,

--- a/src/components/LoansYouMightLike/LymlContainer.vue
+++ b/src/components/LoansYouMightLike/LymlContainer.vue
@@ -89,6 +89,7 @@ export default {
 		LoanCardController,
 		KvLoadingSpinner,
 	},
+	emits: ['add-to-basket', 'processing-add-to-basket', 'no-rec-loans-found'],
 	props: {
 		basketedLoans: {
 			type: Array,

--- a/src/components/MonthlyGood/MonthlyGoodDropInPaymentWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodDropInPaymentWrapper.vue
@@ -54,6 +54,7 @@ export default {
 	mixins: [
 		braintreeDropinError
 	],
+	emits: ['complete-transaction', 'no-update'],
 	props: {
 		amount: {
 			type: Number,

--- a/src/components/MyKiva/MyKivaHero.vue
+++ b/src/components/MyKiva/MyKivaHero.vue
@@ -21,6 +21,8 @@
 import { mdiCogOutline } from '@mdi/js';
 import MyKivaContainer from '#src/components/MyKiva/MyKivaContainer';
 import KvMaterialIcon from '@kiva/kv-components/vue/KvMaterialIcon';
+
+defineEmits(['show-navigation']);
 </script>
 
 <style lang="postcss" scoped>

--- a/src/components/Payment/BraintreeDropInInterface.vue
+++ b/src/components/Payment/BraintreeDropInInterface.vue
@@ -23,6 +23,7 @@ export default {
 		KvLoadingSpinner,
 	},
 	inject: ['apollo'],
+	emits: ['transactions-enabled'],
 	props: {
 		amount: {
 			type: String,

--- a/src/components/Settings/SaveSearchItem.vue
+++ b/src/components/Settings/SaveSearchItem.vue
@@ -51,6 +51,7 @@ export default {
 		KvButton,
 		KvCheckbox
 	},
+	emits: ['delete-saved-search'],
 	props: {
 		savedSearch: {
 			type: Object,

--- a/src/components/Stats/StatsTable.vue
+++ b/src/components/Stats/StatsTable.vue
@@ -84,6 +84,7 @@ export default {
 		KvTabPanel,
 		KvButton,
 	},
+	emits: ['click'],
 	props: {
 		locationLoading: {
 			type: Boolean,

--- a/src/components/Subscriptions/SubscriptionsAutoDeposit.vue
+++ b/src/components/Subscriptions/SubscriptionsAutoDeposit.vue
@@ -357,6 +357,7 @@ export default {
 		KvSettingsCard,
 		KvTextInput,
 	},
+	emits: ['cancel-subscription', 'unsaved-changes'],
 	data() {
 		return {
 			isSaving: false,

--- a/src/components/Subscriptions/SubscriptionsMonthlyGood.vue
+++ b/src/components/Subscriptions/SubscriptionsMonthlyGood.vue
@@ -235,6 +235,7 @@ export default {
 		MonthlyGoodUpdateForm,
 		SubscriptionsMonthlyGoodCancellationFlow,
 	},
+	emits: ['cancel-subscription', 'unsaved-changes'],
 	data() {
 		return {
 			isSaving: false,

--- a/src/components/Subscriptions/SubscriptionsMonthlyGoodCancellationFlow.vue
+++ b/src/components/Subscriptions/SubscriptionsMonthlyGoodCancellationFlow.vue
@@ -187,6 +187,7 @@ export default {
 		KvButton,
 		KvLightbox,
 	},
+	emits: ['abort-cancel', 'confirm-cancel', 'modify-cancel'],
 	props: {
 		showCancelLightbox: {
 			type: Boolean,

--- a/src/components/Thanks/Badges/DetailSection.vue
+++ b/src/components/Thanks/Badges/DetailSection.vue
@@ -105,6 +105,7 @@ const imageRequire = metaGlobReader(imageGlob, '/src/assets/images/thanks-page/b
 export default {
 	name: 'DetailSection',
 	inject: ['apollo', 'cookieStore'],
+	emits: ['back'],
 	props: {
 		selectedBadgeIdx: {
 			type: Number,

--- a/src/components/Thanks/Badges/DiscoverSection.vue
+++ b/src/components/Thanks/Badges/DiscoverSection.vue
@@ -65,6 +65,7 @@ const images = metaGlobReader(imageRequire, '/src/assets/images/thanks-page/badg
 
 export default {
 	name: 'DiscoverSection',
+	emits: ['back', 'select-badge'],
 	props: {
 		isGuest: {
 			type: Boolean,

--- a/src/components/Thanks/Badges/FirstScreen.vue
+++ b/src/components/Thanks/Badges/FirstScreen.vue
@@ -304,6 +304,7 @@ export default {
 		KvButton,
 		KvMaterialIcon,
 	},
+	emits: ['show-new-bg'],
 	props: {
 		receipt: {
 			type: Object,

--- a/src/components/Thanks/Badges/RevealedBadge.vue
+++ b/src/components/Thanks/Badges/RevealedBadge.vue
@@ -123,6 +123,7 @@ export default {
 		AnimatedStars,
 		GuestAccountCreation,
 	},
+	emits: ['show-discover-badges'],
 	props: {
 		isGuest: {
 			type: Boolean,

--- a/src/components/Thanks/ThanksPageCommentAndShare.vue
+++ b/src/components/Thanks/ThanksPageCommentAndShare.vue
@@ -241,6 +241,7 @@ export default {
 		KvPageContainer,
 		KvButton
 	},
+	emits: ['guest-create-account'],
 	props: {
 		receipt: {
 			type: Object,

--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -179,6 +179,7 @@ export default {
 		KvMaterialIcon
 	},
 	mixins: [smoothReflow, smoothScrollMixin],
+	emits: ['amount-selected', 'toggle-banner'],
 	props: {
 		targetAmount: {
 			type: Number,

--- a/src/components/WwwFrame/PromotionalBanner/Banners/Donation/DonationBanner.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/Donation/DonationBanner.vue
@@ -123,6 +123,7 @@ export default {
 		};
 	},
 	mixins: [smoothScrollMixin],
+	emits: ['close-banner'],
 	props: {
 		buttonAmounts: {
 			type: Array,

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -687,6 +687,7 @@ export default {
 			loansInBasket: [],
 		};
 	},
+	emits: ['show-basket'],
 	props: {
 		hideSearchInHeader: {
 			type: Boolean,

--- a/src/components/WwwFrame/WwwPageCorporate.vue
+++ b/src/components/WwwFrame/WwwPageCorporate.vue
@@ -47,6 +47,7 @@ export default {
 		TheFooterCorporate,
 		TheHeader,
 	},
+	emits: ['show-basket'],
 	props: {
 		corporateLogoUrl: {
 			type: String,

--- a/src/pages/Autolending/CheckList.vue
+++ b/src/pages/Autolending/CheckList.vue
@@ -30,6 +30,7 @@ import KvCheckbox from '#src/components/Kv/KvCheckbox';
 
 export default {
 	name: 'CheckList',
+	emits: ['update'],
 	props: {
 		items: {
 			type: Array,

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -51,6 +51,7 @@ export default {
 		KvLightbox,
 		KvLoadingSpinner,
 	},
+	emits: ['autolendingSaved'],
 	props: {
 		showWarning: {
 			type: Boolean,

--- a/src/pages/Autolending/WhoYoullSupportText.vue
+++ b/src/pages/Autolending/WhoYoullSupportText.vue
@@ -71,6 +71,7 @@ export default {
 			kivaChooses: true,
 		};
 	},
+	emits: ['click'],
 	apollo: {
 		query: gql`query whoYoullSupport {
 			autolending @client {

--- a/src/pages/LendingTeams/TeamSearchBar.vue
+++ b/src/pages/LendingTeams/TeamSearchBar.vue
@@ -33,6 +33,7 @@ export default {
 		KvTextInput,
 	},
 	inject: ['apollo'],
+	emits: ['search'],
 	props: {
 		initialValue: {
 			type: String,

--- a/src/pages/MonthlyGood/LandingForm.vue
+++ b/src/pages/MonthlyGood/LandingForm.vue
@@ -85,6 +85,7 @@ export default {
 			}
 		};
 	},
+	emits: ['update:amount', 'update:selectedGroup'],
 	props: {
 		amount: {
 			type: Number,

--- a/src/pages/Portfolio/ImpactDashboard/AsyncPortfolioSection.vue
+++ b/src/pages/Portfolio/ImpactDashboard/AsyncPortfolioSection.vue
@@ -16,6 +16,7 @@ import delayUntilVisibleMixin from '#src/plugins/delay-until-visible-mixin';
 export default {
 	name: 'AsyncPortfolioSection',
 	mixins: [delayUntilVisibleMixin],
+	emits: ['visible'],
 	props: {
 		variant: {
 			validator(value) {

--- a/src/pages/Portfolio/ImpactDashboard/LoanCommentModal.vue
+++ b/src/pages/Portfolio/ImpactDashboard/LoanCommentModal.vue
@@ -59,6 +59,7 @@ export default {
 		KvMaterialIcon,
 		KvButton,
 	},
+	emits: ['comment-modal-closed'],
 	props: {
 		loan: {
 			type: Object,

--- a/src/pages/Portfolio/ImpactDashboard/RecentLoanItem.vue
+++ b/src/pages/Portfolio/ImpactDashboard/RecentLoanItem.vue
@@ -99,6 +99,7 @@ export default {
 		KvLoadingPlaceholder,
 		KvProgressBar,
 	},
+	emits: ['open-comment-modal'],
 	props: {
 		loanId: {
 			type: Number,

--- a/src/pages/Settings/RecoveryCodeConfirm.vue
+++ b/src/pages/Settings/RecoveryCodeConfirm.vue
@@ -55,6 +55,7 @@ export default {
 		KvButton,
 		KvCheckbox,
 	},
+	emits: ['done'],
 	props: {
 		mfaRecoveryCode: {
 			type: String,

--- a/src/plugins/add-to-basket-exp-mixin.js
+++ b/src/plugins/add-to-basket-exp-mixin.js
@@ -8,6 +8,7 @@ export default {
 			enableAddToBasketExp: false,
 		};
 	},
+	emits: ['show-cart-modal'],
 	created() {
 		// MP-346 New Add To Basket
 		const newAddToBasketExpData = this.apollo.readFragment({

--- a/src/plugins/any-or-selected-autolending-radio-mixin.js
+++ b/src/plugins/any-or-selected-autolending-radio-mixin.js
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-tag';
 
 export default {
+	emits: ['update'],
 	props: {
 		selectorShown: {
 			type: Boolean,

--- a/src/plugins/retry-after-expired-basket-mixin.js
+++ b/src/plugins/retry-after-expired-basket-mixin.js
@@ -5,6 +5,7 @@ import logFormatter from '#src/util/logFormatter';
 const injections = ['apollo', 'cookieStore'];
 
 export default {
+	emits: ['add-to-basket'],
 	mounted() {
 		checkInjections(this, injections);
 

--- a/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
+++ b/test/unit/specs/components/Lend/LoanSearch/LoanSearchFilterChips.spec.js
@@ -89,7 +89,7 @@ describe('LoanSearchFilterChips', () => {
 
 		await user.click(getByText('a'));
 
-		expect(filterConfig.config.a.getRemovedFacet).toHaveBeenCalledTimes(2);
+		expect(filterConfig.config.a.getRemovedFacet).toHaveBeenCalledTimes(1);
 		expect(filterConfig.config.a.getRemovedFacet)
 			.toHaveBeenCalledWith({ name: 'a' }, { name: 'a', key: 'a', __typename: 'TypeA' });
 		expect(emitted().updated[0]).toEqual([{ a: null }]);
@@ -113,7 +113,7 @@ describe('LoanSearchFilterChips', () => {
 
 		await user.click(getByText('a'));
 
-		expect(spyTrackEvent).toHaveBeenCalledTimes(2);
+		expect(spyTrackEvent).toHaveBeenCalledTimes(1);
 		expect(spyTrackEvent).toHaveBeenCalledWith('Lending', 'click-remove-filter-chip', 'TypeA-a');
 	});
 });

--- a/test/unit/specs/server/live-loan-fetch.spec.js
+++ b/test/unit/specs/server/live-loan-fetch.spec.js
@@ -41,6 +41,11 @@ describe('live-loan-fetch', () => {
 			expect(sortBy).toEqual(expectedSort);
 		}
 
+		beforeEach(() => {
+			// Suppress console warnings
+			jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+		});
+
 		it('converts input strings to valid LoanSearchFiltersInput objects', async () => {
 			// Using sort_random forces using the legacy loan search
 			await testFilterParsing('sort_random,gender_male,sector_education', { gender: 'male', sector: [15] });


### PR DESCRIPTION
With Vue 3 it is best practice to declare the events that can be emitted by a component using the `emits` option or the `defineEmits` method (see https://v3-migration.vuejs.org/breaking-changes/emits-option.html). This is especially important for components that emit events with the same name as native html events (click, change, update, input, etc.) because:
> ...Vue will now add all event listeners that are not defined as component-emitted events in the child as **native event listeners** to the child's root element (unless inheritAttrs: false has been set in the child's options). (https://v3-migration.vuejs.org/breaking-changes/v-on-native-modifier-removed.html)

If the events are not declared it can lead to unexpected behavior, like event listeners being called twice; first with the custom event value, and then again with an html event.

Events that are not named the same as html events behave as expected whether or not they are declared, which is why this issue was not obvious.

Here are components changed in this PR that use native html event names that we should confirm still work after these changes:

**change**
- src/components/Kv/KvCarousel.vue
- src/components/Kv/KvCauseSelector.vue
- src/components/Kv/KvRangeSlider.vue
- src/components/Kv/KvToggle.vue

**click**
- src/components/15Years/15YearsButton.vue
- src/components/Kv/KvChipClassic.vue
- src/components/Stats/StatsTable.vue
- src/pages/Autolending/WhoYoullSupportText.vue

**update**
- src/components/Forms/ReCaptchaEnterprise.vue
- src/components/Kv/KvCheckbox.vue
- src/components/LoansByCategory/HelpmeChoose/HelpmeChooseTrigger.vue
- src/components/LoansByCategory/HelpmeChoose/HelpmeChooseWrapper.vue
- src/pages/Autolending/CheckList.vue
- src/plugins/any-or-selected-autolending-radio-mixin.js

**input**
- src/components/Kv/KvCurrencyInput.vue
- src/components/Kv/KvPhoneInput.vue
- src/components/Kv/KvRangeSlider.vue
- src/components/Kv/KvVerificationCodeInput.vue

**select**
- src/components/LoansByCategory/HelpmeChoose/HelpmeChooseBorrowerSelector.vue

I'm not sure how the `emits` option is merged when it is used in a mixin, or if it works in a mixin at all, so we should also confirm that components using these mixins still work:
- src/components/LoanCards/ExpandableLoanCard/expandableLoanCardMixin.js
- src/components/LoanCards/HoverLoanCard/hoverLoanCardMixin.js
- src/plugins/add-to-basket-exp-mixin.js
- src/plugins/any-or-selected-autolending-radio-mixin.js
- src/plugins/retry-after-expired-basket-mixin.js