### PR TITLE
feat: change contentful level to a string and update code accordingly

### DIFF
--- a/.storybook/mock-data/badge-journey-data-mock.js
+++ b/.storybook/mock-data/badge-journey-data-mock.js
@@ -5,49 +5,49 @@ export const badgeWomensEquality = {
 		{
 			"id": "womens-equality",
 			"level": 1,
-			"levelName": "Women's equality",
+			"levelName": "1",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg"
 		},
 		{
 			"id": "womens-equality",
 			"level": 2,
-			"levelName": "Women's equality",
+			"levelName": "2",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg"
 		},
 		{
 			"id": "womens-equality",
 			"level": 3,
-			"levelName": "Women's equality",
+			"levelName": "3",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg"
 		},
 		{
 			"id": "womens-equality",
 			"level": 4,
-			"levelName": "Women's equality",
+			"levelName": "4",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg"
 		},
 		{
 			"id": "womens-equality",
 			"level": 5,
-			"levelName": "Women's equality",
+			"levelName": "5",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg"
 		},
 		{
 			"id": "womens-equality",
 			"level": 6,
-			"levelName": "Women's equality ✨50✨",
+			"levelName": "✨50✨",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg"
 		},
 		{
 			"id": "womens-equality",
 			"level": 7,
-			"levelName": "Women's equality ✨100✨",
+			"levelName": "✨100✨",
 			"challengeName": "Women's equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg"
 		}
@@ -118,49 +118,49 @@ export const badgeUsEconomicEquality = {
 		{
 			"id": "us-economic-equality",
 			"level": 1,
-			"levelName": "U.S. economic equality",
+			"levelName": "1",
 			"challengeName": "U.S. economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 2,
-			"levelName": "U.S. Economic equality",
+			"levelName": "2",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 3,
-			"levelName": "U.S. Economic equality",
+			"levelName": "3",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/6cb471c2c85e39c7cc98d9795ea1e066/US_Business_30.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 4,
-			"levelName": "U.S. Economic equality",
+			"levelName": "4",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 5,
-			"levelName": "U.S. Economic equality",
+			"levelName": "5",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 6,
-			"levelName": "U.S. Economic equality ✨50✨",
+			"levelName": "✨50✨",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 7,
-			"levelName": "U.S. Economic equality ✨100✨",
+			"levelName": "✨100✨",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg"
 		}
@@ -232,49 +232,49 @@ export const badgeClimateAction = {
 		{
 			"id": "climate-action",
 			"level": 1,
-			"levelName": "Climate action",
+			"levelName": "1",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg"
 		},
 		{
 			"id": "climate-action",
 			"level": 2,
-			"levelName": "Climate action",
+			"levelName": "2",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg"
 		},
 		{
 			"id": "climate-action",
 			"level": 3,
-			"levelName": "Climate action",
+			"levelName": "3",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg"
 		},
 		{
 			"id": "climate-action",
 			"level": 4,
-			"levelName": "Climate action",
+			"levelName": "4",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg"
 		},
 		{
 			"id": "climate-action",
 			"level": 5,
-			"levelName": "Climate action",
+			"levelName": "5",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg"
 		},
 		{
 			"id": "climate-action",
 			"level": 6,
-			"levelName": "Climate action ✨50✨",
+			"levelName": "✨50✨",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg"
 		},
 		{
 			"id": "climate-action",
 			"level": 7,
-			"levelName": "Climate action ✨100✨",
+			"levelName": "✨100✨",
 			"challengeName": "Climate action",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg"
 		}
@@ -345,49 +345,49 @@ export const badgeRefugeeEquality = {
 		{
 			"id": "refugee-equality",
 			"level": 1,
-			"levelName": "Refugee equality",
+			"levelName": "1",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg"
 		},
 		{
 			"id": "refugee-equality",
 			"level": 2,
-			"levelName": "Refugee equality",
+			"levelName": "2",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg"
 		},
 		{
 			"id": "refugee-equality",
 			"level": 3,
-			"levelName": "Refugee equality",
+			"levelName": "3",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg"
 		},
 		{
 			"id": "refugee-equality",
 			"level": 4,
-			"levelName": "Refugee equality",
+			"levelName": "4",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg"
 		},
 		{
 			"id": "refugee-equality",
 			"level": 5,
-			"levelName": "Refugee equality",
+			"levelName": "5",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg"
 		},
 		{
 			"id": "refugee-equality",
 			"level": 6,
-			"levelName": "Refugee equality ✨50✨",
+			"levelName": "✨50✨",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg"
 		},
 		{
 			"id": "refugee-equality",
 			"level": 7,
-			"levelName": "Refugee equality ✨100✨",
+			"levelName": "✨100✨",
 			"challengeName": "Refugee equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg"
 		}
@@ -458,49 +458,49 @@ export const badgeBasicNeeds = {
 		{
 			"id": "basic-needs",
 			"level": 1,
-			"levelName": "Basic needs",
+			"levelName": "1",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg"
 		},
 		{
 			"id": "basic-needs",
 			"level": 2,
-			"levelName": "Basic needs",
+			"levelName": "2",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg"
 		},
 		{
 			"id": "basic-needs",
 			"level": 3,
-			"levelName": "Basic needs",
+			"levelName": "3",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg"
 		},
 		{
 			"id": "basic-needs",
 			"level": 4,
-			"levelName": "Basic needs",
+			"levelName": "4",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg"
 		},
 		{
 			"id": "basic-needs",
 			"level": 5,
-			"levelName": "Basic needs",
+			"levelName": "5",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg"
 		},
 		{
 			"id": "basic-needs",
 			"level": 6,
-			"levelName": "Basic needs ✨50✨",
+			"levelName": "✨50✨",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg"
 		},
 		{
 			"id": "basic-needs",
 			"level": 7,
-			"levelName": "Basic needs ✨100✨",
+			"levelName": "✨100✨",
 			"challengeName": "Basic needs",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg"
 		}
@@ -571,49 +571,49 @@ export const badgeFirstTierComplete = {
 		{
 			"id": "us-economic-equality",
 			"level": 1,
-			"levelName": "U.S. economic equality",
+			"levelName": "1",
 			"challengeName": "U.S. economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 2,
-			"levelName": "U.S. Economic equality",
+			"levelName": "2",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 3,
-			"levelName": "U.S. Economic equality",
+			"levelName": "3",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/6cb471c2c85e39c7cc98d9795ea1e066/US_Business_30.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 4,
-			"levelName": "U.S. Economic equality",
+			"levelName": "4",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 5,
-			"levelName": "U.S. Economic equality",
+			"levelName": "5",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 6,
-			"levelName": "U.S. Economic equality ✨50✨",
+			"levelName": "✨50✨",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg"
 		},
 		{
 			"id": "us-economic-equality",
 			"level": 7,
-			"levelName": "U.S. Economic equality ✨100✨",
+			"levelName": "✨100✨",
 			"challengeName": "U.S. Economic equality",
 			"imageUrl": "//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg"
 		}

--- a/src/components/MyKiva/BadgeCompleted.vue
+++ b/src/components/MyKiva/BadgeCompleted.vue
@@ -2,7 +2,7 @@
 	<div class="container">
 		<div class="badge-container tw-flex-col tw-mb-4">
 			<h2 class="tw-text-center tw-mb-2">
-				{{ badgeCategory }}
+				{{ badgeData.tierName }}
 			</h2>
 			<div class="tw-relative tw-z-1 tw-mb-3" :style="{ minWidth: '16rem'}">
 				<div
@@ -14,7 +14,7 @@
 				<img
 					:src="badgeImage"
 					class="badge tw-z-2"
-					:alt="badgeCategory"
+					:alt="badgeData.tierName"
 				>
 			</div>
 			<h2 class="tw-italic tw-font-medium tw-text-desert-rose-4 tw-mb-2 tw-text-center">
@@ -117,8 +117,6 @@ const badgeImage = computed(() => {
 	return badgeData.value.contentfulData?.imageUrl ?? '';
 });
 
-const badgeCategory = computed(() => badgeData.value?.challengeName ?? '');
-
 const badgeLevel = computed(() => {
 	return badgeData.value?.achievementData?.target ?? 0;
 });
@@ -157,7 +155,7 @@ const trackLearnMore = () => {
 		'portfolio',
 		'click',
 		label,
-		badgeCategory.value,
+		badgeData.value.challengeName,
 		badgeLevel.value
 	);
 };
@@ -171,7 +169,7 @@ const trackSharing = () => {
 		'portfolio',
 		'click',
 		label,
-		badgeCategory.value,
+		badgeData.value.challengeName,
 		badgeLevel.value
 	);
 };

--- a/src/components/MyKiva/BadgeInProgress.vue
+++ b/src/components/MyKiva/BadgeInProgress.vue
@@ -11,7 +11,7 @@
 				>
 			</BadgeContainer>
 			<div>
-				<h3>{{ badge.challengeName }}</h3>
+				<h3>{{ tierBadgeData.tierName }}</h3>
 				<p>{{ subHeader }}</p>
 			</div>
 		</div>

--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -145,7 +145,10 @@ const getBadgeStatus = index => {
 
 const getTierName = index => {
 	const contentfulData = badgeWithVisibleTiers.value.contentfulData[index];
-	return `${contentfulData.challengeName} ${contentfulData.levelName}`;
+	if (contentfulData.challengeName && contentfulData.levelName) {
+		return `${contentfulData.challengeName} ${contentfulData.levelName}`;
+	}
+	return `Level ${index + 1}`;
 };
 
 const handleBadgeClick = index => {

--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -54,7 +54,7 @@
 				</div>
 				<div class="tw-text-center tw-bg-white tw-z-1 tw-relative">
 					<div class="tw-font-medium">
-						{{ badgeWithVisibleTiers.contentfulData[index].levelName }}
+						{{ getTierName(index) }}
 					</div>
 					<div class="tw-text-small">
 						{{ tierCaption(index) }}
@@ -141,6 +141,11 @@ const getBadgeStatus = index => {
 		return BADGE_IN_PROGRESS;
 	}
 	return BADGE_LOCKED;
+};
+
+const getTierName = index => {
+	const contentfulData = badgeWithVisibleTiers.value.contentfulData[index];
+	return `${contentfulData.challengeName} ${contentfulData.levelName}`;
 };
 
 const handleBadgeClick = index => {

--- a/src/components/MyKiva/EarnedBadgesSection.vue
+++ b/src/components/MyKiva/EarnedBadgesSection.vue
@@ -123,7 +123,7 @@ const getBadgeTitle = badge => {
 		return badge?.contentfulData?.[0]?.challengeName ?? '';
 	}
 	const badgeData = badge?.contentfulData?.find(data => data.level === badge.level);
-	return `${badgeData?.challengeName} ${badgeData?.level}` ?? '';
+	return `${badgeData?.challengeName} ${badgeData?.levelName}` ?? '';
 };
 
 const getBadgeImgUrl = badge => {

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -251,6 +251,7 @@ export default function useBadgeData() {
 			...badge,
 			contentfulData,
 			achievementData,
+			tierName: `${(contentfulData.challengeName ?? '')} ${(contentfulData.levelName ?? '')}`
 		};
 	};
 

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -34,8 +34,8 @@ export default function useBadgeData() {
 	const getContentfulLevelData = entry => ({
 		id: entry?.fields?.key?.replace(/-level-\d+/, '') ?? '',
 		level: +(entry?.fields?.key?.replace(/\D/g, '') ?? ''),
-		levelName: entry?.fields?.challengeName ?? '',
-		challengeName: (entry?.fields?.challengeName ?? '').replace(/\s*✨\d+✨/, ''),
+		levelName: entry?.fields?.levelName ?? '',
+		challengeName: entry?.fields?.challengeName ?? '',
 		imageUrl: entry?.fields?.badgeImage?.fields?.file?.url ?? '',
 	});
 

--- a/test/unit/fixtures/useBadgeDataMock.js
+++ b/test/unit/fixtures/useBadgeDataMock.js
@@ -336,8 +336,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'us-economic-equality-level-6',
-						challengeName: 'U.S. Economic equality ✨50✨',
-						level: 6,
+						challengeName: 'U.S. Economic equality',
+						levelName: '✨50✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -468,8 +468,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'refugee-equality-level-7',
-						challengeName: 'Refugee equality ✨100✨',
-						level: 7,
+						challengeName: 'Refugee equality',
+						levelName: '✨100✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -600,8 +600,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'refugee-equality-level-6',
-						challengeName: 'Refugee equality ✨50✨',
-						level: 6,
+						challengeName: 'Refugee equality',
+						levelName: '✨50✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -732,8 +732,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'climate-action-level-7',
-						challengeName: 'Climate action ✨100✨',
-						level: 7,
+						challengeName: 'Climate action',
+						levelName: '✨100✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -864,8 +864,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'climate-action-level-6',
-						challengeName: 'Climate action✨50✨',
-						level: 6,
+						challengeName: 'Climate action',
+						levelName: '✨50✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -996,8 +996,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'basic-needs-level-7',
-						challengeName: 'Basic needs✨100✨',
-						level: 7,
+						challengeName: 'Basic needs',
+						levelName: '✨100✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1128,8 +1128,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'basic-needs-level-6',
-						challengeName: 'Basic needs ✨50✨',
-						level: 6,
+						challengeName: 'Basic needs',
+						levelName: '✨50✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1260,8 +1260,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'womens-equality-level-7',
-						challengeName: "Women's equality ✨100✨",
-						level: 7,
+						challengeName: "Women's equality",
+						levelName: '✨100✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1392,8 +1392,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'womens-equality-level-6',
-						challengeName: "Women's equality ✨50✨",
-						level: 6,
+						challengeName: "Women's equality",
+						levelName: '✨50✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1525,7 +1525,7 @@ export const contentfulData = {
 					fields: {
 						key: 'womens-equality-level-5',
 						challengeName: "Women's equality",
-						level: 5,
+						levelName: '5',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1657,7 +1657,7 @@ export const contentfulData = {
 					fields: {
 						key: 'womens-equality-level-4',
 						challengeName: "Women's equality",
-						level: 4,
+						levelName: '4',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1789,7 +1789,7 @@ export const contentfulData = {
 					fields: {
 						key: 'womens-equality-level-3',
 						challengeName: "Women's equality",
-						level: 3,
+						levelName: '3',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -1921,7 +1921,7 @@ export const contentfulData = {
 					fields: {
 						key: 'womens-equality-level-2',
 						challengeName: "Women's equality",
-						level: 2,
+						levelName: '2',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2052,8 +2052,8 @@ export const contentfulData = {
 					},
 					fields: {
 						key: 'us-economic-equality-level-7',
-						challengeName: 'U.S. Economic equality ✨100✨',
-						level: 7,
+						challengeName: 'U.S. Economic equality',
+						levelName: '✨100✨',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2185,7 +2185,7 @@ export const contentfulData = {
 					fields: {
 						key: 'us-economic-equality-level-5',
 						challengeName: 'U.S. Economic equality',
-						level: 5,
+						levelName: '5',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2317,7 +2317,7 @@ export const contentfulData = {
 					fields: {
 						key: 'us-economic-equality-level-4',
 						challengeName: 'U.S. Economic equality',
-						level: 4,
+						levelName: '4',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2449,7 +2449,7 @@ export const contentfulData = {
 					fields: {
 						key: 'us-economic-equality-level-3',
 						challengeName: 'U.S. Economic equality',
-						level: 3,
+						levelName: '3',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2581,7 +2581,7 @@ export const contentfulData = {
 					fields: {
 						key: 'us-economic-equality-level-2',
 						challengeName: 'U.S. Economic equality',
-						level: 2,
+						levelName: '2',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2716,7 +2716,7 @@ export const contentfulData = {
 					fields: {
 						key: 'refugee-equality-level-5',
 						challengeName: 'Refugee equality',
-						level: 5,
+						levelName: '5',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2848,7 +2848,7 @@ export const contentfulData = {
 					fields: {
 						key: 'refugee-equality-level-4',
 						challengeName: 'Refugee equality',
-						level: 4,
+						levelName: '4',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -2980,7 +2980,7 @@ export const contentfulData = {
 					fields: {
 						key: 'refugee-equality-level-3',
 						challengeName: 'Refugee equality',
-						level: 3,
+						levelName: '3',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3112,7 +3112,7 @@ export const contentfulData = {
 					fields: {
 						key: 'refugee-equality-level-2',
 						challengeName: 'Refugee equality',
-						level: 2,
+						levelName: '2',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3244,7 +3244,7 @@ export const contentfulData = {
 					fields: {
 						key: 'climate-action-level-5',
 						challengeName: 'Climate action',
-						level: 5,
+						levelName: '5',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3376,7 +3376,7 @@ export const contentfulData = {
 					fields: {
 						key: 'climate-action-level-4',
 						challengeName: 'Climate action',
-						level: 4,
+						levelName: '4',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3508,7 +3508,7 @@ export const contentfulData = {
 					fields: {
 						key: 'climate-action-level-3',
 						challengeName: 'Climate action',
-						level: 3,
+						levelName: '3',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3640,7 +3640,7 @@ export const contentfulData = {
 					fields: {
 						key: 'climate-action-level-2',
 						challengeName: 'Climate action',
-						level: 2,
+						levelName: '2',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3772,7 +3772,7 @@ export const contentfulData = {
 					fields: {
 						key: 'basic-needs-level-5',
 						challengeName: 'Basic needs',
-						level: 5,
+						levelName: '5',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -3904,7 +3904,7 @@ export const contentfulData = {
 					fields: {
 						key: 'basic-needs-level-4',
 						challengeName: 'Basic needs',
-						level: 4,
+						levelName: '4',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4036,7 +4036,7 @@ export const contentfulData = {
 					fields: {
 						key: 'basic-needs-level-3',
 						challengeName: 'Basic needs',
-						level: 3,
+						levelName: '3',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4168,7 +4168,7 @@ export const contentfulData = {
 					fields: {
 						key: 'basic-needs-level-2',
 						challengeName: 'Basic needs',
-						level: 2,
+						levelName: '2',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4300,7 +4300,7 @@ export const contentfulData = {
 					fields: {
 						key: 'basic-needs-level-1',
 						challengeName: 'Basic needs',
-						level: 1,
+						levelName: '1',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4432,7 +4432,7 @@ export const contentfulData = {
 					fields: {
 						key: 'us-economic-equality-level-1',
 						challengeName: 'U.S. Economic equality',
-						level: 1,
+						levelName: '1',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4565,7 +4565,7 @@ export const contentfulData = {
 					fields: {
 						key: 'refugee-equality-level-1',
 						challengeName: 'Refugee equality',
-						level: 1,
+						levelName: '1',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4697,7 +4697,7 @@ export const contentfulData = {
 					fields: {
 						key: 'climate-action-level-1',
 						challengeName: 'Climate action',
-						level: 1,
+						levelName: '1',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -4829,7 +4829,7 @@ export const contentfulData = {
 					fields: {
 						key: 'womens-equality-level-1',
 						challengeName: "Women's equality",
-						level: 1,
+						levelName: '1',
 						badgeImage: {
 							metadata: {
 								tags: [],
@@ -8958,49 +8958,49 @@ export const combinedData = [
 			{
 				id: 'us-economic-equality',
 				level: 1,
-				levelName: 'U.S. Economic equality',
+				levelName: '1',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3C3ddaga4hEXBlb9WxsdlQ/0155bb0e9a32be6b00071afa4769b10c/US_Business_10.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 2,
-				levelName: 'U.S. Economic equality',
+				levelName: '2',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/62zEUpZbO7qWZPoV1z2pZU/9664408940c996a953658c0d7508ecca/US_Business_20.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 3,
-				levelName: 'U.S. Economic equality',
+				levelName: '3',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4q0Das9uTU0gfrwtld137n/27262f02db91bc35ab0b4ac06dbb940a/US_Business_40.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 4,
-				levelName: 'U.S. Economic equality',
+				levelName: '4',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4f5MR6ggWdXx3AC7oxx596/96c431c599c42c56483f7d18f43fe0aa/US_Business_40.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 5,
-				levelName: 'U.S. Economic equality',
+				levelName: '5',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2s7t7DyW1EBoF4S7HhO4eZ/9d9c46c77f5dac5f4e979c23d213a875/US_Business_50.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 6,
-				levelName: 'U.S. Economic equality ✨50✨',
+				levelName: '✨50✨',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4nUE568E3WCZ1rYpbH3G1z/e2b568f72e76ef888b97e28fb2cd21b3/US_Business_60.svg'
 			},
 			{
 				id: 'us-economic-equality',
 				level: 7,
-				levelName: 'U.S. Economic equality ✨100✨',
+				levelName: '✨100✨',
 				challengeName: 'U.S. Economic equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6p6BcDBlAb7ZoCaZaypJIT/959a8c1e856fc5f9bf3227f6b92edbd4/US_Business_70.svg'
 			},
@@ -9078,49 +9078,49 @@ export const combinedData = [
 			{
 				id: 'climate-action',
 				level: 1,
-				levelName: 'Climate action',
+				levelName: '1',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3YklKNLbiA4kAcOgk5ouaw/14b41006455dfd756f141e0217bb8e9c/Climate_10.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 2,
-				levelName: 'Climate action',
+				levelName: '2',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/7crCD9q1xCii5mcLAj3SKa/86d912839e1785e4ebc4d00a633d2595/Climate_20.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 3,
-				levelName: 'Climate action',
+				levelName: '3',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6dKOH8W4ZCWxTO7OXPfAWo/e809280605febcc79f4178b582b48ecc/Climate_30.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 4,
-				levelName: 'Climate action',
+				levelName: '4',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4FAMdCiqyrNBzGH7IzYJ6G/dfc9dc1f2025387315d1667c429fecb2/Climate_40.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 5,
-				levelName: 'Climate action',
+				levelName: '5',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/7LVRDYs9PmApE3LhZ4D4Ek/18738b77ee8cd2ca090792b203a30b41/Climate_50.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 6,
-				levelName: 'Climate action✨50✨',
+				levelName: '✨50✨',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3vmiyohO4jjDEwnzO4QMZh/f724ce214554fd10b7bd5980cf34d0a0/Climate_60.svg'
 			},
 			{
 				id: 'climate-action',
 				level: 7,
-				levelName: 'Climate action ✨100✨',
+				levelName: '✨100✨',
 				challengeName: 'Climate action',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/JdDGpZIjI7FXBouv3bJa4/14ccc8f267f9232c784243c1c25e87c4/Climate_70.svg'
 			},
@@ -9198,49 +9198,49 @@ export const combinedData = [
 			{
 				id: 'womens-equality',
 				level: 1,
-				levelName: "Women's equality",
+				levelName: '1',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/3dAEh0zYSkqK5Up5q8Flv8/70d21f8db5f93b20be1581ef333dc60e/Women_10.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 2,
-				levelName: "Women's equality",
+				levelName: '2',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6PcVN0gI5MIwytZm5AFQ32/08e39f77b0ecbeb4dd67f7e4625e3e07/Women_20.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 3,
-				levelName: "Women's equality",
+				levelName: '3',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/25FLM7Cyv1kik5nFkdIT2O/654e6fa5affd8d05b17b57291e8a5a73/Women_30.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 4,
-				levelName: "Women's equality",
+				levelName: '4',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/15RLZ1WiHmGQgtlkkMZTH0/b45086ce91aadae2b74c4adeae294f0d/Women_40.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 5,
-				levelName: "Women's equality",
+				levelName: '5',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6mqr1eJTJHksfTlRmpI7bB/ef75875bffc8c437b2d21725cd87ffae/Women_50.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 6,
-				levelName: "Women's equality ✨50✨",
+				levelName: '✨50✨',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/5SpskyxoH08WfjVuzXjq6T/95fdd254220d2dccae8a40552f602846/Women_75.svg'
 			},
 			{
 				id: 'womens-equality',
 				level: 7,
-				levelName: "Women's equality ✨100✨",
+				levelName: '✨100✨',
 				challengeName: "Women's equality",
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2rJH0UWfITf7KPuySP8x9/3de2dff5953335b9bcebc5e875a8ccfa/Women_70.svg'
 			},
@@ -9317,49 +9317,49 @@ export const combinedData = [
 			{
 				id: 'refugee-equality',
 				level: 1,
-				levelName: 'Refugee equality',
+				levelName: '1',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1SEhQMUbYUqZopjP2o67XK/c9b1f51837d87905d2a71578c0d6c434/Refugees_10.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 2,
-				levelName: 'Refugee equality',
+				levelName: '2',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4EfRGWaySxx9eCxkwJJ71S/524e2d4220f0c593171f5019b5684cc1/Refugees_20.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 3,
-				levelName: 'Refugee equality',
+				levelName: '3',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/5TO71LArbZCXuey6JJnrm8/8f0f4bdc54a00a7a9420b26c20f59feb/Refugees_30.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 4,
-				levelName: 'Refugee equality',
+				levelName: '4',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2rCdTrkgqrajqscTGgt6YZ/1266c781e4b92e999a3a2fe7cf7925ff/Refugees_40.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 5,
-				levelName: 'Refugee equality',
+				levelName: '5',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6oSmu0Kc94YpMllGEsw2o4/1d7dc0a0ace39dc673e0f969cf2ea155/Refugees_50.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 6,
-				levelName: 'Refugee equality ✨50✨',
+				levelName: '✨50✨',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/4sN0hJtCkirthBDrSOh2YA/d2e9935c50443577ccc5344cd548d78c/Refugees_60.svg'
 			},
 			{
 				id: 'refugee-equality',
 				level: 7,
-				levelName: 'Refugee equality ✨100✨',
+				levelName: '✨100✨',
 				challengeName: 'Refugee equality',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1vGn9ZCa3OFC7Tiqv14G7K/d26af7d84652d82625a7df5414115fc6/Refugees_70.svg'
 			},
@@ -9437,49 +9437,49 @@ export const combinedData = [
 			{
 				id: 'basic-needs',
 				level: 1,
-				levelName: 'Basic needs',
+				levelName: '1',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 2,
-				levelName: 'Basic needs',
+				levelName: '2',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 3,
-				levelName: 'Basic needs',
+				levelName: '3',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 4,
-				levelName: 'Basic needs',
+				levelName: '4',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 5,
-				levelName: 'Basic needs',
+				levelName: '5',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 6,
-				levelName: 'Basic needs ✨50✨',
+				levelName: '✨50✨',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
 			},
 			{
 				id: 'basic-needs',
 				level: 7,
-				levelName: 'Basic needs✨100✨',
+				levelName: '✨100✨',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
 			},
@@ -9558,49 +9558,49 @@ export const badgeNoProgress = {
 		{
 			id: 'basic-needs',
 			level: 1,
-			levelName: 'Basic needs',
+			levelName: '1',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 2,
-			levelName: 'Basic needs',
+			levelName: '2',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 3,
-			levelName: 'Basic needs',
+			levelName: '3',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 4,
-			levelName: 'Basic needs',
+			levelName: '4',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 5,
-			levelName: 'Basic needs',
+			levelName: '5',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 6,
-			levelName: 'Basic needs ✨50✨',
+			levelName: '✨50✨',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 7,
-			levelName: 'Basic needs✨100✨',
+			levelName: '✨100✨',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
 		},
@@ -9678,49 +9678,49 @@ export const badgeLastTier = {
 		{
 			id: 'basic-needs',
 			level: 1,
-			levelName: 'Basic needs',
+			levelName: '1',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 2,
-			levelName: 'Basic needs',
+			levelName: '2',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/SHdA5oclQUy5T5YQhfTd2/e508b6444f2d2da060962b4f286e3f43/Basic_Needs_20.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 3,
-			levelName: 'Basic needs',
+			levelName: '3',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1dZrR0nnWsEB9AGjW2qOL6/b347be0178ead388ef75a23761c854a2/Basic_Needs_30.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 4,
-			levelName: 'Basic needs',
+			levelName: '4',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/2AptyhDdjcbumiax0upWWZ/9c94a554f7126c41ad8f584d73b9e35b/Basic_Needs_40.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 5,
-			levelName: 'Basic needs',
+			levelName: '5',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/6m9RP1jcZxZMz5EqWyl8a8/95c9827a6d097703b1c048391634178a/Basic_Needs_50.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 6,
-			levelName: 'Basic needs ✨50✨',
+			levelName: '✨50✨',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/ESTL9bCh4khif4gxZO8ft/14e72f360d5adb4e4be6f94ef6b1dbae/Basic_Needs_60.svg'
 		},
 		{
 			id: 'basic-needs',
 			level: 7,
-			levelName: 'Basic needs✨100✨',
+			levelName: '✨100✨',
 			challengeName: 'Basic needs',
 			imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg'
 		},

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -111,6 +111,7 @@ describe('useBadgeData.js', () => {
 				...sampleBadge,
 				contentfulData: sampleBadge.contentfulData?.[tier - 1],
 				achievementData: sampleBadge.achievementData?.tiers?.[tier - 1],
+				tierName: `${sampleBadge.contentfulData?.[tier - 1].challengeName} ${sampleBadge.contentfulData?.[tier - 1].levelName}`,
 			});
 		});
 	});

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -51,7 +51,7 @@ describe('useBadgeData.js', () => {
 			expect(getActiveTierData(badgeNoProgress)).toEqual({
 				id: 'basic-needs',
 				level: 1,
-				levelName: 'Basic needs',
+				levelName: '1',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/694uSymh8om0MxbiCjWZxl/b55c8cb3f3743efdd56b56beea8dfb42/Basic_Needs_10.svg',
 				__typename: 'Tier',
@@ -68,7 +68,7 @@ describe('useBadgeData.js', () => {
 			expect(getActiveTierData(badgeLastTier)).toEqual({
 				id: 'basic-needs',
 				level: 7,
-				levelName: 'Basic needs✨100✨',
+				levelName: '✨100✨',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
 				__typename: 'Tier',
@@ -89,7 +89,7 @@ describe('useBadgeData.js', () => {
 			expect(getActiveTierData(data)).toEqual({
 				id: 'basic-needs',
 				level: 7,
-				levelName: 'Basic needs✨100✨',
+				levelName: '✨100✨',
 				challengeName: 'Basic needs',
 				imageUrl: '//images.ctfassets.net/j0p9a6ql0rn7/1LLL9K4PgaUZb3H0JLWEPU/4ed0ec9c5515fa25410b9e32d6a8e7cf/Basic_Needs_70.svg',
 				__typename: 'Tier',


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-980

- Created new field on challenges in Contentful, `levelName` short string, and removed unused `level` field -> simplifies differentiating challenge and level names
- Updated field for all 7 levels of the current 5 badges on dev in Contentful
- Updated `useBadgeData` to utilize this new field (allows us to have `levelNames` as strings)
- Updated UI to use the new field as required