### PR TITLE
feat: bp why special position fixed

### DIFF
--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -129,7 +129,12 @@
 						</div>
 					</div>
 				</template>
-				<why-special data-testid="bp-why-special" :loan-id="loanId" />
+				<template v-if="!loading" #why-special>
+					<why-special
+						data-testid="bp-why-special"
+						:loan-id="loanId"
+					/>
+				</template>
 			</kv-carousel>
 		</div>
 		<kv-lightbox


### PR DESCRIPTION
- Comments section is showing after "why this loan is special" first when it should be last fixed

<img width="771" alt="Screenshot 2025-01-06 at 12 58 47 p m" src="https://github.com/user-attachments/assets/e3b70139-afef-4e9b-8fa2-04f6d1e9b76b" />

<img width="701" alt="Screenshot 2025-01-06 at 12 58 54 p m" src="https://github.com/user-attachments/assets/f2b260aa-7870-49eb-8d48-2805881ef46b" />
