### PR TITLE
fix: mp-1878 / Borrower Images in Lending Stats Recommended Card Should be Top Center

### DIFF
--- a/src/components/MyKiva/MyKivaCard.vue
+++ b/src/components/MyKiva/MyKivaCard.vue
@@ -18,7 +18,7 @@
 				<template v-for="(image, index) in images" #[`slide${index+1}`] :key="index">
 					<img
 						:src="image"
-						class="tw-rounded tw-w-full tw-aspect-video tw-object-cover"
+						class="tw-rounded tw-w-full tw-aspect-video tw-object-cover tw-object-top"
 					>
 				</template>
 			</KvCarousel>


### PR DESCRIPTION
Applies `tw-object-top` tailwind class to img to fix the issue.