### PR TITLE
feat: prevent users from loading mykiva if they are not qualified to see mykiva

### DIFF
--- a/src/graphql/query/myKivaRedirect.graphql
+++ b/src/graphql/query/myKivaRedirect.graphql
@@ -1,0 +1,23 @@
+query MyKivaRedirect {
+	my {
+		id
+		userPreferences {
+			id
+			preferences
+		}
+		lender {
+			id
+			loanCount
+		}
+	}
+	general {
+		my_kiva_all_users: uiConfigSetting(key: "my_kiva_all_users_enable") {
+			key
+			value
+		}
+	}
+	experiment(id: "my_kiva_jan_2025") @client {
+		id
+		version
+	}
+}

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -7,6 +7,8 @@
 <script>
 import WwwPage from '#src/components/WwwFrame/WwwPage';
 import MyKivaPageContent from '#src/pages/MyKiva/MyKivaPageContent';
+import myKivaRedirectQuery from '#src/graphql/query/myKivaRedirect.graphql';
+import { shouldRejectMyKivaHomeRedirect } from '#src/util/myKivaUtils';
 
 /**
  * Options API parent needed to ensure WWwPage children options API preFetch works,
@@ -14,9 +16,21 @@ import MyKivaPageContent from '#src/pages/MyKiva/MyKivaPageContent';
  */
 export default {
 	name: 'MyKivaPage',
+	inject: ['apollo', 'cookieStore'],
 	components: {
 		WwwPage,
 		MyKivaPageContent,
+	},
+	apollo: {
+		preFetch(_, client, args) {
+			return client.query({ query: myKivaRedirectQuery })
+				.then(({ data }) => {
+					const result = shouldRejectMyKivaHomeRedirect(client, args, data);
+					if (result) {
+						return Promise.reject(result);
+					}
+				});
+		}
 	},
 };
 </script>

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -25,9 +25,8 @@ export default {
 		preFetch(_, client, args) {
 			return client.query({ query: myKivaRedirectQuery })
 				.then(({ data }) => {
-					const result = shouldRejectMyKivaHomeRedirect(client, args, data);
-					if (result) {
-						return Promise.reject(result);
+					if (shouldRejectMyKivaHomeRedirect(client, args, data)) {
+						return Promise.reject({ path: '/' });
 					}
 				});
 		}

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -237,7 +237,7 @@ export const shouldRejectMyKivaHomeRedirect = (client, args, data) => {
 		return !getIsMyKivaEnabled(
 			client,
 			undefined, // Passing undefined ensures no experiment tracking for users not qualified
-			userData?.userPreferences,
+			userData.userPreferences,
 			userData.lender?.loanCount,
 			myKivaAllUsersEnabled,
 			cookieStore,

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -224,18 +224,17 @@ export const getIsMyKivaEnabled = (
  * @param client The Apollo client
  * @param args The arguments containing cookieStore and route
  * @param data The data containing user information
- * @return Object containing the redirect path if MyKiva is not enabled
+ * @return Whether the MyKiva route should be rejected
  */
 export const shouldRejectMyKivaHomeRedirect = (client, args, data) => {
 	const { cookieStore, route } = args;
 	const currentRoute = route?.value ?? route ?? {};
 
 	if (currentRoute.path === '/mykiva') {
-		const { query } = currentRoute;
 		const userData = data?.my ?? {};
 		const myKivaAllUsersEnabled = readBoolSetting(data, 'general.my_kiva_all_users.value');
 
-		const showMyKivaPage = getIsMyKivaEnabled(
+		return !getIsMyKivaEnabled(
 			client,
 			undefined, // Passing undefined ensures no experiment tracking for users not qualified
 			userData?.userPreferences,
@@ -243,15 +242,7 @@ export const shouldRejectMyKivaHomeRedirect = (client, args, data) => {
 			myKivaAllUsersEnabled,
 			cookieStore,
 		);
-
-		// Handle when the user is being redirect via the Fastly home redirect
-		const isHomeRedirect = query?.home === 'true';
-
-		if (!showMyKivaPage) {
-			return {
-				// Take users to correct page if MyKiva is not enabled
-				path: isHomeRedirect ? '/' : '/portfolio',
-			};
-		}
 	}
+
+	return false;
 };


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1530

- While testing I encountered that our new `/mykiva` path is accessible to all logged-in users on dev, not just users in MyKiva experiment
- The MyKiva page now redirects during `preFetch` as necessary