### PR TITLE
fix: atb modal content when hitting a new achievement or user is one loan away

### DIFF
--- a/src/util/atbAchievementUtils.js
+++ b/src/util/atbAchievementUtils.js
@@ -36,13 +36,25 @@ export const filterAchievementData = (nonContributingAchievements, badgeAchievem
 	return filteredAchievementsData;
 };
 
-export const getOneLoanAwayAchievement = (filteredAchievementsData, loanAchievements) => {
-	return filteredAchievementsData.find(achievement => {
+export const getOneLoanAwayAchievement = (addedLoanId, filteredAchievementsData, loanAchievements) => {
+	let currentTarget = null;
+	const oneLoanAwayAchievement = filteredAchievementsData.find(achievement => {
 		// eslint-disable-next-line max-len
 		const progressInBasket = loanAchievements.find(loanAchievement => loanAchievement.achievementId === achievement.id);
 		const contributingLoanIds = progressInBasket?.contributingLoanIds ?? [];
+		const addedLoanInContributingLoans = contributingLoanIds.includes(addedLoanId.toString());
 		const loansProgressCount = achievement.totalProgressToAchievement + contributingLoanIds.length;
+		currentTarget = achievement?.tiers.find(tier => tier.target - 1 === loansProgressCount)?.target ?? null;
 
-		return achievement?.tiers.some(tier => tier.target - 1 === loansProgressCount);
+		return addedLoanInContributingLoans && currentTarget;
 	});
+
+	if (oneLoanAwayAchievement) {
+		return {
+			...oneLoanAwayAchievement,
+			target: currentTarget,
+		};
+	}
+
+	return null;
 };

--- a/test/unit/specs/util/atbAchievementUtils.spec.js
+++ b/test/unit/specs/util/atbAchievementUtils.spec.js
@@ -80,10 +80,12 @@ describe('achievementUtils', () => {
 			];
 
 			const loanAchievements = [
-				{ achievementId: 2, contributingLoanIds: [101] },
+				{ achievementId: 2, contributingLoanIds: ['101'] },
 			];
 
-			const result = getOneLoanAwayAchievement(filteredAchievementsData, loanAchievements);
+			const addedLoanId = 101;
+
+			const result = getOneLoanAwayAchievement(addedLoanId, filteredAchievementsData, loanAchievements);
 			expect(result?.id).toBe(2);
 		});
 
@@ -100,8 +102,10 @@ describe('achievementUtils', () => {
 				{ achievementId: 1, contributingLoanIds: [] },
 			];
 
-			const result = getOneLoanAwayAchievement(filteredAchievementsData, loanAchievements);
-			expect(result).toBeUndefined();
+			const addedLoanId = 101;
+
+			const result = getOneLoanAwayAchievement(addedLoanId, filteredAchievementsData, loanAchievements);
+			expect(result).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1531

- refactor `newAchivementReached` method by using tierTable variable
- Change logic from oneLoanAway to take into account the addedLoan, so the added loan should be within `contributingLoanIds`.  This prevents `oneLoanAway` repetition error 
- Modifying `target` prop in `oneLoanAway` when you hit a greater target. Currently `target` was always the same value even if you hit a new milestone with your current basket