### PR TITLE
fix: tracking event trigger fixed for loans number

### DIFF
--- a/src/components/MyKiva/BorrowerCarousel.vue
+++ b/src/components/MyKiva/BorrowerCarousel.vue
@@ -126,7 +126,8 @@ import {
 	toRefs,
 	inject,
 	onMounted,
-	onBeforeUnmount
+	onBeforeUnmount,
+	watch,
 } from 'vue';
 import {
 	PAYING_BACK,
@@ -257,13 +258,15 @@ const onInteractCarousel = interaction => {
 	tabs.value.tabContext.selectedIndex = interaction.value;
 };
 
-onMounted(() => {
+watch(() => loans.value, () => {
 	if (!hasActiveLoans.value) {
 		$kvTrackEvent('portfolio', 'view', 'No active borrowers');
 	} else {
 		$kvTrackEvent('portfolio', 'view', 'Active borrowers', loans.value.length);
 	}
+});
 
+onMounted(() => {
 	window.addEventListener('resize', throttledResize);
 
 	handleResize();

--- a/src/components/MyKiva/BorrowerCarousel.vue
+++ b/src/components/MyKiva/BorrowerCarousel.vue
@@ -262,7 +262,7 @@ watch(() => loans.value, () => {
 	if (!hasActiveLoans.value) {
 		$kvTrackEvent('portfolio', 'view', 'No active borrowers');
 	} else {
-		$kvTrackEvent('portfolio', 'view', 'Active borrowers', loans.value.length);
+		$kvTrackEvent('portfolio', 'view', 'Active borrowers', filteredLoans.value.length);
 	}
 });
 


### PR DESCRIPTION
- Tracking event trigger fixed for MyKiva loans number
- As `hasActiveLoans` is a computed prop, was always false on mounted hook