### PR TITLE
perf: analyze /borrow page with lighthouse

### DIFF
--- a/lighthouserc-prod.cjs
+++ b/lighthouserc-prod.cjs
@@ -21,6 +21,7 @@ module.exports = {
 				'https://www.kiva.org/design',
 				'https://www.kiva.org/ui-site-map',
 				'https://www.kiva.org/cc/kiva-partner',
+				'https://www.kiva.org/borrow',
 			],
 			numberOfRuns: 5,
 		},


### PR DESCRIPTION
`/borrow` is in our top 10 most visited pages, so we're going to try improving the performance but first we need to start tracking the lighthouse scores.