### PR TITLE
feat: various fixes for form inputs and /register/social MP-938

### DIFF
--- a/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
+++ b/src/components/Checkout/CheckoutDropInPaymentWrapper.vue
@@ -48,10 +48,10 @@
 						'Where should we email your receipt?'
 					)"
 				/>
-				<p v-if="promoGuestCheckoutEnabled && v$.email?.$invalid">
+				<p v-if="promoGuestCheckoutEnabled && v$.email?.$error">
 					Valid campaign email required
 				</p>
-				<p v-else-if="v$.email?.$invalid" class="input-error tw-text-danger tw-text-base tw-mb-2">
+				<p v-else-if="v$.email?.$error" class="input-error tw-text-danger tw-text-base tw-mb-2">
 					Valid email required.
 				</p>
 				<user-updates-preference
@@ -87,7 +87,7 @@
 							target="_blank"
 							:title="`Open Privacy ${enableCommsExperiment ? 'Notice' : 'Policy' } in a new window`"
 						>Privacy {{ enableCommsExperiment ? 'Notice' : 'Policy' }}</a>.
-						<p v-if="v$.termsAgreement?.$invalid" class="input-error tw-text-danger tw-text-base">
+						<p v-if="v$.termsAgreement?.$error" class="input-error tw-text-danger tw-text-base">
 							You must agree to the Kiva Terms of service & Privacy
 							{{ enableCommsExperiment ? 'Notice' : 'Policy' }}.
 						</p>

--- a/src/components/Checkout/KivaCreditGuestPayment.vue
+++ b/src/components/Checkout/KivaCreditGuestPayment.vue
@@ -22,7 +22,7 @@
 					'Where should we email your receipt?'
 				)"
 			/>
-			<p v-if="v$.email?.$invalid" class="input-error tw-text-danger tw-text-base tw-mb-2">
+			<p v-if="v$.email?.$error" class="input-error tw-text-danger tw-text-base tw-mb-2">
 				Valid email required.
 			</p>
 			<kv-checkbox
@@ -50,7 +50,7 @@
 					target="_blank"
 					title="Open Privacy Policy in a new window"
 				>Privacy Policy</a>.
-				<p v-if="v$.termsAgreement?.$invalid" class="input-error tw-text-danger tw-text-base">
+				<p v-if="v$.termsAgreement?.$error" class="input-error tw-text-danger tw-text-base">
 					You must agree to the Kiva Terms of service & Privacy
 					policy.
 				</p>

--- a/src/components/Checkout/UserUpdatesPreference.vue
+++ b/src/components/Checkout/UserUpdatesPreference.vue
@@ -4,7 +4,7 @@
 			@input="event => $emit('update:modelValue', event.target.value)"
 			class="tw-flex tw-flex-col tw-gap-2 tw-mt-1 tw-mb-2 tw-text-small"
 		>
-			<div :class="{'radio-error': v$.selectedComms?.$invalid}">
+			<div :class="{'radio-error': v$.selectedComms?.$error}">
 				<kv-radio
 					value="on"
 					v-model="selectedComms"
@@ -21,7 +21,7 @@
 					Send me updates from people I've funded, my impact, and other ways I can help.
 				</kv-radio>
 			</div>
-			<div :class="{'radio-error': v$.selectedComms?.$invalid}">
+			<div :class="{'radio-error': v$.selectedComms?.$error}">
 				<kv-radio
 					value="off"
 					name="newsConsent"
@@ -40,7 +40,7 @@
 			</div>
 		</fieldset>
 		<p
-			v-if="v$.selectedComms?.$invalid"
+			v-if="v$.selectedComms?.$error"
 			class="input-error tw-text-danger tw-text-base tw-mb-2 tw-text-small"
 		>
 			Choose your communication preferences.

--- a/src/components/Forms/GuestAccountCreation.vue
+++ b/src/components/Forms/GuestAccountCreation.vue
@@ -3,30 +3,32 @@
 		id="guestUpsellForm"
 		@submit.prevent.stop="submit"
 	>
-		<kv-base-input
-			name="firstName"
-			class="data-hj-suppress tw-mb-2"
-			type="text"
-			v-model.trim="firstName"
-			:validation="v$.firstName"
-		>
-			First name
-			<template #required>
-				Enter first name.
-			</template>
-		</kv-base-input>
-		<kv-base-input
-			name="lastName"
-			class="data-hj-suppress tw-mb-2"
-			type="text"
-			v-model.trim="lastName"
-			:validation="v$.lastName"
-		>
-			Last name
-			<template #required>
-				Enter last name.
-			</template>
-		</kv-base-input>
+		<div class="data-hj-suppress tw-mb-2">
+			<kv-base-input
+				name="firstName"
+				type="text"
+				v-model.trim="firstName"
+				:validation="v$.firstName"
+			>
+				First name
+				<template #required>
+					Enter first name.
+				</template>
+			</kv-base-input>
+		</div>
+		<div class="data-hj-suppress tw-mb-2">
+			<kv-base-input
+				name="lastName"
+				type="text"
+				v-model.trim="lastName"
+				:validation="v$.lastName"
+			>
+				Last name
+				<template #required>
+					Enter last name.
+				</template>
+			</kv-base-input>
+		</div>
 		<p
 			v-if="serverError"
 			class="tw-text-danger tw-text-small tw-font-medium tw-mb-2"

--- a/src/components/Kv/KvLoadingOverlay.vue
+++ b/src/components/Kv/KvLoadingOverlay.vue
@@ -1,14 +1,14 @@
 <template>
 	<div class="loading-overlay">
 		<div class="spinner-wrapper" :style="{ top }">
-			<kv-loading-spinner />
+			<kv-loading-spinner size="large" />
 		</div>
 	</div>
 </template>
 
 <script>
 import _throttle from 'lodash/throttle';
-import KvLoadingSpinner from '#src/components/Kv/KvLoadingSpinner';
+import KvLoadingSpinner from '@kiva/kv-components/vue/KvLoadingSpinner';
 import getCacheKey from '#src/util/getCacheKey';
 
 export default {

--- a/src/components/Settings/PhoneAuthentication.vue
+++ b/src/components/Settings/PhoneAuthentication.vue
@@ -24,14 +24,14 @@
 						<kv-phone-input
 							class="phone-authentication__phone-input tw-mb-1 data-hj-suppress"
 							:disabled="enrollmentPending"
-							:valid="!v$.phoneNumber?.$invalid"
+							:valid="!v$.phoneNumber?.$error"
 							id="phone_input"
 							ref="phoneInput"
 							v-model="phoneNumber"
 							@blur="v$.phoneNumber.$touch"
 							@validity-changed="onValidityChanged"
 						/>
-						<ul class="validation-errors" v-if="v$.phoneNumber?.$invalid">
+						<ul class="validation-errors" v-if="v$.phoneNumber?.$error">
 							<li v-if="v$.phoneNumber?.required?.$invalid">
 								Field is required
 							</li>

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -43,7 +43,7 @@
 					<kv-base-input
 						name="firstName"
 						type="text"
-						v-show="true"
+						v-show="needsNames"
 						v-model.trim="firstName"
 						:validation="v$.firstName"
 					>

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -153,6 +153,7 @@
 					Cancel registration
 				</a>
 			</div>
+			<kv-loading-overlay v-if="loading" class="tw-rounded" />
 		</div>
 	</system-page>
 </template>
@@ -163,6 +164,7 @@ import { useVuelidate } from '@vuelidate/core';
 import { required, requiredIf } from '@vuelidate/validators';
 import logReadQueryError from '#src/util/logReadQueryError';
 import KvBaseInput from '#src/components/Kv/KvBaseInput';
+import KvLoadingOverlay from '#src/components/Kv/KvLoadingOverlay';
 import ReCaptchaEnterprise from '#src/components/Forms/ReCaptchaEnterprise';
 import SystemPage from '#src/components/SystemFrame/SystemPage';
 import KvButton from '@kiva/kv-components/vue/KvButton';
@@ -184,6 +186,7 @@ export default {
 	components: {
 		KvBaseInput,
 		KvButton,
+		KvLoadingOverlay,
 		ReCaptchaEnterprise,
 		SystemPage,
 		UserUpdatesPreference,
@@ -219,6 +222,7 @@ export default {
 			needsComms: false,
 			selectedComms: '',
 			enableRadioBtnExperiment: false,
+			loading: false,
 		};
 	},
 	setup() { return { v$: useVuelidate() }; },
@@ -368,6 +372,7 @@ export default {
 					this.newsConsent = this.selectedComms === '1';
 				}
 
+				this.loading = true;
 				this.$kvTrackEvent('Register', 'register-social-success');
 			} else {
 				event.preventDefault();

--- a/src/pages/LoginAndRegister/RegisterSocial.vue
+++ b/src/pages/LoginAndRegister/RegisterSocial.vue
@@ -129,7 +129,7 @@
 					/>
 					<p
 						class="tw-text-center tw-text-danger tw-text-small tw-font-medium tw-mt-1"
-						v-if="needsCaptcha && v$.captcha?.$invalid"
+						v-if="needsCaptcha && v$.captcha?.$error"
 					>
 						Please complete the captcha.
 					</p>


### PR DESCRIPTION
I found various issues when completing some checkouts in dev, one using a guest account and another using a new signup.

* form input error messages were showing when they shouldn't. I found all the cases where checks for `$error` had been switched to `$invalid` and switched them back.
* the first name input was always displaying on /register/social, even when it was not required. looks like that was due to a line for debugging that was left in.
* it's possible to click "complete registration" multiple times, but only the first request will succeed. Clicking the button cancels the in-flight request and starts a new one, which will end in being sent to the error page. I added a loading overlay so that none of the form can be interacted with after the button is clicked.
* I found a case of KvBaseInput usage where classes were still being applied directly instead of to a wrapper
* I replaced the loading spinner in the loading overlay with the one from kv-components:

https://github.com/user-attachments/assets/b990a87a-98a4-46db-8f30-f6a11b1390f3

