### PR TITLE
fix: encoding the full loginHint value instead of just the username

### DIFF
--- a/server/auth-router.js
+++ b/server/auth-router.js
@@ -94,10 +94,10 @@ export default function authRouter(config = {}) {
 		if (req.query.forgot === 'true') {
 			options.prompt = 'login';
 			const username = req.query.username || '';
-			options.login_hint = encodeURIComponent(`forgotPassword|${JSON.stringify({
+			options.login_hint = `forgotPassword|${JSON.stringify({
 				guest: true,
-				username,
-			})}`);
+				username: encodeURIComponent(username),
+			})}`;
 		}
 		// Override the login hint with whatever hint is set in the request
 		if (req.query.loginHint) {

--- a/src/components/Forms/GuestAccountCreation.vue
+++ b/src/components/Forms/GuestAccountCreation.vue
@@ -138,7 +138,7 @@ export default {
 						throw new Error('Missing reset url');
 					}
 					if (this.guestUsername) {
-						resetUrl += `&username=${encodeURIComponent(this.guestUsername)}`;
+						resetUrl += `&username=${this.guestUsername}`;
 					}
 
 					window.location = resetUrl;

--- a/src/pages/LoginAndRegister/GuestAccountRedirect.vue
+++ b/src/pages/LoginAndRegister/GuestAccountRedirect.vue
@@ -51,10 +51,10 @@ export default {
 					return Promise.reject({
 						path: '/ui-login',
 						query: {
-							loginHint: encodeURIComponent(`login|${JSON.stringify({
+							loginHint: `login|${JSON.stringify({
 								guest: true,
-								username,
-							})}`),
+								username: encodeURIComponent(username),
+							})}`,
 							doneUrl: `${path}?${queryString}`,
 						},
 					});


### PR DESCRIPTION
Encoding the whole loginHint value to avoid double encoding of the username