### PR TITLE
chore: add request/response metadata to logs

### DIFF
--- a/server/util/errorLogger.js
+++ b/server/util/errorLogger.js
@@ -8,7 +8,6 @@ export const requestLogger = expressWinston.logger({
 			stringify: true
 		})
 	],
-	meta: false,
 	requestWhitelist: ['url', 'responseTime', 'level', 'message', 'headers.host', 'headers.method'],
 	msg: 'HTTP {{res.statusCode}} {{req.method}} {{req.url}} {{res.responseTime}}ms',
 	ignoreRoute: req => {


### PR DESCRIPTION
Making inferences from the logs is difficult at the moment because the request/response metadata is not structured (just dumped to `message`). This makes the logs much more searchable/sortable by changing the log format from this:

```
{"meta":{},"level":"info","message":"HTTP 200 GET /UI_REVISION 663ms"}
```

To this:

```
{"meta":{"req":{"url":"/UI_REVISION","headers":{"host":"localhost:8888"}},"res":{"statusCode":200},"responseTime":221},"level":"info","message":"HTTP 200 GET /UI_REVISION 221ms"}
```