### PR TITLE
fix: event with journeyBadgeEarned value in no loans use cases

### DIFF
--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -245,7 +245,7 @@ onMounted(() => {
 		isOptInDonate ? 'optInDonate' : '',
 		showOptInModule.value && !isOptInLoan && !isOptInDonate ? 'optInOther' : '',
 		showKivaCardsModule.value ? 'kivaCard' : '',
-		showBadgeModule.value ? 'journeyBadgeEarned' : '',
+		showBadgeModule.value && !onlyKivaCardsAndDonations.value ? 'journeyBadgeEarned' : '',
 		showJourneyModule.value ? 'journeyBadgeNotEarned' : '',
 		showControlModule.value ? 'journeyGeneral' : '',
 		showLoanComment.value ? 'commenting' : '',


### PR DESCRIPTION
Removing `journeyBadgeEarned` from event property in no loans cases