### PR TITLE
feat: badges show just 3 levels at a time

### DIFF
--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<p>
-			{{ badge.description }}
+			{{ badgeWthVisibleTiers.description }}
 		</p>
 		<div
 			class="tw-flex tw-overflow-x-auto tw-overflow-y-hidden"
@@ -38,7 +38,7 @@
 							:style="getLineStyle(positions[index - 1], position)"
 						/>
 						<img
-							:src="badge.contentfulData[index].imageUrl"
+							:src="badgeWthVisibleTiers.contentfulData[index].imageUrl"
 							alt="Badge"
 							style="height: 133px; width: 133px;"
 						>
@@ -49,12 +49,12 @@
 							tw-text-center tw-px-0.5 tw-z-2"
 						:style="getNumberCircleStyles()"
 					>
-						{{ badge.achievementData.totalProgressToAchievement }}
+						{{ badgeWthVisibleTiers.achievementData.totalProgressToAchievement }}
 					</div>
 				</div>
 				<div class="tw-text-center tw-bg-white tw-z-1 tw-relative">
 					<div class="tw-font-medium">
-						{{ badge.contentfulData[index].levelName }}
+						{{ badgeWthVisibleTiers.contentfulData[index].levelName }}
 					</div>
 					<div class="tw-text-small">
 						{{ tierCaption(index) }}
@@ -76,7 +76,7 @@
 </template>
 
 <script setup>
-import { defineProps, ref } from 'vue';
+import { defineProps, ref, computed } from 'vue';
 import { format } from 'date-fns';
 import useIsMobile from '#src/composables/useIsMobile';
 import useBadgeModal,
@@ -87,6 +87,7 @@ import useBadgeModal,
 	BADGE_LOCKED
 } from '#src/composables/useBadgeModal';
 import KvButton from '@kiva/kv-components/vue/KvButton';
+import useBadgeData from '#src/composables/useBadgeData';
 import BadgeContainer from './BadgeContainer';
 
 const props = defineProps({
@@ -96,37 +97,43 @@ const props = defineProps({
 	},
 });
 
+const { getBadgeWithVisibleTiers } = useBadgeData();
+
 const { isMobile } = useIsMobile(MOBILE_BREAKPOINT);
+
+const badgeWthVisibleTiers = computed(() => getBadgeWithVisibleTiers(props.badge));
+
 const {
 	getTierPositions,
 	getLineComponent,
 	getLineStyle,
 	getBadgeShape,
 	getNumberCircleStyles,
-} = useBadgeModal(props.badge);
+} = useBadgeModal(badgeWthVisibleTiers.value);
 
 const emit = defineEmits(['badge-level-clicked']);
 
 const positions = ref(getTierPositions());
 
 const tierCaption = index => {
-	const tier = props.badge.achievementData.tiers[index];
+	const tier = badgeWthVisibleTiers.value.achievementData.tiers[index];
 	if (tier.completedDate) {
 		return format(new Date(tier.completedDate), 'MMMM do, yyyy');
 	}
 	if (tier.target) {
-		return `${props.badge.achievementData.totalProgressToAchievement} of ${tier.target} loans`;
+		return `${badgeWthVisibleTiers.value.achievementData.totalProgressToAchievement} of ${tier.target} loans`;
 	}
 };
 
 const showEarnBadge = index => {
 	return (
-		!props.badge.achievementData.tiers[index - 1] || !!props.badge.achievementData.tiers[index - 1]?.completedDate
-	) && !props.badge.achievementData.tiers[index].completedDate;
+		!badgeWthVisibleTiers.value.achievementData.tiers[index - 1]
+		|| !!badgeWthVisibleTiers.value.achievementData.tiers[index - 1]?.completedDate
+	) && !badgeWthVisibleTiers.value.achievementData.tiers[index].completedDate;
 };
 
 const getBadgeStatus = index => {
-	const tier = props.badge.achievementData.tiers[index] ?? {};
+	const tier = badgeWthVisibleTiers.value.achievementData.tiers[index] ?? {};
 	if (tier.completedDate) {
 		return BADGE_COMPLETED;
 	}
@@ -139,8 +146,8 @@ const getBadgeStatus = index => {
 const handleBadgeClick = index => {
 	if (getBadgeStatus(index) !== BADGE_LOCKED) {
 		emit('badge-level-clicked', {
-			challengeName: props.badge.challengeName,
-			tier: props.badge.achievementData.tiers[index]
+			challengeName: badgeWthVisibleTiers.value.challengeName,
+			tier: badgeWthVisibleTiers.value.achievementData.tiers[index]
 		});
 	}
 };

--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<p>
-			{{ badgeWthVisibleTiers.description }}
+			{{ badgeWithVisibleTiers.description }}
 		</p>
 		<div
 			class="tw-flex tw-overflow-x-auto tw-overflow-y-hidden"
@@ -38,7 +38,7 @@
 							:style="getLineStyle(positions[index - 1], position)"
 						/>
 						<img
-							:src="badgeWthVisibleTiers.contentfulData[index].imageUrl"
+							:src="badgeWithVisibleTiers.contentfulData[index].imageUrl"
 							alt="Badge"
 							style="height: 133px; width: 133px;"
 						>
@@ -49,12 +49,12 @@
 							tw-text-center tw-px-0.5 tw-z-2"
 						:style="getNumberCircleStyles()"
 					>
-						{{ badgeWthVisibleTiers.achievementData.totalProgressToAchievement }}
+						{{ badgeWithVisibleTiers.achievementData.totalProgressToAchievement }}
 					</div>
 				</div>
 				<div class="tw-text-center tw-bg-white tw-z-1 tw-relative">
 					<div class="tw-font-medium">
-						{{ badgeWthVisibleTiers.contentfulData[index].levelName }}
+						{{ badgeWithVisibleTiers.contentfulData[index].levelName }}
 					</div>
 					<div class="tw-text-small">
 						{{ tierCaption(index) }}
@@ -101,7 +101,7 @@ const { getBadgeWithVisibleTiers } = useBadgeData();
 
 const { isMobile } = useIsMobile(MOBILE_BREAKPOINT);
 
-const badgeWthVisibleTiers = computed(() => getBadgeWithVisibleTiers(props.badge));
+const badgeWithVisibleTiers = computed(() => getBadgeWithVisibleTiers(props.badge));
 
 const {
 	getTierPositions,
@@ -109,31 +109,31 @@ const {
 	getLineStyle,
 	getBadgeShape,
 	getNumberCircleStyles,
-} = useBadgeModal(badgeWthVisibleTiers.value);
+} = useBadgeModal(badgeWithVisibleTiers.value);
 
 const emit = defineEmits(['badge-level-clicked']);
 
 const positions = ref(getTierPositions());
 
 const tierCaption = index => {
-	const tier = badgeWthVisibleTiers.value.achievementData.tiers[index];
+	const tier = badgeWithVisibleTiers.value.achievementData.tiers[index];
 	if (tier.completedDate) {
 		return format(new Date(tier.completedDate), 'MMMM do, yyyy');
 	}
 	if (tier.target) {
-		return `${badgeWthVisibleTiers.value.achievementData.totalProgressToAchievement} of ${tier.target} loans`;
+		return `${badgeWithVisibleTiers.value.achievementData.totalProgressToAchievement} of ${tier.target} loans`;
 	}
 };
 
 const showEarnBadge = index => {
 	return (
-		!badgeWthVisibleTiers.value.achievementData.tiers[index - 1]
-		|| !!badgeWthVisibleTiers.value.achievementData.tiers[index - 1]?.completedDate
-	) && !badgeWthVisibleTiers.value.achievementData.tiers[index].completedDate;
+		!badgeWithVisibleTiers.value.achievementData.tiers[index - 1]
+		|| !!badgeWithVisibleTiers.value.achievementData.tiers[index - 1]?.completedDate
+	) && !badgeWithVisibleTiers.value.achievementData.tiers[index].completedDate;
 };
 
 const getBadgeStatus = index => {
-	const tier = badgeWthVisibleTiers.value.achievementData.tiers[index] ?? {};
+	const tier = badgeWithVisibleTiers.value.achievementData.tiers[index] ?? {};
 	if (tier.completedDate) {
 		return BADGE_COMPLETED;
 	}
@@ -146,8 +146,8 @@ const getBadgeStatus = index => {
 const handleBadgeClick = index => {
 	if (getBadgeStatus(index) !== BADGE_LOCKED) {
 		emit('badge-level-clicked', {
-			challengeName: badgeWthVisibleTiers.value.challengeName,
-			tier: badgeWthVisibleTiers.value.achievementData.tiers[index]
+			challengeName: badgeWithVisibleTiers.value.challengeName,
+			tier: badgeWithVisibleTiers.value.achievementData.tiers[index]
 		});
 	}
 };

--- a/src/components/MyKiva/BadgesSection.vue
+++ b/src/components/MyKiva/BadgesSection.vue
@@ -37,7 +37,7 @@
 					v-if="badge.hasStarted"
 					class="tw-mx-auto"
 				>
-					Level {{ badge.level }}/{{ getBadgeWithVisibleTiers(badge).achievementData.tiers.length }}
+					{{ levelCaption(badge) }}
 				</span>
 				<button
 					class="tw-text-action hover:tw-underline tw-mt-auto"
@@ -71,6 +71,10 @@ const visibleBadges = computed(() => {
 		.filter(b => defaultBadges.includes(b.id))
 		.sort(indexIn(defaultBadges, 'id'));
 });
+
+const levelCaption = badge => {
+	return `Level ${getActiveTierData(badge).level}/${getBadgeWithVisibleTiers(badge).achievementData.tiers.length}`;
+};
 </script>
 
 <style lang="postcss" scoped>

--- a/src/components/MyKiva/BadgesSection.vue
+++ b/src/components/MyKiva/BadgesSection.vue
@@ -28,7 +28,7 @@
 				style="height: 148px;"
 			>
 				<img
-					:src="getCurrentTierData(badge).imageUrl"
+					:src="getActiveTierData(badge).imageUrl"
 					class="tw-h-full tw-mx-auto"
 				>
 			</div>
@@ -64,7 +64,7 @@ const props = defineProps({
 	},
 });
 
-const { getCurrentTierData } = useBadgeData();
+const { getActiveTierData } = useBadgeData();
 
 const visibleBadges = computed(() => {
 	return props.badgeData

--- a/src/components/MyKiva/BadgesSection.vue
+++ b/src/components/MyKiva/BadgesSection.vue
@@ -37,7 +37,7 @@
 					v-if="badge.hasStarted"
 					class="tw-mx-auto"
 				>
-					Level {{ badge.level }}/5
+					Level {{ badge.level }}/{{ getBadgeWithVisibleTiers(badge).achievementData.tiers.length }}
 				</span>
 				<button
 					class="tw-text-action hover:tw-underline tw-mt-auto"
@@ -64,7 +64,7 @@ const props = defineProps({
 	},
 });
 
-const { getActiveTierData } = useBadgeData();
+const { getActiveTierData, getBadgeWithVisibleTiers } = useBadgeData();
 
 const visibleBadges = computed(() => {
 	return props.badgeData

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -171,20 +171,14 @@ export default function useBadgeData() {
 	};
 
 	/**
-	 * Gets the current (incomplete) tier for the provided badge
+	 * Gets the active (inprogress or completed final) tier for the provided badge
 	 *
-	 * @param badge The badge to get the current tier for
-	 * @returns The current tier of the badge
+	 * @param badge The badge to get the active tier for
+	 * @returns The active tier of the badge
 	 */
-	const getCurrentTierData = badge => {
-		let currentTier;
-		badge.achievementData.tiers.forEach(t => {
-			if (!currentTier) {
-				currentTier = t;
-			} else if (!!currentTier.completedDate && !t.completedDate) {
-				currentTier = t;
-			}
-		});
+	const getActiveTierData = badge => {
+		const levelIndex = (badge.level === badge.achievementData.tiers.length ? badge.level - 1 : badge.level) ?? 0;
+		const currentTier = badge.achievementData.tiers[levelIndex];
 		/**
 		 * {
 		 *   "id": "",
@@ -282,15 +276,37 @@ export default function useBadgeData() {
 		}
 	};
 
+	/**
+	 * Gets the visible tiers to ensure the user doesn't get overwhelmed
+	 *
+	 * @param combinedBadgeData The combined data for the badge
+	 * @returns The tiers to show to the user
+	 */
+	const getVisibleTiers = combinedBadgeData => {
+		const currentTier = getActiveTierData(combinedBadgeData);
+		const visibleData = JSON.parse(JSON.stringify(combinedBadgeData));
+
+		if (currentTier.level < 4) {
+			visibleData.contentfulData.splice(3);
+			visibleData.achievementData.tiers.splice(3);
+		} else if (currentTier.level > 3 && currentTier.level < 6) {
+			visibleData.contentfulData.splice(5);
+			visibleData.achievementData.tiers.splice(5);
+		}
+
+		return visibleData;
+	};
+
 	return {
 		fetchAchievementData,
 		fetchContentfulData,
 		fetchLoanIdData,
 		combineBadgeData,
 		getContentfulLevelData,
-		getCurrentTierData,
+		getActiveTierData,
 		getTierBadgeDataByLevel,
 		getFilteredUrl,
+		getVisibleTiers,
 		badgeAchievementData,
 		badgeData,
 		badgeLoanIdData,

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -277,12 +277,12 @@ export default function useBadgeData() {
 	};
 
 	/**
-	 * Gets the visible tiers to ensure the user doesn't get overwhelmed
+	 * Gets the badge data visible tiers to ensure the user doesn't get overwhelmed
 	 *
 	 * @param combinedBadgeData The combined data for the badge
-	 * @returns The tiers to show to the user
+	 * @returns The badge data with tiers to show to the user
 	 */
-	const getVisibleTiers = combinedBadgeData => {
+	const getBadgeWithVisibleTiers = combinedBadgeData => {
 		const currentTier = getActiveTierData(combinedBadgeData);
 		const visibleData = JSON.parse(JSON.stringify(combinedBadgeData));
 
@@ -306,7 +306,7 @@ export default function useBadgeData() {
 		getActiveTierData,
 		getTierBadgeDataByLevel,
 		getFilteredUrl,
-		getVisibleTiers,
+		getBadgeWithVisibleTiers,
 		badgeAchievementData,
 		badgeData,
 		badgeLoanIdData,

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -108,7 +108,6 @@
 		</MyKivaContainer>
 		<EarnedBadgesSection
 			:badges-data="badgeData"
-			@badge-clicked="handleBadgeClicked"
 		/>
 	</www-page>
 </template>

--- a/test/unit/fixtures/useBadgeDataMock.js
+++ b/test/unit/fixtures/useBadgeDataMock.js
@@ -9789,5 +9789,5 @@ export const badgeLastTier = {
 		]
 	},
 	hasStarted: false,
-	level: undefined,
+	level: 6,
 };

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -142,21 +142,21 @@ describe('useBadgeData.js', () => {
 		});
 	});
 
-	describe('getVisibleTiers', () => {
+	describe('getBadgeWithVisibleTiers', () => {
 		it('should return expected tiers for not started', () => {
 			const apolloMock = {
 				query: jest.fn()
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = undefined;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(3);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -174,14 +174,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 1;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(3);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -199,14 +199,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 2;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(3);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -224,14 +224,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 3;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(5);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -253,14 +253,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 4;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(5);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -282,14 +282,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 5;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(7);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -315,14 +315,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 6;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(7);
 			expect(result.contentfulData[0].level).toBe(1);
@@ -348,14 +348,14 @@ describe('useBadgeData.js', () => {
 					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
 					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
 			};
-			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const { combineBadgeData, getContentfulLevelData, getBadgeWithVisibleTiers } = useBadgeData(apolloMock);
 			const badgeData = combineBadgeData(
 				achievementData.userAchievementProgress.tieredLendingAchievements,
 				contentfulData.contentful.entries.items.map(getContentfulLevelData),
 			)[0];
 			badgeData.level = 7;
 
-			const result = getVisibleTiers(badgeData);
+			const result = getBadgeWithVisibleTiers(badgeData);
 
 			expect(result.contentfulData.length).toBe(7);
 			expect(result.contentfulData[0].level).toBe(1);

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -44,11 +44,11 @@ describe('useBadgeData.js', () => {
 		});
 	});
 
-	describe('getCurrentTierData', () => {
+	describe('getActiveTierData', () => {
 		it('should get the current tier data', () => {
-			const { getCurrentTierData } = useBadgeData();
+			const { getActiveTierData } = useBadgeData();
 
-			expect(getCurrentTierData(badgeNoProgress)).toEqual({
+			expect(getActiveTierData(badgeNoProgress)).toEqual({
 				id: 'basic-needs',
 				level: 1,
 				levelName: 'Basic needs',
@@ -63,9 +63,9 @@ describe('useBadgeData.js', () => {
 		});
 
 		it('should get the current last data (with emoji)', () => {
-			const { getCurrentTierData } = useBadgeData();
+			const { getActiveTierData } = useBadgeData();
 
-			expect(getCurrentTierData(badgeLastTier)).toEqual({
+			expect(getActiveTierData(badgeLastTier)).toEqual({
 				id: 'basic-needs',
 				level: 7,
 				levelName: 'Basic needs✨100✨',
@@ -75,6 +75,27 @@ describe('useBadgeData.js', () => {
 				target: 100,
 				tierStatement: '',
 				completedDate: undefined,
+				learnMoreURL: ''
+			});
+		});
+
+		it('should get the current last data when all completed', () => {
+			const data = JSON.parse(JSON.stringify(badgeLastTier));
+			data.level = 7;
+			data.achievementData.tiers[6].completedDate = '2024-10-22T18:49:21Z';
+
+			const { getActiveTierData } = useBadgeData();
+
+			expect(getActiveTierData(data)).toEqual({
+				id: 'basic-needs',
+				level: 7,
+				levelName: 'Basic needs✨100✨',
+				challengeName: 'Basic needs',
+				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
+				__typename: 'Tier',
+				target: 100,
+				tierStatement: '',
+				completedDate: '2024-10-22T18:49:21Z',
 				learnMoreURL: ''
 			});
 		});
@@ -118,6 +139,240 @@ describe('useBadgeData.js', () => {
 		it('should return expected filtered url for basic-needs', () => {
 			const { getFilteredUrl } = useBadgeData();
 			expect(getFilteredUrl({ id: ID_BASIC_NEEDS })).toEqual(BASIC_NEEDS_FILTER);
+		});
+	});
+
+	describe('getVisibleTiers', () => {
+		it('should return expected tiers for not started', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = undefined;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(3);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.achievementData.tiers.length).toBe(3);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+		});
+
+		it('should return expected tiers for tier 1', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 1;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(3);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.achievementData.tiers.length).toBe(3);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+		});
+
+		it('should return expected tiers for tier 2', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 2;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(3);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.achievementData.tiers.length).toBe(3);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+		});
+
+		it('should return expected tiers for tier 3', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 3;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(5);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.contentfulData[3].level).toBe(4);
+			expect(result.contentfulData[4].level).toBe(5);
+			expect(result.achievementData.tiers.length).toBe(5);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+			expect(result.achievementData.tiers[3].level).toBe(4);
+			expect(result.achievementData.tiers[4].level).toBe(5);
+		});
+
+		it('should return expected tiers for tier 4', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 4;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(5);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.contentfulData[3].level).toBe(4);
+			expect(result.contentfulData[4].level).toBe(5);
+			expect(result.achievementData.tiers.length).toBe(5);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+			expect(result.achievementData.tiers[3].level).toBe(4);
+			expect(result.achievementData.tiers[4].level).toBe(5);
+		});
+
+		it('should return expected tiers for tier 5', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 5;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(7);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.contentfulData[3].level).toBe(4);
+			expect(result.contentfulData[4].level).toBe(5);
+			expect(result.contentfulData[5].level).toBe(6);
+			expect(result.contentfulData[6].level).toBe(7);
+			expect(result.achievementData.tiers.length).toBe(7);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+			expect(result.achievementData.tiers[3].level).toBe(4);
+			expect(result.achievementData.tiers[4].level).toBe(5);
+			expect(result.achievementData.tiers[5].level).toBe(6);
+			expect(result.achievementData.tiers[6].level).toBe(7);
+		});
+
+		it('should return expected tiers for tier 6', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 6;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(7);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.contentfulData[3].level).toBe(4);
+			expect(result.contentfulData[4].level).toBe(5);
+			expect(result.contentfulData[5].level).toBe(6);
+			expect(result.contentfulData[6].level).toBe(7);
+			expect(result.achievementData.tiers.length).toBe(7);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+			expect(result.achievementData.tiers[3].level).toBe(4);
+			expect(result.achievementData.tiers[4].level).toBe(5);
+			expect(result.achievementData.tiers[5].level).toBe(6);
+			expect(result.achievementData.tiers[6].level).toBe(7);
+		});
+
+		it('should return expected tiers for tier 7', () => {
+			const apolloMock = {
+				query: jest.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: achievementData }))
+					.mockReturnValueOnce(Promise.resolve({ data: contentfulData }))
+			};
+			const { combineBadgeData, getContentfulLevelData, getVisibleTiers } = useBadgeData(apolloMock);
+			const badgeData = combineBadgeData(
+				achievementData.userAchievementProgress.tieredLendingAchievements,
+				contentfulData.contentful.entries.items.map(getContentfulLevelData),
+			)[0];
+			badgeData.level = 7;
+
+			const result = getVisibleTiers(badgeData);
+
+			expect(result.contentfulData.length).toBe(7);
+			expect(result.contentfulData[0].level).toBe(1);
+			expect(result.contentfulData[1].level).toBe(2);
+			expect(result.contentfulData[2].level).toBe(3);
+			expect(result.contentfulData[3].level).toBe(4);
+			expect(result.contentfulData[4].level).toBe(5);
+			expect(result.contentfulData[5].level).toBe(6);
+			expect(result.contentfulData[6].level).toBe(7);
+			expect(result.achievementData.tiers.length).toBe(7);
+			expect(result.achievementData.tiers[0].level).toBe(1);
+			expect(result.achievementData.tiers[1].level).toBe(2);
+			expect(result.achievementData.tiers[2].level).toBe(3);
+			expect(result.achievementData.tiers[3].level).toBe(4);
+			expect(result.achievementData.tiers[4].level).toBe(5);
+			expect(result.achievementData.tiers[5].level).toBe(6);
+			expect(result.achievementData.tiers[6].level).toBe(7);
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-945

- Created tested util/composable method
- Renamed another util to be more accurately named
- Updated badge section to just show "visible tiers"
- Updated badge journey to just show "visible tiers"
- Badges section now shows "active" level number to match the badge icon shown

![image](https://github.com/user-attachments/assets/1f9dce47-d0c0-4eac-b79e-d04da31ac615)

![image](https://github.com/user-attachments/assets/aeb011e6-350e-415c-b2be-ac7fa793b27d)
