### PR TITLE
fix: update gifts url in the footer to new path

### DIFF
--- a/src/components/WwwFrame/TheFooter.vue
+++ b/src/components/WwwFrame/TheFooter.vue
@@ -224,7 +224,7 @@
 							</li>
 							<li>
 								<router-link
-									to="/gifts"
+									to="/gifts-that-give-back"
 									v-kv-track-event="['Footer', 'click-Explore-Gifts']"
 									class="tw-text-small"
 								>
@@ -512,7 +512,7 @@
 								</li>
 								<li>
 									<router-link
-										to="/gifts"
+										to="/gifts-that-give-back"
 										v-kv-track-event="['Footer', 'click-Explore-Gifts']"
 										class="tw-text-small"
 									>


### PR DESCRIPTION
We have a new page path for the Gifts landing page.