### PR TITLE
fix: potential race condition for contentful data

### DIFF
--- a/src/components/Thanks/SingleVersion/BadgeMilestone.vue
+++ b/src/components/Thanks/SingleVersion/BadgeMilestone.vue
@@ -159,13 +159,12 @@ const funFactSource = computed(() => {
 });
 
 onMounted(async () => {
-	// Load combined badge data, since badgesAchieved prop only contains the badge IDs
-	fetchContentfulData(apollo);
-
-	if (!showEqualityBadge.value) {
+	await Promise.all([
+		// Load combined badge data, since badgesAchieved prop only contains the badge IDs
+		fetchContentfulData(apollo),
 		// Achievement data isn't needed when showing the equity badge
-		await fetchAchievementData(apollo);
-	}
+		!showEqualityBadge.value ? fetchAchievementData(apollo) : undefined,
+	]);
 });
 
 watch(() => badgeContentfulData.value, () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1384

- There was one case where the new IWD badge on dev had missing contentful data, but I couldn't repro
- It is likely just a hiccup in the dev API, because the implementation seems OK
- But here's a quick improvement that will help both performance slightly and make sure the two types of data load "together"