### PR TITLE
feat: resolve issue with TY page redirect and simplify MyKiva experiment logic

### DIFF
--- a/src/components/Thanks/MyKiva/ThanksBadges.vue
+++ b/src/components/Thanks/MyKiva/ThanksBadges.vue
@@ -230,7 +230,7 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
-	isMyKivaAllUsers: {
+	myKivaEnabled: {
 		type: Boolean,
 		default: false,
 	},
@@ -363,7 +363,7 @@ const handleContinue = () => {
 			numberOfBadges.value,
 		);
 
-		router?.push(props.isMyKivaAllUsers ? '/mykiva' : '/portfolio');
+		router?.push(props.myKivaEnabled ? '/mykiva' : '/portfolio');
 	}
 };
 

--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -139,10 +139,6 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
-	isMyKivaAllUsers: {
-		type: Boolean,
-		default: false,
-	},
 });
 
 const receiptSection = ref(null);
@@ -233,7 +229,7 @@ const handleContinue = () => {
 			numberOfBadges.value,
 		);
 
-		router?.push(props.isMyKivaAllUsers ? '/mykiva' : '/portfolio');
+		router?.push(props.myKivaEnabled ? '/mykiva' : '/portfolio');
 	}
 };
 

--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -224,8 +224,6 @@ onMounted(async () => {
 	myKivaExperimentEnabled.value = getIsMyKivaEnabled(
 		apollo,
 		$kvTrackEvent,
-		userData.value?.my?.userPreferences,
-		!isGuest.value ? userData.value?.my?.loans?.totalCount : 0,
 		myKivaFlagEnabled.value,
 		cookieStore,
 	);

--- a/src/composables/useMyKivaHome.js
+++ b/src/composables/useMyKivaHome.js
@@ -39,8 +39,6 @@ export default function useMyKivaHome(apollo, $kvTrackEvent, cookieStore) {
 			redirectToMyKivaHomepage.value = getIsMyKivaEnabled(
 				apollo,
 				$kvTrackEvent,
-				userData.value?.userPreferences,
-				userData.value?.loans?.totalCount ?? 0,
 				myKivaFlagEnabled.value,
 				cookieStore,
 			) && userData.value?.id;

--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -24,10 +24,6 @@ query initializeCheckout($basketId: String) {
 			totalCount
 		}
 		depositIncentiveAmountToLend
-		userPreferences {
-			id
-			preferences
-		}
 	}
 	general {
 		guestCheckoutEnabled: featureSetting(key: "guest_checkout.enabled") {

--- a/src/graphql/query/portfolioQuery.graphql
+++ b/src/graphql/query/portfolioQuery.graphql
@@ -31,10 +31,6 @@ query portfolioQuery {
 			id
 			preferences
 		}
-		lender {
-			id
-			loanCount
-		}
 	}
 	general {
 		team_challenge_enable: uiConfigSetting(key: "portfolio_team_challenge_enable") {

--- a/src/graphql/query/shared/myKivaForAllUsers.graphql
+++ b/src/graphql/query/shared/myKivaForAllUsers.graphql
@@ -1,4 +1,7 @@
 query myKivaForAllUsers {
+	my {
+		id
+	}
 	general {
 		my_kiva_all_users: uiConfigSetting(key: "my_kiva_all_users_enable") {
 			key

--- a/src/graphql/query/shared/myKivaForAllUsers.graphql
+++ b/src/graphql/query/shared/myKivaForAllUsers.graphql
@@ -1,14 +1,4 @@
 query myKivaForAllUsers {
-	my {
-		id
-		userPreferences {
-			id
-			preferences
-		}
-		loans {
-			totalCount
-		}
-	}
 	general {
 		my_kiva_all_users: uiConfigSetting(key: "my_kiva_all_users_enable") {
 			key

--- a/src/graphql/query/thanksPage.graphql
+++ b/src/graphql/query/thanksPage.graphql
@@ -40,10 +40,6 @@ query thanksPage {
 			lenderNews
 			loanUpdates
 		}
-		userPreferences {
-			id
-			preferences
-		}
 	}
 	general {
 		shareAskCopy: uiExperimentSetting(key: "share_ask_copy") {

--- a/src/graphql/query/userAtbModal.graphql
+++ b/src/graphql/query/userAtbModal.graphql
@@ -2,10 +2,6 @@ query userAtbModal {
 	hasEverLoggedIn @client
 	my {
 		id
-		userPreferences {
-			id
-			preferences
-		}
 		loans {
 			totalCount
 		}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -451,8 +451,6 @@ export default {
 			newAtbExpEnabled: false,
 			myKivaFlagEnabled: false,
 			isMyKivaEnabled: false,
-			userPreferences: null,
-			lenderLoanCount: null,
 		};
 	},
 	apollo: {
@@ -537,8 +535,6 @@ export default {
 			this.newAtbExpEnabled = readBoolSetting(data, 'general.new_atb_experience_enable.value');
 
 			this.myKivaFlagEnabled = readBoolSetting(data, MY_KIVA_FOR_ALL_USERS_KEY);
-			this.userPreferences = data?.my?.userPreferences ?? null;
-			this.lenderLoanCount = data?.my?.lender?.loanCount ?? 0;
 		}
 	},
 	beforeRouteEnter(to, from, next) {
@@ -645,8 +641,6 @@ export default {
 			this.isMyKivaEnabled = getIsMyKivaEnabled(
 				this.apollo,
 				this.$kvTrackEvent,
-				this.userPreferences,
-				this.lenderLoanCount,
 				this.myKivaFlagEnabled,
 				this.cookieStore,
 			);

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -156,8 +156,6 @@ export default {
 		const isMykivaEnabled = getIsMyKivaEnabled(
 			this.apollo,
 			this.$kvTrackEvent,
-			userData?.userPreferences,
-			userData.lender?.loanCount,
 			myKivaAllUsersEnabled,
 			this.cookieStore,
 		);

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -14,7 +14,6 @@
 				:badges-achieved="badgesAchieved"
 				:my-kiva-enabled="myKivaExperimentEnabled"
 				:guest-username="guestUsername"
-				:is-my-kiva-all-users="myKivaFlagEnabled"
 			/>
 		</template>
 		<template v-if="activeView === DONATION_ONLY_VIEW">
@@ -32,7 +31,7 @@
 				:receipt="receipt"
 				:badges-achieved="badgesAchieved"
 				:guest-username="guestUsername"
-				:is-my-kiva-all-users="myKivaFlagEnabled"
+				:my-kiva-enabled="myKivaExperimentEnabled"
 			/>
 		</template>
 		<template v-if="activeView === MARKETING_OPT_IN_VIEW">
@@ -298,7 +297,6 @@ export default {
 			thanksSingleVersionEnabled: false,
 			SINGLE_VERSION_VIEW,
 			guestUsername: '',
-			myKivaFlagEnabled: false,
 		};
 	},
 	apollo: {
@@ -527,9 +525,6 @@ export default {
 		// Enable single version TY page
 		this.thanksSingleVersionEnabled = readBoolSetting(data, TY_SINGLE_VERSION_KEY);
 
-		// Enable My Kiva Page for all users
-		this.myKivaFlagEnabled = readBoolSetting(data, MY_KIVA_FOR_ALL_USERS_KEY);
-
 		this.optedIn = (data?.my?.communicationSettings?.lenderNews && data?.my?.communicationSettings?.loanUpdates)
 			|| this.$route.query?.optedIn === 'true';
 
@@ -539,9 +534,7 @@ export default {
 		this.myKivaExperimentEnabled = getIsMyKivaEnabled(
 			this.apollo,
 			this.$kvTrackEvent,
-			data?.my?.userPreferences,
-			!this.isGuest ? data?.my?.loans?.totalCount : 1,
-			this.myKivaFlagEnabled,
+			readBoolSetting(data, MY_KIVA_FOR_ALL_USERS_KEY),
 			this.cookieStore,
 		);
 

--- a/src/plugins/my-kiva-homepage-mixin.js
+++ b/src/plugins/my-kiva-homepage-mixin.js
@@ -28,8 +28,6 @@ export default {
 			this.redirectToMyKivaHomepage = getIsMyKivaEnabled(
 				this.apollo,
 				this.$kvTrackEvent,
-				userData?.userPreferences,
-				userData?.loans?.totalCount ?? 0,
 				myKivaFlagEnabled,
 				this.cookieStore,
 			) && userData?.id;

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -97,18 +97,20 @@ export const setMyKivaRedirectCookie = cookieStore => {
  */
 export const getIsMyKivaEnabled = (apollo, $kvTrackEvent, myKivaFlagEnabled, cookieStore) => {
 	if (myKivaFlagEnabled) {
+		const hadGuestAssignment = checkGuestAssignmentCookie(cookieStore);
+
 		const { version: myKivaVersion } = apollo.readFragment({
 			id: `Experiment:${MY_KIVA_EXP}`,
 			fragment: experimentVersionFragment,
 		}) ?? {};
-		const isMyKivaExperimentEnabled = myKivaVersion === 'b';
 
-		trackExperimentVersion(
-			apollo,
-			$kvTrackEvent,
+		const isMyKivaExperimentEnabled = hadGuestAssignment || myKivaVersion === 'b';
+
+		$kvTrackEvent(
 			'event-tracking',
-			MY_KIVA_EXP,
-			'EXP-MP-1235-Jan2025'
+			'EXP-MP-1235-Jan2025',
+			// Ensure tracking is consistent for guest users who login
+			hadGuestAssignment ? 'b' : myKivaVersion,
 		);
 
 		// Set cookie used in Fastly VCL to redirect to MyKiva homepage

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -1,7 +1,6 @@
 import experimentVersionFragment from '#src/graphql/fragments/experimentVersion.graphql';
 import postCheckoutAchievementsQuery from '#src/graphql/query/postCheckoutAchievements.graphql';
 import logReadQueryError from '#src/util/logReadQueryError';
-import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
 
 export const MY_KIVA_PREFERENCE_KEY = 'myKivaJan2025Exp';
 const MY_KIVA_EXP = 'my_kiva_jan_2025';

--- a/src/util/myKivaUtils.js
+++ b/src/util/myKivaUtils.js
@@ -2,7 +2,6 @@ import experimentVersionFragment from '#src/graphql/fragments/experimentVersion.
 import postCheckoutAchievementsQuery from '#src/graphql/query/postCheckoutAchievements.graphql';
 import logReadQueryError from '#src/util/logReadQueryError';
 import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
-import { gql } from 'graphql-tag';
 
 export const MY_KIVA_PREFERENCE_KEY = 'myKivaJan2025Exp';
 const MY_KIVA_EXP = 'my_kiva_jan_2025';
@@ -11,33 +10,6 @@ export const GUEST_ASSIGNMENT_COOKIE = 'myKivaGuestAssignment';
 export const CONTENTFUL_CAROUSEL_KEY = 'my-kiva-hero-carousel';
 export const MY_KIVA_HERO_ENABLE_KEY = 'new_mykiva_hero_enable';
 export const TRANSACTION_LOANS_KEY = 'loan_purchase';
-
-export const createUserPreferencesMutation = gql`
-	mutation createUserPreferences($preferences: String) {
-		my {
-			createUserPreferences(userPreferences: { preferences: $preferences }) {
-				id
-				preferences
-			}
-		}
-	}
-`;
-
-export const updateUserPreferencesMutation = gql`
-	mutation UpdateUserPreferences(
-		$updateUserPreferencesId: Int!,
-		$preferences: String
-	) {
-		my {
-			updateUserPreferences(id: $updateUserPreferencesId, userPreferences: {
-				preferences: $preferences
-		}) {
-				id
-				preferences
-			}
-		}
-	}
-`;
 
 /**
  * Determines whether the provided loan needs a footnote
@@ -75,49 +47,6 @@ export const fetchPostCheckoutAchievements = async (apollo, loanIds) => {
 		});
 	} catch (e) {
 		logReadQueryError(e, 'myKivaUtils postCheckoutAchievementsQuery');
-	}
-};
-
-/**
- * Creates user preferences for the current user
- *
- * @param apollo The current Apollo client
- * @param newPreferences The new preferences to add
- * @returns The results of the mutation
- */
-export const createUserPreferences = async (apollo, newPreferences) => {
-	try {
-		return await apollo.mutate({
-			mutation: createUserPreferencesMutation,
-			variables: { preferences: JSON.stringify(newPreferences) },
-		});
-	} catch (e) {
-		logReadQueryError(e, 'myKivaUtils createUserPreferencesMutation');
-	}
-};
-
-/**
- * Updates the user preferences for the current user
- *
- * @param apollo The current Apollo client
- * @param userPreferences The original user preferences
- * @param parsedPreferences The parsed user preferences
- * @param newPreferences The new preferences to add
- * @returns The updated user preferences
- */
-export const updateUserPreferences = async (apollo, userPreferences, parsedPreferences, newPreferences) => {
-	try {
-		const preferences = JSON.stringify({ ...parsedPreferences, ...newPreferences });
-
-		return await apollo.mutate({
-			mutation: updateUserPreferencesMutation,
-			variables: {
-				updateUserPreferencesId: userPreferences.id,
-				preferences,
-			},
-		});
-	} catch (e) {
-		logReadQueryError(e, 'myKivaUtils updateUserPreferencesMutation');
 	}
 };
 

--- a/src/util/userPreferenceUtils.js
+++ b/src/util/userPreferenceUtils.js
@@ -1,0 +1,72 @@
+import { gql } from 'graphql-tag';
+import logReadQueryError from './logReadQueryError';
+
+export const createUserPreferencesMutation = gql`
+	mutation createUserPreferences($preferences: String) {
+		my {
+			createUserPreferences(userPreferences: { preferences: $preferences }) {
+				id
+				preferences
+			}
+		}
+	}
+`;
+
+export const updateUserPreferencesMutation = gql`
+	mutation UpdateUserPreferences(
+		$updateUserPreferencesId: Int!,
+		$preferences: String
+	) {
+		my {
+			updateUserPreferences(id: $updateUserPreferencesId, userPreferences: {
+				preferences: $preferences
+		}) {
+				id
+				preferences
+			}
+		}
+	}
+`;
+
+/**
+ * Creates user preferences for the current user
+ *
+ * @param apollo The current Apollo client
+ * @param newPreferences The new preferences to add
+ * @returns The results of the mutation
+ */
+export const createUserPreferences = async (apollo, newPreferences) => {
+	try {
+		return await apollo.mutate({
+			mutation: createUserPreferencesMutation,
+			variables: { preferences: JSON.stringify(newPreferences) },
+		});
+	} catch (e) {
+		logReadQueryError(e, 'userPreferenceUtils createUserPreferencesMutation');
+	}
+};
+
+/**
+ * Updates the user preferences for the current user
+ *
+ * @param apollo The current Apollo client
+ * @param userPreferences The original user preferences
+ * @param parsedPreferences The parsed user preferences
+ * @param newPreferences The new preferences to add
+ * @returns The updated user preferences
+ */
+export const updateUserPreferences = async (apollo, userPreferences, parsedPreferences, newPreferences) => {
+	try {
+		const preferences = JSON.stringify({ ...parsedPreferences, ...newPreferences });
+
+		return await apollo.mutate({
+			mutation: updateUserPreferencesMutation,
+			variables: {
+				updateUserPreferencesId: userPreferences.id,
+				preferences,
+			},
+		});
+	} catch (e) {
+		logReadQueryError(e, 'userPreferenceUtils updateUserPreferencesMutation');
+	}
+};

--- a/test/unit/specs/util/myKivaUtils.spec.js
+++ b/test/unit/specs/util/myKivaUtils.spec.js
@@ -1,11 +1,7 @@
 import {
 	hasLoanFunFactFootnote,
-	createUserPreferences,
-	updateUserPreferences,
 	getIsMyKivaEnabled,
 	fetchPostCheckoutAchievements,
-	createUserPreferencesMutation,
-	updateUserPreferencesMutation,
 	setGuestAssignmentCookie,
 	checkGuestAssignmentCookie,
 	GUEST_ASSIGNMENT_COOKIE,
@@ -16,35 +12,6 @@ import logReadQueryError from '#src/util/logReadQueryError';
 import * as experimentUtils from '#src/util/experiment/experimentUtils';
 
 vi.mock('#src/util/logReadQueryError');
-
-const userPreferenceDataMock = {
-	my: {
-		userPreference: {
-			id: 1,
-			preferences: ''
-		}
-	}
-};
-
-const createPreferenceDataMock = {
-	my: {
-		createUserPreferences: {
-			id: 1,
-			preferences: ''
-		}
-	}
-};
-
-const updatedPreferenceDataMock = {
-	my: {
-		userPreference: {
-			id: 1,
-			preferences: {
-				test: 'test'
-			}
-		}
-	}
-};
 
 describe('myKivaUtils.js', () => {
 	describe('hasLoanFunFactFootnote', () => {
@@ -162,55 +129,6 @@ describe('myKivaUtils.js', () => {
 			await fetchPostCheckoutAchievements(apolloMock, loanIds);
 
 			expect(logReadQueryError).toHaveBeenCalledWith(error, 'myKivaUtils postCheckoutAchievementsQuery');
-		});
-	});
-
-	describe('createUserPreferences', () => {
-		it('should create user preferences as expected', async () => {
-			const apolloMock = {
-				mutate: vi.fn().mockReturnValueOnce(Promise.resolve({ data: createPreferenceDataMock }))
-			};
-			const preferences = { test: 'test' };
-
-			const newUserPreference = await createUserPreferences(apolloMock, preferences);
-
-			expect(newUserPreference).toEqual({
-				data: createPreferenceDataMock
-			});
-			expect(apolloMock.mutate).toHaveBeenCalledTimes(1);
-			expect(apolloMock.mutate).toHaveBeenCalledWith({
-				mutation: createUserPreferencesMutation,
-				variables: { preferences: JSON.stringify(preferences) },
-			});
-		});
-	});
-
-	describe('updateUserPreferences', () => {
-		it('should update user preferences as expected', async () => {
-			const apolloMock = {
-				mutate: vi.fn()
-					.mockReturnValueOnce(Promise.resolve({ data: updatedPreferenceDataMock }))
-			};
-
-			const newUserPreference = await updateUserPreferences(
-				apolloMock,
-				userPreferenceDataMock.my.userPreference,
-				// Pass existing preferences to ensure they are merged correctly
-				{ test: 'test' },
-				{ new: 'new' },
-			);
-
-			expect(newUserPreference).toEqual({
-				data: updatedPreferenceDataMock
-			});
-			expect(apolloMock.mutate).toHaveBeenCalledTimes(1);
-			expect(apolloMock.mutate).toHaveBeenCalledWith({
-				mutation: updateUserPreferencesMutation,
-				variables: {
-					updateUserPreferencesId: userPreferenceDataMock.my.userPreference.id,
-					preferences: JSON.stringify({ test: 'test', new: 'new' }),
-				},
-			});
 		});
 	});
 

--- a/test/unit/specs/util/userPreferenceUtils.spec.js
+++ b/test/unit/specs/util/userPreferenceUtils.spec.js
@@ -1,0 +1,91 @@
+import {
+	describe, it, expect, vi
+} from 'vitest';
+import {
+	createUserPreferences,
+	updateUserPreferences,
+	createUserPreferencesMutation,
+	updateUserPreferencesMutation,
+} from '#src/util/userPreferenceUtils';
+
+vi.mock('#src/util/logReadQueryError');
+
+const userPreferenceDataMock = {
+	my: {
+		userPreference: {
+			id: 1,
+			preferences: ''
+		}
+	}
+};
+
+const createPreferenceDataMock = {
+	my: {
+		createUserPreferences: {
+			id: 1,
+			preferences: ''
+		}
+	}
+};
+
+const updatedPreferenceDataMock = {
+	my: {
+		userPreference: {
+			id: 1,
+			preferences: {
+				test: 'test'
+			}
+		}
+	}
+};
+
+describe('userPreferenceUtils.ts', () => {
+	describe('createUserPreferences', () => {
+		it('should create user preferences as expected', async () => {
+			const apolloMock = {
+				mutate: vi.fn().mockReturnValueOnce(Promise.resolve({ data: createPreferenceDataMock }))
+			};
+			const preferences = { test: 'test' };
+
+			const newUserPreference = await createUserPreferences(apolloMock, preferences);
+
+			expect(newUserPreference).toEqual({
+				data: createPreferenceDataMock
+			});
+			expect(apolloMock.mutate).toHaveBeenCalledTimes(1);
+			expect(apolloMock.mutate).toHaveBeenCalledWith({
+				mutation: createUserPreferencesMutation,
+				variables: { preferences: JSON.stringify(preferences) },
+			});
+		});
+	});
+
+	describe('updateUserPreferences', () => {
+		it('should update user preferences as expected', async () => {
+			const apolloMock = {
+				mutate: vi.fn()
+					.mockReturnValueOnce(Promise.resolve({ data: updatedPreferenceDataMock }))
+			};
+
+			const newUserPreference = await updateUserPreferences(
+				apolloMock,
+				userPreferenceDataMock.my.userPreference,
+				// Pass existing preferences to ensure they are merged correctly
+				{ test: 'test' },
+				{ new: 'new' },
+			);
+
+			expect(newUserPreference).toEqual({
+				data: updatedPreferenceDataMock
+			});
+			expect(apolloMock.mutate).toHaveBeenCalledTimes(1);
+			expect(apolloMock.mutate).toHaveBeenCalledWith({
+				mutation: updateUserPreferencesMutation,
+				variables: {
+					updateUserPreferencesId: userPreferenceDataMock.my.userPreference.id,
+					preferences: JSON.stringify({ test: 'test', new: 'new' }),
+				},
+			});
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1854

- Simplified logic for MyKiva experiment assignment
- Removed user preferences usage -> MyKiva experiment no longer needs check for number of loans
- Moved user preferences utils to dedicated file -> these aren't being used but seem useful to keep around
- Fixed issue where all users were taken to MyKiva from TY page regardless of experiment assignment