### PR TITLE
fix: mp-1753 – Create Watch for disableCache prop in BorrowerCarousel

### DIFF
--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -302,6 +302,9 @@ export default {
 	watch: {
 		loanId(newId, oldId) {
 			if (newId !== oldId && newId) this.loadData();
+		},
+		disableCache(newDC, oldDC) {
+			if (newDC !== oldDC && newDC) this.loadData();
 		}
 	},
 	mounted() {


### PR DESCRIPTION
Hotfix for MP-1753. Fixes the `disableCache` prop not properly triggering a re-load of the data at the child component level in the `CommentsAndWhySpecial` component, leading to the GraphQL query using `cache-first` as opposed to `network-only` as its fetching policy and thus returning the outdated set of comments.