### PR TITLE
feat: lending stats badges section updated

### DIFF
--- a/src/pages/Portfolio/LendingStats/BadgesSection.vue
+++ b/src/pages/Portfolio/LendingStats/BadgesSection.vue
@@ -1,6 +1,6 @@
 <template>
-	<section data-testid="lend-stat-badges" class="stats-section">
-		<h2 class="tw-flex tw-gap-2 tw-mb-4">
+	<section data-testid="lend-stat-badges" class="stats-section tw-bg-gray-100 tw-py-4">
+		<h2 class="tw-flex tw-gap-2 tw-mb-4 tw-ml-2">
 			<span>My Achievements</span>
 			<span
 				v-if="!isLoading"

--- a/src/pages/Portfolio/LendingStats/LendingStatsPage.vue
+++ b/src/pages/Portfolio/LendingStats/LendingStatsPage.vue
@@ -22,11 +22,6 @@
 						Use this page to collect loans and hit milestones along the way.
 					</p>
 					<hr class="tw-border-tertiary tw-my-4">
-					<badges-section
-						:is-loading="badgesLoading"
-						:completed-achievements="completedAchievements"
-					/>
-					<hr class="tw-border-tertiary tw-my-4">
 					<stats-section
 						title="Countries &amp; Territories*"
 						noun="country"
@@ -70,7 +65,12 @@
 						show-more-id="show-more-fieldpartner"
 						lend-new-id="lend-new-fieldpartner"
 					/>
-					<hr class="tw-border-tertiary tw-my-4">
+					<hr class="tw-border-tertiary tw-mt-4">
+					<badges-section
+						:is-loading="badgesLoading"
+						:completed-achievements="completedAchievements"
+					/>
+					<hr class="tw-border-tertiary tw-mb-4">
 					<p>
 						* Please note, Kiva is continually adding and ending partnerships as we deem necessary.
 						This means, you may end up supporting a loan in a country or through a Lending Partner that


### PR DESCRIPTION
- lending stats badges section updated

Desktop:
<img width="900" alt="Screenshot 2025-01-29 at 12 42 05 p m" src="https://github.com/user-attachments/assets/8c1ff04b-5b69-4ea9-bc00-edec0a92fb25" />

Tablet:
<img width="791" alt="Screenshot 2025-01-29 at 12 41 54 p m" src="https://github.com/user-attachments/assets/544c3c40-2a59-4770-8030-c3e1ef175d7f" />

Mobile:
<img width="462" alt="Screenshot 2025-01-29 at 12 41 42 p m" src="https://github.com/user-attachments/assets/6b80b7e2-889b-49bd-a5d2-bd700535a4a4" />
