### PR TITLE
feat: continue expanding use of tiered badge data

### DIFF
--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -154,8 +154,7 @@ const positions = ref(getTierPositions());
 const tierCaption = index => {
 	const tier = sortedTiers.value[index];
 	if (tier.completedDate) {
-		// Date is in format "2024-10-22T18:49:21Z[UTC]"
-		return format(new Date(tier.completedDate.replace('[UTC]', '')), 'MMMM do, yyyy');
+		return format(new Date(tier.completedDate), 'MMMM do, yyyy');
 	}
 	if (tier.target) {
 		return `${props.badge.totalProgressToAchievement} of ${tier.target} loans`;

--- a/src/components/MyKiva/BadgesSection.vue
+++ b/src/components/MyKiva/BadgesSection.vue
@@ -10,7 +10,7 @@
 			}"
 		>
 			<span class="tw-text-base !tw-font-medium tw-text-center tw-mb-1">
-				{{ getBadgeTitle(badge) }}
+				{{ getCurrentTierData(badge).challengeName }}
 			</span>
 			<div
 				class="tw-p-1"
@@ -20,11 +20,11 @@
 				style="height: 148px;"
 			>
 				<img
-					:src="getBadgeImgUrl(badge)"
+					:src="getCurrentTierData(badge).imageUrl"
 					class="tw-h-full tw-mx-auto"
 				>
 			</div>
-			<div class="tw-flex tw-flex-col tw-gap-0.5 tw-mt-2 tw-font-medium">
+			<div class="tw-flex tw-flex-col tw-gap-0.5 tw-font-medium tw-grow">
 				<span
 					v-if="badge.hasStarted"
 					class="tw-mx-auto"
@@ -32,12 +32,12 @@
 					Level {{ badge.level }}/5
 				</span>
 				<button
-					class="tw-text-action hover:tw-underline"
+					class="tw-text-action hover:tw-underline tw-mt-auto"
 					v-kv-track-event="[
 						'portfolio',
 						'click',
 						badge.hasStarted ? 'Continue' : 'Start this journey',
-						getBadgeTitle(badge),
+						getCurrentTierData(badge).challengeName,
 						badge.level
 					]"
 					@click="() => $emit('badge-clicked', badge)"
@@ -52,6 +52,7 @@
 <script setup>
 import { computed } from 'vue';
 import { defaultBadges } from '#src/util/achievementUtils';
+import useBadgeData from '#src/composables/useBadgeData';
 
 defineEmits(['badge-clicked']);
 
@@ -62,11 +63,9 @@ const props = defineProps({
 	},
 });
 
+const { getCurrentTierData } = useBadgeData();
+
 const visibleBadges = computed(() => props.badgeData.filter(b => defaultBadges.includes(b.id)));
-
-const getBadgeTitle = badge => badge?.fields?.challengeName ?? '';
-
-const getBadgeImgUrl = badge => badge?.fields?.badgeImage?.fields?.file?.url ?? '';
 </script>
 
 <style lang="postcss" scoped>

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -131,7 +131,12 @@ const MY_KIVA_EXP_KEY = 'my_kiva_page';
 const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');
 
-const { badgeAchievementData, badgeData } = useBadgeData(apollo);
+const {
+	fetchAchievementData,
+	fetchContentfulData,
+	badgeAchievementData,
+	badgeData,
+} = useBadgeData(apollo);
 
 const lender = ref(null);
 const showNavigation = ref(false);
@@ -196,5 +201,8 @@ onMounted(() => {
 	);
 
 	$kvTrackEvent('portfolio', 'view', 'new-my-kiva');
+
+	fetchAchievementData(apollo);
+	fetchContentfulData(apollo);
 });
 </script>

--- a/test/unit/fixtures/useBadgeDataMock.js
+++ b/test/unit/fixtures/useBadgeDataMock.js
@@ -4431,7 +4431,7 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'us-economic-equality-level-1',
-						challengeName: 'U.S. economic equality',
+						challengeName: 'U.S. Economic equality',
 						level: 1,
 						badgeImage: {
 							metadata: {
@@ -8958,42 +8958,49 @@ export const combinedData = [
 				id: 'us-economic-equality',
 				level: 6,
 				levelName: 'U.S. Economic equality ✨50✨',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 7,
 				levelName: 'U.S. Economic equality ✨100✨',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 5,
 				levelName: 'U.S. Economic equality',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 4,
 				levelName: 'U.S. Economic equality',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 3,
 				levelName: 'U.S. Economic equality',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/27262f02db91bc35ab0b4ac06dbb940a/US_Business_40.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 2,
 				levelName: 'U.S. Economic equality',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 1,
-				levelName: 'U.S. economic equality',
+				levelName: 'U.S. Economic equality',
+				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg'
 			}
 		],
@@ -9061,7 +9068,7 @@ export const combinedData = [
 			]
 		},
 		hasStarted: true,
-		level: 1
+		level: 1,
 	},
 	{
 		id: 'climate-action',
@@ -9070,42 +9077,49 @@ export const combinedData = [
 				id: 'climate-action',
 				level: 7,
 				levelName: 'Climate action ✨100✨',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 6,
 				levelName: 'Climate action✨50✨',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 5,
 				levelName: 'Climate action',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 4,
 				levelName: 'Climate action',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 3,
 				levelName: 'Climate action',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 2,
 				levelName: 'Climate action',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 1,
 				levelName: 'Climate action',
+				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg'
 			}
 		],
@@ -9172,7 +9186,8 @@ export const combinedData = [
 				}
 			]
 		},
-		hasStarted: false
+		hasStarted: false,
+		level: undefined,
 	},
 	{
 		id: 'womens-equality',
@@ -9181,42 +9196,49 @@ export const combinedData = [
 				id: 'womens-equality',
 				level: 7,
 				levelName: "Women's equality ✨100✨",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 6,
 				levelName: "Women's equality ✨50✨",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 5,
 				levelName: "Women's equality",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 4,
 				levelName: "Women's equality",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 3,
 				levelName: "Women's equality",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 2,
 				levelName: "Women's equality",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 1,
 				levelName: "Women's equality",
+				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg'
 			}
 		],
@@ -9282,7 +9304,8 @@ export const combinedData = [
 				}
 			]
 		},
-		hasStarted: false
+		hasStarted: false,
+		level: undefined,
 	},
 	{
 		id: 'refugee-equality',
@@ -9291,42 +9314,49 @@ export const combinedData = [
 				id: 'refugee-equality',
 				level: 7,
 				levelName: 'Refugee equality ✨100✨',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 6,
 				levelName: 'Refugee equality ✨50✨',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 5,
 				levelName: 'Refugee equality',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 4,
 				levelName: 'Refugee equality',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 3,
 				levelName: 'Refugee equality',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 2,
 				levelName: 'Refugee equality',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 1,
 				levelName: 'Refugee equality',
+				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg'
 			}
 		],
@@ -9393,7 +9423,8 @@ export const combinedData = [
 				}
 			]
 		},
-		hasStarted: false
+		hasStarted: false,
+		level: undefined,
 	},
 	{
 		id: 'basic-needs',
@@ -9402,42 +9433,49 @@ export const combinedData = [
 				id: 'basic-needs',
 				level: 7,
 				levelName: 'Basic needs✨100✨',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 6,
 				levelName: 'Basic needs ✨50✨',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 5,
 				levelName: 'Basic needs',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 4,
 				levelName: 'Basic needs',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 3,
 				levelName: 'Basic needs',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 2,
 				levelName: 'Basic needs',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 1,
 				levelName: 'Basic needs',
+				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
 			}
 		],
@@ -9504,6 +9542,247 @@ export const combinedData = [
 				}
 			]
 		},
-		hasStarted: false
+		hasStarted: false,
+		level: undefined,
 	}
 ];
+
+export const badgeNoProgress = {
+	id: 'basic-needs',
+	contentfulData: [
+		{
+			id: 'basic-needs',
+			level: 7,
+			levelName: 'Basic needs✨100✨',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 6,
+			levelName: 'Basic needs ✨50✨',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 5,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 4,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 3,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 2,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 1,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
+		}
+	],
+	achievementData: {
+		__typename: 'TieredLendingAchievement',
+		id: 'basic-needs',
+		totalProgressToAchievement: 0,
+		tiers: [
+			{
+				__typename: 'Tier',
+				target: 2,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 1
+			},
+			{
+				__typename: 'Tier',
+				target: 3,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 2
+			},
+			{
+				__typename: 'Tier',
+				target: 5,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 3
+			},
+			{
+				__typename: 'Tier',
+				target: 10,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 4
+			},
+			{
+				__typename: 'Tier',
+				target: 20,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 5
+			},
+			{
+				__typename: 'Tier',
+				target: 50,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 6
+			},
+			{
+				__typename: 'Tier',
+				target: 100,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 7
+			}
+		]
+	},
+	hasStarted: false,
+	level: undefined,
+};
+
+export const badgeLastTier = {
+	id: 'basic-needs',
+	contentfulData: [
+		{
+			id: 'basic-needs',
+			level: 7,
+			levelName: 'Basic needs✨100✨',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 6,
+			levelName: 'Basic needs ✨50✨',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 5,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 4,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 3,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 2,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
+		},
+		{
+			id: 'basic-needs',
+			level: 1,
+			levelName: 'Basic needs',
+			challengeName: 'Basic needs',
+			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
+		}
+	],
+	achievementData: {
+		__typename: 'TieredLendingAchievement',
+		id: 'basic-needs',
+		totalProgressToAchievement: 95,
+		tiers: [
+			{
+				__typename: 'Tier',
+				target: 2,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
+				learnMoreURL: '',
+				level: 1
+			},
+			{
+				__typename: 'Tier',
+				target: 3,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
+				learnMoreURL: '',
+				level: 2
+			},
+			{
+				__typename: 'Tier',
+				target: 5,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
+				learnMoreURL: '',
+				level: 3
+			},
+			{
+				__typename: 'Tier',
+				target: 10,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
+				learnMoreURL: '',
+				level: 4
+			},
+			{
+				__typename: 'Tier',
+				target: 20,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
+				learnMoreURL: '',
+				level: 5
+			},
+			{
+				__typename: 'Tier',
+				target: 50,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
+				learnMoreURL: '',
+				level: 6
+			},
+			{
+				__typename: 'Tier',
+				target: 100,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: '',
+				level: 7
+			}
+		]
+	},
+	hasStarted: false,
+	level: undefined,
+};

--- a/test/unit/fixtures/useBadgeDataMock.js
+++ b/test/unit/fixtures/useBadgeDataMock.js
@@ -1,0 +1,9509 @@
+/* eslint-disable max-len */
+export const achievementData = {
+	userAchievementProgress: {
+		__typename: 'UserAchievements',
+		id: '5585493#class org.kiva.achievements.graphql.entity.UserAchievements',
+		tieredLendingAchievements: [
+			{
+				__typename: 'TieredLendingAchievement',
+				id: 'us-economic-equality',
+				totalProgressToAchievement: 2,
+				tiers: [
+					{
+						__typename: 'Tier',
+						target: 2,
+						tierStatement: 'statement1',
+						completedDate: '2024-10-22T18:49:21Z[UTC]',
+						learnMoreURL: 'https://www.kiva.org/'
+					},
+					{
+						__typename: 'Tier',
+						target: 3,
+						tierStatement: 'staTEMENT2',
+						completedDate: null,
+						learnMoreURL: 'https://www.kiva.org/'
+					},
+					{
+						__typename: 'Tier',
+						target: 5,
+						tierStatement: 'statement3',
+						completedDate: null,
+						learnMoreURL: 'https://www.kiva.org/'
+					},
+					{
+						__typename: 'Tier',
+						target: 10,
+						tierStatement: 'statement4',
+						completedDate: null,
+						learnMoreURL: 'https://www.kiva.org/'
+					},
+					{
+						__typename: 'Tier',
+						target: 20,
+						tierStatement: 'statement5',
+						completedDate: null,
+						learnMoreURL: 'https://www.kiva.org/'
+					},
+					{
+						__typename: 'Tier',
+						target: 50,
+						tierStatement: 'statement 6',
+						completedDate: null,
+						learnMoreURL: 'https://www.kiva.org/'
+					},
+					{
+						__typename: 'Tier',
+						target: 100,
+						tierStatement: 'statement 7',
+						completedDate: null,
+						learnMoreURL: 'https://www.kiva.org/'
+					}
+				]
+			},
+			{
+				__typename: 'TieredLendingAchievement',
+				id: 'climate-action',
+				totalProgressToAchievement: 0,
+				tiers: [
+					{
+						__typename: 'Tier',
+						target: 2,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 3,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 5,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 10,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 20,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 50,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 100,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					}
+				]
+			},
+			{
+				__typename: 'TieredLendingAchievement',
+				id: 'womens-equality',
+				totalProgressToAchievement: 0,
+				tiers: [
+					{
+						__typename: 'Tier',
+						target: 2,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 3,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 5,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 10,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 20,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 50,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 100,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					}
+				]
+			},
+			{
+				__typename: 'TieredLendingAchievement',
+				id: 'refugee-equality',
+				totalProgressToAchievement: 0,
+				tiers: [
+					{
+						__typename: 'Tier',
+						target: 2,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 3,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 5,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 10,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 20,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 50,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 100,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					}
+				]
+			},
+			{
+				__typename: 'TieredLendingAchievement',
+				id: 'basic-needs',
+				totalProgressToAchievement: 0,
+				tiers: [
+					{
+						__typename: 'Tier',
+						target: 2,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 3,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 5,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 10,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 20,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 50,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					},
+					{
+						__typename: 'Tier',
+						target: 100,
+						tierStatement: '',
+						completedDate: null,
+						learnMoreURL: ''
+					}
+				]
+			}
+		]
+	}
+};
+
+export const contentfulData = {
+	contentful: {
+		__typename: 'Contentful',
+		entries: {
+			sys: {
+				type: 'Array'
+			},
+			total: 45,
+			skip: 0,
+			limit: 200,
+			items: [
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5pPaBjhrIf2qmEScZZxHp',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:31:30.591Z',
+						updatedAt: '2024-10-25T01:03:31.204Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 14,
+						revision: 4,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-6',
+						challengeName: 'U.S. Economic equality ✨50✨',
+						level: 6,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4nUE568E3WCZ1rYpbH3G1z',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:31:17.425Z',
+								updatedAt: '2024-10-25T00:51:55.052Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg',
+									details: {
+										size: 43294,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4nUE568E3WCZ1rYpbH3G1z',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:31:17.425Z',
+								updatedAt: '2024-10-25T00:51:55.052Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg',
+									details: {
+										size: 43294,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '6WZsKCCbervj1xAiXnZJEZ',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:36:17.356Z',
+						updatedAt: '2024-10-25T01:01:59.001Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 10,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-7',
+						challengeName: 'Refugee equality ✨100✨',
+						level: 7,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1vGn9ZCa3OFC7Tiqv14G7K',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:35:50.256Z',
+								updatedAt: '2024-10-25T00:41:08.229Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg',
+									details: {
+										size: 40515,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1vGn9ZCa3OFC7Tiqv14G7K',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:35:50.256Z',
+								updatedAt: '2024-10-25T00:41:08.229Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg',
+									details: {
+										size: 40515,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '79J012kjCp1PjEXr7hXwfI',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:34:43.402Z',
+						updatedAt: '2024-10-25T01:01:47.707Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 10,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-6',
+						challengeName: 'Refugee equality ✨50✨',
+						level: 6,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4sN0hJtCkirthBDrSOh2YA',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:34:18.062Z',
+								updatedAt: '2024-10-25T00:40:09.265Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 11,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg',
+									details: {
+										size: 44192,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4sN0hJtCkirthBDrSOh2YA',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:34:18.062Z',
+								updatedAt: '2024-10-25T00:40:09.265Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 11,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg',
+									details: {
+										size: 44192,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '19CXqj1hWQhbdQKQV4JCGE',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:22:21.571Z',
+						updatedAt: '2024-10-25T01:01:28.572Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 11,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-7',
+						challengeName: 'Climate action ✨100✨',
+						level: 7,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: 'JdDGpZIjI7FXBouv3bJa4',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:21:23.897Z',
+								updatedAt: '2024-10-25T00:33:17.425Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg',
+									details: {
+										size: 34255,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: 'JdDGpZIjI7FXBouv3bJa4',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:21:23.897Z',
+								updatedAt: '2024-10-25T00:33:17.425Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg',
+									details: {
+										size: 34255,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '4n6Alaz3IHt9u73Y734Exc',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:20:09.944Z',
+						updatedAt: '2024-10-25T01:01:17.127Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 12,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-6',
+						challengeName: 'Climate action✨50✨',
+						level: 6,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3vmiyohO4jjDEwnzO4QMZh',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:19:44.764Z',
+								updatedAt: '2024-10-25T00:32:35.143Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 12,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg',
+									details: {
+										size: 14373,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3vmiyohO4jjDEwnzO4QMZh',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:19:44.764Z',
+								updatedAt: '2024-10-25T00:32:35.143Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 12,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg',
+									details: {
+										size: 14373,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '74fUSHpBBcQ5XWzYJq8Xpu',
+						type: 'Entry',
+						createdAt: '2024-10-10T01:07:09.610Z',
+						updatedAt: '2024-10-25T01:00:37.297Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 11,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-7',
+						challengeName: 'Basic needs✨100✨',
+						level: 7,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1LLL9K4PgaUZb3H0JLWEPU',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:06:37.362Z',
+								updatedAt: '2024-10-25T00:15:11.836Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
+									details: {
+										size: 10243,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1LLL9K4PgaUZb3H0JLWEPU',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:06:37.362Z',
+								updatedAt: '2024-10-25T00:15:11.836Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
+									details: {
+										size: 10243,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5mXBWjX6Z24yAySZXri0md',
+						type: 'Entry',
+						createdAt: '2024-10-10T01:05:48.217Z',
+						updatedAt: '2024-10-25T01:00:15.660Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 14,
+						revision: 4,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-6',
+						challengeName: 'Basic needs ✨50✨',
+						level: 6,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: 'ESTL9bCh4khif4gxZO8ft',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:05:08.610Z',
+								updatedAt: '2024-10-25T00:13:58.662Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg',
+									details: {
+										size: 36584,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: 'ESTL9bCh4khif4gxZO8ft',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:05:08.610Z',
+								updatedAt: '2024-10-25T00:13:58.662Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg',
+									details: {
+										size: 36584,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 60.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '7aGHF4GQrgMhhWfuWhp0Mp',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:51:38.738Z',
+						updatedAt: '2024-10-25T00:59:43.508Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 11,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-7',
+						challengeName: "Women's equality ✨100✨",
+						level: 7,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2rJH0UWfITf7KPuySP8x9',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:51:19.821Z',
+								updatedAt: '2024-10-25T00:59:38.810Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg',
+									details: {
+										size: 45263,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2rJH0UWfITf7KPuySP8x9',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:51:19.821Z',
+								updatedAt: '2024-10-25T00:59:38.810Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg',
+									details: {
+										size: 45263,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5EdYCzSBBSt2bzP2rOLDRY',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:50:12.503Z',
+						updatedAt: '2024-10-25T00:58:32.797Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-6',
+						challengeName: "Women's equality ✨50✨",
+						level: 6,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '5SpskyxoH08WfjVuzXjq6T',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:49:37.971Z',
+								updatedAt: '2024-10-23T22:03:33.377Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 2,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg',
+									details: {
+										size: 40971,
+										image: {
+											width: 204,
+											height: 285
+										}
+									},
+									fileName: 'Women 75.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '5SpskyxoH08WfjVuzXjq6T',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:49:37.971Z',
+								updatedAt: '2024-10-23T22:03:33.377Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 2,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 6',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg',
+									details: {
+										size: 40971,
+										image: {
+											width: 204,
+											height: 285
+										}
+									},
+									fileName: 'Women 75.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '4B3UaqephhpkVBNzaxEVVE',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:48:24.166Z',
+						updatedAt: '2024-10-25T00:58:00.420Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 8,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-5',
+						challengeName: "Women's equality",
+						level: 5,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6mqr1eJTJHksfTlRmpI7bB',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:48:07.039Z',
+								updatedAt: '2024-10-25T00:57:55.264Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg',
+									details: {
+										size: 41429,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6mqr1eJTJHksfTlRmpI7bB',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:48:07.039Z',
+								updatedAt: '2024-10-25T00:57:55.264Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg',
+									details: {
+										size: 41429,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '2gxBIB5dWakNphtXT8Ez5K',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:46:47.006Z',
+						updatedAt: '2024-10-25T00:57:14.148Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-4',
+						challengeName: "Women's equality",
+						level: 4,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '15RLZ1WiHmGQgtlkkMZTH0',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:46:29.744Z',
+								updatedAt: '2024-10-25T00:57:04.439Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg',
+									details: {
+										size: 53983,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '15RLZ1WiHmGQgtlkkMZTH0',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:46:29.744Z',
+								updatedAt: '2024-10-25T00:57:04.439Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg',
+									details: {
+										size: 53983,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '4Jfh3AQdMvs5TZktlHt0He',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:42:52.117Z',
+						updatedAt: '2024-10-25T00:56:31.036Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 7,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-3',
+						challengeName: "Women's equality",
+						level: 3,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '25FLM7Cyv1kik5nFkdIT2O',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:42:26.656Z',
+								updatedAt: '2024-10-25T00:56:22.416Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 9,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg',
+									details: {
+										size: 38908,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '25FLM7Cyv1kik5nFkdIT2O',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:42:26.656Z',
+								updatedAt: '2024-10-25T00:56:22.416Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 9,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg',
+									details: {
+										size: 38908,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '6LTVHnwawnDngL1TqoIlfw',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:41:23.766Z',
+						updatedAt: '2024-10-25T00:55:49.906Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 8,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-2',
+						challengeName: "Women's equality",
+						level: 2,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6PcVN0gI5MIwytZm5AFQ32',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:40:54.347Z',
+								updatedAt: '2024-10-25T00:55:45.440Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg',
+									details: {
+										size: 36814,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6PcVN0gI5MIwytZm5AFQ32',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:40:54.347Z',
+								updatedAt: '2024-10-25T00:55:45.440Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg',
+									details: {
+										size: 36814,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '2QeWQR6pXKFh3I74dqS0e0',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:32:39.633Z',
+						updatedAt: '2024-10-25T00:52:44.632Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 13,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-7',
+						challengeName: 'U.S. Economic equality ✨100✨',
+						level: 7,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6p6BcDBlAb7ZoCaZaypJIT',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:32:25.037Z',
+								updatedAt: '2024-10-25T00:53:09.706Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 9,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equalitty Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg',
+									details: {
+										size: 43444,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6p6BcDBlAb7ZoCaZaypJIT',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:32:25.037Z',
+								updatedAt: '2024-10-25T00:53:09.706Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 9,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equalitty Level 7',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg',
+									details: {
+										size: 43444,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 70.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5S0r7mPll6B4dB7Y37H5QG',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:30:17.753Z',
+						updatedAt: '2024-10-25T00:47:25.940Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-5',
+						challengeName: 'U.S. Economic equality',
+						level: 5,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2s7t7DyW1EBoF4S7HhO4eZ',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:30:00.156Z',
+								updatedAt: '2024-10-25T00:47:22.575Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg',
+									details: {
+										size: 43277,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2s7t7DyW1EBoF4S7HhO4eZ',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:30:00.156Z',
+								updatedAt: '2024-10-25T00:47:22.575Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg',
+									details: {
+										size: 43277,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '2eJ8dYOxfkCXUYT8UhSKdW',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:28:25.438Z',
+						updatedAt: '2024-10-25T00:46:56.215Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-4',
+						challengeName: 'U.S. Economic equality',
+						level: 4,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4f5MR6ggWdXx3AC7oxx596',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:28:08.418Z',
+								updatedAt: '2024-10-25T00:46:52.600Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg',
+									details: {
+										size: 44264,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4f5MR6ggWdXx3AC7oxx596',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:28:08.418Z',
+								updatedAt: '2024-10-25T00:46:52.600Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg',
+									details: {
+										size: 44264,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '3yqBniSubwAXimMzi8mApN',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:26:55.820Z',
+						updatedAt: '2024-10-25T00:45:53.867Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-3',
+						challengeName: 'U.S. Economic equality',
+						level: 3,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4q0Das9uTU0gfrwtld137n',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:26:40.755Z',
+								updatedAt: '2024-10-25T00:45:45.790Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/27262f02db91bc35ab0b4ac06dbb940a/US_Business_40.svg',
+									details: {
+										size: 44264,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4q0Das9uTU0gfrwtld137n',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:26:40.755Z',
+								updatedAt: '2024-10-25T00:45:45.790Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/27262f02db91bc35ab0b4ac06dbb940a/US_Business_40.svg',
+									details: {
+										size: 44264,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5qVq3IF07C8um3AiQVjLK5',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:25:25.114Z',
+						updatedAt: '2024-10-25T00:45:13.168Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 16,
+						revision: 5,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-2',
+						challengeName: 'U.S. Economic equality',
+						level: 2,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '62zEUpZbO7qWZPoV1z2pZU',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:25:01.320Z',
+								updatedAt: '2024-10-25T00:45:08.112Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg',
+									details: {
+										size: 56655,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '62zEUpZbO7qWZPoV1z2pZU',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:25:01.320Z',
+								updatedAt: '2024-10-25T00:45:08.112Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg',
+									details: {
+										size: 56655,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						shareFact: '3 in 5 U.S. business owners brought in more income after their Kiva loan.*',
+						shareFactUrl: '/',
+						dateTagline: 'N/A',
+						shareFactFootnote: 'Kiva borrowers surveyed by 60 Decibels.'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '6QI7bc6qPyYKdE6odm7xxl',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:33:00.953Z',
+						updatedAt: '2024-10-25T00:39:28.545Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 7,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-5',
+						challengeName: 'Refugee equality',
+						level: 5,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6oSmu0Kc94YpMllGEsw2o4',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:32:36.416Z',
+								updatedAt: '2024-10-25T00:39:21.985Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 11,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg',
+									details: {
+										size: 42027,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6oSmu0Kc94YpMllGEsw2o4',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:32:36.416Z',
+								updatedAt: '2024-10-25T00:39:21.985Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 11,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg',
+									details: {
+										size: 42027,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '4VOqHkT6KUwNuXS96YXFwC',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:31:23.054Z',
+						updatedAt: '2024-10-25T00:38:44.477Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-4',
+						challengeName: 'Refugee equality',
+						level: 4,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2rCdTrkgqrajqscTGgt6YZ',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:30:51.968Z',
+								updatedAt: '2024-10-23T22:13:59.763Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 2,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refuguee Equality Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg',
+									details: {
+										size: 44141,
+										image: {
+											width: 305,
+											height: 235
+										}
+									},
+									fileName: 'Refugees 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2rCdTrkgqrajqscTGgt6YZ',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:30:51.968Z',
+								updatedAt: '2024-10-23T22:13:59.763Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 2,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refuguee Equality Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg',
+									details: {
+										size: 44141,
+										image: {
+											width: 305,
+											height: 235
+										}
+									},
+									fileName: 'Refugees 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '3vMgizGv9viPk3NFOnJLda',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:29:17.453Z',
+						updatedAt: '2024-10-25T00:38:27.784Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 10,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-3',
+						challengeName: 'Refugee equality',
+						level: 3,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '5TO71LArbZCXuey6JJnrm8',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:28:53.736Z',
+								updatedAt: '2024-10-25T00:38:23.764Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg',
+									details: {
+										size: 39593,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '5TO71LArbZCXuey6JJnrm8',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:28:53.736Z',
+								updatedAt: '2024-10-25T00:38:23.764Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg',
+									details: {
+										size: 39593,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '0lZZzFUYvCt33bnwp31jQ',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:27:06.017Z',
+						updatedAt: '2024-10-25T00:37:56.782Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-2',
+						challengeName: 'Refugee equality',
+						level: 2,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4EfRGWaySxx9eCxkwJJ71S',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:26:47.031Z',
+								updatedAt: '2024-10-25T00:37:53.038Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 14,
+								revision: 4,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg',
+									details: {
+										size: 40113,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4EfRGWaySxx9eCxkwJJ71S',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:26:47.031Z',
+								updatedAt: '2024-10-25T00:37:53.038Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 14,
+								revision: 4,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg',
+									details: {
+										size: 40113,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '7dypOUbh6EUjDj5mncqqho',
+						type: 'Entry',
+						createdAt: '2024-10-09T23:55:03.591Z',
+						updatedAt: '2024-10-25T00:31:48.426Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 8,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-5',
+						challengeName: 'Climate action',
+						level: 5,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7LVRDYs9PmApE3LhZ4D4Ek',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:54:55.689Z',
+								updatedAt: '2024-10-25T00:31:29.203Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg',
+									details: {
+										size: 16086,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7LVRDYs9PmApE3LhZ4D4Ek',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:54:55.689Z',
+								updatedAt: '2024-10-25T00:31:29.203Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg',
+									details: {
+										size: 16086,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '1VERJxTGHCi2eW4pc7HZVE',
+						type: 'Entry',
+						createdAt: '2024-10-09T23:52:35.668Z',
+						updatedAt: '2024-10-25T00:29:02.950Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 8,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-4',
+						challengeName: 'Climate action',
+						level: 4,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4FAMdCiqyrNBzGH7IzYJ6G',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:51:55.037Z',
+								updatedAt: '2024-10-25T00:30:44.010Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 14,
+								revision: 4,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg',
+									details: {
+										size: 41414,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4FAMdCiqyrNBzGH7IzYJ6G',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:51:55.037Z',
+								updatedAt: '2024-10-25T00:30:44.010Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 14,
+								revision: 4,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg',
+									details: {
+										size: 41414,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: 'IWXIn9gBEKnw3knHnVPeF',
+						type: 'Entry',
+						createdAt: '2024-10-09T23:40:09.987Z',
+						updatedAt: '2024-10-25T00:27:47.494Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-3',
+						challengeName: 'Climate action',
+						level: 3,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6dKOH8W4ZCWxTO7OXPfAWo',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:39:51.822Z',
+								updatedAt: '2024-10-25T00:27:43.231Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg',
+									details: {
+										size: 52177,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6dKOH8W4ZCWxTO7OXPfAWo',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:39:51.822Z',
+								updatedAt: '2024-10-25T00:27:43.231Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg',
+									details: {
+										size: 52177,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5OHOXyQzSmMjKEkJ3NeJhU',
+						type: 'Entry',
+						createdAt: '2024-10-09T23:36:59.417Z',
+						updatedAt: '2024-10-25T00:27:11.319Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-2',
+						challengeName: 'Climate action',
+						level: 2,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7crCD9q1xCii5mcLAj3SKa',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:36:02.795Z',
+								updatedAt: '2024-10-25T00:27:04.325Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg',
+									details: {
+										size: 34776,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7crCD9q1xCii5mcLAj3SKa',
+								type: 'Asset',
+								createdAt: '2024-10-09T23:36:02.795Z',
+								updatedAt: '2024-10-25T00:27:04.325Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg',
+									details: {
+										size: 34776,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: 'JKtgxZ2Iva9pOyn6wURQd',
+						type: 'Entry',
+						createdAt: '2024-10-10T01:04:14.087Z',
+						updatedAt: '2024-10-25T00:09:21.015Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 7,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-5',
+						challengeName: 'Basic needs',
+						level: 5,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6m9RP1jcZxZMz5EqWyl8a8',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:04:00.519Z',
+								updatedAt: '2024-10-25T00:09:15.381Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg',
+									details: {
+										size: 36080,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6m9RP1jcZxZMz5EqWyl8a8',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:04:00.519Z',
+								updatedAt: '2024-10-25T00:09:15.381Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 5',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg',
+									details: {
+										size: 36080,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 50.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '1r6ZSk4MUX3z1wDGxJkTqJ',
+						type: 'Entry',
+						createdAt: '2024-10-10T01:01:51.770Z',
+						updatedAt: '2024-10-25T00:07:47.459Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 8,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-4',
+						challengeName: 'Basic needs',
+						level: 4,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2AptyhDdjcbumiax0upWWZ',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:01:25.949Z',
+								updatedAt: '2024-10-25T00:08:25.562Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg',
+									details: {
+										size: 38003,
+										image: {
+											width: 312,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2AptyhDdjcbumiax0upWWZ',
+								type: 'Asset',
+								createdAt: '2024-10-10T01:01:25.949Z',
+								updatedAt: '2024-10-25T00:08:25.562Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 4',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg',
+									details: {
+										size: 38003,
+										image: {
+											width: 312,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 40.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '69IrwpdJJeP0EcHeOFC3d5',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:56:28.545Z',
+						updatedAt: '2024-10-25T00:07:32.030Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-3',
+						challengeName: 'Basic needs',
+						level: 3,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1dZrR0nnWsEB9AGjW2qOL6',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:55:59.655Z',
+								updatedAt: '2024-10-25T00:07:17.490Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 4,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg',
+									details: {
+										size: 39983,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1dZrR0nnWsEB9AGjW2qOL6',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:55:59.655Z',
+								updatedAt: '2024-10-25T00:07:17.490Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 13,
+								revision: 4,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 3',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg',
+									details: {
+										size: 39983,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 30.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: 'jaBgOTiYjm8brXaoioHM7',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:54:19.888Z',
+						updatedAt: '2024-10-25T00:06:04.731Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 12,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-2',
+						challengeName: 'Basic needs',
+						level: 2,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: 'SHdA5oclQUy5T5YQhfTd2',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:53:51.110Z',
+								updatedAt: '2024-10-25T00:05:44.600Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 11,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg',
+									details: {
+										size: 39056,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: 'SHdA5oclQUy5T5YQhfTd2',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:53:51.110Z',
+								updatedAt: '2024-10-25T00:05:44.600Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 11,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 2',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg',
+									details: {
+										size: 39056,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 20.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '1lNynXs488ebCIG8mLh21n',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:53:03.111Z',
+						updatedAt: '2024-10-25T00:01:01.407Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 11,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'basic-needs-level-1',
+						challengeName: 'Basic needs',
+						level: 1,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '694uSymh8om0MxbiCjWZxl',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:52:28.620Z',
+								updatedAt: '2024-10-25T00:00:36.874Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg',
+									details: {
+										size: 40244,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '694uSymh8om0MxbiCjWZxl',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:52:28.620Z',
+								updatedAt: '2024-10-25T00:00:36.874Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Basic Needs Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg',
+									details: {
+										size: 40244,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Basic Needs 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '1v6rjxNM5uJeQaNEGdn0vR',
+						type: 'Entry',
+						createdAt: '2024-10-08T20:24:07.013Z',
+						updatedAt: '2024-10-21T20:28:12.061Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 12,
+						revision: 4,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'us-economic-equality-level-1',
+						challengeName: 'U.S. economic equality',
+						level: 1,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3C3ddaga4hEXBlb9WxsdlQ',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:23:21.487Z',
+								updatedAt: '2024-10-25T00:44:19.738Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg',
+									details: {
+										size: 40688,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3C3ddaga4hEXBlb9WxsdlQ',
+								type: 'Asset',
+								createdAt: '2024-10-08T20:23:21.487Z',
+								updatedAt: '2024-10-25T00:44:19.738Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'US Economic Equality Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg',
+									details: {
+										size: 40688,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'US Business 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						shareFact: 'Take action and address financial inequity in communities throughout the United States that have been historically and systemically marginalized.',
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '4ngwxEsVsA2ofpZqP3E3L4',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:25:03.086Z',
+						updatedAt: '2024-10-16T20:29:57.199Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'refugee-equality-level-1',
+						challengeName: 'Refugee equality',
+						level: 1,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1SEhQMUbYUqZopjP2o67XK',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:24:28.661Z',
+								updatedAt: '2024-10-25T00:36:16.661Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg',
+									details: {
+										size: 16732,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1SEhQMUbYUqZopjP2o67XK',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:24:28.661Z',
+								updatedAt: '2024-10-25T00:36:16.661Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Refugee Equality Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg',
+									details: {
+										size: 16732,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Refugees 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '3VqGHCjMPkMaGvwjpcD6zn',
+						type: 'Entry',
+						createdAt: '2024-10-09T18:48:42.290Z',
+						updatedAt: '2024-10-16T20:27:48.485Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 9,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-action-level-1',
+						challengeName: 'Climate action',
+						level: 1,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3YklKNLbiA4kAcOgk5ouaw',
+								type: 'Asset',
+								createdAt: '2024-10-09T18:48:25.407Z',
+								updatedAt: '2024-10-25T00:26:15.049Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg',
+									details: {
+										size: 38861,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3YklKNLbiA4kAcOgk5ouaw',
+								type: 'Asset',
+								createdAt: '2024-10-09T18:48:25.407Z',
+								updatedAt: '2024-10-25T00:26:15.049Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Climate Action Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg',
+									details: {
+										size: 38861,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Climate 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '15kVO6p07zb9upT9HLK0zv',
+						type: 'Entry',
+						createdAt: '2024-10-10T00:39:30.956Z',
+						updatedAt: '2024-10-16T20:23:46.169Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 8,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'womens-equality-level-1',
+						challengeName: "Women's equality",
+						level: 1,
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3dAEh0zYSkqK5Up5q8Flv8',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:38:47.073Z',
+								updatedAt: '2024-10-25T00:54:54.599Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg',
+									details: {
+										size: 43685,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3dAEh0zYSkqK5Up5q8Flv8',
+								type: 'Asset',
+								createdAt: '2024-10-10T00:38:47.073Z',
+								updatedAt: '2024-10-25T00:54:54.599Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 10,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Women Level 1',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg',
+									details: {
+										size: 43685,
+										image: {
+											width: 313,
+											height: 313
+										}
+									},
+									fileName: 'Women 10.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'N/A'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '59P1CzNvXrjb1s9efHBJuI',
+						type: 'Entry',
+						createdAt: '2024-09-12T22:17:49.610Z',
+						updatedAt: '2024-09-12T22:17:49.610Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 6,
+						revision: 1,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'equity',
+						challengeName: 'Equity Badge',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6yl0sXP8fgaRaRwIaEVJO4',
+								type: 'Asset',
+								createdAt: '2024-09-12T22:17:31.431Z',
+								updatedAt: '2024-09-12T22:17:31.431Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Equity Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6yl0sXP8fgaRaRwIaEVJO4/89ce4fae6c80ab1aed59a1e3ad055c3b/Equality_Badge_SVG.svg',
+									details: {
+										size: 10000,
+										image: {
+											width: 180,
+											height: 185
+										}
+									},
+									fileName: 'Equality Badge@SVG.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '6yl0sXP8fgaRaRwIaEVJO4',
+								type: 'Asset',
+								createdAt: '2024-09-12T22:17:31.431Z',
+								updatedAt: '2024-09-12T22:17:31.431Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Equity Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/6yl0sXP8fgaRaRwIaEVJO4/89ce4fae6c80ab1aed59a1e3ad055c3b/Equality_Badge_SVG.svg',
+									details: {
+										size: 10000,
+										image: {
+											width: 180,
+											height: 185
+										}
+									},
+									fileName: 'Equality Badge@SVG.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						dateTagline: 'n/a'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: 'YV0efFSVDpAnt1pFWGu6Y',
+						type: 'Entry',
+						createdAt: '2024-06-11T17:52:46.119Z',
+						updatedAt: '2024-06-11T17:52:46.119Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 15,
+						revision: 1,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'wrd-2024-challenge',
+						challengeName: '2024 World Refugee Day',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '5fTewx3XPCnvCujcDkvEvH',
+								type: 'Asset',
+								createdAt: '2024-06-11T17:47:17.290Z',
+								updatedAt: '2024-06-11T17:47:17.290Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: '2024 World Refugee Day Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/5fTewx3XPCnvCujcDkvEvH/ccdd1774f3194febdb55db0d6a1e37e8/WRD24Badge.svg',
+									details: {
+										size: 55750,
+										image: {
+											width: 148,
+											height: 152
+										}
+									},
+									fileName: 'WRD24Badge.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4FdrRfytu5gB8WK2C8Gl6b',
+								type: 'Asset',
+								createdAt: '2024-06-11T17:49:18.476Z',
+								updatedAt: '2024-06-11T17:49:18.476Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: '2024 World Refugee Day Thank You',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4FdrRfytu5gB8WK2C8Gl6b/aa7af154097aa0c65b5888586713a904/WRD24_thankyou.png',
+									details: {
+										size: 623504,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'WRD24_thankyou.png',
+									contentType: 'image/png'
+								}
+							}
+						},
+						thankYouCopyInProgress: {
+							nodeType: 'document',
+							data: {},
+							content: [
+								{
+									nodeType: 'paragraph',
+									data: {},
+									content: [
+										{
+											nodeType: 'text',
+											value: 'You have almost completed the 2024 World Refugee Day challenge! Thank you for supporting vital financial access and inclusion for refugees and displaced communities.',
+											marks: [],
+											data: {}
+										}
+									]
+								}
+							]
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You completed the 2024 World Refugee Day challenge and earned this limited-edition badge! Thank you for supporting vital financial access and inclusion for refugees and displaced communities.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'This World Refugee Day, people like you are helping refugees regain their footing and improve their livelihoods. Today, 1 in every 71 people is forcibly displaced. Kiva is committed to supporting 450,000 refugees & people impacted by forced displacement by 2028.',
+						shareFactUrl: '/blog/refugees',
+						dateTagline: 'June 2024'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5kQiQZGa7hXwwVS2k7ZaL',
+						type: 'Entry',
+						createdAt: '2024-04-10T20:53:41.004Z',
+						updatedAt: '2024-04-10T20:53:41.004Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 12,
+						revision: 1,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'earth-day-2024-challenge',
+						challengeName: 'Earth Day Challenge',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2LVZNRwHjKwnr3vYYsjK4f',
+								type: 'Asset',
+								createdAt: '2024-04-10T20:45:16.856Z',
+								updatedAt: '2024-04-10T20:45:16.856Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Earth Day 2024 Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2LVZNRwHjKwnr3vYYsjK4f/d52b6f92de144840929d4169e68bb12e/EarthDay24_badge.svg',
+									details: {
+										size: 10441,
+										image: {
+											width: 200,
+											height: 200
+										}
+									},
+									fileName: 'EarthDay24_badge.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2WqKsGZYLhVJpWf5Ihnfcy',
+								type: 'Asset',
+								createdAt: '2024-04-10T20:46:01.117Z',
+								updatedAt: '2024-04-10T20:46:01.117Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 5,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Earth Day 2024 Badge Thank You',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2WqKsGZYLhVJpWf5Ihnfcy/80c34c625942fca1695ae4549b1409ea/ED_thankyou_badge.png',
+									details: {
+										size: 771555,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'ED_thankyou_badge.png',
+									contentType: 'image/png'
+								}
+							}
+						},
+						thankYouCopyInProgress: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Almost there!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You have to support 1 more loan to complete this challenge.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You earned the 2024 Earth Day badge! Your support means the world to climate-vulnerable communities.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'You just supported someone facing challenges from climate change. It may seem like a small action, but when so many Kivans take it, it adds up to a more sustainable future for us all. \n\nOver 2 billion underbanked people worldwide are a single major climate event away from losing everything. Learn more about how Kiva is supporting the communities most at risk - and how your action today plays a role. ',
+						shareFactUrl: '/blog/climate-resilience',
+						dateTagline: 'April 2024'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5zlEuP6c5udJyxUxG54GKl',
+						type: 'Entry',
+						createdAt: '2023-05-24T21:15:50.224Z',
+						updatedAt: '2024-02-08T23:30:17.683Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 19,
+						revision: 4,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'iwd-challenge',
+						challengeName: "Women's Day Challenge",
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '4FT6YzFE07Iv40CIWDFcvk',
+								type: 'Asset',
+								createdAt: '2024-02-08T23:29:44.469Z',
+								updatedAt: '2024-02-08T23:29:44.469Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: "Women's Day Challenge Badge",
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/4FT6YzFE07Iv40CIWDFcvk/f9d433da2d343fd09b37f9fe722de0ee/iwd-badge.svg',
+									details: {
+										size: 10778,
+										image: {
+											width: 144,
+											height: 144
+										}
+									},
+									fileName: 'iwd-badge.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '79ZtLGf78ixp46twJjrQxD',
+								type: 'Asset',
+								createdAt: '2024-02-08T23:30:14.651Z',
+								updatedAt: '2024-02-08T23:30:14.651Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: "Women's Day Challenge Thank You Image",
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/79ZtLGf78ixp46twJjrQxD/6c3ac0a60f0e288d40554f30177f4660/IWDthankyou_badge_2x__1_.jpg',
+									details: {
+										size: 120536,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'IWDthankyou_badge_2x__1_.jpg',
+									contentType: 'image/jpeg'
+								}
+							}
+						},
+						thankYouCopyInProgress: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Almost there!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You have to support 1 more loan to complete this challenge.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You earned the 2023 International Women’s Day badge by lending to a woman! Thank you for supporting gender equity worldwide.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'This International Women’s Day, you made a tangible difference in a woman’s life! Globally, the number of unbanked women has dropped 24% in the last six years. Kiva is chipping away at that number and advancing gender equity every day.',
+						shareFactUrl: '/gender-equality',
+						dateTagline: 'March 2023'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '7bx7VdjHbGJSmpGJJ3qtz1',
+						type: 'Entry',
+						createdAt: '2024-02-08T20:10:09.741Z',
+						updatedAt: '2024-02-08T23:28:44.957Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 11,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'iwd-2024-challenge',
+						challengeName: "Women's Day Challenge",
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7r9kCerMO7HTTyFVUIEpwc',
+								type: 'Asset',
+								createdAt: '2024-02-08T23:27:08.576Z',
+								updatedAt: '2024-02-08T23:28:06.645Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 8,
+								revision: 2,
+								locale: 'en-US'
+							},
+							fields: {
+								title: "Women's Day Challenge Badge 2024",
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7r9kCerMO7HTTyFVUIEpwc/eff30216165fdc93775b8783993f9357/Badge.png',
+									details: {
+										size: 22006,
+										image: {
+											width: 320,
+											height: 320
+										}
+									},
+									fileName: 'Badge.png',
+									contentType: 'image/png'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '1M9ILbpZgeR2asP0a7Qp28',
+								type: 'Asset',
+								createdAt: '2024-02-08T23:28:32.073Z',
+								updatedAt: '2024-02-08T23:28:32.073Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: "Women's Day Challenge Thank You Image 2024",
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/1M9ILbpZgeR2asP0a7Qp28/68af348c87f8800edd1d37bb0ee69ba5/thankyou_badge.png',
+									details: {
+										size: 70029,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'thankyou_badge.png',
+									contentType: 'image/png'
+								}
+							}
+						},
+						thankYouCopyInProgress: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Almost there!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You have to support 1 more loan to complete this challenge.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You earned the 2024 International Women’s Day badge by lending to a woman! Thank you for supporting gender equity worldwide.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'This International Women’s Day, you made a tangible difference in a woman’s life! Globally, the number of unbanked women has dropped 24% in the last six years. Kiva is chipping away at that number and advancing gender equity every day.',
+						shareFactUrl: '/gender-equality',
+						dateTagline: 'March 2024'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '59BKYNi8Q77ZQ5T6SHBPAY',
+						type: 'Entry',
+						createdAt: '2023-05-24T20:49:40.497Z',
+						updatedAt: '2023-10-23T21:22:20.226Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 20,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'climate-challenge',
+						challengeName: 'Eco-friendly Challenge',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7vPGmOjS7F8PZGAymeLzG2',
+								type: 'Asset',
+								createdAt: '2023-05-24T20:40:32.283Z',
+								updatedAt: '2023-05-24T20:40:32.283Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Eco-friendly October Challenge Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7vPGmOjS7F8PZGAymeLzG2/98f5db81230cb26e360bb6b9490287e0/eco-badge.svg',
+									details: {
+										size: 7050,
+										image: {
+											width: 95,
+											height: 109
+										}
+									},
+									fileName: 'eco-badge.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '7vPGmOjS7F8PZGAymeLzG2',
+								type: 'Asset',
+								createdAt: '2023-05-24T20:40:32.283Z',
+								updatedAt: '2023-05-24T20:40:32.283Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Eco-friendly October Challenge Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/7vPGmOjS7F8PZGAymeLzG2/98f5db81230cb26e360bb6b9490287e0/eco-badge.svg',
+									details: {
+										size: 7050,
+										image: {
+											width: 95,
+											height: 109
+										}
+									},
+									fileName: 'eco-badge.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouCopyInProgress: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go! ',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: "By supporting this eco-friendly loan, you're enabling sustainable lifestyles that slow climate change.",
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go! ',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: "You've joined more than 800 lenders in collective action against climate change.",
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'Did you know that a biodigester is a system that transforms livestock waste (💩) into organic fertilizer for crops, as well as biogas that can be used for household energy?',
+						shareFactUrl: '/blog/biodigester-borrowers-the-triple-bottom-line?game=won',
+						dateTagline: 'October 2022'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '4kitqPpUASZ80I2kCG62cO',
+						type: 'Entry',
+						createdAt: '2023-06-07T14:55:48.231Z',
+						updatedAt: '2023-10-23T21:21:00.625Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 21,
+						revision: 3,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'wrd-23-challenge',
+						challengeName: 'World Refugee Day Challenge',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '49OApJ5ZtwK2u7kTGOpvqy',
+								type: 'Asset',
+								createdAt: '2023-06-07T14:53:09.681Z',
+								updatedAt: '2023-10-04T17:53:37.715Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 18,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Road to $3B Badge',
+								description: 'Road to $3B Badge',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/49OApJ5ZtwK2u7kTGOpvqy/4fb1d0eecfd5fab281ea6ae7b74fa0ae/badge_Roadto3B.svg',
+									details: {
+										size: 9921,
+										image: {
+											width: 521,
+											height: 520
+										}
+									},
+									fileName: 'badge_Roadto3B.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '11qSWoQeUV1MDRAEWj1Csl',
+								type: 'Asset',
+								createdAt: '2023-06-07T14:55:35.395Z',
+								updatedAt: '2023-10-04T17:54:56.538Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 20,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Road to $3B Badge Thank You Image',
+								description: 'Road to $3B BadgeThank You Image',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/11qSWoQeUV1MDRAEWj1Csl/a8707ab314b84254d2f2fb8923117dbf/thankyou_3Bbadge_2x.jpg',
+									details: {
+										size: 436794,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'thankyou_3Bbadge@2x.jpg',
+									contentType: 'image/jpeg'
+								}
+							}
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You earned the 2023 World Refugee Day badge by lending to a refugee! Thank you for supporting refugees worldwide.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'There are refugee stories that inspire us every day! Read about how in spite of tragedy, Venezuelan refugee Xiomara finds beauty in life—and others.',
+						shareFactUrl: '/blog/in-spite-of-tragedy-venezuelan-refugee-xiomara-finds-beauty-in-life-and-others',
+						dateTagline: 'June 2023'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5xjUNhkvQBbzxAAkwrtGs',
+						type: 'Entry',
+						createdAt: '2023-10-03T18:39:30.854Z',
+						updatedAt: '2023-10-23T18:07:26.913Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 17,
+						revision: 5,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: '2BB-23-Roadto3BB',
+						challengeName: 'Road to $3B Challenge',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '49OApJ5ZtwK2u7kTGOpvqy',
+								type: 'Asset',
+								createdAt: '2023-06-07T14:53:09.681Z',
+								updatedAt: '2023-10-04T17:53:37.715Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 18,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Road to $3B Badge',
+								description: 'Road to $3B Badge',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/49OApJ5ZtwK2u7kTGOpvqy/4fb1d0eecfd5fab281ea6ae7b74fa0ae/badge_Roadto3B.svg',
+									details: {
+										size: 9921,
+										image: {
+											width: 521,
+											height: 520
+										}
+									},
+									fileName: 'badge_Roadto3B.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '11qSWoQeUV1MDRAEWj1Csl',
+								type: 'Asset',
+								createdAt: '2023-06-07T14:55:35.395Z',
+								updatedAt: '2023-10-04T17:54:56.538Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 20,
+								revision: 3,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Road to $3B Badge Thank You Image',
+								description: 'Road to $3B BadgeThank You Image',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/11qSWoQeUV1MDRAEWj1Csl/a8707ab314b84254d2f2fb8923117dbf/thankyou_3Bbadge_2x.jpg',
+									details: {
+										size: 436794,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'thankyou_3Bbadge@2x.jpg',
+									contentType: 'image/jpeg'
+								}
+							}
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You earned the Road to $3B badge! You just helped Kiva get one step closer to $3 billion in loans funded — the next major milestone on the road to financial access for all. ',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'While we celebrate $2 billion in impact around the world, we know we have to keep the momentum going to achieve financial access for all. More than 1.4 billion people around the world are unbanked and can’t access the financial services they need. Learn more about the Kiva community that has powered $2 billion in loans to support millions of people worldwide.',
+						shareFactUrl: '/lp/2-billion',
+						dateTagline: 'October 2023'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '2AnUNnkEbcFQbgGmSZ0or7',
+						type: 'Entry',
+						createdAt: '2023-10-03T18:38:41.917Z',
+						updatedAt: '2023-10-10T16:46:45.763Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 22,
+						revision: 5,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: '2BB-23-Thanks',
+						challengeName: "Kiva's $2 Billion Celebration",
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2EjdfZjdimDXkNvEakByft',
+								type: 'Asset',
+								createdAt: '2023-10-10T16:44:57.439Z',
+								updatedAt: '2023-10-10T16:44:57.439Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 6,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: '2BB Thank You Badge',
+								description: 'Rewarded to all users who have ever made a loan',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2EjdfZjdimDXkNvEakByft/9b2410d4d166fbb3adc7f99d56a989c7/badge_Team2B.svg',
+									details: {
+										size: 12324,
+										image: {
+											width: 550,
+											height: 550
+										}
+									},
+									fileName: 'badge_Team2B.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '2JO4HkOCgS4Mtq206XM65k',
+								type: 'Asset',
+								createdAt: '2023-10-10T16:46:33.935Z',
+								updatedAt: '2023-10-10T16:46:33.935Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 5,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: '2BB TY Image',
+								description: '2BB TY Image',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/2JO4HkOCgS4Mtq206XM65k/4dd94782467ff533858b2bbaa8ecb544/thankyou_2Bbadge_2x__1_.jpg',
+									details: {
+										size: 111012,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'thankyou_2Bbadge@2x (1).jpg',
+									contentType: 'image/jpeg'
+								}
+							}
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Thank you for helping Kiva reach $2Bn in impact this year!',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFactUrl: '/lp/2-billion',
+						dateTagline: 'October 2023'
+					}
+				},
+				{
+					metadata: {
+						tags: [],
+						concepts: []
+					},
+					sys: {
+						space: {
+							sys: {
+								type: 'Link',
+								linkType: 'Space',
+								id: 'j0p9a6ql0rn7'
+							}
+						},
+						id: '5QREEjTdmKF5ytmkAW1Sao',
+						type: 'Entry',
+						createdAt: '2023-05-24T21:25:28.311Z',
+						updatedAt: '2023-05-30T14:56:15.934Z',
+						environment: {
+							sys: {
+								id: 'development',
+								type: 'Link',
+								linkType: 'Environment'
+							}
+						},
+						publishedVersion: 11,
+						revision: 2,
+						contentType: {
+							sys: {
+								type: 'Link',
+								linkType: 'ContentType',
+								id: 'challenge'
+							}
+						},
+						locale: 'en-US'
+					},
+					fields: {
+						key: 'earthday-23-challenge',
+						challengeName: 'Earth Day Challenge',
+						badgeImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3JhGxAJ6gxKvw9WHx1IuQ',
+								type: 'Asset',
+								createdAt: '2023-05-24T21:23:30.058Z',
+								updatedAt: '2023-05-24T21:23:30.058Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Earth Day Challenge Badge',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3JhGxAJ6gxKvw9WHx1IuQ/94edb7668e8a62c89418d82bd6da91b1/earthday-badge.svg',
+									details: {
+										size: 15178,
+										image: {
+											width: 133,
+											height: 134
+										}
+									},
+									fileName: 'earthday-badge.svg',
+									contentType: 'image/svg+xml'
+								}
+							}
+						},
+						thankYouImage: {
+							metadata: {
+								tags: [],
+								concepts: []
+							},
+							sys: {
+								space: {
+									sys: {
+										type: 'Link',
+										linkType: 'Space',
+										id: 'j0p9a6ql0rn7'
+									}
+								},
+								id: '3bPgZ8MFzXyp2f3Qqkxr71',
+								type: 'Asset',
+								createdAt: '2023-05-24T21:24:23.265Z',
+								updatedAt: '2023-05-24T21:24:23.265Z',
+								environment: {
+									sys: {
+										id: 'development',
+										type: 'Link',
+										linkType: 'Environment'
+									}
+								},
+								publishedVersion: 4,
+								revision: 1,
+								locale: 'en-US'
+							},
+							fields: {
+								title: 'Earth Day Challenge Thank You Image',
+								description: '',
+								file: {
+									url: '//images.ctfassets.net/j0p9a6ql0rn7/3bPgZ8MFzXyp2f3Qqkxr71/c394ceea4c7ea008a4c9c76e6f2a008a/thankyou_badge_earthday_2x.jpg',
+									details: {
+										size: 256176,
+										image: {
+											width: 800,
+											height: 800
+										}
+									},
+									fileName: 'thankyou_badge_earthday@2x.jpg',
+									contentType: 'image/jpeg'
+								}
+							}
+						},
+						thankYouCopyComplete: {
+							data: {},
+							content: [
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'Way to go! ',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'heading-2'
+								},
+								{
+									data: {},
+									content: [
+										{
+											data: {},
+											marks: [],
+											value: 'You earned the 2023 Earth Day badge by lending to a climate-smart loan! Thank you for helping people solve climate-related issues in their communities and build resilience for the future.',
+											nodeType: 'text'
+										}
+									],
+									nodeType: 'paragraph'
+								}
+							],
+							nodeType: 'document'
+						},
+						shareFact: 'Thank you for helping someone make a climate-positive change in their community! Climate change could reduce agriculture yields by up to 30% by 2050. Learn more about how Kiva supports climate resilience for smallholder farmers worldwide.\n',
+						shareFactUrl: '/blog/climate-resilience',
+						dateTagline: 'April 2023'
+					}
+				}
+			],
+			includes: {
+				Asset: [
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '11qSWoQeUV1MDRAEWj1Csl',
+							type: 'Asset',
+							createdAt: '2023-06-07T14:55:35.395Z',
+							updatedAt: '2023-10-04T17:54:56.538Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 20,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Road to $3B Badge Thank You Image',
+							description: 'Road to $3B BadgeThank You Image',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/11qSWoQeUV1MDRAEWj1Csl/a8707ab314b84254d2f2fb8923117dbf/thankyou_3Bbadge_2x.jpg',
+								details: {
+									size: 436794,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'thankyou_3Bbadge@2x.jpg',
+								contentType: 'image/jpeg'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '15RLZ1WiHmGQgtlkkMZTH0',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:46:29.744Z',
+							updatedAt: '2024-10-25T00:57:04.439Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 4',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg',
+								details: {
+									size: 53983,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Women 40.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '1LLL9K4PgaUZb3H0JLWEPU',
+							type: 'Asset',
+							createdAt: '2024-10-10T01:06:37.362Z',
+							updatedAt: '2024-10-25T00:15:11.836Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 7',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
+								details: {
+									size: 10243,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 70.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '1M9ILbpZgeR2asP0a7Qp28',
+							type: 'Asset',
+							createdAt: '2024-02-08T23:28:32.073Z',
+							updatedAt: '2024-02-08T23:28:32.073Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: "Women's Day Challenge Thank You Image 2024",
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/1M9ILbpZgeR2asP0a7Qp28/68af348c87f8800edd1d37bb0ee69ba5/thankyou_badge.png',
+								details: {
+									size: 70029,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'thankyou_badge.png',
+								contentType: 'image/png'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '1SEhQMUbYUqZopjP2o67XK',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:24:28.661Z',
+							updatedAt: '2024-10-25T00:36:16.661Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refugee Equality Level 1',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg',
+								details: {
+									size: 16732,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Refugees 10.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '1dZrR0nnWsEB9AGjW2qOL6',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:55:59.655Z',
+							updatedAt: '2024-10-25T00:07:17.490Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 13,
+							revision: 4,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 3',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg',
+								details: {
+									size: 39983,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 30.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '1vGn9ZCa3OFC7Tiqv14G7K',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:35:50.256Z',
+							updatedAt: '2024-10-25T00:41:08.229Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refugee Equality Level 7',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg',
+								details: {
+									size: 40515,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Refugees 70.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '25FLM7Cyv1kik5nFkdIT2O',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:42:26.656Z',
+							updatedAt: '2024-10-25T00:56:22.416Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 9,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 3',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg',
+								details: {
+									size: 38908,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Women 30.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2AptyhDdjcbumiax0upWWZ',
+							type: 'Asset',
+							createdAt: '2024-10-10T01:01:25.949Z',
+							updatedAt: '2024-10-25T00:08:25.562Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 13,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 4',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg',
+								details: {
+									size: 38003,
+									image: {
+										width: 312,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 40.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2EjdfZjdimDXkNvEakByft',
+							type: 'Asset',
+							createdAt: '2023-10-10T16:44:57.439Z',
+							updatedAt: '2023-10-10T16:44:57.439Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 6,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: '2BB Thank You Badge',
+							description: 'Rewarded to all users who have ever made a loan',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2EjdfZjdimDXkNvEakByft/9b2410d4d166fbb3adc7f99d56a989c7/badge_Team2B.svg',
+								details: {
+									size: 12324,
+									image: {
+										width: 550,
+										height: 550
+									}
+								},
+								fileName: 'badge_Team2B.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2JO4HkOCgS4Mtq206XM65k',
+							type: 'Asset',
+							createdAt: '2023-10-10T16:46:33.935Z',
+							updatedAt: '2023-10-10T16:46:33.935Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 5,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: '2BB TY Image',
+							description: '2BB TY Image',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2JO4HkOCgS4Mtq206XM65k/4dd94782467ff533858b2bbaa8ecb544/thankyou_2Bbadge_2x__1_.jpg',
+								details: {
+									size: 111012,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'thankyou_2Bbadge@2x (1).jpg',
+								contentType: 'image/jpeg'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2LVZNRwHjKwnr3vYYsjK4f',
+							type: 'Asset',
+							createdAt: '2024-04-10T20:45:16.856Z',
+							updatedAt: '2024-04-10T20:45:16.856Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Earth Day 2024 Badge',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2LVZNRwHjKwnr3vYYsjK4f/d52b6f92de144840929d4169e68bb12e/EarthDay24_badge.svg',
+								details: {
+									size: 10441,
+									image: {
+										width: 200,
+										height: 200
+									}
+								},
+								fileName: 'EarthDay24_badge.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2WqKsGZYLhVJpWf5Ihnfcy',
+							type: 'Asset',
+							createdAt: '2024-04-10T20:46:01.117Z',
+							updatedAt: '2024-04-10T20:46:01.117Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 5,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Earth Day 2024 Badge Thank You',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2WqKsGZYLhVJpWf5Ihnfcy/80c34c625942fca1695ae4549b1409ea/ED_thankyou_badge.png',
+								details: {
+									size: 771555,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'ED_thankyou_badge.png',
+								contentType: 'image/png'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2rCdTrkgqrajqscTGgt6YZ',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:30:51.968Z',
+							updatedAt: '2024-10-23T22:13:59.763Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 6,
+							revision: 2,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refuguee Equality Level 4',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg',
+								details: {
+									size: 44141,
+									image: {
+										width: 305,
+										height: 235
+									}
+								},
+								fileName: 'Refugees 40.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2rJH0UWfITf7KPuySP8x9',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:51:19.821Z',
+							updatedAt: '2024-10-25T00:59:38.810Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 7',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg',
+								details: {
+									size: 45263,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Women 70.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '2s7t7DyW1EBoF4S7HhO4eZ',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:30:00.156Z',
+							updatedAt: '2024-10-25T00:47:22.575Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equality Level 5',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg',
+								details: {
+									size: 43277,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 50.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '3C3ddaga4hEXBlb9WxsdlQ',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:23:21.487Z',
+							updatedAt: '2024-10-25T00:44:19.738Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equality Level 1',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg',
+								details: {
+									size: 40688,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 10.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '3JhGxAJ6gxKvw9WHx1IuQ',
+							type: 'Asset',
+							createdAt: '2023-05-24T21:23:30.058Z',
+							updatedAt: '2023-05-24T21:23:30.058Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Earth Day Challenge Badge',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/3JhGxAJ6gxKvw9WHx1IuQ/94edb7668e8a62c89418d82bd6da91b1/earthday-badge.svg',
+								details: {
+									size: 15178,
+									image: {
+										width: 133,
+										height: 134
+									}
+								},
+								fileName: 'earthday-badge.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '3YklKNLbiA4kAcOgk5ouaw',
+							type: 'Asset',
+							createdAt: '2024-10-09T18:48:25.407Z',
+							updatedAt: '2024-10-25T00:26:15.049Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 1',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg',
+								details: {
+									size: 38861,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 10.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '3bPgZ8MFzXyp2f3Qqkxr71',
+							type: 'Asset',
+							createdAt: '2023-05-24T21:24:23.265Z',
+							updatedAt: '2023-05-24T21:24:23.265Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Earth Day Challenge Thank You Image',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/3bPgZ8MFzXyp2f3Qqkxr71/c394ceea4c7ea008a4c9c76e6f2a008a/thankyou_badge_earthday_2x.jpg',
+								details: {
+									size: 256176,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'thankyou_badge_earthday@2x.jpg',
+								contentType: 'image/jpeg'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '3dAEh0zYSkqK5Up5q8Flv8',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:38:47.073Z',
+							updatedAt: '2024-10-25T00:54:54.599Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 1',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg',
+								details: {
+									size: 43685,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Women 10.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '3vmiyohO4jjDEwnzO4QMZh',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:19:44.764Z',
+							updatedAt: '2024-10-25T00:32:35.143Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 12,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 6',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg',
+								details: {
+									size: 14373,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 60.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '49OApJ5ZtwK2u7kTGOpvqy',
+							type: 'Asset',
+							createdAt: '2023-06-07T14:53:09.681Z',
+							updatedAt: '2023-10-04T17:53:37.715Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 18,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Road to $3B Badge',
+							description: 'Road to $3B Badge',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/49OApJ5ZtwK2u7kTGOpvqy/4fb1d0eecfd5fab281ea6ae7b74fa0ae/badge_Roadto3B.svg',
+								details: {
+									size: 9921,
+									image: {
+										width: 521,
+										height: 520
+									}
+								},
+								fileName: 'badge_Roadto3B.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4EfRGWaySxx9eCxkwJJ71S',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:26:47.031Z',
+							updatedAt: '2024-10-25T00:37:53.038Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 14,
+							revision: 4,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refugee Equality Level 2',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg',
+								details: {
+									size: 40113,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Refugees 20.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4FAMdCiqyrNBzGH7IzYJ6G',
+							type: 'Asset',
+							createdAt: '2024-10-09T23:51:55.037Z',
+							updatedAt: '2024-10-25T00:30:44.010Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 14,
+							revision: 4,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 4',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg',
+								details: {
+									size: 41414,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 40.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4FT6YzFE07Iv40CIWDFcvk',
+							type: 'Asset',
+							createdAt: '2024-02-08T23:29:44.469Z',
+							updatedAt: '2024-02-08T23:29:44.469Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: "Women's Day Challenge Badge",
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4FT6YzFE07Iv40CIWDFcvk/f9d433da2d343fd09b37f9fe722de0ee/iwd-badge.svg',
+								details: {
+									size: 10778,
+									image: {
+										width: 144,
+										height: 144
+									}
+								},
+								fileName: 'iwd-badge.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4FdrRfytu5gB8WK2C8Gl6b',
+							type: 'Asset',
+							createdAt: '2024-06-11T17:49:18.476Z',
+							updatedAt: '2024-06-11T17:49:18.476Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 6,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: '2024 World Refugee Day Thank You',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4FdrRfytu5gB8WK2C8Gl6b/aa7af154097aa0c65b5888586713a904/WRD24_thankyou.png',
+								details: {
+									size: 623504,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'WRD24_thankyou.png',
+								contentType: 'image/png'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4f5MR6ggWdXx3AC7oxx596',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:28:08.418Z',
+							updatedAt: '2024-10-25T00:46:52.600Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equality Level 4',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg',
+								details: {
+									size: 44264,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 40.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4nUE568E3WCZ1rYpbH3G1z',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:31:17.425Z',
+							updatedAt: '2024-10-25T00:51:55.052Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 13,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equality Level 6',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg',
+								details: {
+									size: 43294,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 60.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4q0Das9uTU0gfrwtld137n',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:26:40.755Z',
+							updatedAt: '2024-10-25T00:45:45.790Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equality Level 3',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/27262f02db91bc35ab0b4ac06dbb940a/US_Business_40.svg',
+								details: {
+									size: 44264,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 40.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '4sN0hJtCkirthBDrSOh2YA',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:34:18.062Z',
+							updatedAt: '2024-10-25T00:40:09.265Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 11,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refugee Equality Level 6',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg',
+								details: {
+									size: 44192,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Refugees 60.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '5SpskyxoH08WfjVuzXjq6T',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:49:37.971Z',
+							updatedAt: '2024-10-23T22:03:33.377Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 6,
+							revision: 2,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 6',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg',
+								details: {
+									size: 40971,
+									image: {
+										width: 204,
+										height: 285
+									}
+								},
+								fileName: 'Women 75.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '5TO71LArbZCXuey6JJnrm8',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:28:53.736Z',
+							updatedAt: '2024-10-25T00:38:23.764Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refugee Equality Level 3',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg',
+								details: {
+									size: 39593,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Refugees 30.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '5fTewx3XPCnvCujcDkvEvH',
+							type: 'Asset',
+							createdAt: '2024-06-11T17:47:17.290Z',
+							updatedAt: '2024-06-11T17:47:17.290Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 6,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: '2024 World Refugee Day Badge',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/5fTewx3XPCnvCujcDkvEvH/ccdd1774f3194febdb55db0d6a1e37e8/WRD24Badge.svg',
+								details: {
+									size: 55750,
+									image: {
+										width: 148,
+										height: 152
+									}
+								},
+								fileName: 'WRD24Badge.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '62zEUpZbO7qWZPoV1z2pZU',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:25:01.320Z',
+							updatedAt: '2024-10-25T00:45:08.112Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equality Level 2',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg',
+								details: {
+									size: 56655,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 20.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '694uSymh8om0MxbiCjWZxl',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:52:28.620Z',
+							updatedAt: '2024-10-25T00:00:36.874Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 1',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg',
+								details: {
+									size: 40244,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 10.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6PcVN0gI5MIwytZm5AFQ32',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:40:54.347Z',
+							updatedAt: '2024-10-25T00:55:45.440Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 2',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg',
+								details: {
+									size: 36814,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Women 20.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6dKOH8W4ZCWxTO7OXPfAWo',
+							type: 'Asset',
+							createdAt: '2024-10-09T23:39:51.822Z',
+							updatedAt: '2024-10-25T00:27:43.231Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 3',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg',
+								details: {
+									size: 52177,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 30.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6m9RP1jcZxZMz5EqWyl8a8',
+							type: 'Asset',
+							createdAt: '2024-10-10T01:04:00.519Z',
+							updatedAt: '2024-10-25T00:09:15.381Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 5',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg',
+								details: {
+									size: 36080,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 50.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6mqr1eJTJHksfTlRmpI7bB',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:48:07.039Z',
+							updatedAt: '2024-10-25T00:57:55.264Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Women Level 5',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg',
+								details: {
+									size: 41429,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Women 50.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6oSmu0Kc94YpMllGEsw2o4',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:32:36.416Z',
+							updatedAt: '2024-10-25T00:39:21.985Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 11,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Refugee Equality Level 5',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg',
+								details: {
+									size: 42027,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Refugees 50.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6p6BcDBlAb7ZoCaZaypJIT',
+							type: 'Asset',
+							createdAt: '2024-10-08T20:32:25.037Z',
+							updatedAt: '2024-10-25T00:53:09.706Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 9,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'US Economic Equalitty Level 7',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg',
+								details: {
+									size: 43444,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'US Business 70.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '6yl0sXP8fgaRaRwIaEVJO4',
+							type: 'Asset',
+							createdAt: '2024-09-12T22:17:31.431Z',
+							updatedAt: '2024-09-12T22:17:31.431Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Equity Badge',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/6yl0sXP8fgaRaRwIaEVJO4/89ce4fae6c80ab1aed59a1e3ad055c3b/Equality_Badge_SVG.svg',
+								details: {
+									size: 10000,
+									image: {
+										width: 180,
+										height: 185
+									}
+								},
+								fileName: 'Equality Badge@SVG.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '79ZtLGf78ixp46twJjrQxD',
+							type: 'Asset',
+							createdAt: '2024-02-08T23:30:14.651Z',
+							updatedAt: '2024-02-08T23:30:14.651Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: "Women's Day Challenge Thank You Image",
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/79ZtLGf78ixp46twJjrQxD/6c3ac0a60f0e288d40554f30177f4660/IWDthankyou_badge_2x__1_.jpg',
+								details: {
+									size: 120536,
+									image: {
+										width: 800,
+										height: 800
+									}
+								},
+								fileName: 'IWDthankyou_badge_2x__1_.jpg',
+								contentType: 'image/jpeg'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '7LVRDYs9PmApE3LhZ4D4Ek',
+							type: 'Asset',
+							createdAt: '2024-10-09T23:54:55.689Z',
+							updatedAt: '2024-10-25T00:31:29.203Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 5',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg',
+								details: {
+									size: 16086,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 50.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '7crCD9q1xCii5mcLAj3SKa',
+							type: 'Asset',
+							createdAt: '2024-10-09T23:36:02.795Z',
+							updatedAt: '2024-10-25T00:27:04.325Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 2',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg',
+								details: {
+									size: 34776,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 20.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '7r9kCerMO7HTTyFVUIEpwc',
+							type: 'Asset',
+							createdAt: '2024-02-08T23:27:08.576Z',
+							updatedAt: '2024-02-08T23:28:06.645Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 8,
+							revision: 2,
+							locale: 'en-US'
+						},
+						fields: {
+							title: "Women's Day Challenge Badge 2024",
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/7r9kCerMO7HTTyFVUIEpwc/eff30216165fdc93775b8783993f9357/Badge.png',
+								details: {
+									size: 22006,
+									image: {
+										width: 320,
+										height: 320
+									}
+								},
+								fileName: 'Badge.png',
+								contentType: 'image/png'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: '7vPGmOjS7F8PZGAymeLzG2',
+							type: 'Asset',
+							createdAt: '2023-05-24T20:40:32.283Z',
+							updatedAt: '2023-05-24T20:40:32.283Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 4,
+							revision: 1,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Eco-friendly October Challenge Badge',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/7vPGmOjS7F8PZGAymeLzG2/98f5db81230cb26e360bb6b9490287e0/eco-badge.svg',
+								details: {
+									size: 7050,
+									image: {
+										width: 95,
+										height: 109
+									}
+								},
+								fileName: 'eco-badge.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: 'ESTL9bCh4khif4gxZO8ft',
+							type: 'Asset',
+							createdAt: '2024-10-10T01:05:08.610Z',
+							updatedAt: '2024-10-25T00:13:58.662Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 13,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 6',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg',
+								details: {
+									size: 36584,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 60.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: 'JdDGpZIjI7FXBouv3bJa4',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:21:23.897Z',
+							updatedAt: '2024-10-25T00:33:17.425Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 10,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Climate Action Level 7',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg',
+								details: {
+									size: 34255,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Climate 70.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					},
+					{
+						metadata: {
+							tags: [],
+							concepts: []
+						},
+						sys: {
+							space: {
+								sys: {
+									type: 'Link',
+									linkType: 'Space',
+									id: 'j0p9a6ql0rn7'
+								}
+							},
+							id: 'SHdA5oclQUy5T5YQhfTd2',
+							type: 'Asset',
+							createdAt: '2024-10-10T00:53:51.110Z',
+							updatedAt: '2024-10-25T00:05:44.600Z',
+							environment: {
+								sys: {
+									id: 'development',
+									type: 'Link',
+									linkType: 'Environment'
+								}
+							},
+							publishedVersion: 11,
+							revision: 3,
+							locale: 'en-US'
+						},
+						fields: {
+							title: 'Basic Needs Level 2',
+							description: '',
+							file: {
+								url: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg',
+								details: {
+									size: 39056,
+									image: {
+										width: 313,
+										height: 313
+									}
+								},
+								fileName: 'Basic Needs 20.svg',
+								contentType: 'image/svg+xml'
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+};
+
+export const combinedData = [
+	{
+		id: 'us-economic-equality',
+		contentfulData: [
+			{
+				id: 'us-economic-equality',
+				level: 6,
+				levelName: 'U.S. Economic equality ✨50✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg'
+			},
+			{
+				id: 'us-economic-equality',
+				level: 7,
+				levelName: 'U.S. Economic equality ✨100✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg'
+			},
+			{
+				id: 'us-economic-equality',
+				level: 5,
+				levelName: 'U.S. Economic equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg'
+			},
+			{
+				id: 'us-economic-equality',
+				level: 4,
+				levelName: 'U.S. Economic equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg'
+			},
+			{
+				id: 'us-economic-equality',
+				level: 3,
+				levelName: 'U.S. Economic equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/27262f02db91bc35ab0b4ac06dbb940a/US_Business_40.svg'
+			},
+			{
+				id: 'us-economic-equality',
+				level: 2,
+				levelName: 'U.S. Economic equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg'
+			},
+			{
+				id: 'us-economic-equality',
+				level: 1,
+				levelName: 'U.S. economic equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg'
+			}
+		],
+		achievementData: {
+			__typename: 'TieredLendingAchievement',
+			id: 'us-economic-equality',
+			totalProgressToAchievement: 2,
+			tiers: [
+				{
+					__typename: 'Tier',
+					target: 2,
+					tierStatement: 'statement1',
+					completedDate: '2024-10-22T18:49:21Z',
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 1
+				},
+				{
+					__typename: 'Tier',
+					target: 3,
+					tierStatement: 'staTEMENT2',
+					completedDate: undefined,
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 2
+				},
+				{
+					__typename: 'Tier',
+					target: 5,
+					tierStatement: 'statement3',
+					completedDate: undefined,
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 3
+				},
+				{
+					__typename: 'Tier',
+					target: 10,
+					tierStatement: 'statement4',
+					completedDate: undefined,
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 4
+				},
+				{
+					__typename: 'Tier',
+					target: 20,
+					tierStatement: 'statement5',
+					completedDate: undefined,
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 5
+				},
+				{
+					__typename: 'Tier',
+					target: 50,
+					tierStatement: 'statement 6',
+					completedDate: undefined,
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 6
+				},
+				{
+					__typename: 'Tier',
+					target: 100,
+					tierStatement: 'statement 7',
+					completedDate: undefined,
+					learnMoreURL: 'https://www.kiva.org/',
+					level: 7
+				}
+			]
+		},
+		hasStarted: true,
+		level: 1
+	},
+	{
+		id: 'climate-action',
+		contentfulData: [
+			{
+				id: 'climate-action',
+				level: 7,
+				levelName: 'Climate action ✨100✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg'
+			},
+			{
+				id: 'climate-action',
+				level: 6,
+				levelName: 'Climate action✨50✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg'
+			},
+			{
+				id: 'climate-action',
+				level: 5,
+				levelName: 'Climate action',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg'
+			},
+			{
+				id: 'climate-action',
+				level: 4,
+				levelName: 'Climate action',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg'
+			},
+			{
+				id: 'climate-action',
+				level: 3,
+				levelName: 'Climate action',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg'
+			},
+			{
+				id: 'climate-action',
+				level: 2,
+				levelName: 'Climate action',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg'
+			},
+			{
+				id: 'climate-action',
+				level: 1,
+				levelName: 'Climate action',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg'
+			}
+		],
+		achievementData: {
+			__typename: 'TieredLendingAchievement',
+			id: 'climate-action',
+			totalProgressToAchievement: 0,
+			tiers: [
+				{
+					__typename: 'Tier',
+					target: 2,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 1
+				},
+				{
+					__typename: 'Tier',
+					target: 3,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 2
+				},
+				{
+					__typename: 'Tier',
+					target: 5,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 3
+				},
+				{
+					__typename: 'Tier',
+					target: 10,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 4
+				},
+				{
+					__typename: 'Tier',
+					target: 20,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 5
+				},
+				{
+					__typename: 'Tier',
+					target: 50,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 6
+				},
+				{
+					__typename: 'Tier',
+					target: 100,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 7
+				}
+			]
+		},
+		hasStarted: false
+	},
+	{
+		id: 'womens-equality',
+		contentfulData: [
+			{
+				id: 'womens-equality',
+				level: 7,
+				levelName: "Women's equality ✨100✨",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg'
+			},
+			{
+				id: 'womens-equality',
+				level: 6,
+				levelName: "Women's equality ✨50✨",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg'
+			},
+			{
+				id: 'womens-equality',
+				level: 5,
+				levelName: "Women's equality",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg'
+			},
+			{
+				id: 'womens-equality',
+				level: 4,
+				levelName: "Women's equality",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg'
+			},
+			{
+				id: 'womens-equality',
+				level: 3,
+				levelName: "Women's equality",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg'
+			},
+			{
+				id: 'womens-equality',
+				level: 2,
+				levelName: "Women's equality",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg'
+			},
+			{
+				id: 'womens-equality',
+				level: 1,
+				levelName: "Women's equality",
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg'
+			}
+		],
+		achievementData: {
+			__typename: 'TieredLendingAchievement',
+			id: 'womens-equality',
+			totalProgressToAchievement: 0,
+			tiers: [
+				{
+					__typename: 'Tier',
+					target: 2,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 1
+				},
+				{
+					__typename: 'Tier',
+					target: 3,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 2
+				},
+				{
+					__typename: 'Tier',
+					target: 5,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 3
+				},
+				{
+					__typename: 'Tier',
+					target: 10,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 4
+				},
+				{
+					__typename: 'Tier',
+					target: 20,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 5
+				},
+				{
+					__typename: 'Tier',
+					target: 50,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 6
+				},
+				{
+					__typename: 'Tier',
+					target: 100,
+					tierStatement: '',
+					learnMoreURL: '',
+					level: 7
+				}
+			]
+		},
+		hasStarted: false
+	},
+	{
+		id: 'refugee-equality',
+		contentfulData: [
+			{
+				id: 'refugee-equality',
+				level: 7,
+				levelName: 'Refugee equality ✨100✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg'
+			},
+			{
+				id: 'refugee-equality',
+				level: 6,
+				levelName: 'Refugee equality ✨50✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg'
+			},
+			{
+				id: 'refugee-equality',
+				level: 5,
+				levelName: 'Refugee equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg'
+			},
+			{
+				id: 'refugee-equality',
+				level: 4,
+				levelName: 'Refugee equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg'
+			},
+			{
+				id: 'refugee-equality',
+				level: 3,
+				levelName: 'Refugee equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg'
+			},
+			{
+				id: 'refugee-equality',
+				level: 2,
+				levelName: 'Refugee equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg'
+			},
+			{
+				id: 'refugee-equality',
+				level: 1,
+				levelName: 'Refugee equality',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg'
+			}
+		],
+		achievementData: {
+			__typename: 'TieredLendingAchievement',
+			id: 'refugee-equality',
+			totalProgressToAchievement: 0,
+			tiers: [
+				{
+					__typename: 'Tier',
+					target: 2,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 1
+				},
+				{
+					__typename: 'Tier',
+					target: 3,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 2
+				},
+				{
+					__typename: 'Tier',
+					target: 5,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 3
+				},
+				{
+					__typename: 'Tier',
+					target: 10,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 4
+				},
+				{
+					__typename: 'Tier',
+					target: 20,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 5
+				},
+				{
+					__typename: 'Tier',
+					target: 50,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 6
+				},
+				{
+					__typename: 'Tier',
+					target: 100,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 7
+				}
+			]
+		},
+		hasStarted: false
+	},
+	{
+		id: 'basic-needs',
+		contentfulData: [
+			{
+				id: 'basic-needs',
+				level: 7,
+				levelName: 'Basic needs✨100✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
+			},
+			{
+				id: 'basic-needs',
+				level: 6,
+				levelName: 'Basic needs ✨50✨',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
+			},
+			{
+				id: 'basic-needs',
+				level: 5,
+				levelName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
+			},
+			{
+				id: 'basic-needs',
+				level: 4,
+				levelName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
+			},
+			{
+				id: 'basic-needs',
+				level: 3,
+				levelName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
+			},
+			{
+				id: 'basic-needs',
+				level: 2,
+				levelName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
+			},
+			{
+				id: 'basic-needs',
+				level: 1,
+				levelName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
+			}
+		],
+		achievementData: {
+			__typename: 'TieredLendingAchievement',
+			id: 'basic-needs',
+			totalProgressToAchievement: 0,
+			tiers: [
+				{
+					__typename: 'Tier',
+					target: 2,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 1
+				},
+				{
+					__typename: 'Tier',
+					target: 3,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 2
+				},
+				{
+					__typename: 'Tier',
+					target: 5,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 3
+				},
+				{
+					__typename: 'Tier',
+					target: 10,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 4
+				},
+				{
+					__typename: 'Tier',
+					target: 20,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 5
+				},
+				{
+					__typename: 'Tier',
+					target: 50,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 6
+				},
+				{
+					__typename: 'Tier',
+					target: 100,
+					tierStatement: '',
+					completedDate: undefined,
+					learnMoreURL: '',
+					level: 7
+				}
+			]
+		},
+		hasStarted: false
+	}
+];

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -1,5 +1,12 @@
+/* eslint-disable max-len */
 import useBadgeData from '#src/composables/useBadgeData';
-import { achievementData, contentfulData, combinedData } from '../../fixtures/useBadgeDataMock';
+import {
+	achievementData,
+	contentfulData,
+	combinedData,
+	badgeNoProgress,
+	badgeLastTier,
+} from '../../fixtures/useBadgeDataMock';
 
 jest.mock('vue', () => ({
 	onMounted: callback => callback(),
@@ -9,18 +16,6 @@ jest.mock('vue', () => ({
 
 describe('useBadgeData.js', () => {
 	describe('getTierPositions', () => {
-		it('should call apollo for data', () => {
-			const apolloMock = {
-				query: jest.fn()
-					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
-					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
-			};
-
-			useBadgeData(apolloMock);
-
-			expect(apolloMock.query).toHaveBeenCalledTimes(2);
-		});
-
 		it('should combine data like expected', () => {
 			const apolloMock = {
 				query: jest.fn()
@@ -35,6 +30,42 @@ describe('useBadgeData.js', () => {
 			);
 
 			expect(badgeData).toEqual(combinedData);
+		});
+	});
+
+	describe('getCurrentTierData', () => {
+		it('should get the current tier data', () => {
+			const { getCurrentTierData } = useBadgeData();
+
+			expect(getCurrentTierData(badgeNoProgress)).toEqual({
+				id: 'basic-needs',
+				level: 1,
+				levelName: 'Basic needs',
+				challengeName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg',
+				__typename: 'Tier',
+				target: 2,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: ''
+			});
+		});
+
+		it('should get the current last data (with emoji)', () => {
+			const { getCurrentTierData } = useBadgeData();
+
+			expect(getCurrentTierData(badgeLastTier)).toEqual({
+				id: 'basic-needs',
+				level: 7,
+				levelName: 'Basic needs✨100✨',
+				challengeName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
+				__typename: 'Tier',
+				target: 100,
+				tierStatement: '',
+				completedDate: undefined,
+				learnMoreURL: ''
+			});
 		});
 	});
 });

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -1,0 +1,40 @@
+import useBadgeData from '#src/composables/useBadgeData';
+import { achievementData, contentfulData, combinedData } from '../../fixtures/useBadgeDataMock';
+
+jest.mock('vue', () => ({
+	onMounted: callback => callback(),
+	ref: value => ({ value }),
+	computed: callback => callback(),
+}));
+
+describe('useBadgeData.js', () => {
+	describe('getTierPositions', () => {
+		it('should call apollo for data', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+
+			useBadgeData(apolloMock);
+
+			expect(apolloMock.query).toHaveBeenCalledTimes(2);
+		});
+
+		it('should combine data like expected', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+
+			const { combineBadgeData, getContentfulLevelData } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			);
+
+			expect(badgeData).toEqual(combinedData);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-966

- Next step is getting the badges section of MyKiva to show the correct badge title, level, and icon based on the current in-progress tier
- Added unit testing for new composable (mostly adding lots of mock data to make a realistic test)
- Fixed small spacing issue on MyKiva badge section badges
- Moved tier date cleanup to composable
- Moved Vue lifecycle methods out of composable so it could be reused as a util
- Other minor cleanup, like commenting

![image](https://github.com/user-attachments/assets/2c2e11bb-093d-4bef-9575-19f93a2b8ef3)
