### PR TITLE
fix: remove extra head closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-		<link rel="manifest" href="/static/manifest.webmanifest"></head>
+		<link rel="manifest" href="/static/manifest.webmanifest">
 		${headTags}
 		${preloadLinks}
 	</head>


### PR DESCRIPTION
There is an extra closing head tag before the preload links. Browsers seem to be correcting for this, which is why this hasn't caused any noticeable problems for months. I only found this when starting to make changes to the template and some of the head tags were not loading.