### PR TITLE
fix: guard printableKivaCards with kivaCards

### DIFF
--- a/src/components/Checkout/CheckoutReceipt.vue
+++ b/src/components/Checkout/CheckoutReceipt.vue
@@ -343,7 +343,7 @@ export default {
 			return this.receipt.items.values.filter(item => item.basketItemType === 'kiva_card');
 		},
 		printableKivaCards() {
-			if (!this.receiptValues.length) return [];
+			if (!this.kivaCards.length) return [];
 			return this.kivaCards.filter(card => card.kivaCardObject.deliveryType === 'print');
 		},
 		donations() {

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -67,7 +67,7 @@
 					:show-mg-cta="!isMonthlyGoodSubscriber && !isGuest && !hasModernSub"
 					:show-guest-upsell="isGuest"
 					:show-share="loans.length > 0"
-					:show-receipt="this.printableKivaCards.length > 0"
+					:show-receipt="printableKivaCards.length > 0"
 				>
 					<template #receipt>
 						<checkout-receipt
@@ -424,7 +424,7 @@ export default {
 			return this.receipt.items.values.filter(item => item.basketItemType === 'kiva_card');
 		},
 		printableKivaCards() {
-			if (!this.receiptValues.length) return [];
+			if (!this.kivaCards.length) return [];
 			return this.kivaCards.filter(card => card.kivaCardObject.deliveryType === 'print');
 		},
 	},


### PR DESCRIPTION
- Remove `this` from template
- Use `kivaCards` length in setup of `printableKivaCards` to ensure an empty array is passed and we don't hit the filter case without any content.