### PR TITLE
feat: [MP-1847] - chore changing GoToLink icon for borrower side sheet #6175

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^6.32.0",
+				"@kiva/kv-components": "^6.37.0",
 				"@kiva/kv-shop": "^3.0.36",
 				"@kiva/kv-tokens": "^3.2.0",
 				"@mdi/js": "^7.4.47",
@@ -3760,9 +3760,9 @@
 			"peer": true
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "6.36.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-6.36.0.tgz",
-			"integrity": "sha512-eokRc31/e/A+XTNFfcuRtx/M82Tb+uSW5r7/ht+Hi8EqKL2/fFoD7txhHNznDLRH5Y22GDttHqyuX1lAQ8laJA==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-6.38.0.tgz",
+			"integrity": "sha512-b9G7qgrSLtaG1W1sA0PFUS1RbatySv+B3DNgCbEaiz0uY/1c/ar7g1EPtJnT9e8kkSHOL0Uek9W57rpJoVwYFw==",
 			"bundleDependencies": [
 				"aria-hidden",
 				"embla-carousel",
@@ -32983,9 +32983,9 @@
 			"peer": true
 		},
 		"@kiva/kv-components": {
-			"version": "6.36.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-6.36.0.tgz",
-			"integrity": "sha512-eokRc31/e/A+XTNFfcuRtx/M82Tb+uSW5r7/ht+Hi8EqKL2/fFoD7txhHNznDLRH5Y22GDttHqyuX1lAQ8laJA==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-6.38.0.tgz",
+			"integrity": "sha512-b9G7qgrSLtaG1W1sA0PFUS1RbatySv+B3DNgCbEaiz0uY/1c/ar7g1EPtJnT9e8kkSHOL0Uek9W57rpJoVwYFw==",
 			"requires": {
 				"aria-hidden": "*",
 				"embla-carousel": "*",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
-		"@kiva/kv-components": "^6.36.0",
+		"@kiva/kv-components": "^6.37.0",
 		"@kiva/kv-shop": "^3.0.36",
 		"@kiva/kv-tokens": "^3.2.0",
 		"@mdi/js": "^7.4.47",


### PR DESCRIPTION
# MP-1847
## Summary

Changing go to link on side sheet for mdiExportVariant to mdiOpenInNew

update @kiva/kv-components module to v 6.37.0

### JIRA US task

https://kiva.atlassian.net/browse/MP-1847

### Evidences

<img width="619" height="520" alt="Screenshot 2025-07-29 at 10 42 02" src="https://github.com/user-attachments/assets/f948886d-563b-4351-a69a-ac91f65957ab" />
