### PR TITLE
fix: showing ty page for monthly donation amount

### DIFF
--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -445,10 +445,8 @@ export default {
 			return this.kivaCards.filter(card => card.kivaCardObject.deliveryType === 'print');
 		},
 		activeView() {
-			// Show the donation only view if the user has only donated and not lent
-			if (this.showDafThanks
-				|| (this.receipt && this.receipt?.totals?.itemTotal === this.receipt?.totals?.donationTotal)
-				|| this.monthlyDonationAmount?.length) {
+			// Show the donation only view if the user has only subscribed to a donation
+			if (this.showDafThanks || this.monthlyDonationAmount) {
 				return DONATION_ONLY_VIEW;
 			}
 			// Show the login required view if we couldn't get the receipt
@@ -458,6 +456,10 @@ export default {
 			// Show the single version view if the experiment is enabled
 			if (this.thanksSingleVersionEnabled) {
 				return SINGLE_VERSION_VIEW;
+			}
+			// Show the donation only view if the user has only donated and not lent
+			if (this.receipt?.totals?.itemTotal === this.receipt?.totals?.donationTotal) {
+				return DONATION_ONLY_VIEW;
 			}
 			// Show the MyKiva view if qualifications are met
 			if (this.myKivaEnabled) {


### PR DESCRIPTION
- Since there's a use case (Monthly Donation from `donate/supportus`) that doesn't have a receipt, I'm moving it to the top to show its thank you page.
- Also, as `transactionId` is `null`, `monthlyDonationAmount` variable is never going to be set with the param value.

You can test with: https://kiva-ui.local/checkout/thanks?monthly_donation_amount=50.00
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/d5830847-f42a-45d0-a86b-e39a7414e5cc" />
