### PR TITLE
fix: mp-1730 / Add isBpModalEnabled prop to LoanFinding and associated components

### DIFF
--- a/src/components/LoanFinding/LendingCategorySection.vue
+++ b/src/components/LoanFinding/LendingCategorySection.vue
@@ -29,7 +29,7 @@
 					<kv-classic-loan-card-container
 						class="tw-h-full"
 						:add-to-basket-exp-enabled="enableAddToBasketExp"
-						:custom-loan-details="true"
+						:custom-loan-details="isBpModalEnabled"
 						:enable-five-dollars-notes="enableFiveDollarsNotes"
 						:five-dollars-selected="fiveDollarsSelected"
 						:large-card="isLargeCard"
@@ -120,6 +120,10 @@ export default {
 			type: Number,
 			default: 6
 		},
+		isBpModalEnabled: {
+			type: Boolean,
+			defaut: false
+		}
 	},
 	inject: ['apollo', 'cookieStore'],
 	mixins: [addToBasketExpMixin],

--- a/src/components/LoanFinding/PartnerSpotlightSection.vue
+++ b/src/components/LoanFinding/PartnerSpotlightSection.vue
@@ -20,6 +20,7 @@
 			:loans="loans"
 			:enable-five-dollars-notes="enableFiveDollarsNotes"
 			:user-balance="userBalance"
+			:is-bp-modal-enabled="isBpModalEnabled"
 			@add-to-basket="$emit('add-to-basket', $event)"
 			@show-cart-modal="showCartModal"
 			@show-loan-details="showLoanDetails"
@@ -68,6 +69,10 @@ export default {
 			type: String,
 			default: undefined
 		},
+		isBpModalEnabled: {
+			type: Boolean,
+			default: false
+		}
 	},
 	computed: {
 		headline() {

--- a/src/components/LoanFinding/QuickFiltersSection.vue
+++ b/src/components/LoanFinding/QuickFiltersSection.vue
@@ -31,7 +31,7 @@
 						v-for="(loan, index) in loans"
 						:key="`new-card-${loan.id}-${index}`"
 						:add-to-basket-exp-enabled="enableAddToBasketExp"
-						:custom-loan-details="true"
+						:custom-loan-details="isBpModalEnabled"
 						:enable-five-dollars-notes="enableFiveDollarsNotes"
 						:loan-id="loan.id"
 						:show-tags="true"
@@ -111,6 +111,10 @@ export default {
 			type: Boolean,
 			default: false
 		},
+		isBpModalEnabled: {
+			type: Boolean,
+			defaut: false
+		}
 	},
 	data() {
 		return {

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -696,10 +696,10 @@ export default {
 			FLSS_ONGOING_EXP_KEY,
 			'EXP-VUE-FLSS-Ongoing-Sitewide'
 		);
-		this.isMounted = true;
-
 		// Load initial basket items
 		this.loadInitialBasketItems();
+		this.initializeIsBpModalEnabledExp('lend-by-category');
+		this.isMounted = true;
 	},
 	beforeUnmount() {
 		this.destroySpotlightViewportObserver();

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -210,7 +210,6 @@ export default {
 			fiveDollarsRowLoans: new Array(30).fill({ id: 0 }),
 			HandOrangeIcon,
 			isAdding: false,
-			isBpModalEnabled: false,
 			isMounted: false,
 			matchedLoansTotal: 0,
 			secondCategoryLoans: new Array(9).fill({ id: 0 }),

--- a/src/pages/LoanFinding/LoanFinding.vue
+++ b/src/pages/LoanFinding/LoanFinding.vue
@@ -19,8 +19,9 @@
 			:enable-five-dollars-notes="enableFiveDollarsNotes"
 			:user-balance="userBalance"
 			:per-step="perStepRecommendedRow"
-			@add-to-basket="addToBasket"
+			:is-bp-modal-enabled="isBpModalEnabled"
 			:class="{ 'tw-pt-3' : !isLoggedIn }"
+			@add-to-basket="addToBasket"
 			@show-cart-modal="handleCartModal"
 			@show-loan-details="showLoanDetails"
 		/>
@@ -33,8 +34,9 @@
 			:loans="almostFundedLoans"
 			:enable-five-dollars-notes="enableFiveDollarsNotes"
 			:user-balance="userBalance"
-			@add-to-basket="trackCategory($event, 'almost-funded')"
+			:is-bp-modal-enabled="isBpModalEnabled"
 			class="tw-pt-3 tw-mb-2"
+			@add-to-basket="trackCategory($event, 'almost-funded')"
 			@show-cart-modal="handleCartModal"
 			@show-loan-details="showLoanDetails"
 		/>
@@ -49,8 +51,9 @@
 			:user-balance="userBalance"
 			:five-dollars-selected="true"
 			:title-icon="HandOrangeIcon"
-			@add-to-basket="trackCategory($event, 'five-dollars')"
+			:is-bp-modal-enabled="isBpModalEnabled"
 			class="tw-pt-3 tw-mb-2"
+			@add-to-basket="trackCategory($event, 'five-dollars')"
 			@show-cart-modal="handleCartModal"
 			@show-loan-details="showLoanDetails"
 		/>
@@ -61,6 +64,7 @@
 				:enable-qf-mobile="enableQFMobileVersion"
 				:enable-almost-funded-row="enableAlmostFundedRow"
 				:user-balance="userBalance"
+				:is-bp-modal-enabled="isBpModalEnabled"
 				@add-to-basket="trackCategory($event, 'quick-filters')"
 				@data-loaded="trackQuickFiltersDisplayedLoans"
 				@show-cart-modal="handleCartModal"
@@ -76,6 +80,7 @@
 				class="tw-py-3"
 				:enable-five-dollars-notes="enableFiveDollarsNotes"
 				:user-balance="userBalance"
+				:is-bp-modal-enabled="isBpModalEnabled"
 				@add-to-basket="trackCategory($event, 'matched-lending')"
 				@show-cart-modal="handleCartModal"
 				@show-loan-details="showLoanDetails"
@@ -87,13 +92,14 @@
 			:loans="spotlightLoans"
 			:enable-five-dollars-notes="enableFiveDollarsNotes"
 			:user-balance="userBalance"
+			:is-bp-modal-enabled="isBpModalEnabled"
 			@add-to-basket="trackCategory($event, `spotlight-${activeSpotlightData.keyword}`)"
 			@show-cart-modal="handleCartModal"
 			@show-loan-details="showLoanDetails"
 		/>
 	</www-page>
 	<KvSideSheet
-		v-if="isMounted"
+		v-if="isMounted && isBpModalEnabled"
 		:kv-track-function="$kvTrackEvent"
 		:show-back-button="false"
 		:show-go-to-link="true"
@@ -114,14 +120,15 @@
 
 <script>
 import numeral from 'numeral';
+import * as Sentry from '@sentry/vue';
+
 import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '#src/plugins/five-dollars-test-mixin';
 import { handleInvalidBasket, hasBasketExpired } from '#src/util/basketUtils';
+import { getExperimentSettingCached, trackExperimentVersion } from '#src/util/experiment/experimentUtils';
 import { runLoansQuery, runRecommendationsQuery } from '#src/util/loanSearch/dataUtils';
 
 import HandOrangeIcon from '#src/assets/images/hand_orange.svg';
 import { spotlightData } from '#src/assets/data/components/LoanFinding/spotlightData.json';
-
-import * as Sentry from '@sentry/vue';
 
 import BorrowerSideSheetContent from '#src/components/BorrowerProfile/BorrowerSideSheetContent';
 import FiveDollarsBanner from '#src/components/LoanFinding/FiveDollarsBanner';
@@ -134,7 +141,6 @@ import WwwPage from '#src/components/WwwFrame/WwwPage';
 import { createIntersectionObserver } from '#src/util/observerUtils';
 import { FLSS_ORIGIN_LEND_BY_CATEGORY } from '#src/util/flssUtils';
 import { KvSideSheet } from '@kiva/kv-components';
-import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
 import basketModalMixin from '#src/plugins/basket-modal-mixin';
 import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
 import flssLoansQueryExtended from '#src/graphql/query/flssLoansQueryExtended.graphql';
@@ -157,12 +163,13 @@ const prefetchedRecommendationsVariables = {
 	limit: 4
 };
 
-const FLSS_ONGOING_EXP_KEY = 'EXP-FLSS-Ongoing-Sitewide-3';
-const THREE_LOANS_RECOMMENDED_ROW_EXP_KEY = 'lh_three_loans_recommended_row';
-const FIVE_DOLLARS_BANNER_KEY = 'kvfivedollarsbanner';
-const QUICK_FILTERS_MOBILE_EXP_KEY = 'lh_qf_mobile_version';
 const ALMOST_FUNDED_ROW_EXP_KEY = 'lh_almost_funded_row';
+const FIVE_DOLLARS_BANNER_KEY = 'kvfivedollarsbanner';
+const FLSS_ONGOING_EXP_KEY = 'EXP-FLSS-Ongoing-Sitewide-3';
+const HOME_BP_MODAL_EXP_KEY = 'home_page_bp_modal';
 const LOAN_RECOMMENDATIONS_EXP_KEY = 'lh_loan_recommendations';
+const QUICK_FILTERS_MOBILE_EXP_KEY = 'lh_qf_mobile_version';
+const THREE_LOANS_RECOMMENDED_ROW_EXP_KEY = 'lh_three_loans_recommended_row';
 
 export default {
 	name: 'LoanFinding',
@@ -203,6 +210,7 @@ export default {
 			fiveDollarsRowLoans: new Array(30).fill({ id: 0 }),
 			HandOrangeIcon,
 			isAdding: false,
+			isBpModalEnabled: false,
 			isMounted: false,
 			matchedLoansTotal: 0,
 			secondCategoryLoans: new Array(9).fill({ id: 0 }),
@@ -243,12 +251,16 @@ export default {
 						variables: { id: FLSS_ONGOING_EXP_KEY }
 					}),
 					client.query({
+						query: experimentAssignmentQuery,
+						variables: { id: HOME_BP_MODAL_EXP_KEY }
+					}),
+					client.query({
 						query: useRecommendations ? loanRecommendationsQueryExtended : flssLoansQueryExtended,
 						variables: useRecommendations ? {
 							...prefetchedRecommendationsVariables,
 							userId
 						} : prefetchedFlssVariables
-					})
+					}),
 				]);
 			});
 		}
@@ -482,6 +494,20 @@ export default {
 				if (daysDifference < 3) this.showFiveDollarsBanner = true;
 			}
 		},
+		async initializeIsBpModalEnabledExp() {
+			const bpModalExp = getExperimentSettingCached(this.apollo, HOME_BP_MODAL_EXP_KEY);
+			if (bpModalExp?.enabled) {
+				const { version } = trackExperimentVersion(
+					this.apollo,
+					this.$kvTrackEvent,
+					'loan-finding',
+					'bpModal',
+				);
+				if (version) {
+					this.isBpModalEnabled = version === 'b';
+				}
+			}
+		},
 		handleCloseSideSheet() {
 			this.showSideSheet = false;
 			this.selectedLoan = undefined;
@@ -589,7 +615,7 @@ export default {
 			window.open(`lend/${this.selectedLoan?.id}`);
 		}
 	},
-	created() {
+	async created() {
 		const loanRecommendationsData = trackExperimentVersion(
 			this.apollo,
 			this.$kvTrackEvent,
@@ -666,6 +692,8 @@ export default {
 			{ id: 0 }, { id: 0 },
 			{ id: 0 }, { id: 0 },
 		];
+
+		await this.initializeIsBpModalEnabledExp();
 
 		// check for $5 notes banner cookie
 		if (this.enableFiveDollarsNotes) this.check5DollarsBannerCookie();

--- a/src/plugins/is-bp-modal-enabled-mixin.js
+++ b/src/plugins/is-bp-modal-enabled-mixin.js
@@ -1,0 +1,27 @@
+import { trackExperimentVersion, getExperimentSettingCached } from '#src/util/experiment/experimentUtils';
+
+export const HOME_BP_MODAL_EXP_KEY = 'home_page_bp_modal';
+
+export default {
+	data() {
+		return {
+			isBpModalEnabled: false
+		};
+	},
+	methods: {
+		initializeIsBpModalEnabledExp() {
+			const bpModalExp = getExperimentSettingCached(this.apollo, HOME_BP_MODAL_EXP_KEY);
+			if (bpModalExp?.enabled) {
+				const { version } = trackExperimentVersion(
+					this.apollo,
+					this.$kvTrackEvent,
+					'loan-finding',
+					'bpModal',
+				);
+				if (version) {
+					this.isBpModalEnabled = version === 'b';
+				}
+			}
+		}
+	},
+};

--- a/src/plugins/is-bp-modal-enabled-mixin.js
+++ b/src/plugins/is-bp-modal-enabled-mixin.js
@@ -1,4 +1,4 @@
-import { trackExperimentVersion, getExperimentSettingCached } from '#src/util/experiment/experimentUtils';
+import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
 
 export const HOME_BP_MODAL_EXP_KEY = 'home_page_bp_modal';
 
@@ -10,18 +10,15 @@ export default {
 	},
 	methods: {
 		initializeIsBpModalEnabledExp() {
-			const bpModalExp = getExperimentSettingCached(this.apollo, HOME_BP_MODAL_EXP_KEY);
-			if (bpModalExp?.enabled) {
-				const { version } = trackExperimentVersion(
-					this.apollo,
-					this.$kvTrackEvent,
-					'home',
-					HOME_BP_MODAL_EXP_KEY,
-					'EXP-MP-671-Dec2024',
-				);
-				if (version) {
-					this.isBpModalEnabled = version === 'b';
-				}
+			const { version } = trackExperimentVersion(
+				this.apollo,
+				this.$kvTrackEvent,
+				'event-tracking',
+				HOME_BP_MODAL_EXP_KEY,
+				'EXP-MP-671-Dec2024',
+			);
+			if (version) {
+				this.isBpModalEnabled = version === 'b';
 			}
 		}
 	},

--- a/src/plugins/is-bp-modal-enabled-mixin.js
+++ b/src/plugins/is-bp-modal-enabled-mixin.js
@@ -15,8 +15,9 @@ export default {
 				const { version } = trackExperimentVersion(
 					this.apollo,
 					this.$kvTrackEvent,
-					'loan-finding',
-					'bpModal',
+					'home',
+					HOME_BP_MODAL_EXP_KEY,
+					'EXP-MP-671-Dec2024',
 				);
 				if (version) {
 					this.isBpModalEnabled = version === 'b';
@@ -24,4 +25,7 @@ export default {
 			}
 		}
 	},
+	mounted() {
+		this.initializeIsBpModalEnabledExp();
+	}
 };

--- a/src/plugins/is-bp-modal-enabled-mixin.js
+++ b/src/plugins/is-bp-modal-enabled-mixin.js
@@ -9,11 +9,11 @@ export default {
 		};
 	},
 	methods: {
-		initializeIsBpModalEnabledExp() {
+		initializeIsBpModalEnabledExp(category) {
 			const { version } = trackExperimentVersion(
 				this.apollo,
 				this.$kvTrackEvent,
-				'event-tracking',
+				category,
 				HOME_BP_MODAL_EXP_KEY,
 				'EXP-MP-671-Dec2024',
 			);
@@ -22,7 +22,4 @@ export default {
 			}
 		}
 	},
-	mounted() {
-		this.initializeIsBpModalEnabledExp();
-	}
 };


### PR DESCRIPTION
Reinstates the usage of the `isBpModalEnabled` prop as the determinant for whether or not the `KvSideSheet` and `showLoanDetails` functionality are active in the LBC page.