### PR TITLE
fix: missing encoding in post purchase

### DIFF
--- a/src/pages/Checkout/PostPurchase.vue
+++ b/src/pages/Checkout/PostPurchase.vue
@@ -56,7 +56,7 @@ export default {
 						}
 
 						if (username) {
-							successRoute.query.username = username;
+							successRoute.query.username = encodeURIComponent(username);
 						}
 
 						// track the transaction event


### PR DESCRIPTION
Bad formatting starts on thanks url `username` query param