### PR TITLE
feat: ensure MyKiva assignment consistent through guest account creation

### DIFF
--- a/src/components/NotFound/NotFoundWrapper.vue
+++ b/src/components/NotFound/NotFoundWrapper.vue
@@ -40,7 +40,8 @@ import useMyKivaHome from '#src/composables/useMyKivaHome';
 
 const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');
+const cookieStore = inject('cookieStore');
 
-const { homePagePath } = useMyKivaHome(apollo, $kvTrackEvent);
+const { homePagePath } = useMyKivaHome(apollo, $kvTrackEvent, cookieStore);
 
 </script>

--- a/src/components/Thanks/SingleVersion/JourneyGeneralPrompt.vue
+++ b/src/components/Thanks/SingleVersion/JourneyGeneralPrompt.vue
@@ -94,9 +94,10 @@ import useMyKivaHome from '#src/composables/useMyKivaHome';
 
 const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');
+const cookieStore = inject('cookieStore');
 
 const router = useRouter();
-const { portfolioPath } = useMyKivaHome(apollo, $kvTrackEvent);
+const { portfolioPath } = useMyKivaHome(apollo, $kvTrackEvent, cookieStore);
 
 const emit = defineEmits(['continue-as-guest']);
 

--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -95,10 +95,12 @@ import GuestAccountCreation from '#src/components/Forms/GuestAccountCreation';
 import { KvLightbox } from '@kiva/kv-components';
 import { useRouter } from 'vue-router';
 import _orderBy from 'lodash/orderBy';
+import { setGuestAssignmentCookie } from '#src/util/myKivaUtils';
 
 const EVENT_CATEGORY = 'post-checkout';
 
 const $kvTrackEvent = inject('$kvTrackEvent');
+const cookieStore = inject('cookieStore');
 
 const props = defineProps({
 	isGuest: {
@@ -262,6 +264,8 @@ onMounted(() => {
 		analyticsModuleOrder,
 		userType.value,
 	);
+
+	setGuestAssignmentCookie(cookieStore, props.myKivaEnabled, props.isGuest);
 });
 </script>
 

--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -322,6 +322,7 @@ onMounted(async () => {
 		userData.value?.my?.userPreferences,
 		!isGuest.value ? userData.value?.my?.loans?.totalCount : 0,
 		myKivaFlagEnabled.value,
+		cookieStore,
 	);
 
 	if (myKivaExperimentEnabled.value && !isGuest.value) {

--- a/src/composables/useMyKivaHome.js
+++ b/src/composables/useMyKivaHome.js
@@ -8,7 +8,7 @@ import { readBoolSetting } from '#src/util/settingsUtils';
 import logFormatter from '#src/util/logFormatter';
 import myKivaForAllUsersQuery from '#src/graphql/query/shared/myKivaForAllUsers.graphql';
 
-export default function useMyKivaHome(apollo, $kvTrackEvent) {
+export default function useMyKivaHome(apollo, $kvTrackEvent, cookieStore) {
 	const redirectToMyKivaHomepage = ref(false);
 	const myKivaFlagEnabled = ref(false);
 	const userData = ref(false);
@@ -41,6 +41,7 @@ export default function useMyKivaHome(apollo, $kvTrackEvent) {
 			userData.value?.userPreferences,
 			userData.value?.loans?.totalCount ?? 0,
 			myKivaFlagEnabled.value,
+			cookieStore,
 		) && userData.value?.id;
 	});
 

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -647,13 +647,17 @@ export default {
 			this.possibleAchievementProgress = response?.postCheckoutAchievements?.overallProgress ?? [];
 		}
 
-		this.isMyKivaEnabled = getIsMyKivaEnabled(
-			this.apollo,
-			this.$kvTrackEvent,
-			this.userPreferences,
-			this.lenderLoanCount,
-			this.myKivaFlagEnabled,
-		);
+		// Checkout page MyKiva pills only visible with new feature
+		if (this.myKivaFlagEnabled) {
+			this.isMyKivaEnabled = getIsMyKivaEnabled(
+				this.apollo,
+				this.$kvTrackEvent,
+				this.userPreferences,
+				this.lenderLoanCount,
+				this.myKivaFlagEnabled,
+				this.cookieStore,
+			);
+		}
 	},
 	mounted() {
 		// update current time every second for reactivity

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -140,6 +140,8 @@ export default {
 				this.$kvTrackEvent,
 				userData?.userPreferences,
 				userData.lender?.loanCount,
+				false,
+				this.cookieStore,
 			);
 		} else {
 			const { version } = this.apollo.readFragment({

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -543,6 +543,7 @@ export default {
 			data?.my?.userPreferences,
 			!this.isGuest ? data?.my?.loans?.totalCount : 1,
 			this.myKivaFlagEnabled,
+			this.cookieStore,
 		);
 
 		this.monthlyDonationAmount = this.$route.query?.monthly_donation_amount ?? null;

--- a/src/plugins/my-kiva-homepage-mixin.js
+++ b/src/plugins/my-kiva-homepage-mixin.js
@@ -31,6 +31,7 @@ export default {
 				userData?.userPreferences,
 				userData?.loans?.totalCount ?? 0,
 				myKivaFlagEnabled,
+				this.cookieStore,
 			) && userData?.id;
 		}
 	}

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -9,6 +9,7 @@ export const MY_KIVA_PREFERENCE_KEY = 'myKivaJan2025Exp';
 const MY_KIVA_EXP = 'my_kiva_jan_2025';
 const MY_KIVA_LOAN_LIMIT = 4;
 export const MY_KIVA_FOR_ALL_USERS_KEY = 'general.my_kiva_all_users.value';
+export const GUEST_ASSIGNMENT_COOKIE = 'myKivaGuestAssignment';
 
 export const createUserPreferencesMutation = gql`
 	mutation createUserPreferences($preferences: String) {
@@ -120,6 +121,30 @@ export const updateUserPreferences = async (apollo, userPreferences, parsedPrefe
 };
 
 /**
+ * Set session cookie for guest MyKiva assignment to ensure consistent assignment after login
+ *
+ * @param cookieStore The cookie store
+ * @param myKivaEnabled Whether the MyKiva experience is enabled
+ * @param isGuest Whether the user is a guest
+ */
+export const setGuestAssignmentCookie = (cookieStore, myKivaEnabled, isGuest) => {
+	// Only add the session cookie if the user is a guest and MyKiva is enabled
+	if (isGuest && myKivaEnabled) {
+		cookieStore?.set(GUEST_ASSIGNMENT_COOKIE, 'true', { path: '/' });
+	}
+};
+
+/**
+ * Checks for existence of session cookie for guest MyKiva assignment
+ *
+ * @param cookieStore The cookie store
+ * @returns Whether the guest assignment cookie exists
+ */
+export const checkGuestAssignmentCookie = cookieStore => {
+	return !!cookieStore?.get(GUEST_ASSIGNMENT_COOKIE);
+};
+
+/**
  * Gets whether the MyKiva experience is enabled for the user, excluding some specific logic for the TY page
  *
  * @param apollo The current Apollo client
@@ -127,9 +152,17 @@ export const updateUserPreferences = async (apollo, userPreferences, parsedPrefe
  * @param userPreferences The user preferences object
  * @param loanTotal The total number of loans the user has made
  * @param myKivaFlagEnabled Whether the MyKiva flag is enabled
+ * @param cookieStore The cookie store
  * @returns Whether the MyKiva experience is enabled for the user
  */
-export const getIsMyKivaEnabled = (apollo, $kvTrackEvent, userPreferences, loanTotal, myKivaFlagEnabled) => {
+export const getIsMyKivaEnabled = (
+	apollo,
+	$kvTrackEvent,
+	userPreferences,
+	loanTotal,
+	myKivaFlagEnabled,
+	cookieStore,
+) => {
 	// Parse the user preferences to determine if the user has seen MyKiva
 	let parsedPreferences = {};
 	let hasSeenMyKiva = false;
@@ -141,7 +174,8 @@ export const getIsMyKivaEnabled = (apollo, $kvTrackEvent, userPreferences, loanT
 		logFormatter('getIsMyKivaEnabled JSON parsing exception', 'error');
 	}
 
-	if (hasSeenMyKiva || loanTotal < MY_KIVA_LOAN_LIMIT || myKivaFlagEnabled) {
+	// eslint-disable-next-line max-len
+	if (hasSeenMyKiva || loanTotal < MY_KIVA_LOAN_LIMIT || myKivaFlagEnabled || checkGuestAssignmentCookie(cookieStore)) {
 		const { version: myKivaVersion } = apollo.readFragment({
 			id: `Experiment:${MY_KIVA_EXP}`,
 			fragment: experimentVersionFragment,

--- a/test/unit/specs/util/myKivaUtils.spec.js
+++ b/test/unit/specs/util/myKivaUtils.spec.js
@@ -7,6 +7,9 @@ import {
 	MY_KIVA_PREFERENCE_KEY,
 	createUserPreferencesMutation,
 	updateUserPreferencesMutation,
+	setGuestAssignmentCookie,
+	checkGuestAssignmentCookie,
+	GUEST_ASSIGNMENT_COOKIE,
 } from '#src/util/myKivaUtils';
 import postCheckoutAchievementsQuery from '#src/graphql/query/postCheckoutAchievements.graphql';
 import logReadQueryError from '#src/util/logReadQueryError';
@@ -210,6 +213,78 @@ describe('myKivaUtils.js', () => {
 					preferences: JSON.stringify({ test: 'test', new: 'new' }),
 				},
 			});
+		});
+	});
+
+	describe('setGuestAssignmentCookie', () => {
+		it('should set the guest assignment cookie if MyKiva is enabled and the user is a guest', () => {
+			const cookieStore = {
+				set: vi.fn(),
+			};
+			const myKivaEnabled = true;
+			const isGuest = true;
+
+			setGuestAssignmentCookie(cookieStore, myKivaEnabled, isGuest);
+
+			expect(cookieStore.set).toHaveBeenCalledWith(GUEST_ASSIGNMENT_COOKIE, 'true', { path: '/' });
+		});
+
+		it('should not set the guest assignment cookie if MyKiva is not enabled', () => {
+			const cookieStore = {
+				set: vi.fn(),
+			};
+			const myKivaEnabled = false;
+			const isGuest = true;
+
+			setGuestAssignmentCookie(cookieStore, myKivaEnabled, isGuest);
+
+			expect(cookieStore.set).not.toHaveBeenCalled();
+		});
+
+		it('should not set the guest assignment cookie if the user is not a guest', () => {
+			const cookieStore = {
+				set: vi.fn(),
+			};
+			const myKivaEnabled = true;
+			const isGuest = false;
+
+			setGuestAssignmentCookie(cookieStore, myKivaEnabled, isGuest);
+
+			expect(cookieStore.set).not.toHaveBeenCalled();
+		});
+
+		it('should not throw an error if cookieStore is undefined', () => {
+			expect(() => setGuestAssignmentCookie(undefined, true, true)).not.toThrow();
+		});
+	});
+
+	describe('checkGuestAssignmentCookie', () => {
+		it('should return true if the guest assignment cookie exists', () => {
+			const cookieStore = {
+				get: vi.fn().mockReturnValue('true'),
+			};
+
+			const result = checkGuestAssignmentCookie(cookieStore);
+
+			expect(result).toBe(true);
+			expect(cookieStore.get).toHaveBeenCalledWith(GUEST_ASSIGNMENT_COOKIE);
+		});
+
+		it('should return false if the guest assignment cookie does not exist', () => {
+			const cookieStore = {
+				get: vi.fn().mockReturnValue(undefined),
+			};
+
+			const result = checkGuestAssignmentCookie(cookieStore);
+
+			expect(result).toBe(false);
+			expect(cookieStore.get).toHaveBeenCalledWith(GUEST_ASSIGNMENT_COOKIE);
+		});
+
+		it('should return false if cookieStore is undefined', () => {
+			const result = checkGuestAssignmentCookie(undefined);
+
+			expect(result).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1516

- Use session cookie to ensure guests see the same MyKiva experiment assignment after account creation
- Usually we don't care too much about the edge case of before/after account creation assignment changing, but consistent experience is critical for MyKiva data analysis
- Fixed issue where we were showing the MyKiva pills in the checkout page if the ATB feature was disabled