### PR TITLE
fix: adjust when badge module shown for kiva cards and donations

### DIFF
--- a/.storybook/stories/ThanksPageSingleVersion.stories.js
+++ b/.storybook/stories/ThanksPageSingleVersion.stories.js
@@ -59,6 +59,20 @@ const receiptWithOnlyDonations = {
 	},
 };
 
+const receiptWithKivaCardsAndLoans = {
+	...mockedReceiptData,
+	items: {
+		values: mockedReceiptData.items.values.filter(item => ['loan_reservation', 'kiva_card'].includes(item.basketItemType)),
+	},
+};
+
+const receiptWithDonationsAndLoans = {
+	...mockedReceiptData,
+	items: {
+		values: mockedReceiptData.items.values.filter(item => ['loan_reservation', 'donation'].includes(item.basketItemType)),
+	},
+};
+
 const story = (args = {}, result = queryResult) => {
 	const template = (_args, { argTypes }) => ({
 		props: Object.keys(argTypes),
@@ -97,8 +111,38 @@ export const Donations = story({
 	myKivaEnabled: true,
 });
 
+export const KivaCardsWithLoans = story({
+	isOptedIn: true,
+	loans: mockLoans,
+	receipt: receiptWithKivaCardsAndLoans,
+	myKivaEnabled: true,
+});
+
+export const KivaCardsWithBadge = story({
+	isOptedIn: true,
+	loans: mockLoans,
+	receipt: receiptWithKivaCardsAndLoans,
+	badgesAchieved: [mockTieredBadge],
+	myKivaEnabled: true,
+});
+
 export const DonationsNotOptedIn = story({
 	receipt: receiptWithOnlyDonations,
+	myKivaEnabled: true,
+});
+
+export const DonationsWithLoans = story({
+	isOptedIn: true,
+	loans: mockLoans,
+	receipt: receiptWithDonationsAndLoans,
+	myKivaEnabled: true,
+});
+
+export const DonationsWithBadge = story({
+	isOptedIn: true,
+	loans: mockLoans,
+	receipt: receiptWithDonationsAndLoans,
+	badgesAchieved: [mockTieredBadge],
 	myKivaEnabled: true,
 });
 

--- a/src/components/Thanks/SingleVersion/BadgeMilestone.vue
+++ b/src/components/Thanks/SingleVersion/BadgeMilestone.vue
@@ -35,7 +35,7 @@
 					style="height: 250px; width: 250px;"
 				>
 			</BadgeContainer>
-			<h3 v-if="isOptedIn">
+			<h3 v-if="showSimplifiedTitle">
 				Take the next step on your impact journey.
 			</h3>
 			<KvButton class="continue-button tw-w-full tw-my-0.5" @click="emit('continue-clicked')">
@@ -92,7 +92,11 @@ const props = defineProps({
 	loanCommentModuleShown: {
 		type: Boolean,
 		default: false,
-	}
+	},
+	kivaCardsModuleShown: {
+		type: Boolean,
+		default: false,
+	},
 });
 
 const apollo = inject('apollo');
@@ -114,7 +118,9 @@ const showEqualityBadge = computed(() => props.isGuest || props.onlyKivaCards ||
 
 const showBadgeModule = computed(() => showEqualityBadge.value || !!props.badgeAchievedIds.length);
 
-const title = computed(() => (props.isOptedIn ? 'Thank you!' : 'Take the next step on your impact journey.'));
+const showSimplifiedTitle = computed(() => props.isOptedIn && !props.kivaCardsModuleShown);
+
+const title = computed(() => (showSimplifiedTitle.value ? 'Thank you!' : 'Take the next step on your impact journey.'));
 
 const displayedBadgeData = computed(() => {
 	if (badgeDataAchieved.value?.length) {

--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -24,6 +24,7 @@
 				:only-donations="onlyDonations"
 				:loans="loans"
 				:loan-comment-module-shown="showLoanComment"
+				:kiva-cards-module-shown="showKivaCardsModule"
 				@continue-clicked="handleContinue"
 				class="tw-mb-2.5"
 			/>
@@ -169,7 +170,9 @@ const hasTeamAttributedPartnerLoan = computed(
 
 const showOptInModule = computed(() => !props.isOptedIn);
 const showKivaCardsModule = computed(() => printableKivaCards.value.length);
-const showBadgeModule = computed(() => props.myKivaEnabled && props.badgesAchieved.length > 0);
+const showBadgeModule = computed(() => {
+	return props.myKivaEnabled && (props.badgesAchieved.length > 0 || onlyDonations.value || onlyKivaCards.value);
+});
 const showJourneyModule = computed(() => props.myKivaEnabled && !showBadgeModule.value);
 const showControlModule = computed(() => !props.myKivaEnabled);
 const showLoanComment = computed(() => hasPfpLoan.value || hasTeamAttributedPartnerLoan.value);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1334

- The simple equity version of the badge module should display when only donations or only kiva cards when there are no loans

![image](https://github.com/user-attachments/assets/45c958f8-833b-43ac-94bd-6e88a69917b8)
![image](https://github.com/user-attachments/assets/a188bbc1-0b6f-48b0-b414-6babb5f26636)
