### PR TITLE
fix: reset stats when active loan switch toggles

### DIFF
--- a/src/pages/Portfolio/ImpactDashboard/DistributionGraphs.vue
+++ b/src/pages/Portfolio/ImpactDashboard/DistributionGraphs.vue
@@ -250,15 +250,23 @@ export default {
 		showOnlyActiveLoans() {
 			const tableRefs = this.$refs.table.$refs;
 			if (tableRefs.locationPanel?.isActive) {
+				this.locationLoading = true;
+				this.locationStats = [];
 				this.fetchLocationStats();
 			}
 			if (tableRefs.genderPanel?.isActive) {
+				this.genderLoading = true;
+				this.genderStats = [];
 				this.fetchGenderStats();
 			}
 			if (tableRefs.sectorPanel?.isActive) {
+				this.sectorLoading = true;
+				this.sectorStats = [];
 				this.fetchSectorStats();
 			}
 			if (tableRefs.partnerPanel?.isActive) {
+				this.partnerLoading = true;
+				this.partnerStats = [];
 				this.fetchPartnerStats();
 			}
 		},


### PR DESCRIPTION
Reset variables was needed to fetch new data from endpoint