### PR TITLE
feat: fix href to match all the card and open a new window, fix the t…

### DIFF
--- a/src/components/MyKiva/BlogCard.vue
+++ b/src/components/MyKiva/BlogCard.vue
@@ -1,6 +1,10 @@
 <template>
 	<div
-		class="blog-card tw-w-full tw-relative tw-rounded tw-bg-cover tw-bg-center tw-bg-white"
+		class="blog-card tw-w-full tw-relative tw-rounded tw-bg-cover
+				tw-bg-center tw-bg-white tw-block focus:tw-outline-none cursor-pointer"
+		@click="handleCardClick"
+		role="link"
+		@keydown.enter="handleCardClick"
 	>
 		<div
 			class="tw-bg-cover tw-bg-center tw-rounded-t"
@@ -21,13 +25,9 @@
 
 		<div class="tw-px-2 tw-pt-1.5 tw-flex-1 tw-flex tw-flex-col">
 			<p class="tw-font-medium tw-leading-snug tw-line-clamp-3 tw-text-black">
-				<a
-					:href="`/blog/${slug}`"
-					class="tw-text-black tw-font-bold tw-no-underline hover:tw-underline "
-					@click="emit('track', { title, slug, category })"
-				>
+				<span class="tw-text-black tw-font-bold tw-no-underline hover:tw-underline">
 					{{ title }}
-				</a>
+				</span>
 			</p>
 		</div>
 		<div class="tw-absolute tw-left-0 tw-bottom-0 tw-pl-2 tw-pb-2 tw-text-gray-500 tw-text-small">
@@ -75,6 +75,11 @@ const formattedDate = computed(() => {
 		year: 'numeric',
 	});
 });
+
+function handleCardClick() {
+	emit('track', `Blog-${props.category.replace(/\./g, '').replace(/\s+/g, '-')}`);
+	window.open(`/blog/${props.slug}`, '_blank', 'noopener');
+}
 </script>
 
 <style lang="postcss" scoped>

--- a/src/components/MyKiva/LatestBlogCarousel.vue
+++ b/src/components/MyKiva/LatestBlogCarousel.vue
@@ -19,7 +19,7 @@
 					:title="card.title"
 					:date="card.date"
 					:slug="card.slug"
-					@track="trackBlogCard({ title: card.title, slug: card.slug, category: card.category })"
+					@track="trackBlogCard"
 				/>
 			</template>
 		</KvCarousel>
@@ -51,11 +51,8 @@ const singleSlideWidth = computed(() => {
 	return '336px';
 });
 
-function trackBlogCard({ title, slug, category }) {
-	// Replace with your actual tracking function
-	if (typeof $kvTrackEvent === 'function') {
-		$kvTrackEvent('portfolio', 'click', `${category}:${title}`, slug);
-	}
+function trackBlogCard(payload) {
+	$kvTrackEvent('portfolio', 'click', `Blog-${payload}`);
 }
 </script>
 <style lang="postcss" scoped>


### PR DESCRIPTION
feat(blog-carousel): make entire card clickable, open in new tab, and improve tracking

- Updated BlogCard so the entire card is clickable and opens the blog post in a new browser tab, improving user experience and accessibility.
- Refactored tracking to emit only the blog slug, reducing coupling between BlogCard and LatestBlogCarousel.
- Ensured tracking events are fired consistently when a card is clicked.