### PR TITLE
chore: filter out addition Failed to fetch calls from 3rd party scripts

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -135,7 +135,7 @@ async function setupSentry(app, router) {
 			// Skip Load failed caused by failed fetch calls in 3rd party libraries
 			// NOTE: we do see failed loads for our own async modules, this doesn't filter those out
 			// Sentry Event Link: https://kiva.sentry.io/issues/3808313433/events/427b92cf47ed4aaeb321caf20783eba0/
-			if (eventAsString.indexOf('Load failed') !== -1
+			if ((eventAsString.indexOf('Load failed') !== -1 || eventAsString.indexOf('Failed to fetch') !== -1)
 				&& (
 					(eventAsString.indexOf('ct.pinterest') !== -1)
 					|| (eventAsString.indexOf('rum.management') !== -1)


### PR DESCRIPTION
Excludes another/duplicate form of the Failed to fetch error from 3rd party scripts.