### PR TITLE
feat: completed badge modal updates

### DIFF
--- a/src/components/MyKiva/BadgeCompleted.vue
+++ b/src/components/MyKiva/BadgeCompleted.vue
@@ -17,8 +17,8 @@
 					:alt="badgeData.tierName"
 				>
 			</div>
-			<h2 class="tw-italic tw-font-medium tw-text-desert-rose-4 tw-mb-2 tw-text-center">
-				"{{ funFact }}" <span v-if="funFactSource">*</span> <a
+			<h2 class="tw-text-h3 tw-italic tw-text-desert-rose-4 tw-mb-2 tw-text-center">
+				{{ funFact }} <span v-if="funFactSource">*</span> <a
 					:href="learnMoreLink"
 					@click="trackLearnMore"
 					class="tw-underline tw-text-desert-rose-4 hover:tw-text-desert-rose-4"


### PR DESCRIPTION
- Quotation marks around the fun fact removed
- Font size for the fun fact fixed to be h3

<img width="866" alt="Screenshot 2025-02-11 at 3 49 53 p m" src="https://github.com/user-attachments/assets/46768c59-edb7-41cf-bbff-18e6b4284823" />
