### PR TITLE
feat: add lazy loading and portfolio navigation to JournalUpdatesCaro…

### DIFF
--- a/src/components/MyKiva/JournalUpdatesCarousel.vue
+++ b/src/components/MyKiva/JournalUpdatesCarousel.vue
@@ -21,17 +21,27 @@
 					@share-loan-clicked="shareLoanClicked"
 				/>
 			</template>
-			<template v-if="showLoadMore" #view-more>
+			<template v-if="showLoadMore || atEndOfCarousel" #view-more>
 				<div
 					:key="`view-more-card`"
 					class="tw-flex tw-items-center tw-h-full tw-pl-4"
 				>
 					<kv-button
+						v-if="showLoadMore"
 						class="tw-mt-2 tw-whitespace-nowrap"
 						variant="secondary"
 						@click="loadMoreUpdates"
 					>
 						Load more
+					</kv-button>
+					<kv-button
+						v-else
+						class="tw-mt-2 tw-whitespace-nowrap"
+						variant="secondary"
+						:to="'/portfolio'"
+						tag="router-link"
+					>
+						View portfolio
 					</kv-button>
 				</div>
 			</template>
@@ -103,6 +113,10 @@ const props = defineProps({
 	totalUpdates: {
 		type: Number,
 		default: 0,
+	},
+	atEndOfCarousel: {
+		type: Boolean,
+		default: false,
 	},
 });
 

--- a/src/components/MyKiva/LatestBlogCarousel.vue
+++ b/src/components/MyKiva/LatestBlogCarousel.vue
@@ -11,7 +11,6 @@
 				align: 'start',
 			}"
 			:multiple-slides-visible="true"
-			@change="handleChange"
 		>
 			<template v-for="(card, idx) in blogCards" #[`slide${idx}`] :key="card.slug || idx">
 				<BlogCard

--- a/src/graphql/query/myKiva.graphql
+++ b/src/graphql/query/myKiva.graphql
@@ -35,7 +35,7 @@ query myKivaQuery {
       filter: {
         category: loan
       }
-      limit: 100
+      limit: 15
     ) {
       values {
         category

--- a/src/pages/MyKiva/AsyncMyKivaSection.vue
+++ b/src/pages/MyKiva/AsyncMyKivaSection.vue
@@ -1,0 +1,18 @@
+<template>
+	<div>
+		<slot></slot>
+	</div>
+</template>
+
+<script>
+import delayUntilVisibleMixin from '#src/plugins/delay-until-visible-mixin';
+
+export default {
+	name: 'AsyncMyKivaSection',
+	mixins: [delayUntilVisibleMixin],
+	emits: ['visible'],
+	mounted() {
+		this.delayUntilVisible(entry => this.$emit('visible', entry));
+	},
+};
+</script>


### PR DESCRIPTION
> git commit -am "feat: add lazy loading and portfolio navigation to JournalUpdatesCarousel

- Implemented lazy loading for updates section using a wrapper component.
- Updated carousel to show 'Load more' until the end, then display 'View portfolio' button as a router-link.
- Ensured layout remains consistent and improved navigation experience for users."
⧗   input: feat: add lazy loading and portfolio navigation to JournalUpdatesCarousel

- Implemented lazy loading for updates section using a wrapper component.
- Updated carousel to show 'Load more' until the end, then display 'View portfolio' button as a router-link.
- Ensured layout remains consistent and improved navigation experience for users.
