### PR TITLE
feat: add brand bg to tw safelist for KvTreepMap

### DIFF
--- a/tailwind.purge.safelist.txt
+++ b/tailwind.purge.safelist.txt
@@ -101,6 +101,17 @@ tw-bg-stone-1
 tw-bg-marigold-1
 tw-bg-eco-green-1
 tw-bg-desert-rose-1
+# KvTreeMapChart Background Colors
+tw-bg-brand-100
+tw-bg-brand-200
+tw-bg-brand-300
+tw-bg-brand-400
+tw-bg-brand-500
+tw-bg-brand-600
+tw-bg-brand-700
+tw-bg-brand-800
+tw-bg-brand-900
+tw-bg-brand-1000
 
 # Whitespace Classes
 tw-whitespace-normal


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1755

As these background colors are not being used in UI, tailwind was removing them from the compiled file and causing the chart having white spaces with the `tw-bg-brand-*` classes :
<img width="1606" height="1100" alt="image" src="https://github.com/user-attachments/assets/34bd8493-c2a4-41a5-b00c-f418fbf9a1bb" />

Solution:
<img width="759" height="478" alt="image" src="https://github.com/user-attachments/assets/8ed23b84-93d5-4117-88c3-41ff811ddcbb" />
