### PR TITLE
fix: reset receipt value after you click close lightbox

### DIFF
--- a/src/components/MyKiva/JournalUpdatesCarousel.vue
+++ b/src/components/MyKiva/JournalUpdatesCarousel.vue
@@ -169,6 +169,7 @@ const openLightbox = async updateId => {
 
 const closeLightbox = () => {
 	isLightboxVisible.value = false;
+	receipt.value = null;
 	$kvTrackEvent('portfolio', 'click', 'borrower-update-lightbox-closed', clickedUpdate.value);
 };
 


### PR DESCRIPTION
As receipt kept its previous values, lightbox was showing the receipt of the transaction update you opened before

https://kiva.atlassian.net/browse/MP-1725