### PR TITLE
fix: apply Vue 3 linting rules

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,7 +34,7 @@ module.exports = {
 		browser: true,
 		es2022: true,
 	},
-	extends: ['plugin:vue/strongly-recommended', 'airbnb-base', 'plugin:storybook/recommended'],
+	extends: ['plugin:vue/vue3-strongly-recommended', 'airbnb-base', 'plugin:storybook/recommended'],
 	// required to lint *.vue files
 	plugins: [
 		'graphql',

--- a/src/components/15Years/15YearsButton.vue
+++ b/src/components/15Years/15YearsButton.vue
@@ -46,8 +46,6 @@ export default {
 	methods: {
 		onClick(e) {
 			if (this.tag === 'button' && this.$attrs.type !== 'submit') {
-				// emit a vue event and prevent native event
-				// so we don't have to write @click in our templates
 				e.preventDefault();
 				this.$emit('click', e);
 			}

--- a/src/components/15Years/15YearsButton.vue
+++ b/src/components/15Years/15YearsButton.vue
@@ -47,7 +47,7 @@ export default {
 		onClick(e) {
 			if (this.tag === 'button' && this.$attrs.type !== 'submit') {
 				// emit a vue event and prevent native event
-				// so we don't have to write @click.native in our templates
+				// so we don't have to write @click in our templates
 				e.preventDefault();
 				this.$emit('click', e);
 			}

--- a/src/components/15Years/15YearsGlobe.vue
+++ b/src/components/15Years/15YearsGlobe.vue
@@ -156,7 +156,7 @@ export default {
 			}
 		};
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.gkview) {
 			this.gkview.release();
 		}

--- a/src/components/15Years/15YearsLightbox.vue
+++ b/src/components/15Years/15YearsLightbox.vue
@@ -110,7 +110,7 @@ export default {
 	mounted() {
 		this.isShown = this.visible;
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.closeLightbox();
 	},
 	methods: {

--- a/src/components/15Years/SwashieFace.vue
+++ b/src/components/15Years/SwashieFace.vue
@@ -132,7 +132,7 @@ export default {
 	mounted() {
 		this.fillErUp();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		clearInterval(this.timer);
 		this.timer = null;
 	},

--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -429,7 +429,7 @@ export default {
 		window.addEventListener('resize', this.throttledResize);
 		this.determineIfMobile();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 		window.removeEventListener('resize', this.throttledResize);
 	},

--- a/src/components/BorrowerProfile/CountryInfo.vue
+++ b/src/components/BorrowerProfile/CountryInfo.vue
@@ -184,7 +184,7 @@ export default {
 	mounted() {
 		this.createObserver();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 	},
 };

--- a/src/components/BorrowerProfile/FundedBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FundedBorrowerProfile.vue
@@ -395,7 +395,7 @@ export default {
 			}
 		},
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyViewportObserver();
 	},
 };

--- a/src/components/BorrowerProfile/JournalUpdates.vue
+++ b/src/components/BorrowerProfile/JournalUpdates.vue
@@ -182,7 +182,7 @@ export default {
 	mounted() {
 		this.createObserver();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 	},
 };

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -82,7 +82,7 @@
 										'click-Modify loan amount',
 										'open dialog'
 									]"
-									@update:modelValue="trackLendAmountSelection"
+									@update:model-value="trackLendAmountSelection"
 								>
 									<option
 										v-for="priceOption in prices"

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -873,7 +873,7 @@ export default {
 	mounted() {
 		this.createWrapperObserver();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyWrapperObserver();
 	},
 };

--- a/src/components/BorrowerProfile/LendersAndTeams.vue
+++ b/src/components/BorrowerProfile/LendersAndTeams.vue
@@ -416,7 +416,7 @@ export default {
 		this.createObserver();
 		this.gatherCurrentUserData();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 	},
 };

--- a/src/components/BorrowerProfile/MoreAboutLoan.vue
+++ b/src/components/BorrowerProfile/MoreAboutLoan.vue
@@ -253,7 +253,7 @@ export default {
 	mounted() {
 		this.createObserver();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 	},
 };

--- a/src/components/BorrowerProfile/SupporterDetails.vue
+++ b/src/components/BorrowerProfile/SupporterDetails.vue
@@ -213,7 +213,7 @@ export default {
 			this.isMobile = document.documentElement.clientWidth < 735;
 		},
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', _throttle(() => {
 			this.determineIfMobile();
 		}, 200));

--- a/src/components/BorrowerProfile/WhySpecial.vue
+++ b/src/components/BorrowerProfile/WhySpecial.vue
@@ -113,7 +113,7 @@ export default {
 	mounted() {
 		this.createObserver();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 	},
 };

--- a/src/components/Checkout/BasketVerification.vue
+++ b/src/components/Checkout/BasketVerification.vue
@@ -20,7 +20,7 @@
 			<p class="tw-mb-4">
 				Once we verify your account, you can continue checking out!
 			</p>
-			<kv-button v-if="!sending" @click.native="send" data-testid="basket-verification-send-button">
+			<kv-button v-if="!sending" @click="send" data-testid="basket-verification-send-button">
 				Send verification link
 			</kv-button>
 			<kv-loading-spinner class="sending-spinner" v-else />
@@ -40,7 +40,7 @@
 			<p class="tw-mb-4">
 				After receiving the email, follow the link provided to continue checking out with your Kiva Credit.
 			</p>
-			<kv-button v-if="!sending" @click.native="send" data-testid="basket-verification-resend-button">
+			<kv-button v-if="!sending" @click="send" data-testid="basket-verification-resend-button">
 				Resend email
 			</kv-button>
 			<kv-loading-spinner class="sending-spinner" v-else />

--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -57,7 +57,7 @@
 				<user-updates-preference
 					v-if="enableRadioBtnExperiment"
 					tracking-category="basket"
-					@update:modelValue="selectedComms = $event"
+					@update:model-value="selectedComms = $event"
 					is-checkout
 				/>
 				<template v-else>
@@ -67,7 +67,7 @@
 						name="termsAgreement"
 						class="checkbox tw-text-small tw-mb-2"
 						v-model="termsAgreement"
-						@update:modelValue="$kvTrackEvent(
+						@update:model-value="$kvTrackEvent(
 							'basket',
 							'click',
 							'terms-of-use',
@@ -98,7 +98,7 @@
 						class="checkbox tw-text-small tw-mb-2"
 						name="emailUpdates"
 						v-model="emailUpdates"
-						@update:modelValue="$kvTrackEvent(
+						@update:model-value="$kvTrackEvent(
 							'basket',
 							'click',
 							'marketing-updates',

--- a/src/components/Checkout/DonateRepaymentsToggle.vue
+++ b/src/components/Checkout/DonateRepaymentsToggle.vue
@@ -21,7 +21,7 @@
 				data-testid="donate-repayments"
 				v-if="!myDonateRepayments"
 				v-model="donateRepayments"
-				@update:modelValue="setDonateRepayments"
+				@update:model-value="setDonateRepayments"
 			>
 				<span
 					id="donate-repayments-tooltip"

--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -76,7 +76,7 @@
 						<div class="tw-self-center md:tw-w-full">
 							<kv-button
 								class="tw-w-14 md:tw-w-full"
-								@click.native="setCustomDonationAndClose"
+								@click="setCustomDonationAndClose"
 								id="customDonationSubmitBtn"
 								data-testid="custom-donation-submit-btn"
 							>

--- a/src/components/Checkout/EmptyBasketCarousel.vue
+++ b/src/components/Checkout/EmptyBasketCarousel.vue
@@ -1,6 +1,7 @@
 <template>
 	<transition name="kvfade">
 		<div
+			v-if="randomLoans.length"
 			class="
 				section-wrapper
 				random-loan-cards
@@ -10,7 +11,7 @@
 				tw-border-tertiary
 			"
 		>
-			<div v-if="randomLoans.length" class="section-container tw-mx-auto tw-my-0">
+			<div class="section-container tw-mx-auto tw-my-0">
 				<kv-carousel
 					v-if="randomLoans.length > 0 && !loading"
 					class="tw-w-full tw-overflow-visible md:tw-overflow-hidden"

--- a/src/components/Checkout/EmptyBasketCarousel.vue
+++ b/src/components/Checkout/EmptyBasketCarousel.vue
@@ -119,7 +119,7 @@ export default {
 		// we're doing this all client side
 		this.loadLoans();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.handleResize);
 	}
 };

--- a/src/components/Checkout/InContext/InContextCheckout.vue
+++ b/src/components/Checkout/InContext/InContextCheckout.vue
@@ -107,7 +107,7 @@
 				@complete-transaction="completeTransaction"
 				class="checkout-button"
 				id="kiva-credit-payment-button"
-				@refreshtotals="$emit('refresh-totals')"
+				@refreshtotals="$emit('refreshtotals')"
 				@updating-totals="setUpdatingTotals"
 				@checkout-failure="handleCheckoutFailure"
 			/>
@@ -123,7 +123,7 @@
 				:managed-account-id="managedAccountId"
 				:promo-guest-checkout-enabled="promoGuestCheckoutEnabled"
 				:promo-name="promoName"
-				@refreshtotals="$emit('refresh-totals')"
+				@refreshtotals="$emit('refreshtotals')"
 				@updating-totals="setUpdatingTotals"
 				@checkout-failure="handleCheckoutFailure"
 			/>
@@ -186,7 +186,10 @@ export default {
 		'complete-transaction',
 		'checkout-failure',
 		'refreshtotals',
-		'updating-totals'
+		'updating-totals',
+		'jump-to-loans',
+		'credit-removed',
+		'transaction-complete',
 	],
 	props: {
 		isLoggedIn: {

--- a/src/components/Checkout/KivaCreditGuestPayment.vue
+++ b/src/components/Checkout/KivaCreditGuestPayment.vue
@@ -78,7 +78,7 @@
 			class="tw-mb-2"
 			v-kv-track-event="['payment.continueBtn']"
 			title="Checkout using your Kiva credit"
-			@click.native.prevent="validateCreditBasket"
+			@click.prevent="validateCreditBasket"
 		>
 			<slot>Complete order</slot>
 		</kv-button>

--- a/src/components/Checkout/KivaCreditGuestPayment.vue
+++ b/src/components/Checkout/KivaCreditGuestPayment.vue
@@ -31,7 +31,7 @@
 				name="termsAgreement"
 				class="checkbox tw-text-small tw-mb-2"
 				v-model="termsAgreement"
-				@update:modelValue="$kvTrackEvent(
+				@update:model-value="$kvTrackEvent(
 					'basket',
 					'click-terms-of-use',
 					'I have read and agree to the Terms of Use and Privacy Policy.',
@@ -61,7 +61,7 @@
 				class="checkbox tw-text-small tw-mb-2"
 				name="emailUpdates"
 				v-model="emailUpdates"
-				@update:modelValue="$kvTrackEvent(
+				@update:model-value="$kvTrackEvent(
 					'basket',
 					'click-marketing-updates',
 					'Receive email updates from Kiva (including borrower updates and promos). You can unsubscribe anytime.', // eslint-disable-line

--- a/src/components/Checkout/KivaCreditPayment.vue
+++ b/src/components/Checkout/KivaCreditPayment.vue
@@ -5,7 +5,7 @@
 		class="tw-mb-2"
 		v-kv-track-event="['payment.continueBtn']"
 		title="Checkout using your Kiva credit"
-		@click.native.prevent="validateCreditBasket"
+		@click.prevent="validateCreditBasket"
 	>
 		<slot>Complete order</slot>
 	</kv-button>

--- a/src/components/Checkout/LoanPrice.vue
+++ b/src/components/Checkout/LoanPrice.vue
@@ -7,7 +7,7 @@
 				class="loan-price tw-w-full"
 				style="max-width: 18rem;"
 				id="loan-price"
-				@update:modelValue="updateLoanReservation()"
+				@update:model-value="updateLoanReservation()"
 			>
 				<option
 					v-for="priceOption in prices"

--- a/src/components/Checkout/LoanReservation.vue
+++ b/src/components/Checkout/LoanReservation.vue
@@ -135,7 +135,7 @@ export default {
 	mounted() {
 		this.activateReservationTimer();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.reservationMessageId) {
 			clearInterval(this.reservationMessageId);
 		}

--- a/src/components/Checkout/TeamAttribution.vue
+++ b/src/components/Checkout/TeamAttribution.vue
@@ -8,7 +8,7 @@
 				v-model="selectedId"
 				class="team-select-dd data-hj-suppress tw-float-left"
 				style="max-width: rem-calc(250);"
-				@update:modelValue="updateLoanReservation()"
+				@update:model-value="updateLoanReservation()"
 			>
 				<option value="0">
 					None

--- a/src/components/Checkout/TeamAttribution.vue
+++ b/src/components/Checkout/TeamAttribution.vue
@@ -34,7 +34,7 @@ import KvSelect from '@kiva/kv-components/vue/KvSelect';
 
 export default {
 	name: 'TeamAttribution',
-	emits: ['refresh-totals', 'updating-totals'],
+	emits: ['refreshtotals', 'updating-totals'],
 	props: {
 		teams: {
 			type: Array,
@@ -106,7 +106,7 @@ export default {
 							: 'Team Attribution Removal Success',
 						numeral(this.selectedId).value()
 					);
-					this.$emit('refresh-totals', 'team-update');
+					this.$emit('refreshtotals', 'team-update');
 					this.cachedId = this.selectedId;
 				}
 			}).catch(error => {

--- a/src/components/CorporateCampaign/CampaignHero.vue
+++ b/src/components/CorporateCampaign/CampaignHero.vue
@@ -32,7 +32,7 @@
 				</p>
 				<div class="tw-flex tw-flex-wrap tw-gap-2">
 					<kv-ui-button
-						@click.native.prevent="jumpToLoans"
+						@click.prevent="jumpToLoans"
 						v-kv-track-event="[
 							'Campaign',
 							'click-hero-cta',

--- a/src/components/CorporateCampaign/CampaignJoinTeamForm.vue
+++ b/src/components/CorporateCampaign/CampaignJoinTeamForm.vue
@@ -41,16 +41,16 @@
 				<template #controls>
 					<div class="tw-text-center">
 						<div v-if="showForm">
-							<kv-button class="smaller" @click.native.prevent="handleJoinTeam">
+							<kv-button class="smaller" @click.prevent="handleJoinTeam">
 								Join Now
 							</kv-button>
 							<br><br>
-							<kv-button class="text-link" @click.native.prevent="handleRejectTeam">
+							<kv-button class="text-link" @click.prevent="handleRejectTeam">
 								Opt-out
 							</kv-button>
 						</div>
 						<div v-if="showSuccess || showError">
-							<kv-button class="smaller" @click.native.prevent="handleContinue">
+							<kv-button class="smaller" @click.prevent="handleContinue">
 								Continue
 							</kv-button>
 						</div>

--- a/src/components/CorporateCampaign/CampaignVerificationForm.vue
+++ b/src/components/CorporateCampaign/CampaignVerificationForm.vue
@@ -16,7 +16,7 @@
 			<div class="tw-text-center">
 				<kv-button
 					class="text-link"
-					@click.native="optOut"
+					@click="optOut"
 				>
 					No thanks, I'll opt out
 				</kv-button>

--- a/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
+++ b/src/components/CorporateCampaign/LoanSearch/LoanSearchFilters.vue
@@ -94,7 +94,7 @@
 							v-if="isChipsCollapsable"
 							variant="secondary"
 							class="chips__toggle tw-mb-2"
-							@click.native="isChipsCollapsed = !isChipsCollapsed"
+							@click="isChipsCollapsed = !isChipsCollapsed"
 						>
 							{{ isChipsCollapsed ? `Show all ${filterChips.length} filters` : 'Hide filters' }}
 						</kv-button>
@@ -102,7 +102,7 @@
 						<kv-button
 							v-if="!isInitialFilters"
 							class="chips__toggle"
-							@click.native="handleResetFilters"
+							@click="handleResetFilters"
 						>
 							Reset all
 						</kv-button>
@@ -236,7 +236,7 @@
 			<template #controls>
 				<kv-button
 					variant="primary"
-					@click.native.prevent="applyFilters"
+					@click.prevent="applyFilters"
 				>
 					Apply Filters
 				</kv-button>

--- a/src/components/Kv/KvCarousel.vue
+++ b/src/components/Kv/KvCarousel.vue
@@ -251,7 +251,7 @@ export default {
 			this.$emit('change', this.currentIndex);
 		});
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.autoplay) {
 			clearInterval(this.intervalTimer);
 		}

--- a/src/components/Kv/KvDropdown.vue
+++ b/src/components/Kv/KvDropdown.vue
@@ -71,7 +71,7 @@ export default {
 			this.popper.scheduleUpdate();
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.unmakeDropdown();
 	},
 	methods: {

--- a/src/components/Kv/KvLightbox.vue
+++ b/src/components/Kv/KvLightbox.vue
@@ -128,7 +128,7 @@ export default {
 		this.isShown = this.visible;
 		this.init();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.closeLightbox();
 	},
 	methods: {

--- a/src/components/Kv/KvLoadingOverlay.vue
+++ b/src/components/Kv/KvLoadingOverlay.vue
@@ -53,7 +53,7 @@ export default {
 		this.onScroll();
 		window.addEventListener('scroll', this.throttledScroll);
 	},
-	destroyed() {
+	unmounted() {
 		window.removeEventListener('scroll', this.throttledScroll);
 	},
 };

--- a/src/components/Kv/KvMap.vue
+++ b/src/components/Kv/KvMap.vue
@@ -309,7 +309,7 @@ export default {
 			}
 		},
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.mapInstance) {
 			if (!this.hasWebGL && !this.leafletReady) {
 				// turn off the leaflet instance

--- a/src/components/Kv/KvPopper.vue
+++ b/src/components/Kv/KvPopper.vue
@@ -70,7 +70,7 @@ export default {
 			this.popper.scheduleUpdate();
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.removeEvents();
 		if (this.popper) {
 			this.popper.destroy();

--- a/src/components/Kv/KvSelectBox.vue
+++ b/src/components/Kv/KvSelectBox.vue
@@ -101,7 +101,7 @@ export default {
 		document.addEventListener('click', this.clickDocument);
 		document.addEventListener('touchstart', this.clickDocument);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		document.removeEventListener('click', this.clickDocument);
 		document.removeEventListener('touchstart', this.clickDocument);
 

--- a/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchFilterChips.vue
@@ -60,7 +60,7 @@ export default {
 
 		window.addEventListener('resize', this.throttledDetermineIsCollapsable);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.throttledDetermineIsCollapsable);
 	},
 	computed: {

--- a/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
+++ b/src/components/Lend/LoanSearch/LoanSearchSavedSearch.vue
@@ -43,7 +43,7 @@
 					Email me when new loans become available
 				</kv-checkbox>
 				<kv-button
-					@click.native="saveSavedSearch"
+					@click="saveSavedSearch"
 					:state="savedSearchName.length === 0 ? 'disabled' : null"
 				>
 					Create Saved Search

--- a/src/components/Lightboxes/AddToBasketInterstitial.vue
+++ b/src/components/Lightboxes/AddToBasketInterstitial.vue
@@ -39,7 +39,7 @@
 									'Lending',
 									'Add-to-basket Interstitial',
 									'keep-exploring-button-click']"
-								@click.native.prevent="closeLightbox"
+								@click.prevent="closeLightbox"
 							>
 								Find more loans
 							</kv-button>
@@ -52,7 +52,7 @@
 									'Lending',
 									'Add-to-basket Interstitial',
 									'checkout-button-click']"
-								@click.native="closeLightbox"
+								@click="closeLightbox"
 							>
 								Checkout
 							</kv-button>

--- a/src/components/Lightboxes/AddToBasketInterstitial.vue
+++ b/src/components/Lightboxes/AddToBasketInterstitial.vue
@@ -232,7 +232,7 @@ export default {
 			);
 		}
 	},
-	destroyed() {
+	unmounted() {
 		clearTimeout(this.loadingOnTimeout);
 		clearTimeout(this.loadingOffTimeout);
 	}

--- a/src/components/LoanCards/AdaptiveMicroLoanCard.vue
+++ b/src/components/LoanCards/AdaptiveMicroLoanCard.vue
@@ -6,7 +6,7 @@
 			:retina-image-url="loan.image.retina"
 			:standard-image-url="loan.image.default"
 			:is-visitor="true"
-			@click.native="trackProfileClick"
+			@click="trackProfileClick"
 			:open-in-new-tab="true"
 			:use-default-styles="false"
 		/>

--- a/src/components/LoanCards/Buttons/LendButton2.vue
+++ b/src/components/LoanCards/Buttons/LendButton2.vue
@@ -1,7 +1,7 @@
 <template>
 	<kv-button
 		v-if="showLend || showLendAgain"
-		@click.native="addToBasket"
+		@click="addToBasket"
 		:class="{ secondary: showLendAgain }"
 		v-kv-track-event="['Lending', 'Add to basket', 'lend-button-click', loanId, loanId]"
 	>

--- a/src/components/LoanCards/Buttons/LendIncrementButton.vue
+++ b/src/components/LoanCards/Buttons/LendIncrementButton.vue
@@ -4,7 +4,7 @@
 			<kv-select
 				id="lend-increment-amount"
 				v-model="selectedOption"
-				@update:modelValue="trackLendAmountSelection"
+				@update:model-value="trackLendAmountSelection"
 			>
 				<option
 					v-for="price in prices"
@@ -21,7 +21,7 @@
 			:class="{ 'tw-w-full': loading }"
 			:price="selectedOption"
 			:loan-id="loanId"
-			:loading.sync="loading"
+			v-model:loading="loading"
 			@add-to-basket="$emit('add-to-basket', $event)"
 		>
 			{{ buttonText }}

--- a/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
+++ b/src/components/LoanCards/ExpandableLoanCard/ExpandableLoanCard.vue
@@ -55,7 +55,7 @@
 					:is-simple-lend-button="true"
 					:enable-five-dollars-notes="enableFiveDollarsNotes"
 
-					@click.native="trackInteraction({
+					@click="trackInteraction({
 						interactionType: 'addToBasket',
 						interactionElement: 'Lend25'
 					})"

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -92,7 +92,7 @@ export default {
 		LoanTag
 	},
 	inject: ['apollo'],
-	emit: ['track-interaction', 'toggle-favorite'],
+	emits: ['track-interaction', 'toggle-favorite', 'add-to-basket'],
 	props: {
 		amountLeft: {
 			type: Number,

--- a/src/components/LoanCards/GridLoanCard.vue
+++ b/src/components/LoanCards/GridLoanCard.vue
@@ -53,7 +53,7 @@
 					:is-visitor="isVisitor"
 					class="tw-mt-2 tw-w-full"
 					:class="{'tw-mb-2' : !isMatchAtRisk && !isFunded}"
-					@click.native="trackInteraction({
+					@click="trackInteraction({
 						interactionType: 'addToBasket',
 						interactionElement: 'Lend25'
 					})"

--- a/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
+++ b/src/components/LoanCards/HoverLoanCard/DetailedLoanCard.vue
@@ -98,7 +98,7 @@
 							:amount-left="amountLeft"
 							:show-now="!enableFiveDollarsNotes"
 							:enable-five-dollars-notes="enableFiveDollarsNotes"
-							@click.native="trackInteraction({
+							@click="trackInteraction({
 								interactionType: 'addToBasket',
 								interactionElement: 'Lend25'
 							})"

--- a/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
+++ b/src/components/LoanCards/HoverLoanCard/HoverLoanCardLarge.vue
@@ -61,7 +61,7 @@
 					:minimal-checkout-button="true"
 					:is-amount-lend-button="lessThan25"
 					:amount-left="amountLeft"
-					@click.native="trackInteraction({
+					@click="trackInteraction({
 						interactionType: 'addToBasket',
 						interactionElement: 'Lend25'
 					})"

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -588,7 +588,7 @@ export default {
 			this.createViewportObserver();
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyViewportObserver();
 		this.watchedQuery.subscription?.unsubscribe();
 	},

--- a/src/components/LoanCards/KvClassicLoanCardContainer.vue
+++ b/src/components/LoanCards/KvClassicLoanCardContainer.vue
@@ -494,7 +494,7 @@ export default {
 			this.fetchLoanActivity();
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyViewportObserver();
 		this.watchedQuery.subscription?.unsubscribe();
 	},

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -82,7 +82,7 @@
 						:enable-huge-amount="enableHugeAmount"
 						:is-visitor="isVisitor"
 						class="tw-mt-0 tw-w-full"
-						@click.native="trackInteraction({
+						@click="trackInteraction({
 							interactionType: 'addToBasket',
 							interactionElement: 'Lend25'
 						})"
@@ -139,7 +139,7 @@
 						:is-visitor="isVisitor"
 						class="tw-mt-0 tw-w-full"
 
-						@click.native="trackInteraction({
+						@click="trackInteraction({
 							interactionType: 'addToBasket',
 							interactionElement: 'Lend25'
 						})"

--- a/src/components/LoanCards/ListLoanCard.vue
+++ b/src/components/LoanCards/ListLoanCard.vue
@@ -179,7 +179,7 @@ export default {
 		BorrowerInfoHeader,
 		BorrowerInfoBody,
 	},
-	emits: ['track-interaction', 'toggle-favorite'],
+	emits: ['track-interaction', 'toggle-favorite', 'add-to-basket'],
 	props: {
 		isVisitor: {
 			type: Boolean,

--- a/src/components/LoanCards/NewHomePageLoanCard.vue
+++ b/src/components/LoanCards/NewHomePageLoanCard.vue
@@ -365,7 +365,7 @@ export default {
 			this.createViewportObserver();
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyViewportObserver();
 	},
 	watch: {

--- a/src/components/LoanCollections/HomeExp/LoanCategorySelectorHomeExp.vue
+++ b/src/components/LoanCollections/HomeExp/LoanCategorySelectorHomeExp.vue
@@ -10,7 +10,7 @@
 					:vertical="true"
 					v-for="category in loanChannels" :key="category.id"
 					:for-panel="`tab-${category.id}`"
-					@click.native="handleCategoryClick(category)"
+					@click="handleCategoryClick(category)"
 				>
 					{{ category.shortName }}
 				</kv-tab>

--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -171,7 +171,7 @@ export default {
 	mounted() {
 		window.addEventListener('resize', this.handleResize);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.handleResize);
 	}
 };

--- a/src/components/LoansByCategory/FeaturedHeroLoan.vue
+++ b/src/components/LoansByCategory/FeaturedHeroLoan.vue
@@ -65,7 +65,7 @@
 									:amount-left="amountLeft"
 									:show-now="!enableFiveDollarsNotes"
 									:enable-five-dollars-notes="enableFiveDollarsNotes"
-									@click.native="trackInteraction({
+									@click="trackInteraction({
 										interactionType: 'addToBasket',
 										interactionElement: 'Lend25'
 									})"

--- a/src/components/LoansByCategory/QuickFilters/LocationSelector.vue
+++ b/src/components/LoansByCategory/QuickFilters/LocationSelector.vue
@@ -103,7 +103,7 @@
 										:items="getItems(region.countries)"
 										:selected-values="selectedCountries"
 										@updated="updateCountries($event)"
-										@closeRegions="toggleRegions()"
+										@close-regions="toggleRegions()"
 									/>
 								</div>
 							</div>
@@ -130,7 +130,7 @@
 					:items="getItems(activeCountries)"
 					:selected-values="selectedCountries"
 					@updated="updateCountries($event)"
-					@closeRegions="toggleRegions()"
+					@close-regions="toggleRegions()"
 				/>
 				<div class="tw-flex tw-gap-2 tw-justify-end">
 					<button @click="selectedCountries = []" class="tw-text-link">

--- a/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
+++ b/src/components/LoansByCategory/QuickFilters/QuickFilters.vue
@@ -53,7 +53,7 @@
 						v-model="selectedGender"
 						id="gender"
 						style="min-width: 140px;"
-						@click.native="trackDropdownClick('gender')"
+						@click="trackDropdownClick('gender')"
 					>
 						<option
 							v-for="gender in filterOptions.gender"
@@ -68,7 +68,7 @@
 				<div class="tw-w-full">
 					<location-selector
 						v-if="!removeLocationDropdown"
-						@click.native="trackDropdownClick('location')"
+						@click="trackDropdownClick('location')"
 						@handle-overlay="handleQuickFiltersOverlay"
 						:regions="filterOptions.location"
 						:total-loans="totalLoans"
@@ -95,7 +95,7 @@
 					:disabled="!filtersLoaded"
 					v-model="sortBy"
 					style="min-width: 180px;"
-					@click.native="trackDropdownClick('sort')"
+					@click="trackDropdownClick('sort')"
 				>
 					<option
 						v-for="sortType in filterOptions.sorting"
@@ -120,7 +120,7 @@
 					id="sortBy"
 					:disabled="!filtersLoaded"
 					v-model="sortBy"
-					@click.native="trackDropdownClick('sort')"
+					@click="trackDropdownClick('sort')"
 				>
 					<option
 						v-for="sortType in filterOptions.sorting"

--- a/src/components/LoansYouMightLike/LymlContainer.vue
+++ b/src/components/LoansYouMightLike/LymlContainer.vue
@@ -1,10 +1,7 @@
 <template>
 	<transition name="kvfade">
-		<div class="lyml-section-wrapper">
-			<div
-				class="lyml-section-container"
-				v-if="showLYML"
-			>
+		<div v-if="showLYML" class="lyml-section-wrapper">
+			<div class="lyml-section-container">
 				<div id="lyml-row-cards">
 					<div class="lyml-row-wrapper" ref="lymlContainer">
 						<span

--- a/src/components/LoansYouMightLike/LymlContainer.vue
+++ b/src/components/LoansYouMightLike/LymlContainer.vue
@@ -194,7 +194,7 @@ export default {
 			this.saveWindowWidth();
 		});
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.throttledResize());
 	},
 	methods: {

--- a/src/components/MonthlyGood/MonthlyGoodSelectorDesktop.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorDesktop.vue
@@ -184,7 +184,7 @@ export default {
 	mounted() {
 		document.addEventListener('keyup', this.onKeyUp);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		document.removeEventListener('keyup', this.onKeyUp);
 	},
 	methods: {

--- a/src/components/MonthlyGood/MonthlyGoodSelectorDesktop.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorDesktop.vue
@@ -82,7 +82,7 @@
 			<div class="shrink column monthly-selector__take-action-wrapper">
 				<!--  classic hollow -->
 				<kv-button
-					@click.native="navigateToMG"
+					@click="navigateToMG"
 					class="monthly-selector__take-action"
 					v-kv-track-event="[
 						'homepage',

--- a/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorMobile.vue
@@ -68,7 +68,7 @@
 					id="mgAmountDropdown"
 					class="tw-w-full"
 					v-model.number="mgAmount"
-					@update:modelValue="trackMgAmountSelection"
+					@update:model-value="trackMgAmountSelection"
 				>
 					<option
 						v-for="(option, index) in mgAmountOptions"

--- a/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
+++ b/src/components/MonthlyGood/MonthlyGoodSelectorWrapper.vue
@@ -165,7 +165,7 @@ export default {
 			this.mgStickBarOffset = offsetHeight;
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('scroll', this.throttledScroll);
 		window.removeEventListener('scroll', () => {
 			this.hasScrolled = true;

--- a/src/components/Settings/AppAuthentication.vue
+++ b/src/components/Settings/AppAuthentication.vue
@@ -162,7 +162,7 @@ export default {
 	mounted() {
 		this.startEnrollment();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.lightboxVisible = false;
 	},
 	methods: {

--- a/src/components/Settings/PhoneAuthentication.vue
+++ b/src/components/Settings/PhoneAuthentication.vue
@@ -221,7 +221,7 @@ export default {
 			return 'Phone number';
 		},
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.lightboxVisible = false;
 	},
 	methods: {

--- a/src/components/Settings/SubscriptionsSettingsCards.vue
+++ b/src/components/Settings/SubscriptionsSettingsCards.vue
@@ -140,7 +140,7 @@ export default {
 	mounted() {
 		window.addEventListener('beforeunload', this.onLeave);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('beforeunload', this.onLeave);
 	},
 	methods: {

--- a/src/components/Subscriptions/SubscriptionsMonthlyGoodCancellationFlow.vue
+++ b/src/components/Subscriptions/SubscriptionsMonthlyGoodCancellationFlow.vue
@@ -65,7 +65,7 @@
 					<kv-button
 						class="tw-w-full"
 						variant="secondary"
-						@click.native.prevent="trackEvent({
+						@click.prevent="trackEvent({
 							label: `monthly good cancel ; Continue cancellation`,
 							property: 'cancel reason ; amount_other'}); goToStep('3-expensive')"
 					>

--- a/src/components/Thanks/Badges/FirstScreen.vue
+++ b/src/components/Thanks/Badges/FirstScreen.vue
@@ -304,7 +304,7 @@ export default {
 		KvButton,
 		KvMaterialIcon,
 	},
-	emits: ['show-new-bg'],
+	emits: ['show-new-bg', 'show-discover-badges'],
 	props: {
 		receipt: {
 			type: Object,

--- a/src/components/Thanks/ThanksLayoutV2.vue
+++ b/src/components/Thanks/ThanksLayoutV2.vue
@@ -11,7 +11,7 @@
 					class="thanks-page__icon-button expanded"
 					v-if="showGuestUpsell"
 					:class="{ active: isGuestSelected }"
-					@click.native="setVisibleSection('guest')"
+					@click="setVisibleSection('guest')"
 				>
 					<template #icon-left>
 						<kv-icon
@@ -33,7 +33,7 @@
 					class="thanks-page__icon-button expanded"
 					v-if="showMgCta"
 					:class="{ active: isMgSelected }"
-					@click.native="setVisibleSection('mg')"
+					@click="setVisibleSection('mg')"
 				>
 					<template #icon-left>
 						<kv-icon
@@ -54,7 +54,7 @@
 					data-testid="thanks-page-button-receipt"
 					class="thanks-page__icon-button expanded"
 					:class="{ active: isReceiptSelected }"
-					@click.native="setVisibleSection('receipt')"
+					@click="setVisibleSection('receipt')"
 				>
 					<template #icon-left>
 						<kv-icon
@@ -75,7 +75,7 @@
 					data-testid="thanks-page-button-share"
 					class="thanks-page__icon-button expanded"
 					:class="{ active: isShareSelected }"
-					@click.native="setVisibleSection('share')"
+					@click="setVisibleSection('share')"
 					v-if="showShare"
 				>
 					<template #icon-left>
@@ -151,7 +151,7 @@
 						:class="{ active: isGuestSelected }"
 						aria-controls="`kv-accordion-mg-accordion`"
 						:aria-expanded="isGuestSelected ? 'true' : 'false'"
-						@click.native="setVisibleSection('guest')"
+						@click="setVisibleSection('guest')"
 					>
 						<template #icon-left>
 							<kv-icon
@@ -196,7 +196,7 @@
 						aria-controls="`kv-accordion-mg-accordion`"
 						:aria-expanded="isMgSelected ? 'true' : 'false'"
 						v-kv-track-event="['thanks', 'click-Monthly-Good', 'Monthly Good']"
-						@click.native="setVisibleSection('mg')"
+						@click="setVisibleSection('mg')"
 					>
 						<template #icon-left>
 							<kv-icon
@@ -240,7 +240,7 @@
 						aria-controls="`kv-accordion-receipt-accordion`"
 						:aria-expanded="isReceiptSelected ? 'true' : 'false'"
 						v-kv-track-event="['thanks', 'click-Order-Confirmation', 'Order Confirmation']"
-						@click.native="setVisibleSection('receipt')"
+						@click="setVisibleSection('receipt')"
 					>
 						<template #icon-left>
 							<kv-icon
@@ -285,7 +285,7 @@
 						aria-controls="`kv-accordion-share-accordion`"
 						:aria-expanded="isShareSelected ? 'true' : 'false'"
 						v-kv-track-event="['thanks', 'click-Share', 'Share']"
-						@click.native="setVisibleSection('share')"
+						@click="setVisibleSection('share')"
 					>
 						<template #icon-left>
 							<kv-icon

--- a/src/components/Thanks/ThanksLayoutV2.vue
+++ b/src/components/Thanks/ThanksLayoutV2.vue
@@ -391,7 +391,7 @@ export default {
 			return this.visibleSection === 'share';
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', _throttle(() => {
 			this.determineIfMobile();
 		}, 200));

--- a/src/components/WwwFrame/CookieBanner.vue
+++ b/src/components/WwwFrame/CookieBanner.vue
@@ -9,7 +9,7 @@
 					preferences please see our <a href="/legal/cookie" target="_blank">cookie policy</a>.
 					<kv-button
 						class="setting close-button"
-						@click.native.stop.prevent="handleClickClose"
+						@click.stop.prevent="handleClickClose"
 						aria-label="Close"
 					>
 						Sounds good

--- a/src/components/WwwFrame/LendMenu/LendListMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendListMenu.vue
@@ -3,7 +3,7 @@
 		<router-link
 			v-if="showMGUpsellLink"
 			to="/monthlygood"
-			@click.native="trackMgLinkClick"
+			@click="trackMgLinkClick"
 		>
 			<!-- eslint-disable-next-line max-len -->
 			<span class="tw-inline-flex tw-items-center tw-py-2 tw-mb-2 tw-gap-0.5 tw-border-b tw-border-tertiary tw-font-medium">

--- a/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
+++ b/src/components/WwwFrame/LendMenu/LendMegaMenu.vue
@@ -3,7 +3,7 @@
 		<router-link
 			v-if="showMGUpsellLink"
 			to="/monthlygood"
-			@click.native="trackMgLinkClick"
+			@click="trackMgLinkClick"
 		>
 			<span class="tw-inline-flex tw-items-center tw-py-2 tw-mb-2 tw-gap-0.5 tw-font-medium">
 				Lend monthly

--- a/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/AppealBanner/AppealBannerCircular.vue
@@ -70,7 +70,7 @@
 								:key="`amount-${index}`"
 								variant="secondary"
 								class="tw-border-brand tw-text-brand"
-								@click.native="onClickAmountBtn(buttonAmount)"
+								@click="onClickAmountBtn(buttonAmount)"
 								v-kv-track-event="[
 									'promo',
 									'click-amount-btn',
@@ -135,7 +135,7 @@
 					</div>
 					<div class="tw-flex-shrink tw-mx-2">
 						<kv-button
-							@click.native="onClickToggleBanner"
+							@click="onClickToggleBanner"
 							variant="primary"
 							v-kv-track-event="[
 								'promo',

--- a/src/components/WwwFrame/PromotionalBanner/Banners/PromoCreditBanner.vue
+++ b/src/components/WwwFrame/PromotionalBanner/Banners/PromoCreditBanner.vue
@@ -15,7 +15,7 @@
 		>
 
 			Please go back to your first Kiva tab or <span class="tw-underline">
-				click here</span> to use your {{ promoData.bonusBalance | numeral('$0.00') }} promo credit.
+				click here</span> to use your {{ promoData.bonusBalanceFormatted }} promo credit.
 
 		</a>
 	</div>
@@ -194,6 +194,7 @@ export default {
 		promoData() {
 			return {
 				bonusBalance: this.bonusBalance,
+				bonusBalanceFormatted: numeral(this.bonusBalance).format('$0[.]00'),
 				available: this.creditAvailable,
 				displayName: this.promoFundDisplayName,
 				pageId: this.managedAccountPageId,

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -123,10 +123,10 @@
 							data-testid="header-lend"
 							class="header__button header__lend tw-inline-flex"
 							v-kv-track-event="['TopNav','click-Lend']"
-							@pointerenter.native.stop="onLendLinkPointerEnter"
-							@pointerleave.native.stop="onLendLinkPointerLeave"
-							@pointerup.native.stop="onLendLinkPointerUp"
-							@click.native.stop="onLendLinkClick"
+							@pointerenter.stop="onLendLinkPointerEnter"
+							@pointerleave.stop="onLendLinkPointerLeave"
+							@pointerup.stop="onLendLinkPointerUp"
+							@click.stop="onLendLinkClick"
 						>
 							<span class="tw-flex tw-items-center">Lend
 								<kv-material-icon
@@ -149,8 +149,8 @@
 								<kv-page-container>
 									<the-lend-menu
 										ref="lendMenu"
-										@pointerenter.native="onLendMenuPointerEnter"
-										@pointerleave.native="onLendMenuPointerLeave"
+										@pointerenter="onLendMenuPointerEnter"
+										@pointerleave="onLendMenuPointerLeave"
 									/>
 								</kv-page-container>
 							</div>

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -889,7 +889,7 @@ export default {
 		});
 		window.addEventListener('resize', this.determineIfMobile());
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.determineIfMobile());
 	},
 	methods: {

--- a/src/components/WwwFrame/WwwPageDesign.vue
+++ b/src/components/WwwFrame/WwwPageDesign.vue
@@ -283,7 +283,7 @@ This is a message requesting the Kiva Post Grot typekit for the purpose(s) of
 	mounted() {
 		this.createObserver();
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroyObserver();
 	},
 };

--- a/src/components/WwwFrame/WwwPageDesign.vue
+++ b/src/components/WwwFrame/WwwPageDesign.vue
@@ -37,7 +37,7 @@
 									variant="ghost"
 									class="tw-w-full md:tw-w-auto"
 									href="#creative-studio-logo-intro"
-									@click.native.prevent="scrollPastNav('#creative-studio-logo-intro')"
+									@click.prevent="scrollPastNav('#creative-studio-logo-intro')"
 									:state="activeSection.includes('creative-studio-logo') ? 'active' : ''"
 								>
 									Logos
@@ -48,7 +48,7 @@
 									variant="ghost"
 									class="tw-w-full md:tw-w-auto"
 									href="#creative-studio-colors-intro"
-									@click.native.prevent="scrollPastNav('#creative-studio-colors-intro')"
+									@click.prevent="scrollPastNav('#creative-studio-colors-intro')"
 									:state="activeSection.includes('creative-studio-colors') ? 'active' : ''"
 								>
 									Colors
@@ -59,7 +59,7 @@
 									variant="ghost"
 									class="tw-w-full md:tw-w-auto"
 									href="#creative-studio-typography-intro"
-									@click.native.prevent="scrollPastNav('#creative-studio-typography-intro')"
+									@click.prevent="scrollPastNav('#creative-studio-typography-intro')"
 									:state="activeSection.includes('creative-studio-typography') ? 'active' : ''"
 								>
 									Type

--- a/src/pages/Autolending/AutolendingSettingsPage.vue
+++ b/src/pages/Autolending/AutolendingSettingsPage.vue
@@ -103,7 +103,7 @@ export default {
 	mounted() {
 		window.addEventListener('beforeunload', this.onLeave);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('beforeunload', this.onLeave);
 	},
 	methods: {

--- a/src/pages/Autolending/AutolendingWhen.vue
+++ b/src/pages/Autolending/AutolendingWhen.vue
@@ -75,7 +75,7 @@
 						data-test="when-save-button"
 						class="smaller button"
 						v-if="!isSaving"
-						@click.native="save"
+						@click="save"
 						:disabled="!isChanged"
 					>
 						Save

--- a/src/pages/Autolending/AutolendingWho.vue
+++ b/src/pages/Autolending/AutolendingWho.vue
@@ -114,7 +114,7 @@
 				<template #controls>
 					<div class="row">
 						<div class="columns shrink">
-							<save-button @autolendingSaved="settingsSaved" />
+							<save-button @autolending-saved="settingsSaved" />
 						</div>
 						<div class="columns" v-show="!kivaChooses">
 							<inline-counter />

--- a/src/pages/Autolending/InlineCounter.vue
+++ b/src/pages/Autolending/InlineCounter.vue
@@ -84,7 +84,7 @@ export default {
 		window.addEventListener('resize', this.throttledResize);
 		window.addEventListener('scroll', this.throttledScroll);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.throttledResize);
 		window.removeEventListener('scroll', this.throttledScroll);
 	},

--- a/src/pages/Autolending/SaveButton.vue
+++ b/src/pages/Autolending/SaveButton.vue
@@ -4,7 +4,7 @@
 			data-test="save-button"
 			class="smaller"
 			v-if="!saving"
-			@click.native="checkSave"
+			@click="checkSave"
 			:disabled="!isChanged"
 		>
 			Save
@@ -24,10 +24,10 @@
 			</p>
 			<template #controls>
 				<div class="warning-buttons">
-					<kv-button class="smallest secondary" @click.native="save">
+					<kv-button class="smallest secondary" @click="save">
 						Continue anyway
 					</kv-button>
-					<kv-button class="smallest" @click.native="closeWarning">
+					<kv-button class="smallest" @click="closeWarning">
 						Add more categories
 					</kv-button>
 				</div>

--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -668,7 +668,7 @@ export default {
 			this.isMobile = document.documentElement.clientWidth < 735;
 		},
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', _throttle(() => {
 			this.determineIfMobile();
 		}, 200));

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -1130,7 +1130,7 @@ export default {
 			return thanksBadgeExp?.version;
 		}
 	},
-	destroyed() {
+	unmounted() {
 		clearInterval(this.currentTimeInterval);
 	},
 };

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -250,7 +250,7 @@
 						<router-link
 							to="/lend-by-category"
 							data-testid="empty-basket-loans-link"
-							v-kv-track-event.native="
+							v-kv-track-event="
 								['basket', 'click-empty-basket-browse-all-loans', 'browse all loans']
 							"
 						>

--- a/src/pages/GetStarted/GetStartedCauses.vue
+++ b/src/pages/GetStarted/GetStartedCauses.vue
@@ -41,7 +41,7 @@
 						class="get-started__submit-btn"
 						type="submit"
 						:disabled="selectedCauses.length === 0"
-						@click.native="trackTransition"
+						@click="trackTransition"
 					>
 						Next
 					</kv-button>

--- a/src/pages/GetStarted/GetStartedPlaces.vue
+++ b/src/pages/GetStarted/GetStartedPlaces.vue
@@ -148,7 +148,7 @@
 							<kv-button
 								class="text-link"
 								v-if="selectedCountries.length !== 0"
-								@click.prevent.native="toggleAllCountries(false)"
+								@click.prevent="toggleAllCountries(false)"
 								v-kv-track-event="['Lending', 'click-place-clear', 'clear']"
 							>
 								Clear

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -738,7 +738,7 @@ export default {
 
 		this.setAuthStatus(this.kvAuth0?.user ?? {});
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		clearInterval(this.currentTimeInterval);
 	},
 	watch: {

--- a/src/pages/LandingPages/Unbounce/IFrameEmbed.vue
+++ b/src/pages/LandingPages/Unbounce/IFrameEmbed.vue
@@ -105,7 +105,7 @@ export default {
 			oneTrustGlobalEvent();
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('oneTrustAccepted', this.handleOneTrustAccepted);
 
 		window.removeEventListener('resize', _throttle(() => {

--- a/src/pages/Lend/LoanChannelCategoryControl.vue
+++ b/src/pages/Lend/LoanChannelCategoryControl.vue
@@ -10,7 +10,7 @@
 				<router-link
 					:to="filterUrl"
 					class="tw-text-action tw-flex tw-items-center tw-float-right"
-					@click.native="trackAdvancedFilters"
+					@click="trackAdvancedFilters"
 				>
 					<img class="tw-w-2 tw-mr-1" :src="tuneUrl">
 					Advanced filters

--- a/src/pages/LendingTeams/TeamLeaderboard.vue
+++ b/src/pages/LendingTeams/TeamLeaderboard.vue
@@ -209,7 +209,7 @@ export default {
 		this.determineIfMobile();
 		window.addEventListener('resize', this.throttledResize);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		window.removeEventListener('resize', this.throttledResize);
 	},
 };

--- a/src/pages/LendingTeams/TeamListing.vue
+++ b/src/pages/LendingTeams/TeamListing.vue
@@ -21,7 +21,7 @@
 				<kv-select
 					id="category"
 					v-model="teamCategory"
-					@update:modelValue="pushChangesToUrl"
+					@update:model-value="pushChangesToUrl"
 					v-kv-track-event="['teams', 'filter', 'teams-search', teamCategory]"
 				>
 					<option v-for="(category, index) in teamCategories" :key="index" :value="category.value">
@@ -33,7 +33,7 @@
 				<kv-select
 					id="categoryTeams"
 					v-model="teamOption"
-					@update:modelValue="pushChangesToUrl"
+					@update:model-value="pushChangesToUrl"
 					v-kv-track-event="['teams', 'filter', 'teams-search', teamOption]"
 				>
 					<option value="">
@@ -56,7 +56,7 @@
 				<div>
 					<kv-select
 						id="categorySort" v-model="teamSort"
-						@update:modelValue="pushChangesToUrl"
+						@update:model-value="pushChangesToUrl"
 					>
 						<!-- <option value="recentActivityScore">
 							Recent Activity

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -503,7 +503,7 @@ export default {
 			'EXP-VUE-FLSS-Ongoing-Sitewide'
 		);
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		this.destroySpotlightViewportObserver();
 	},
 };

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -70,7 +70,7 @@
 				<user-updates-preference
 					v-if="enableRadioBtnExperiment"
 					tracking-category="authentication"
-					@update:modelValue="selectedComms = $event"
+					@update:model-value="selectedComms = $event"
 				/>
 				<input
 					v-if="enableRadioBtnExperiment"
@@ -86,7 +86,7 @@
 						v-show="needsTerms"
 						v-model="newAcctTerms"
 						:validation="v$.newAcctTerms"
-						@update:modelValue="$kvTrackEvent(
+						@update:model-value="$kvTrackEvent(
 							'authentication',
 							'click',
 							'terms-of-use',
@@ -111,7 +111,7 @@
 						type="checkbox"
 						v-show="needsNews"
 						v-model="newsConsent"
-						@update:modelValue="$kvTrackEvent(
+						@update:model-value="$kvTrackEvent(
 							'authentication',
 							'click',
 							'marketing-updates',

--- a/src/pages/MonthlyGood/LandingForm.vue
+++ b/src/pages/MonthlyGood/LandingForm.vue
@@ -9,7 +9,7 @@
 				<kv-select
 					class="tw-w-full" id="borrower-categories"
 					:model-value="selectedGroup"
-					@update:modelValue="updateSelected"
+					@update:model-value="updateSelected"
 				>
 					<option v-for="(option, index) in lendingCategories" :value="option.value" :key="index">
 						{{ option.label }}

--- a/src/pages/Settings/EmailSettings.vue
+++ b/src/pages/Settings/EmailSettings.vue
@@ -331,7 +331,7 @@
 					<div class="columns small-12 large-8">
 						<kv-button
 							class="smallest"
-							@click.native="saveSettings"
+							@click="saveSettings"
 							:disabled="!isChanged || isProcessing"
 						>
 							Save email settings <kv-loading-spinner v-if="isProcessing" />

--- a/src/pages/Settings/PaymentSettings.vue
+++ b/src/pages/Settings/PaymentSettings.vue
@@ -81,7 +81,7 @@
 									<kv-button
 										class="smaller payment-settings-default-form__save-button"
 										v-if="!isProcessing"
-										@click.native="savePaymentSettings"
+										@click="savePaymentSettings"
 										:disabled="!isChanged || v$.$invalid"
 									>
 										Save Settings
@@ -96,7 +96,7 @@
 										id="dropin-submit"
 										class="smaller payment-settings-default-form__add-button"
 										:disabled="!enableAddCardButton || isProcessing"
-										@click.native="submitDropInAddACard"
+										@click="submitDropInAddACard"
 									>
 										<kv-icon name="lock" />
 										Add card <kv-loading-spinner v-if="isProcessing" />
@@ -124,7 +124,7 @@
 			<template #controls>
 				<kv-button
 					class="smallest secondary"
-					@click.prevent.native="showRemoveLightbox = false"
+					@click.prevent="showRemoveLightbox = false"
 				>
 					Cancel
 				</kv-button>
@@ -132,7 +132,7 @@
 				<kv-button
 					class="smallest alert"
 					v-if="!isProcessing"
-					@click.prevent.native="removeCard(selectedPaymentMethod.nonce)"
+					@click.prevent="removeCard(selectedPaymentMethod.nonce)"
 				>
 					Remove card
 				</kv-button>
@@ -161,7 +161,7 @@
 				<kv-button
 					id="active-card-no"
 					class="smallest secondary"
-					@click.prevent.native="showActiveLightbox = false"
+					@click.prevent="showActiveLightbox = false"
 				>
 					Close
 				</kv-button>

--- a/src/plugins/delay-until-visible-mixin.js
+++ b/src/plugins/delay-until-visible-mixin.js
@@ -27,7 +27,7 @@ export default {
 			}
 		}
 	},
-	beforeDestroy() {
+	beforeUnmount() {
 		if (this.delayUntilVisibleObserver) {
 			this.delayUntilVisibleObserver.disconnect();
 		}


### PR DESCRIPTION
This switches our eslint ruleset to vue 3 instead of vue 2, and addresses the resulting lint errors and warnings.

- `beforeDestroy` -> `beforeUnmount`
- `destroyed` -> `unmounted`
- `@update:modelValue` -> `@update:model-value`
- removed `.native`
- refactored `.sync`
- replaced filter usage
- moved `v-if` to transition root elements
- added missing `emits` definitions
- `refresh-totals` -> `refreshtotals` for consistency