### PR TITLE
feat: using totalProgressToAchievement to evaluate if journey started

### DIFF
--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -135,7 +135,7 @@ export default function useBadgeData() {
 					// Get specific properties used in the UI
 					const completedTiers = sortedTiers.filter(t => !!t.completedDate);
 					const hasStarted = completedTiers.length > 0 || achievementData?.totalProgressToAchievement > 0;
-					const level = hasStarted ? completedTiers?.[completedTiers.length - 1]?.level ?? 1 : undefined;
+					const level = hasStarted ? completedTiers?.[completedTiers.length - 1]?.level : undefined;
 
 					// Clean up milestone progress date format
 					const { milestoneProgress } = achievementData;

--- a/test/unit/fixtures/useBadgeDataMock.js
+++ b/test/unit/fixtures/useBadgeDataMock.js
@@ -63,7 +63,7 @@ export const achievementData = {
 			{
 				__typename: 'TieredLendingAchievement',
 				id: 'climate-action',
-				totalProgressToAchievement: 0,
+				totalProgressToAchievement: 1,
 				tiers: [
 					{
 						__typename: 'Tier',
@@ -9128,7 +9128,7 @@ export const combinedData = [
 		achievementData: {
 			__typename: 'TieredLendingAchievement',
 			id: 'climate-action',
-			totalProgressToAchievement: 0,
+			totalProgressToAchievement: 1,
 			tiers: [
 				{
 					__typename: 'Tier',
@@ -9188,7 +9188,7 @@ export const combinedData = [
 				}
 			]
 		},
-		hasStarted: false,
+		hasStarted: true,
 		level: undefined,
 	},
 	{


### PR DESCRIPTION
`hasStarted` didn't evaluate `totalProgressToAchievement` so journeys without completed tiers were showing the "Start journey" copy 

<img width="1078" alt="image" src="https://github.com/user-attachments/assets/9dbd62c0-5e53-46fe-85b2-8d401adebe58">
<img width="846" alt="image" src="https://github.com/user-attachments/assets/32ef93f9-c533-4685-bdf2-2b8338cac176">
