### PR TITLE
feat: optional run & wait time recordings in vue worker pool

### DIFF
--- a/config/dynamic.js
+++ b/config/dynamic.js
@@ -101,6 +101,7 @@ export const server = {
 	minVueWorkers: parseInt(process.env.MIN_VUE_WORKERS, 10) || 1,
 	maxVueWorkers: parseInt(process.env.MAX_VUE_WORKERS, 10) || 3,
 	vueWorkerIdleTimeout: parseInt(process.env.VUE_WORKER_IDLE_TIMEOUT, 10) || 0,
+	vueWorkerRecordTiming: process.env.VUE_WORKER_RECORD_TIMING === 'true',
 };
 
 export default {

--- a/config/index.js
+++ b/config/index.js
@@ -79,6 +79,7 @@ export const server = {
 	minVueWorkers: 1,
 	maxVueWorkers: 3,
 	vueWorkerIdleTimeout: 0,
+	vueWorkerRecordTiming: false,
 };
 
 export default {

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -53,6 +53,7 @@ export default function createMiddleware({ config, vite }) {
 			idleTimeout: config.server.vueWorkerIdleTimeout,
 			minWorkers: config.server.minVueWorkers,
 			maxWorkers: config.server.maxVueWorkers,
+			recordTiming: config.server.vueWorkerRecordTiming,
 			workerData: {
 				ssrManifest,
 				serverConfig: config.server,

--- a/server/vue-worker-pool.js
+++ b/server/vue-worker-pool.js
@@ -10,6 +10,7 @@ export default function createWorkerPool({
 	idleTimeout,
 	minWorkers,
 	maxWorkers,
+	recordTiming,
 	workerData
 } = {}) {
 	// Terminate the existing pool if it was created
@@ -21,6 +22,7 @@ export default function createWorkerPool({
 	pool = new Piscina({
 		filename: resolve(dirname(fileURLToPath(import.meta.url)), 'vue-worker.js'),
 		taskQueue: new FixedQueue(),
+		recordTiming: recordTiming === true,
 		idleTimeout,
 		minThreads: minWorkers,
 		maxThreads: maxWorkers,


### PR DESCRIPTION
Piscina creates nodejs performance histograms that it updates continually as requests come in for the [run time](https://github.com/piscinajs/piscina?tab=readme-ov-file#property-runtime-readonly) and the [wait time](https://github.com/piscinajs/piscina?tab=readme-ov-file#property-waittime-readonly). These stats can only be read in terms of the lifetime of the pool, not any smaller or larger time segments, which makes them not very useful outside of development testing. In our real environments, we can use our existing metrics in grafana to get the same information.

There is a chance that constantly updating these histograms is what is contributing to the increasing event loop lap over the lifetime of the UI pods that keeps happening, so I'm creating this PR to test that. The recordTiming option can be set to `false` to prevent the histograms from being created https://github.com/piscinajs/piscina?tab=readme-ov-file#constructor-new-piscinaoptions. 