### PR TITLE
fix: missing encoding for username

### DIFF
--- a/src/pages/LoginAndRegister/GuestAccountRedirect.vue
+++ b/src/pages/LoginAndRegister/GuestAccountRedirect.vue
@@ -53,7 +53,7 @@ export default {
 						query: {
 							loginHint: `login|${JSON.stringify({
 								guest: true,
-								username,
+								username: encodeURIComponent(username),
 							})}`,
 							doneUrl: `${path}?${queryString}`,
 						},


### PR DESCRIPTION
Missing encoding for username, made special characters to don't appear on username field