### PR TITLE
fix: position of bg rays in control module

### DIFF
--- a/src/components/Thanks/SingleVersion/ControlModule.vue
+++ b/src/components/Thanks/SingleVersion/ControlModule.vue
@@ -18,7 +18,7 @@
 		>
 			<h2 v-html="title" class="tw-text-center" style="line-height: 1.25;"></h2>
 			<div class="tw-relative">
-				<BgRays style="top: -40px; left: -30px" />
+				<BgRays class="bg-rays" />
 				<Globe class="tw-z-1 tw-my-2" style="width: 194px; height: 189px;" />
 			</div>
 			<KvButton
@@ -65,3 +65,14 @@ const title = computed(() => {
 });
 
 </script>
+
+<style lang="postcss" scoped>
+.bg-rays {
+	top: -70px;
+	left: -30px;
+
+	@screen md {
+		top: -40px;
+	}
+}
+</style>


### PR DESCRIPTION
### Before
<img width="586" alt="image" src="https://github.com/user-attachments/assets/dc2b12d7-4337-439d-b056-76f769bec8fc" />

### After
<img width="595" alt="image" src="https://github.com/user-attachments/assets/c242b2ea-2690-4917-ac2f-b568222a0b0f" />

<img width="588" alt="image" src="https://github.com/user-attachments/assets/4ded6999-99cd-470a-b94b-f93918de9b28" />

<img width="362" alt="image" src="https://github.com/user-attachments/assets/9f44cef8-f1b6-401e-9151-f798d0cfbf66" />
