### PR TITLE
chore: turn off lighthouse push to external server

### DIFF
--- a/lighthouserc-prod.cjs
+++ b/lighthouserc-prod.cjs
@@ -24,11 +24,11 @@ module.exports = {
 			],
 			numberOfRuns: 5,
 		},
-		upload: {
-			target: 'lhci',
-			serverBaseUrl: 'https://lighthouse-ci-kiva-prod.herokuapp.com/',
-			token: process.env.LHCI_PROD_BUILD_TOKEN,
-			ignoreDuplicateBuildFailure: true
-		},
+		// upload: {
+		// 	target: 'lhci',
+		// 	serverBaseUrl: 'https://lighthouse-ci-kiva-prod.herokuapp.com/',
+		// 	token: process.env.LHCI_PROD_BUILD_TOKEN,
+		// 	ignoreDuplicateBuildFailure: true
+		// },
 	},
 };


### PR DESCRIPTION
This will turn off pushing data to our external server and retain the static uploads which are used internally.

[More info here](https://kiva.atlassian.net/browse/CIT-2372)