### PR TITLE
fix: optin notification avatar sizes

### DIFF
--- a/src/components/Thanks/MyKiva/OptInNotification.vue
+++ b/src/components/Thanks/MyKiva/OptInNotification.vue
@@ -64,8 +64,8 @@ const notificationMsg = computed(() => {
 }
 
 .smaller-borrower-avatar, .smaller-borrower-avatar :deep(img), .smaller-borrower-avatar :deep(.loading-placeholder) {
-	height: 30px;
-	width: 30px;
+	height: 30px !important;
+	width: 30px !important;
 }
 
 .message {


### PR DESCRIPTION
Before:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/6b8dfd9e-0d5c-4a53-9047-4386d5e691a6" />

After:
<img width="354" alt="image" src="https://github.com/user-attachments/assets/0e7c6339-a6cb-4c7c-8c89-bc02615ae571" />

