### PR TITLE
fix: guest account flow store name in userAccount instead of lender

### DIFF
--- a/src/components/MyKiva/MyKivaProfile.vue
+++ b/src/components/MyKiva/MyKivaProfile.vue
@@ -40,16 +40,20 @@ const props = defineProps({
 		type: Object,
 		default: () => ({}),
 	},
+	userInfo: {
+		type: Object,
+		default: () => ({}),
+	},
 	isLoading: {
 		type: Boolean,
 		default: false,
 	},
 });
 
-const { lender } = toRefs(props);
+const { lender, userInfo } = toRefs(props);
 
 const lenderName = computed(() => {
-	return lender?.value?.name ?? '';
+	return userInfo?.value?.userAccount?.firstName ?? '';
 });
 
 const lenderImageUrl = computed(() => {

--- a/src/graphql/query/myKiva.graphql
+++ b/src/graphql/query/myKiva.graphql
@@ -55,6 +55,7 @@ query myKivaQuery {
     }
     userAccount {
       id
+      firstName
       balance
     }
     trustee {

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -11,6 +11,7 @@
 		/>
 		<MyKivaProfile
 			:lender="lender"
+			:user-info="userInfo"
 			:is-loading="isLoading"
 		/>
 		<MyKivaContainer>


### PR DESCRIPTION
Within `GuestAccountCreation` component, mutation  `startGuestAccountClaim` store `firstName` and `lastName` in `userAccount` instead of `lender`. That's why `lenderName` is `empty` causing first letter not being shown
