### PR TITLE
fix: loan away when logic when atb loan make progress in different ba…

### DIFF
--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -248,7 +248,7 @@ const fetchPostCheckoutAchievements = async loanIds => {
 			const progressInBasket = loanAchievements.find(loanAchievement => loanAchievement.achievementId === achievement.id);
 			const contributingLoanIds = progressInBasket?.contributingLoanIds ?? [];
 
-			return (achievement.target - (achievement.totalProgressToAchievement + contributingLoanIds.length)) === 1;
+			return achievement.totalProgressToAchievement + contributingLoanIds.length === achievement.target - 1;
 		});
 		if (oneLoanAwayAchievement) {
 			oneLoanAwayFilteredUrl.value = getFilteredUrl(oneLoanAwayAchievement);


### PR DESCRIPTION
…dges

Currently we weren't adding contributing loans to the `totalProgressToAchievement` causing one loan away message to remain hidden in some scenarios