### PR TITLE
feat: add card for regions - data - add tracker

### DIFF
--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -125,6 +125,7 @@ const props = defineProps({
 
 const interval = ref(null);
 const loanRegionsElement = ref(null);
+defineExpose({ loanRegionsElement });
 const topCategory = ref(null);
 const topCategoryLoans = ref([]);
 const topCategoryTarget = ref('');

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -24,6 +24,7 @@
 		/>
 		<section v-if="isLendingStatsExp" class="tw-mt-4">
 			<LendingStats
+				ref="lendingStats"
 				:regions="lendingStats.regionsWithLoanStatus"
 				:loans="loans"
 			/>
@@ -264,6 +265,7 @@ export default {
 		} = useBadgeData(this.apollo);
 
 		return {
+			lendingStatsObserver: null,
 			badgeData,
 			blogCards: [],
 			blogCategories,
@@ -594,6 +596,30 @@ export default {
 		this.fetchMoreWaysToHelpData();
 		this.loadInitialBasketItems();
 		this.initializeIsBpModalEnabledExp('my-kiva-page-content');
+
+		this.$nextTick(() => {
+			const loanRegionsEl = this.$refs.lendingStats?.loanRegionsElement;
+			if (loanRegionsEl) {
+				const observer = new window.IntersectionObserver(
+					(entries, obs) => {
+						entries.forEach(entry => {
+							if (entry.isIntersecting) {
+								this.$kvTrackEvent('event-tracking', 'show', 'regions-lent-to');
+								obs.disconnect();
+							}
+						});
+					},
+					{ threshold: 0.2 }
+				);
+				observer.observe(loanRegionsEl);
+				this.lendingStatsObserver = observer;
+			}
+		});
+	},
+	beforeUnmount() {
+		if (this.lendingStatsObserver) {
+			this.lendingStatsObserver.disconnect();
+		}
 	},
 };
 </script>


### PR DESCRIPTION
- The parent now tracks when a specific part of the child (`loanRegionsElement` in `LendingStats`) is visible.
- This is done by exposing the ref from the child, referencing it in the parent, and using Intersection Observer for accurate, one-time event tracking.
- The observer is properly cleaned up on component unmount.