### PR TITLE
fix: remove header gap caused by non-existent grid area

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -932,7 +932,6 @@ export default {
 
 /* CSS grid areas to manage position changes across breakpoints without markup duplication */
 .header__logo { grid-area: logo; }
-.header__explore { grid-area: explore; }
 .header__lend { grid-area: lend; }
 .header__search { grid-area: search; }
 .header__right-side { grid-area: right-side; }
@@ -965,8 +964,8 @@ export default {
 
 @screen lg {
 	.header.header--tablet-open {
-		grid-template-areas: "logo explore lend search right-side";
-		grid-template-columns: auto auto auto 1fr auto;
+		grid-template-areas: "logo lend search right-side";
+		grid-template-columns: auto auto 1fr auto;
 	}
 }
 


### PR DESCRIPTION
There is an extra-wide gap in the header between the logo and the lend menu button for large screens when a user is logged in with a balance greater than $0. This gap is caused by a grid area that isn't being used but is configured to appear.

Before
<img width="1104" alt="Screenshot 2025-06-24 at 4 51 29 PM" src="https://github.com/user-attachments/assets/8d76c83c-6ffa-4b09-9c1f-9ed388b6fe28" />

After
<img width="1102" alt="Screenshot 2025-06-24 at 4 51 55 PM" src="https://github.com/user-attachments/assets/a2ac8609-b09b-4ff1-a2c1-d722bf8eb04d" />