### PR TITLE
feat: added loader for badge modal async components

### DIFF
--- a/src/components/MyKiva/BadgeModal.vue
+++ b/src/components/MyKiva/BadgeModal.vue
@@ -30,14 +30,39 @@
 
 <script setup>
 import KvLightbox from '@kiva/kv-components/vue/KvLightbox';
-import { defineProps, defineAsyncComponent, computed } from 'vue';
+import {
+	defineProps,
+	defineAsyncComponent,
+	computed,
+	defineComponent,
+	h,
+} from 'vue';
 import { STATE_JOURNEY, STATE_EARNED, STATE_IN_PROGRESS } from '#src/composables/useBadgeModal';
 import { mdiArrowLeft } from '@mdi/js';
 import KvMaterialIcon from '@kiva/kv-components/vue/KvMaterialIcon';
+import KvLoadingPlaceholder from '@kiva/kv-components/vue/KvLoadingPlaceholder';
 
-const BadgeModalContentJourney = defineAsyncComponent(() => import('#src/components/MyKiva/BadgeModalContentJourney'));
-const BadgeInProgress = defineAsyncComponent(() => import('#src/components/MyKiva/BadgeInProgress'));
-const BadgeCompleted = defineAsyncComponent(() => import('#src/components/MyKiva/BadgeCompleted'));
+const ModalLoader = defineComponent(() => {
+	return () => {
+		return h(KvLoadingPlaceholder, { style: 'height: 200px; width: 100%; min-width: 300px' });
+	};
+});
+
+const BadgeModalContentJourney = defineAsyncComponent({
+	loader: () => import('#src/components/MyKiva/BadgeModalContentJourney'),
+	loadingComponent: ModalLoader,
+	delay: 100,
+});
+const BadgeInProgress = defineAsyncComponent({
+	loader: () => import('#src/components/MyKiva/BadgeInProgress'),
+	loadingComponent: ModalLoader,
+	delay: 100,
+});
+const BadgeCompleted = defineAsyncComponent({
+	loader: () => import('#src/components/MyKiva/BadgeCompleted'),
+	loadingComponent: ModalLoader,
+	delay: 100,
+});
 
 const emit = defineEmits(['badge-modal-closed', 'badge-level-clicked', 'back-to-journey']);
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1006

- Added a loader component for the async components that occasionally take a 1-2 seconds to load

![image](https://github.com/user-attachments/assets/2964cf37-3fee-4607-9538-c19f6db21842)
