### PR TITLE
fix: change how bluesky shares links

### DIFF
--- a/src/components/MyKiva/MyKivaSharingModal.vue
+++ b/src/components/MyKiva/MyKivaSharingModal.vue
@@ -106,6 +106,7 @@ export default {
 		KvLightbox,
 		KvMaterialIcon,
 	},
+	inject: ['apollo'],
 	mixins: [socialSharingMixin],
 	emits: ['close-modal'],
 	props: {

--- a/src/graphql/query/myKiva.graphql
+++ b/src/graphql/query/myKiva.graphql
@@ -61,6 +61,7 @@ query myKivaQuery {
         url
       }
       memberSince
+	  publicId
     }
     userAccount {
       id

--- a/src/plugins/social-sharing-mixin.js
+++ b/src/plugins/social-sharing-mixin.js
@@ -55,8 +55,8 @@ export default {
 					utm_content: utmContent,
 				});
 				return getFullUrl('https://bsky.app/intent/compose', {
-					text: this.shareMessage,
-					url: blueskyShareUrlWithUtms,
+					// Bluesky requires the URL to be in the text field
+					text: `${this.shareMessage} ${blueskyShareUrlWithUtms}`
 				});
 			}
 			return '';


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1550

- Bluesky requires the URL shared to be in the text, otherwise it isn't shown in the post
- We were missing the public ID in one share use case, so `undefined` was in the URL
- There was a console error for one share component that needed `apollo`

<img width="638" alt="image" src="https://github.com/user-attachments/assets/5a8af5b3-dc31-4943-9066-191e5e88c351" />
