### PR TITLE
fix: ensure foundation mixins use settings variables

### DIFF
--- a/src/assets/scss/_settings.scss
+++ b/src/assets/scss/_settings.scss
@@ -69,8 +69,8 @@
 // is working on switching to the new module system for their v7 release (as
 // noted in https://github.com/foundation/foundation-sites/releases/tag/v6.9.0)
 // but until then we need to use the @import syntax here in order for the
-// breakpoint mixin to work correctly.
-@import 'foundation-sites/scss/util/util';
+// foundation mixins to work correctly.
+@import 'foundation-sites/scss/foundation';
 
 // 1. Global
 // ---------
@@ -641,13 +641,13 @@ $input-checked-border-color: $kiva-green;
 // 17. Dropdown
 // ------------
 
-// $dropdown-padding: 0;
-// $dropdown-background: $body-background;
-// $dropdown-border: 1px solid $light-gray;
-// $dropdown-font-size: $global-font-size;
-// $dropdown-width: auto;
-// $dropdown-radius: $global-radius;
-// $dropdown-sizes: ();
+$dropdown-padding: 0;
+$dropdown-background: $body-background;
+$dropdown-border: 1px solid $light-gray;
+$dropdown-font-size: $global-font-size;
+$dropdown-width: auto;
+$dropdown-radius: $global-radius;
+$dropdown-sizes: ();
 
 // 18. Dropdown Menu
 // -----------------

--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -8,7 +8,7 @@
 @use 'global/drop-in';
 
 // import global foundation components
-@use 'foundation-sites/scss/foundation' as f;
-@include f.foundation-flex-classes ();
-@include f.foundation-flex-grid ();
-@include f.foundation-visibility-classes ();
+@use 'settings' as *;
+@include foundation-flex-classes ();
+@include foundation-flex-grid ();
+@include foundation-visibility-classes ();

--- a/src/components/Checkout/SocialShareV2.vue
+++ b/src/components/Checkout/SocialShareV2.vue
@@ -184,7 +184,6 @@ export default {
 <style lang="scss" scoped>
 @use 'sass:math';
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 $color-facebook: #3b5998;
 $color-bluesky: #1185FE;
@@ -449,19 +448,19 @@ $loan-triangle-size: rem-calc(12);
 		&--facebook {
 			display: flex;
 			justify-content: center;
-			@include f.button-style($color-facebook, auto, #fff);
+			@include button-style($color-facebook, auto, #fff);
 		}
 
 		&--bluesky {
 			display: flex;
 			justify-content: center;
-			@include f.button-style($color-bluesky, auto, #fff);
+			@include button-style($color-bluesky, auto, #fff);
 		}
 
 		&--linkedin {
 			display: flex;
 			justify-content: center;
-			@include f.button-style($color-linkedin, auto, #fff);
+			@include button-style($color-linkedin, auto, #fff);
 		}
 
 		&--link {

--- a/src/components/CorporateCampaign/CampaignLoanRow.vue
+++ b/src/components/CorporateCampaign/CampaignLoanRow.vue
@@ -310,7 +310,6 @@ export default {
 
 <style lang="scss" scoped>
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 .component-wrapper {
 	text-align: left;

--- a/src/components/Kv/KvButton.vue
+++ b/src/components/Kv/KvButton.vue
@@ -34,7 +34,6 @@ export default {
 <style lang="scss">
 @use 'sass:color';
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 @mixin secondary-styles() {
 	background-color: $button-secondary-background;
@@ -56,7 +55,7 @@ export default {
 	font-weight: $button-font-weight;
 	box-shadow: $button-primary-shadow;
 
-	@include f.button();
+	@include button();
 	@include button-primary-styles();
 
 	&.rounded {
@@ -80,7 +79,7 @@ export default {
 	&.alert {
 		box-shadow: $button-secondary-shadow color.adjust($kiva-accent-red, $lightness: -10%);
 
-		@include f.button-style($kiva-accent-red, auto, $white);
+		@include button-style($kiva-accent-red, auto, $white);
 	}
 
 	&.classic {
@@ -138,7 +137,7 @@ export default {
 
 	&.disabled,
 	&[disabled] {
-		@include f.button-disabled();
+		@include button-disabled();
 	}
 
 	&.expanded {

--- a/src/components/Kv/KvCarousel.vue
+++ b/src/components/Kv/KvCarousel.vue
@@ -323,7 +323,6 @@ export default {
 <style lang="scss" scoped>
 @use 'sass:math';
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 $arrow-width: rem-calc(41);
 $arrow-margin: rem-calc(8);
@@ -383,7 +382,7 @@ $bar-indicator-margin: rem-calc(4);
 		}
 
 		&[disabled] {
-			@include f.button-disabled();
+			@include button-disabled();
 
 			background: $kiva-text-light;
 		}

--- a/src/components/Kv/KvDropdown.vue
+++ b/src/components/Kv/KvDropdown.vue
@@ -182,8 +182,8 @@ export default {
 </script>
 
 <style lang="scss">
-@use 'foundation-sites/scss/foundation' as f;
-@include f.foundation-dropdown ();
+@use '#src/assets/scss/settings' as *;
+@include foundation-dropdown ();
 </style>
 
 <style lang="postcss" scoped>

--- a/src/components/Thanks/ThanksPageCommentAndShare.vue
+++ b/src/components/Thanks/ThanksPageCommentAndShare.vue
@@ -390,7 +390,6 @@ export default {
 
 <style lang="scss" scoped>
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 $color-facebook: #3b5998;
 $color-bluesky: #1185FE;
@@ -400,7 +399,7 @@ $color-copy-link: #2B7C5F;
 .social {
 	&__btn {
 		&--facebook {
-			@include f.button-style($color-facebook, auto, #fff);
+			@include button-style($color-facebook, auto, #fff);
 
 			.social__icon {
 				fill: #fff;

--- a/src/components/Thanks/ThanksPageDonationOnly.vue
+++ b/src/components/Thanks/ThanksPageDonationOnly.vue
@@ -255,7 +255,6 @@ export default {
 
 <style lang="scss" scoped>
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 $color-facebook: #3b5998;
 $color-bluesky: #1185FE;
@@ -265,7 +264,7 @@ $color-copy-link: #2B7C5F;
 .social {
 	&__btn {
 		&--facebook {
-			@include f.button-style($color-facebook, auto, #fff);
+			@include button-style($color-facebook, auto, #fff);
 
 			.social__icon {
 				fill: #fff;

--- a/src/pages/Possibility/GivingTuesday.vue
+++ b/src/pages/Possibility/GivingTuesday.vue
@@ -91,7 +91,6 @@ export default {
 <style lang="scss" scoped>
 @use 'sass:color';
 @use '#src/assets/scss/settings' as *;
-@use 'foundation-sites/scss/foundation' as f;
 
 $cta-color: #02582e;
 
@@ -114,7 +113,7 @@ $cta-color: #02582e;
 	// Include in order to override the default box-shadow of this button
 	box-shadow: 0 2px color.adjust($cta-color, $lightness: -10%);
 
-	@include f.button-style($cta-color, auto, #fff);
+	@include button-style($cta-color, auto, #fff);
 }
 
 .cta-link {


### PR DESCRIPTION
Mixins imported directly from foundation were not using the values defined in _settings.scss. This fixes that by providing all the foundation mixins from settings and only using settings in other files instead of using foundation.