### PR TITLE
fix: encoding a non redirect in post purchase

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -877,7 +877,7 @@ export default {
 					checkoutAdditionalQueryParams += `&optedIn=${this.userOptedIn}`;
 				}
 				if (payload?.username) {
-					checkoutAdditionalQueryParams += `&username=${payload.username}`;
+					checkoutAdditionalQueryParams += `&username=${encodeURIComponent(payload.username)}`;
 				}
 
 				// redirect to thanks

--- a/src/pages/Checkout/PostPurchase.vue
+++ b/src/pages/Checkout/PostPurchase.vue
@@ -56,7 +56,7 @@ export default {
 						}
 
 						if (username) {
-							successRoute.query.username = encodeURIComponent(username);
+							successRoute.query.username = username;
 						}
 
 						// track the transaction event


### PR DESCRIPTION
Checkout redirects to `PostPurchase` so we needed to encode username in that url instead 