### PR TITLE
feat: footnote support for borrower status cards in MyKiva

### DIFF
--- a/src/components/MyKiva/BorrowerStatusCard.vue
+++ b/src/components/MyKiva/BorrowerStatusCard.vue
@@ -31,7 +31,7 @@
 						{{ title }}
 					</h3>
 					<p class="tw-text-center md:tw-text-left">
-						{{ description }}
+						{{ description }}{{ hasLoanFunFactFootnote(loan) ? '*' : '' }}
 						<br>
 						<a
 							class="tw-text-action"
@@ -104,6 +104,7 @@ import {
 import {
 	FUNDRAISING,
 } from '#src/api/fixtures/LoanStatusEnum';
+import { hasLoanFunFactFootnote } from '#src/util/myKivaUtils';
 
 const $kvTrackEvent = inject('$kvTrackEvent');
 
@@ -131,13 +132,11 @@ const title = computed(() => `${borrowerName.value} in ${borrowerCountry.value}`
 const loanUse = computed(() => loan.value?.use ?? '');
 
 const loanFunFact = computed(() => {
-	// TODO: Replace this logic once MP-820 is complete
 	const region = loan.value?.geocode?.country?.region ?? '';
 	if (region === 'North America') {
 		switch (borrowerCountry.value) {
 			case 'United States':
-
-				return '3 in 5 U.S. business owners felt less stressed about finances after support from Kiva.*';
+				return '3 in 5 U.S. business owners felt less stressed about finances after support from Kiva.';
 			case 'Puerto Rico':
 				// eslint-disable-next-line max-len
 				return 'Small businesses are a crucial part of Puerto Rico\'s economy, employing around 44% of Puerto Rico\'s workforce.';
@@ -158,13 +157,13 @@ const loanFunFact = computed(() => {
 	switch (region) {
 		case 'Central America':
 			// eslint-disable-next-line max-len
-			return 'In Central America, 95% of people surveyed said their quality of life improved as a result of their loan.*';
+			return 'In Central America, 95% of people surveyed said their quality of life improved as a result of their loan.';
 		case 'South America':
 			// eslint-disable-next-line max-len
 			return 'People living in poverty in South America has decreased from ~30% in 2002 to less than 20% by 2020.';
 		case 'Africa':
 			// eslint-disable-next-line max-len
-			return 'In Africa, 92% of people surveyed said their confidence in their own abilities improved as a result of their loan.*';
+			return 'In Africa, 92% of people surveyed said their confidence in their own abilities improved as a result of their loan.';
 		case 'Middle East':
 			// eslint-disable-next-line max-len
 			return 'The number of people with bank accounts is on the rise in the Middle East, a vital step in driving economic opportunity.';
@@ -173,7 +172,7 @@ const loanFunFact = computed(() => {
 			return 'Eastern European countries have made progress in reducing poverty levels over the past decade through social protection programs.';
 		case 'Asia':
 			// eslint-disable-next-line max-len
-			return 'In Asia, 86% of people surveyed were better able to manage their finances as a result of their loan.*';
+			return 'In Asia, 86% of people surveyed were better able to manage their finances as a result of their loan.';
 		default:
 			// eslint-disable-next-line max-len
 			return 'In areas of Oceania like Fiji, the gender gap is improving—with more women able to access financial services.';

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -115,6 +115,13 @@
 				@badge-clicked="handleEarnedBadgeClicked"
 			/>
 		</template>
+		<div v-if="showLoanFootnote" class="tw-bg-white tw-text-small tw-py-4 md:tw-py-2.5">
+			<MyKivaContainer>
+				<section>
+					*Borrowers of Kiva Lending Partners surveyed by 60 Decibels.
+				</section>
+			</MyKivaContainer>
+		</div>
 	</www-page>
 </template>
 
@@ -137,6 +144,7 @@ import useBadgeData from '#src/composables/useBadgeData';
 import EarnedBadgesSection from '#src/components/MyKiva/EarnedBadgesSection';
 import { STATE_JOURNEY, STATE_EARNED, STATE_IN_PROGRESS } from '#src/composables/useBadgeModal';
 import useUserPreferences from '#src/composables/useUserPreferences';
+import { hasLoanFunFactFootnote } from '#src/util/myKivaUtils';
 
 import {
 	ref,
@@ -170,6 +178,7 @@ const selectedBadgeData = ref();
 const state = ref(STATE_JOURNEY);
 const tier = ref(null);
 const isEarnedSectionModal = ref(false);
+const showLoanFootnote = ref(false);
 
 const isLoading = computed(() => !lender.value);
 
@@ -243,7 +252,8 @@ const fetchMyKivaData = () => {
 			lender.value = result.data?.my?.lender ?? null;
 			loans.value = result.data?.my?.loans?.values ?? [];
 			if (loans.value.length > 0) {
-			// eslint-disable-next-line prefer-destructuring
+				showLoanFootnote.value = loans.value.some(l => hasLoanFunFactFootnote(l));
+				// eslint-disable-next-line prefer-destructuring
 				activeLoan.value = loans.value[0];
 				fetchLoanUpdates(activeLoan.value.id);
 			}

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -1,0 +1,21 @@
+/**
+ * Determines whether the provided loan needs a footnote
+ *
+ * @param loan The loan to check
+ * @returns Whether the loan needs a footnote
+ */
+export const hasLoanFunFactFootnote = loan => {
+	const region = loan?.geocode?.country?.region ?? '';
+	const country = loan?.geocode?.country?.name ?? '';
+	if (region === 'North America' && country === 'United States') {
+		return true;
+	}
+	switch (region) {
+		case 'Central America':
+		case 'Africa':
+		case 'Asia':
+			return true;
+		default:
+			return false;
+	}
+};

--- a/test/unit/specs/util/myKivaUtils.spec.js
+++ b/test/unit/specs/util/myKivaUtils.spec.js
@@ -1,0 +1,91 @@
+import { hasLoanFunFactFootnote } from '#src/util/myKivaUtils';
+
+describe('myKivaUtils.js', () => {
+	describe('hasLoanFunFactFootnote', () => {
+		it('should return true for loan in United States', () => {
+			const loan = {
+				geocode: {
+					country: {
+						region: 'North America',
+						name: 'United States'
+					}
+				}
+			};
+
+			const result = hasLoanFunFactFootnote(loan);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false for loan in North America but not United States', () => {
+			const loan = {
+				geocode: {
+					country: {
+						region: 'North America',
+						name: 'Mexico'
+					}
+				}
+			};
+
+			const result = hasLoanFunFactFootnote(loan);
+
+			expect(result).toBe(false);
+		});
+
+		it('should return true for loan in Central America', () => {
+			const loan = {
+				geocode: {
+					country: {
+						region: 'Central America'
+					}
+				}
+			};
+
+			const result = hasLoanFunFactFootnote(loan);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true for loan in Africa', () => {
+			const loan = {
+				geocode: {
+					country: {
+						region: 'Africa'
+					}
+				}
+			};
+
+			const result = hasLoanFunFactFootnote(loan);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return true for loan in Asia', () => {
+			const loan = {
+				geocode: {
+					country: {
+						region: 'Asia'
+					}
+				}
+			};
+
+			const result = hasLoanFunFactFootnote(loan);
+
+			expect(result).toBe(true);
+		});
+
+		it('should return false for loan in Middle East', () => {
+			const loan = {
+				geocode: {
+					country: {
+						region: 'Middle East'
+					}
+				}
+			};
+
+			const result = hasLoanFunFactFootnote(loan);
+
+			expect(result).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-995

- Dynamically adding footnote asterisk to borrower status cards
- Dynamically adding footnote to bottom of MyKiva page (only one footnote currently)

![image](https://github.com/user-attachments/assets/cfe2fe11-455a-4d8a-9adb-7d25564a60e2)

![image](https://github.com/user-attachments/assets/3514896e-6796-443d-9da1-3cd7e4ddd7aa)
