### PR TITLE
fix: change event handler to transition

### DIFF
--- a/src/components/LoanCards/KvClassicLoanCardContainer.vue
+++ b/src/components/LoanCards/KvClassicLoanCardContainer.vue
@@ -39,7 +39,7 @@
 				:lender-name="borrowerName"
 				:lender-image-url="borrowerImageUrl"
 				:class="{'animate': isAnimating}"
-				@animationend="resetBubble"
+				@transitionend="resetBubble"
 			/>
 		</div>
 	</div>


### PR DESCRIPTION
`CSS` uses transition for the bubble, so the correct directive is `transitioned`, instead of `animationend`