### PR TITLE
fix: get loan number in title from badge target

### DIFF
--- a/src/composables/useBadgeContentfulData.js
+++ b/src/composables/useBadgeContentfulData.js
@@ -8,6 +8,17 @@ export const badgeQuery = gql`query contentfulBadgeImage ($badgeKey: String!) {
 	}
 }`;
 
+// Targets defined for each level
+const levelsTarget = {
+	level1: 2,
+	level2: 3,
+	level3: 5,
+	level4: 10,
+	level5: 20,
+	level6: 50,
+	level7: 100,
+};
+
 export default function useBadgeContentfulData(client, route) {
 	const utmCampaign = route?.query?.utm_campaign ?? '';
 	const isUtmValid = utmCampaign.includes('badge_') && utmCampaign.includes('social_share');
@@ -16,6 +27,7 @@ export default function useBadgeContentfulData(client, route) {
 	const loadBadgeInfo = async () => {
 		let badgeImage = null;
 		let badgeCategory = '';
+		let badgeTarget = 0;
 
 		try {
 			const data = client.readQuery({
@@ -27,6 +39,7 @@ export default function useBadgeContentfulData(client, route) {
 			if (contentfulData) {
 				badgeImage = contentfulData?.[0]?.fields?.badgeImage?.fields?.file?.url ?? null;
 				badgeCategory = contentfulData?.[0]?.fields?.challengeName ?? '';
+				badgeTarget = levelsTarget?.[`level${contentfulData?.[0]?.fields?.level}`] ?? 0;
 			}
 		} catch (e) {
 			logReadQueryError(e, 'useBadgeContentfulData');
@@ -34,14 +47,15 @@ export default function useBadgeContentfulData(client, route) {
 
 		return {
 			badgeImage,
-			badgeCategory
+			badgeCategory,
+			badgeTarget,
 		};
 	};
 
 	return {
 		badgeQuery,
 		badgeKey,
-		isBadgeKeyValid: isUtmValid && defaultBadges.includes(badgeKey),
+		isBadgeKeyValid: isUtmValid && defaultBadges.some(badgeName => badgeKey.includes(badgeName)),
 		loadBadgeInfo,
 	};
 }

--- a/src/pages/LenderProfile/LenderProfile.vue
+++ b/src/pages/LenderProfile/LenderProfile.vue
@@ -99,6 +99,7 @@ export default {
 			enableBadgeContent: false,
 			badgeImage: null,
 			badgeCategory: '',
+			badgeTarget: 0,
 		};
 	},
 	apollo: {
@@ -125,8 +126,7 @@ export default {
 		},
 		pageTitle() {
 			if (this.enableBadgeContent) {
-				const checkoutLoans = this.$route.query?.badgeLoans ?? 0;
-				return `${this.lenderName} has supported ${checkoutLoans} to ${this.badgeCategory}`;
+				return `${this.lenderName} has supported ${this.badgeTarget} to ${this.badgeCategory}`;
 			}
 
 			let title = `Lender > ${this.lenderName}`;
@@ -169,9 +169,10 @@ export default {
 		const { isBadgeKeyValid, loadBadgeInfo } = useBadgeContentfulData(this.apollo, this.$route);
 
 		if (isBadgeKeyValid) {
-			const { badgeImage, badgeCategory } = await loadBadgeInfo();
+			const { badgeImage, badgeCategory, badgeTarget } = await loadBadgeInfo();
 			this.badgeImage = badgeImage;
 			this.badgeCategory = badgeCategory;
+			this.badgeTarget = badgeTarget;
 			this.enableBadgeContent = true;
 		}
 	}


### PR DESCRIPTION
Get the loan target with the new level field from Contentful. Also, as the badge key will have `-level-#` format, `isBadgeKeyValid` validation needed some adjustments