### PR TITLE
feat: add badge sidesheet to public profile

### DIFF
--- a/src/components/Badges/JourneySideSheet.vue
+++ b/src/components/Badges/JourneySideSheet.vue
@@ -1,0 +1,125 @@
+<template>
+	<KvSideSheet
+		:visible="visible"
+		:show-back-button="false"
+		:show-headline-border="false"
+		:headline="computedHeadLine"
+		:show-go-to-link="false"
+		:kv-track-function="$kvTrackEvent"
+		:animation-source-element="triggerButton"
+		@side-sheet-closed="handleComponentClosed"
+		:width-dimensions="{ default: '100%', lg: '480px', md: '460px', sm:'100%' }"
+	>
+		<template #default>
+			<BadgeModalContentJourney
+				:key="selectedBadgeData.id"
+				:badge="selectedBadgeData"
+				:loans="loans"
+				@badge-level-clicked="handleBadgeJourneyLevelClicked"
+				@toggle-gradient="($event) => hideBotomGradient = $event"
+			/>
+			<div
+				id="journey-bottom-gradient"
+				class="
+					tw-w-full tw-bg-red tw-absolute
+					tw-left-0 tw-bg-white tw-opacity-50
+					tw-pointer-events-none tw-z-sticky
+					tw-transition-opacity tw-duration-500
+					tw-ease-in-out
+				"
+				:class="{
+					'tw-opacity-0': hideBotomGradient,
+					'tw-opacity-full': !hideBotomGradient,
+				}"
+				style="
+					background: linear-gradient(to top, rgb(255 255 255), rgb(255 255 255 / 0%));
+					bottom: 81px;
+					height: 124px;
+				"
+			>
+			</div>
+		</template>
+		<template #controls>
+			<div
+				id="journey-controls"
+				class="tw-bg-white tw-border-t tw-w-full tw-border-tertiary"
+			>
+				<div class="tw-flex tw-justify-end tw-bg-white">
+					<kv-button
+						class="tw-mb-2 tw-pt-2 tw-px-4 tw-w-full md:tw-w-auto"
+						@click="handleContinueJourneyClicked"
+					>
+						{{ journeyCtaBtn }}
+					</kv-button>
+				</div>
+			</div>
+		</template>
+	</KvSideSheet>
+</template>
+
+<script setup>
+import BadgeModalContentJourney from '#src/components/MyKiva/BadgeModalContentJourney';
+import {
+	ref,
+	computed,
+	inject,
+} from 'vue';
+
+import { KvButton, KvSideSheet } from '@kiva/kv-components';
+
+const $kvTrackEvent = inject('$kvTrackEvent');
+
+const props = defineProps({
+	visible: {
+		type: Boolean,
+		default: false,
+	},
+	selectedBadgeData: {
+		type: Object,
+		default: () => ({}),
+	},
+	loans: {
+		type: Array,
+		default: () => ([]),
+	},
+	allBadgesCompleted: {
+		type: Boolean,
+		default: false,
+	},
+	isSelectedJourneyComplete: {
+		type: Boolean,
+		default: false,
+	},
+});
+
+const triggerButton = ref(null);
+const hideBotomGradient = ref(false);
+
+const emit = defineEmits(['badge-journey-level-clicked', 'continue-journey-clicked', 'sidesheet-closed']);
+
+const computedHeadLine = computed(() => `Achievements for lending to ${props.selectedBadgeData?.challengeName}`);
+
+const handleComponentClosed = () => {
+	hideBotomGradient.value = false;
+	emit('sidesheet-closed');
+};
+
+const handleContinueJourneyClicked = () => {
+	emit('continue-journey-clicked');
+};
+
+const handleBadgeJourneyLevelClicked = payload => {
+	emit('badge-journey-level-clicked', payload);
+};
+
+const journeyCtaBtn = computed(() => {
+	if (props.allBadgesCompleted) {
+		return 'See all of your impact stats';
+	}
+	if (props.isSelectedJourneyComplete) {
+		return 'See all journeys';
+	}
+	return 'Continue this journey';
+});
+
+</script>

--- a/src/components/LenderProfile/LenderBadges.vue
+++ b/src/components/LenderProfile/LenderBadges.vue
@@ -22,8 +22,15 @@
 				</div>
 			</div>
 		</section>
+		<JourneySideSheet
+			v-if="showSideSheet"
+			class="badge-journey"
+			:visible="showSideSheet"
+			:selected-badge-data="selectedBadgeData"
+			@sidesheet-closed="handleSideSheetClosed"
+		/>
 		<BadgeModal
-			v-if="selectedBadgeData"
+			v-if="showBadgeModal"
 			:show="showBadgeModal"
 			:badge="selectedBadgeData"
 			:state="state"
@@ -38,10 +45,11 @@
 import { computed, inject, ref } from 'vue';
 import { defaultBadges } from '#src/util/achievementUtils';
 import useBadgeData from '#src/composables/useBadgeData';
-import BadgeModal from '#src/components/MyKiva/BadgeModal';
 import { STATE_EARNED } from '#src/composables/useBadgeModal';
+import BadgeModal from '#src/components/MyKiva/BadgeModal';
 import AsyncLenderSection from './AsyncLenderSection';
 import BadgeCard from './BadgeCard';
+import JourneySideSheet from '../Badges/JourneySideSheet';
 
 const props = defineProps({
 	lenderInfo: {
@@ -66,6 +74,7 @@ const showBadgeModal = ref(false);
 const selectedBadgeData = ref();
 const state = ref(STATE_EARNED);
 const tier = ref(null);
+const showSideSheet = ref(false);
 
 const sortedTieredBadges = computed(() => {
 	const tieredBadges = [];
@@ -111,11 +120,31 @@ const handleBadgeClicked = badge => {
 	const selectedTier = badge.achievementData?.tiers?.find(tierEl => tierEl.level === badge.level) ?? null;
 	tier.value = selectedTier;
 	selectedBadgeData.value = badge;
-	showBadgeModal.value = true;
+	if (tier.value) {
+		showSideSheet.value = true;
+	} else {
+		showBadgeModal.value = true;
+	}
 };
 
 const handleBadgeModalClosed = () => {
-	selectedBadgeData.value = undefined;
 	showBadgeModal.value = false;
+	selectedBadgeData.value = undefined;
+};
+
+const handleSideSheetClosed = () => {
+	showSideSheet.value = false;
+	selectedBadgeData.value = undefined;
+	tier.value = null;
 };
 </script>
+
+<style lang="postcss" scoped>
+:deep(.badge-journey div#journey-controls) {
+	display: none;
+}
+
+:deep(.badge-journey div#journey-bottom-gradient) {
+	bottom: 0 !important;
+}
+</style>

--- a/src/components/MyKiva/BadgeModalContentJourney.vue
+++ b/src/components/MyKiva/BadgeModalContentJourney.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="tw-flex tw-flex-col tw-h-full">
-		<div class="tw-flex tw-space-x-1 tw-items-center tw-pb-2 tw-pl-2">
+		<div v-if="journeyLoans.length" class="tw-flex tw-space-x-1 tw-items-center tw-pb-2 tw-pl-2">
 			<div class="tw-flex">
 				<KvUserAvatar
 					class="avatar tw-border-white tw-rounded-full tw-border-2"

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -92,60 +92,16 @@
 						:selected-journey="selectedJourney"
 						@badge-clicked="handleBadgeSectionClicked"
 					/>
-					<KvSideSheet
+					<JourneySideSheet
 						:visible="showSideSheet"
-						:show-back-button="false"
-						:show-headline-border="false"
-						:headline="computedHeadLine"
-						:show-go-to-link="false"
-						:kv-track-function="$kvTrackEvent"
-						:animation-source-element="triggerButton"
-						@side-sheet-closed="handleComponentClosed"
-						:width-dimensions="{ default: '100%', lg: '480px', md: '460px', sm:'100%' }"
-					>
-						<template #default>
-							<BadgeModalContentJourney
-								:key="selectedBadgeData.id"
-								:badge="selectedBadgeData"
-								:loans="loans"
-								@badge-level-clicked="handleBadgeJourneyLevelClicked"
-								@toggle-gradient="($event) => hideBotomGradient = $event"
-							/>
-							<div
-								class="
-									tw-w-full tw-bg-red tw-absolute
-									tw-left-0 tw-bg-white tw-opacity-50
-									tw-pointer-events-none tw-z-sticky
-									tw-transition-opacity tw-duration-500
-									tw-ease-in-out
-								"
-								:class="{
-									'tw-opacity-0': hideBotomGradient,
-									'tw-opacity-full': !hideBotomGradient,
-								}"
-								style="
-									background: linear-gradient(to top, rgb(255 255 255), rgb(255 255 255 / 0%));
-									bottom: 81px;
-									height: 124px;
-								"
-							>
-							</div>
-						</template>
-						<template #controls>
-							<div
-								class="tw-bg-white tw-border-t tw-w-full tw-border-tertiary"
-							>
-								<div class="tw-flex tw-justify-end tw-bg-white">
-									<kv-button
-										class="tw-mb-2 tw-pt-2 tw-px-4 tw-w-full md:tw-w-auto"
-										@click="handleContinueJourneyClicked"
-									>
-										{{ journeyCtaBtn }}
-									</kv-button>
-								</div>
-							</div>
-						</template>
-					</KvSideSheet>
+						:selected-badge-data="selectedBadgeData"
+						:loans="loans"
+						:all-badges-completed="allBadgesCompleted"
+						:is-selected-journey-complete="isSelectedJourneyComplete"
+						@badge-journey-level-clicked="handleBadgeJourneyLevelClicked"
+						@continue-journey-clicked="handleContinueJourneyClicked"
+						@sidesheet-closed="handleComponentClosed"
+					/>
 					<BadgeModal
 						v-if="selectedBadgeData"
 						:show="showBadgeModal"
@@ -185,7 +141,6 @@ import MyKivaContainer from '#src/components/MyKiva/MyKivaContainer';
 import MyKivaBorrowerCarousel from '#src/components/MyKiva/BorrowerCarousel';
 import JournalUpdatesCarousel from '#src/components/MyKiva/JournalUpdatesCarousel';
 import BadgeModal from '#src/components/MyKiva/BadgeModal';
-import BadgeModalContentJourney from '#src/components/MyKiva/BadgeModalContentJourney';
 import BadgesSection from '#src/components/MyKiva/BadgesSection';
 import MyKivaStats from '#src/components/MyKiva/MyKivaStats';
 import BadgeTile from '#src/components/MyKiva/BadgeTile';
@@ -201,7 +156,7 @@ import {
 } from 'vue';
 import { fireHotJarEvent } from '#src/util/hotJarUtils';
 import { defaultBadges } from '#src/util/achievementUtils';
-import { KvButton, KvSideSheet } from '@kiva/kv-components';
+import JourneySideSheet from '#src/components/Badges/JourneySideSheet';
 
 const { getBadgeWithVisibleTiers } = useBadgeData();
 
@@ -274,8 +229,6 @@ const allBadgesCompleted = computed(() => {
 	const tieredBadges = badgeData.value?.filter(b => defaultBadges.includes(b?.id));
 	return tieredBadges?.every(b => !b.achievementData?.tiers?.find(t => !t?.completedDate));
 });
-
-const computedHeadLine = computed(() => `Achievements for lending to ${selectedBadgeData.value?.challengeName}`);
 
 const handleShowNavigation = () => {
 	showNavigation.value = true;
@@ -387,16 +340,6 @@ const showLoanFootnote = computed(() => props.loans.some(l => hasLoanFunFactFoot
 const updateJourney = journey => {
 	selectedJourney.value = journey;
 };
-
-const journeyCtaBtn = computed(() => {
-	if (allBadgesCompleted.value) {
-		return 'See all of your impact stats';
-	}
-	if (isSelectedJourneyComplete.value) {
-		return 'See all journeys';
-	}
-	return 'Continue this journey';
-});
 
 const userInHomepage = computed(() => {
 	return router.currentRoute.value?.path === '/mykiva';


### PR DESCRIPTION
- Living Badge Modal for non-tiered badges
- Reusing a journey component for My Kiva and Public profile but hiding CTA at bottom and not showing loans images in public profile.

<img width="1265" alt="image" src="https://github.com/user-attachments/assets/529c6c0a-8bd0-4e32-83e1-53f2be537032" />
