### PR TITLE
fix: loan card updated in inprogress carousel

### DIFF
--- a/src/components/MyKiva/BadgeInProgress.vue
+++ b/src/components/MyKiva/BadgeInProgress.vue
@@ -33,7 +33,6 @@
 					:loan-id="loanId"
 					:show-tags="true"
 					:use-full-width="true"
-					:show-view-loan="true"
 					class="tw-h-full"
 				/>
 			</template>
@@ -59,7 +58,6 @@
 				<KvClassicLoanCardContainer
 					:loan-id="loanId"
 					:show-tags="true"
-					:show-view-loan="true"
 					class="tw-h-full"
 				/>
 			</template>


### PR DESCRIPTION
- in progress carousel loan card updated to show loan amount dropdown

<img width="947" alt="Screenshot 2024-11-11 at 4 53 28 p m" src="https://github.com/user-attachments/assets/ff3ed502-e455-40da-99c9-6642be0444e5">
