### PR TITLE
fix: force login screen to load for sso redirects

### DIFF
--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -110,6 +110,7 @@ export default function authRouter(config = {}) {
 		// Specify ssoRedirect url
 		if (req.query.ssoRedirect) {
 			options.ssoRedirect = req.query.ssoRedirect;
+			options.prompt = 'login';
 		}
 		// Enable Kiva Corp Partner version of the login UI
 		if (req.query.kivaCorpPartner) {


### PR DESCRIPTION
This should make it so that we always attempt an sso connection via the login screen when using the ssoRedirect parameter.