### PR TITLE
feat: calculate milestones progress in basket using tiers difference

### DIFF
--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -224,6 +224,17 @@ const isFirstLoan = computed(() => {
 	return myKivaExperimentEnabled.value && (isGuest.value || !userData.value?.my?.loans?.totalCount);
 });
 
+const numberOfMilestones = computed(() => {
+	return achievementsFromBasket.value.reduce(
+		(total, achievement) => {
+			const achievementProgress = achievement.postCheckoutTier - achievement.preCheckoutTier;
+
+			return total + (achievementProgress > 0 ? achievementProgress : 0);
+		},
+		0
+	);
+});
+
 const showOneAway = computed(() => oneLoanAwayCategory.value && oneLoanAwayFilteredUrl.value && !isFirstLoan.value);
 
 const pillMsg = computed(() => {
@@ -242,8 +253,8 @@ const pillMsg = computed(() => {
 		return 'You’re close to your next milestone!';
 	}
 
-	const milestonesCopy = achievementsFromBasket.value.length > 1
-		? `${achievementsFromBasket.value.length} of your milestones`
+	const milestonesCopy = numberOfMilestones.value > 1
+		? `${numberOfMilestones.value} of your milestones`
 		: 'your next milestone';
 
 	return borrowerName.value


### PR DESCRIPTION
Current behaviour just counted possible badges earned in basket, now we're using the tier difference to count the number of times you hit a milestone within a badge journey

<img width="464" alt="image" src="https://github.com/user-attachments/assets/ad024ca7-7406-4aba-a064-5c67fd12c59d" />
