### PR TITLE
fix: carousel was not using the filtered loans variable

### DIFF
--- a/src/components/MyKiva/BorrowerCarousel.vue
+++ b/src/components/MyKiva/BorrowerCarousel.vue
@@ -66,7 +66,7 @@
 				</template>
 				<template #tabPanels>
 					<KvTabPanel
-						v-for="(loan, index) in loans"
+						v-for="(loan, index) in filteredLoans"
 						:key="index"
 						:id="`${loan.id}`"
 					>


### PR DESCRIPTION
`filteredLoans` is being used for tabs