### PR TITLE
feat: alter my kiva experiment assignment

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -431,17 +431,6 @@ export default {
 		teamName() {
 			return this.loans?.[0]?.team?.name ?? '';
 		},
-		landedOnUSLoan() {
-			const bpPattern = /^\/lend\/(\d+)/;
-
-			if (bpPattern.test(this.$appConfig.firstPage)) {
-				const url = this.$appConfig.firstPage?.split('/');
-				const firstVisitloanId = url?.[2] ?? null;
-				const landedLoan = this.loans.find(loan => loan.id === Number(firstVisitloanId));
-				return landedLoan?.geocode?.country?.isoCode === 'US';
-			}
-			return false;
-		},
 		receiptValues() {
 			return this.receipt?.items?.values ?? [];
 		},
@@ -468,8 +457,8 @@ export default {
 			if (this.badgesCustomExpEnabled) {
 				return BADGES_VIEW;
 			}
-			// Show the marketing opt-in view if the user has not opted in, has loans, and has not landed on a US loan
-			if (!this.landedOnUSLoan && !this.optedIn && this.loans.length > 0) {
+			// Show the marketing opt-in view if the user has not opted in and has loans
+			if (!this.optedIn && this.loans.length > 0) {
 				return MARKETING_OPT_IN_VIEW;
 			}
 			// Show the login required view if we couldn't get the receipt

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -625,7 +625,7 @@ export default {
 		this.optedIn = data?.my?.communicationSettings?.lenderNews || this.$route.query?.optedIn === 'true';
 
 		// MyKiva Badges Experiment
-		if (!this.landedOnUSLoan && !this.printableKivaCards.length && hasLentBefore) {
+		if (!this.printableKivaCards.length && hasLentBefore) {
 			this.myKivaEnabled = getIsMyKivaEnabled(
 				this.apollo,
 				this.$kvTrackEvent,

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -631,7 +631,8 @@ export default {
 				this.$kvTrackEvent,
 				data?.general ?? {},
 				data?.my?.userPreferences?.preferences ?? null,
-				totalLoans
+				totalLoans,
+				true,
 			);
 
 			if (this.myKivaEnabled) {

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -57,9 +57,17 @@ export const fetchPostCheckoutAchievements = async (apollo, loanIds) => {
  * @param generalSettings The general settings object
  * @param preferences The user preferences object
  * @param loanTotal The total number of loans the user has made
+ * @param trackExperiment Whether to track the experiment version
  * @returns Whether the MyKiva experience is enabled for the user
  */
-export const getIsMyKivaEnabled = (apollo, $kvTrackEvent, generalSettings, preferences, loanTotal) => {
+export const getIsMyKivaEnabled = (
+	apollo,
+	$kvTrackEvent,
+	generalSettings,
+	preferences,
+	loanTotal,
+	trackExperiment = false,
+) => {
 	const myKivaFeatureEnabled = readBoolSetting(generalSettings, 'myKivaEnabled.value');
 	if (myKivaFeatureEnabled) {
 		const { version: thanksVersion } = apollo.readFragment({
@@ -78,13 +86,15 @@ export const getIsMyKivaEnabled = (apollo, $kvTrackEvent, generalSettings, prefe
 			}) ?? {};
 			const isMyKivaExperimentEnabled = myKivaVersion === 'b';
 
-			trackExperimentVersion(
-				apollo,
-				$kvTrackEvent,
-				'event-tracking',
-				MY_KIVA_EXP,
-				'EXP-MP-623-Sept2024'
-			);
+			if (trackExperiment) {
+				trackExperimentVersion(
+					apollo,
+					$kvTrackEvent,
+					'event-tracking',
+					MY_KIVA_EXP,
+					'EXP-MP-623-Sept2024'
+				);
+			}
 
 			// The user preference hasSeenMyKiva can be true when we override for internal testing
 			return hasSeenMyKiva || isMyKivaExperimentEnabled;


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1150

- We want to now show the MyKiva TY to all types of lenders
- We were getting uneven experiment assignment -> my current theory is that the slightly different users being assigned between TY and portfolio pages were affecting the assignment numbers, so we now only track assignment on the TY page