### PR TITLE
feat: scroll to on page load on sections with async data

### DIFF
--- a/src/components/Thanks/MyKiva/ThanksBadges.vue
+++ b/src/components/Thanks/MyKiva/ThanksBadges.vue
@@ -151,7 +151,7 @@ import CheckoutReceipt from '#src/components/Checkout/CheckoutReceipt';
 import GuestAccountCreation from '#src/components/Forms/GuestAccountCreation';
 import BadgeContainer from '#src/components/MyKiva/BadgeContainer';
 import KvButton from '@kiva/kv-components/vue/KvButton';
-import useBadgeData from '#src/composables/useBadgeData';
+import useBadgeData, { MY_IMPACT_JOURNEYS_ID, MY_ACHIEVEMENTS_ID } from '#src/composables/useBadgeData';
 import OptInModule from './OptInModule';
 
 const props = defineProps({
@@ -234,8 +234,10 @@ const handleContinue = () => {
 	if (props.isGuest) {
 		showGuestAccountModal.value = true;
 	} else {
+		const hasBadges = numberOfBadges.value > 0;
+		const sectionToScrollTo = numberOfBadges.value === 1 ? MY_IMPACT_JOURNEYS_ID : MY_ACHIEVEMENTS_ID;
 		// eslint-disable-next-line vue/no-mutating-props
-		props.router?.push('/portfolio');
+		props.router?.push(`/portfolio${hasBadges ? `#${sectionToScrollTo}` : ''}`);
 	}
 };
 

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -16,6 +16,8 @@ export const CLIMATE_ACTION_FILTER = 'tag=9';
 export const REFUGEE_EQUALITY_FILTER = 'attribute=28';
 export const WOMENS_EQUALITY_FILTER = 'gender=female';
 export const BASIC_NEEDS_FILTER = 'sector=6,10';
+export const MY_IMPACT_JOURNEYS_ID = 'my-impact-journeys';
+export const MY_ACHIEVEMENTS_ID = 'my-achievements';
 
 /**
  * Utilities for loading and combining tiered badge data

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -57,7 +57,7 @@
 				</div>
 			</section>
 		</MyKivaContainer>
-		<template v-if="badgeAchievementData">
+		<template v-if="isAchievementDataLoaded">
 			<section class="tw-my-2">
 				<MyKivaStats :user-achievements="badgeAchievementData" />
 				<MyKivaContainer>
@@ -94,7 +94,7 @@
 							BADGES AND ACHIEVEMENTS
 						</span>
 					</div>
-					<div class="tw-mt-3">
+					<div :id="MY_IMPACT_JOURNEYS_ID" class="tw-mt-3">
 						<h3
 							class="tw-text-center tw-mb-2"
 						>
@@ -121,6 +121,7 @@
 				</section>
 			</MyKivaContainer>
 			<EarnedBadgesSection
+				:id="MY_ACHIEVEMENTS_ID"
 				:badges-data="badgeData"
 				@badge-clicked="handleEarnedBadgeClicked"
 			/>
@@ -156,15 +157,18 @@ import EarnedBadgesSection from '#src/components/MyKiva/EarnedBadgesSection';
 import { STATE_JOURNEY, STATE_EARNED, STATE_IN_PROGRESS } from '#src/composables/useBadgeModal';
 import useUserPreferences from '#src/composables/useUserPreferences';
 import { hasLoanFunFactFootnote } from '#src/util/myKivaUtils';
-
 import {
 	ref,
 	computed,
 	inject,
 	onMounted,
+	watch,
+	nextTick,
 } from 'vue';
 
 const MY_KIVA_EXP_KEY = 'my_kiva_page';
+const MY_IMPACT_JOURNEYS_ID = 'my-impact-journeys';
+const MY_ACHIEVEMENTS_ID = 'my-achievements';
 
 const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');
@@ -193,7 +197,7 @@ const showLoanFootnote = ref(false);
 const totalLoans = ref(0);
 
 const isLoading = computed(() => !lender.value);
-
+const isAchievementDataLoaded = computed(() => !!badgeAchievementData.value);
 const userBalance = computed(() => userInfo.value?.userAccount?.balance ?? '');
 
 const handleShowNavigation = () => {
@@ -314,5 +318,18 @@ onMounted(async () => {
 	fetchAchievementData(apollo);
 	fetchContentfulData(apollo);
 	saveMyKivaToUserPreferences();
+});
+
+watch(isAchievementDataLoaded, () => {
+	if (isAchievementDataLoaded.value) {
+		nextTick(() => {
+			// Scroll to section once async data is loaded
+			const targetId = window.location.hash.replace('#', '');
+			const targetElement = document.getElementById(targetId);
+			if (targetElement) {
+				targetElement.scrollIntoView({ behavior: 'smooth' });
+			}
+		});
+	}
 });
 </script>

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -152,7 +152,7 @@ import BadgeModal from '#src/components/MyKiva/BadgeModal';
 import BadgesSection from '#src/components/MyKiva/BadgesSection';
 import MyKivaStats from '#src/components/MyKiva/MyKivaStats';
 import BadgeTile from '#src/components/MyKiva/BadgeTile';
-import useBadgeData from '#src/composables/useBadgeData';
+import useBadgeData, { MY_IMPACT_JOURNEYS_ID, MY_ACHIEVEMENTS_ID } from '#src/composables/useBadgeData';
 import EarnedBadgesSection from '#src/components/MyKiva/EarnedBadgesSection';
 import { STATE_JOURNEY, STATE_EARNED, STATE_IN_PROGRESS } from '#src/composables/useBadgeModal';
 import useUserPreferences from '#src/composables/useUserPreferences';
@@ -167,8 +167,6 @@ import {
 } from 'vue';
 
 const MY_KIVA_EXP_KEY = 'my_kiva_page';
-const MY_IMPACT_JOURNEYS_ID = 'my-impact-journeys';
-const MY_ACHIEVEMENTS_ID = 'my-achievements';
 
 const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');

--- a/src/pages/Portfolio/MyKiva/MyKivaPage.vue
+++ b/src/pages/Portfolio/MyKiva/MyKivaPage.vue
@@ -322,8 +322,8 @@ watch(isAchievementDataLoaded, () => {
 	if (isAchievementDataLoaded.value) {
 		nextTick(() => {
 			// Scroll to section once async data is loaded
-			const targetId = window.location.hash.replace('#', '');
-			const targetElement = document.getElementById(targetId);
+			const targetId = window?.location?.hash?.replace('#', '');
+			const targetElement = document?.getElementById(targetId);
 			if (targetElement) {
 				targetElement.scrollIntoView({ behavior: 'smooth' });
 			}


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1041

- We want to scroll to two different MyKiva sections when continuing from the TY page
- Data is loaded async, so we needed a way to wait for that data
- This implements the logged-in use case, there's another ticket for the guest use case