### PR TITLE
feat: persist apollo cache in session storage

### DIFF
--- a/config/dynamic.js
+++ b/config/dynamic.js
@@ -1,6 +1,7 @@
 const apolloBatching = process.env.APOLLO_BATCH !== 'false';
 const apolloNetworkErrorRetryActive = process.env.APOLLO_NETWORK_RETRY_ACTIVE === 'true';
 const apolloNetworkErrorRetryAttempts = parseInt(process.env.APOLLO_NETWORK_RETRY_ATTEMPTS, 10) || 1;
+const apolloPersistCache = process.env.APOLLO_PERSIST_CACHE === 'true';
 const memcachedServers = process.env.MEMCACHE_HOST || 'ui-memcached:11211';
 const baseUrl = process.env.BASE_URL || 'development.kiva.org';
 const env = process.env.SHORT_ENV || 'dev';
@@ -29,6 +30,7 @@ export const app = {
 	apolloQueryFetchLogging: process.env.APOLLO_QUERY_FETCH_LOGGING || false,
 	apolloNetworkErrorRetryActive,
 	apolloNetworkErrorRetryAttempts,
+	apolloPersistCache,
 	auth0: {
 		loginRedirectUrls: {
 			[adminAuthId]: `https://admin.${baseUrl}/admin/login?force=1`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
 				"@vuelidate/core": "^2.0.3",
 				"@vuelidate/validators": "^2.0.4",
 				"apollo-server-express": "^2.18.2",
+				"apollo3-cache-persist": "^0.15.0",
 				"auth0-js": "^9.19.2",
 				"body-parser": "^1.19.0",
 				"bowser": "^2.11.0",
@@ -15384,6 +15385,15 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+		},
+		"node_modules/apollo3-cache-persist": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.15.0.tgz",
+			"integrity": "sha512-asxhPOHGddgXYvY4/Wa+XLODYpjci/kPB4zdy82D0tVGzVmvO4lqp3k06NtzHvd//gd9kCnTaG8iziwAcXZYjw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@apollo/client": "^3.7.17"
+			}
 		},
 		"node_modules/app-root-dir": {
 			"version": "1.0.2",
@@ -49239,6 +49249,12 @@
 					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
+		},
+		"apollo3-cache-persist": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/apollo3-cache-persist/-/apollo3-cache-persist-0.15.0.tgz",
+			"integrity": "sha512-asxhPOHGddgXYvY4/Wa+XLODYpjci/kPB4zdy82D0tVGzVmvO4lqp3k06NtzHvd//gd9kCnTaG8iziwAcXZYjw==",
+			"requires": {}
 		},
 		"app-root-dir": {
 			"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"@vuelidate/core": "^2.0.3",
 		"@vuelidate/validators": "^2.0.4",
 		"apollo-server-express": "^2.18.2",
+		"apollo3-cache-persist": "^0.15.0",
 		"auth0-js": "^9.19.2",
 		"body-parser": "^1.19.0",
 		"bowser": "^2.11.0",

--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -59,6 +59,14 @@ async function getUserId(apolloClient) {
 	return result?.data?.my?.userAccount?.id ?? null;
 }
 
+async function setupApolloCachePersistence(cache) {
+	const { persistCache, SessionStorageWrapper } = await import('apollo3-cache-persist');
+	await persistCache({
+		cache,
+		storage: new SessionStorageWrapper(window.sessionStorage),
+	});
+}
+
 async function setupAuthErrorHandling(kvAuth0, apolloClient) {
 	const { default: showTipMessage } = await import('#src/graphql/mutation/tipMessage/showTipMessage.graphql');
 	// Show a tip message when there is an unhandled auth0 error
@@ -239,6 +247,10 @@ async function initApp() {
 	// Apply Server state to Client Store
 	if (window.__APOLLO_STATE__) {
 		apolloClient.cache.restore(window.__APOLLO_STATE__);
+	}
+	// Apply persisted state from session storage to Client Store
+	if (config.apolloPersistCache) {
+		setupApolloCachePersistence(apolloClient.cache);
 	}
 
 	setupAuthErrorHandling(kvAuth0, apolloClient);


### PR DESCRIPTION
This allows for two things that noticeably improve performance:

- The apollo cache is maintained when the page is refreshed
- The apollo cache is **shared between ui and cps!** (see kiva/cms-page-server#1927)

I tried this out in the tilt VM and navigating between pages I had already visited was *much* faster. I didn't spot any problems with stale data or anything else, though I haven't tried checking out. We've already used the 'network-only' fetch policy for many of the queries that need to be up-to-date, so I don't expect that this would cause problems in any important user journeys.

I've set this up with a feature flag so that we can test it out in development and staging for a while before moving to production. The main difference is that data will stay cached much longer than it has in the past, so we should be looking out for any data that appears stale or appears different with a new session.