### PR TITLE
feat: settings menu modal gets pushed down when banner enabled

### DIFF
--- a/src/components/MyKiva/BorrowerCarousel.vue
+++ b/src/components/MyKiva/BorrowerCarousel.vue
@@ -83,7 +83,7 @@
 					:embla-options="{ loop: false, align: 'center'}"
 				>
 					<template v-for="(loan, index) in loans" #[`slide${index+1}`] :key="loan.id || index">
-						<BorrowerStatusCard :loan="loan" />
+						<BorrowerStatusCard :loan="loan" class="tw-h-full" />
 					</template>
 				</KvCarousel>
 			</div>

--- a/src/components/MyKiva/EarnedBadgesSection.vue
+++ b/src/components/MyKiva/EarnedBadgesSection.vue
@@ -15,7 +15,8 @@
 							class="badge-container tw-flex tw-flex-col tw-justify-between tw-p-1.5 tw-rounded"
 						>
 							<div
-								class="tw-p-1 tw-cursor-pointer"
+								class="tw-p-1"
+								:class="{ 'tw-cursor-pointer': isTieredBadge(badge) }"
 								style="height: 148px;"
 								@click="clickBadge(badge)"
 							>
@@ -143,15 +144,20 @@ const loadMoreBadges = () => {
 	visibleOffset.value += 1;
 };
 
+const isTieredBadge = badge => !!badge?.achievementData?.tiers?.length;
+
 const clickBadge = badge => {
-	$kvTrackEvent(
-		'portfolio',
-		'click',
-		'already-earned-badge-modal-from-earned-badge-section',
-		badge.challengeName,
-		badge.level,
-	);
-	emit('badge-clicked', badge);
+	// Badge click behavior only supported for tiered badges
+	if (isTieredBadge(badge)) {
+		$kvTrackEvent(
+			'portfolio',
+			'click',
+			'already-earned-badge-modal-from-earned-badge-section',
+			badge.challengeName,
+			badge.level,
+		);
+		emit('badge-clicked', badge);
+	}
 };
 </script>
 

--- a/src/components/MyKiva/MyKivaNavigation.vue
+++ b/src/components/MyKiva/MyKivaNavigation.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
 		v-if="visible"
-		class="tw-absolute tw-inset-0 tw-z-modal tw-mt-8 md:tw-mt-9 tw-pt-0.5 tw-overflow-hidden"
+		class="tw-absolute tw-inset-0 tw-z-modal tw-pt-0.5 tw-overflow-hidden"
 	>
 		<div
 			class="tw-absolute tw-inset-0 tw-bg-black tw-transition-all tw-duration-150"

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -1,5 +1,5 @@
 <template>
-	<www-page main-class="tw-bg-secondary tw-overflow-hidden" class="tw-relative">
+	<www-page main-class="tw-bg-secondary tw-overflow-hidden tw-relative" class="tw-relative">
 		<MyKivaNavigation
 			:visible="showNavigation"
 			:user-balance="userBalance"


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-996
https://kiva.atlassian.net/browse/MP-997
https://kiva.atlassian.net/browse/MP-998

Settings menu fixed (now just over MyKiva page content):
![image](https://github.com/user-attachments/assets/ec18a52f-3517-48e5-b6fc-21f34d83d502)

Borrower carousel height fixed (now all same height):
![image](https://github.com/user-attachments/assets/3f247bdb-56da-41d4-948c-724fc1e2b725)

Old tiered badges no longer clickable (no screenshot needed).
