### PR TITLE
fix: ensure timesync is bundled for the server build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -129,7 +129,8 @@ export default defineConfig(({ isSsrBuild, mode }) => {
 		ssr: {
 			noExternal: [
 				'@kiva/kv-components',
-				'@kiva/kv-shop'
+				'@kiva/kv-shop',
+				'timesync',
 			],
 		},
 		test: {


### PR DESCRIPTION
The server-entry built by vite has `import { create } from "timesync";`, and it doesn't bundle `timesync`, so node is trying to resolve it and running into the `require('promise')` issue. We have an internal package for using the node native Promise type, and we have the alias configured in vite, but vite has externalized `timesync` so the alias is never used. This PR makes vite not externalize `timesync` so that the `require('promise')` in `timesync` is replaced by our alias.

The dependencies for `@storybook/vue3-vite` include `promise`, so that's why we don't see this error locally, where we have all the dev dependencies installed.