### PR TITLE
fix: static header for mobile

### DIFF
--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -10,7 +10,7 @@
 				'--modal-right': `${modalPosition.right}px`,
 				'--modal-top': `${modalPosition.top}px`
 			}"
-			class="cart-modal"
+			class="cart-modal tw-top-0"
 			:added-loan="addedLoan"
 			:visible="cartModalVisible"
 			:photo-path="PHOTO_PATH"

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -2,7 +2,7 @@
 	<header
 		class="tw-transition-all tw-duration-1000 tw-ease-in-out"
 		:class="{
-			'tw-sticky tw-z-banner tw-w-full tw-top-0' : enableBasketExperiment,
+			'md:tw-sticky tw-z-banner tw-w-full tw-top-0' : enableBasketExperiment,
 		}"
 	>
 		<nav
@@ -596,7 +596,6 @@ import PromoCreditBanner from './PromotionalBanner/Banners/PromoCreditBanner';
 const hasLentBeforeCookie = 'kvu_lb';
 const hasDepositBeforeCookie = 'kvu_db';
 const COMMS_OPT_IN_EXP_KEY = 'opt_in_comms';
-const NEW_ADD_TO_BASKET_EXP = 'new_add_to_basket';
 
 const optimizelyUserDataQuery = gql`query optimizelyUserDataQuery {
 	my {
@@ -656,7 +655,6 @@ export default {
 			basketTotal: 0,
 			teams: null,
 			teamsMenuEnabled: false,
-			enableAddToBasketExp: false,
 			loansInBasket: [],
 		};
 	},
@@ -833,20 +831,6 @@ export default {
 
 		if (version) {
 			this.cookieStore.set(COMMS_OPT_IN_EXP_KEY, version, { path: '/' });
-		}
-
-		const newAddToBasketExpData = this.apollo.readFragment({
-			id: `Experiment:${NEW_ADD_TO_BASKET_EXP}`,
-			fragment: experimentVersionFragment,
-		}) ?? {};
-
-		if (newAddToBasketExpData?.version) {
-			this.enableAddToBasketExp = newAddToBasketExpData?.version === 'b';
-			this.$kvTrackEvent(
-				'basket',
-				NEW_ADD_TO_BASKET_EXP,
-				newAddToBasketExpData?.version,
-			);
 		}
 
 		userHasLentBefore(this.cookieStore.get(hasLentBeforeCookie) === 'true');

--- a/src/pages/Lend/LoanChannelCategoryPage.vue
+++ b/src/pages/Lend/LoanChannelCategoryPage.vue
@@ -9,7 +9,7 @@
 				'--modal-right': `${modalPosition.right}px`,
 				'--modal-top': `${modalPosition.top}px`
 			}"
-			class="cart-modal"
+			class="cart-modal tw-top-0"
 			:added-loan="addedLoan"
 			:visible="cartModalVisible"
 			:photo-path="PHOTO_PATH"

--- a/src/pages/Lend/LoanSearchPage.vue
+++ b/src/pages/Lend/LoanSearchPage.vue
@@ -6,7 +6,7 @@
 				'--modal-right': `${modalPosition.right}px`,
 				'--modal-top': `${modalPosition.top}px`
 			}"
-			class="cart-modal"
+			class="cart-modal tw-top-0"
 			:added-loan="addedLoan"
 			:visible="cartModalVisible"
 			:photo-path="PHOTO_PATH"

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -6,7 +6,7 @@
 				'--modal-right': `${modalPosition.right}px`,
 				'--modal-top': `${modalPosition.top}px`
 			}"
-			class="cart-modal"
+			class="cart-modal tw-top-0"
 			:added-loan="addedLoan"
 			:visible="cartModalVisible"
 			:photo-path="PHOTO_PATH"


### PR DESCRIPTION
Issue: With sticky header on mobile we were not able to show navigation correctly
Solution: Have static header on mobile as before across the site but showing ATB modal at top of the viewport

<img width="465" alt="Screenshot 2025-02-27 at 12 10 19 p m" src="https://github.com/user-attachments/assets/552f18b8-57b1-4018-b83d-fae28d3fe5d1" />

<img width="500" alt="Screenshot 2025-02-27 at 12 10 54 p m" src="https://github.com/user-attachments/assets/c5b779fb-dde4-431c-a5fa-c5f112705a89" />
