### PR TITLE
fix: journeyBadgeNotEarned not in event for no loan cases

### DIFF
--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -239,6 +239,7 @@ onMounted(() => {
 
 	const isOptInLoan = showOptInModule.value && props.loans.length > 0;
 	const isOptInDonate = showOptInModule.value && onlyDonations.value;
+	const badgeNotEarned = onlyKivaCardsAndDonations.value && !showControlModule.value;
 
 	const analyticsModuleOrder = [
 		isOptInLoan ? 'optInLoan' : '',
@@ -246,7 +247,7 @@ onMounted(() => {
 		showOptInModule.value && !isOptInLoan && !isOptInDonate ? 'optInOther' : '',
 		showKivaCardsModule.value ? 'kivaCard' : '',
 		showBadgeModule.value && !onlyKivaCardsAndDonations.value ? 'journeyBadgeEarned' : '',
-		showJourneyModule.value ? 'journeyBadgeNotEarned' : '',
+		showJourneyModule.value || badgeNotEarned ? 'journeyBadgeNotEarned' : '',
 		showControlModule.value ? 'journeyGeneral' : '',
 		showLoanComment.value ? 'commenting' : '',
 		props.isGuest ? 'drawerCreateAccount' : '',


### PR DESCRIPTION
`kivaCard-journeyBadgeNotEarned-drawerCreateAccount-drawerOrderConfirmation-drawerShare`

<img width="685" alt="image" src="https://github.com/user-attachments/assets/505a50f9-3aee-4b21-9739-a0937b34e2ad" />
