### PR TITLE
fix: set vite options per config file

### DIFF
--- a/config/dev-custom-host.js
+++ b/config/dev-custom-host.js
@@ -29,5 +29,15 @@ export default merge(base, {
 		sessionUri: `https://www.${kivaHost}/start-ui-session`,
 		memcachedEnabled: false,
 		memcachedServers: '',
+		viteConfig: {
+			server: {
+				allowedHosts: [host],
+				hmr: {
+					// Use a different client port to allow Caddy to reverse proxy with SSL cert
+					clientPort: 24679,
+					port: 24678,
+				},
+			},
+		}
 	},
 });

--- a/config/k8s-local.js
+++ b/config/k8s-local.js
@@ -50,5 +50,10 @@ export default merge(base, {
 		memcachedEnabled: true,
 		memcachedServers: 'localhost:11211',
 		sessionUri: `${transport}://${monolithHostname}/start-ui-session`,
+		viteConfig: {
+			server: {
+				allowedHosts: [monolithHostname],
+			},
+		},
 	}
 });

--- a/server/dev-server.js
+++ b/server/dev-server.js
@@ -3,6 +3,7 @@ import chokidar from 'chokidar';
 import express from 'express';
 import helmet from 'helmet';
 import locale from 'locale';
+import { merge } from 'webpack-merge';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import promBundle from 'express-prom-bundle';
@@ -48,11 +49,11 @@ const port = argv.port || config.server.port;
 const app = express();
 (async function createServer() {
 	// Setup Vite Server
-	const vite = await createViteServer({
+	const vite = await createViteServer(merge({
 		server: { middlewareMode: true },
 		appType: 'custom',
 		root: path.resolve(__dirname, '../'),
-	});
+	}, config.server.viteConfig ?? {}));
 
 	// promise to delay request handling until bundles are created
 	let resolveHandlerReady;

--- a/vite.config.js
+++ b/vite.config.js
@@ -118,14 +118,6 @@ export default defineConfig(({ isSsrBuild, mode }) => {
 			},
 			extensions: ['.mjs', '.js', '.mts', '.ts', '.jsx', '.tsx', '.json', '.vue'],
 		},
-		server: {
-			hmr: {
-				// Use a different client port to allow Caddy to reverse proxy with SSL cert
-				clientPort: 24679,
-				port: 24678,
-			},
-			...(!isProd && { allowedHosts: ['kiva-ui.local'] }),
-		},
 		optimizeDeps: {
 			include: [
 				'vue',


### PR DESCRIPTION
This moves the vite config options that were specific to `dev-custom-host` into that config file and merges them into the vite config when the server is created, which fixes the issue with hmr not working when using the `local` config.

This also fixes the issue with the tilt vm where vite won't run without monolith.kiva.local being added to allowed hosts. There is still a separate issue with hmr in the tilt vm related to ssl.