### PR TITLE
feat: get achievement progress in basket before evaluating added loan

### DIFF
--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -274,7 +274,7 @@ const fetchAchievementFromBasket = async () => {
 		const loanAchievements = data.postCheckoutAchievements?.overallProgress ?? [];
 		achievementsFromBasket.value = loanAchievements.filter(achievement => achievement.postCheckoutTier !== achievement.preCheckoutTier); // eslint-disable-line max-len
 	}).catch(e => {
-		logFormatter(e, 'Modal ATB Post Checkout Achievements Query');
+		logFormatter(e, 'Modal ATB Basket Achievements Query ');
 	});
 };
 


### PR DESCRIPTION
Comparing achievements progress before and after the added loan to evaluate if showing modal content (`hit next milestone`). Loan away message was already handled.

https://github.com/user-attachments/assets/c0211739-49d5-4584-9974-9d41d6d4e290

