### PR TITLE
fix: in progress badge container fixed

### DIFF
--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -45,8 +45,9 @@
 					</BadgeContainer>
 					<div
 						v-if="showEarnBadge(index)"
-						class="tw-absolute tw-rounded-full tw-min-w-3 tw-h-3 tw-font-medium tw-bg-gray-200
-							tw-text-center tw-px-0.5 tw-z-2"
+						class="tw-absolute tw-flex tw-items-center tw-justify-center tw-rounded-full tw-min-w-3
+							tw-min-h-3 tw-font-medium tw-bg-gray-200 tw-text-center tw-z-2 tw-px-0.5
+							tw-aspect-square tw-text-small"
 						:style="getNumberCircleStyles()"
 					>
 						{{ badgeWithVisibleTiers.achievementData.totalProgressToAchievement }}


### PR DESCRIPTION
- in-progress badge container fixed

<img width="164" alt="Screenshot 2024-11-07 at 3 01 50 p m" src="https://github.com/user-attachments/assets/1a2986ee-9229-4110-a28b-203a8ea3fa04">
