### PR TITLE
feat: mp-1829-MyKiva Update card adjustments

### DIFF
--- a/src/components/MyKiva/JournalUpdateCard.vue
+++ b/src/components/MyKiva/JournalUpdateCard.vue
@@ -38,20 +38,12 @@
 			</div>
 		</div>
 		<div
-			class="tw-my-1 " style="height:200px;"
+			class="tw-my-1"
 		>
-			<p class="tw-font-bold tw-mb-1">
-				<span v-if="update.isRepayment">
-					{{ subject }}
-				</span>
-				<span v-else-if="subject">
-					Subject line: {{ subject }}
-				</span>
-			</p>
 			<p
-				class="tw-line-clamp-5"
+				class="tw-line-clamp-3"
 			>
-				<span v-html="body" class=" "></span>
+				<span v-html="displayText" class=" "></span>
 				<span v-if="update.isRepayment">
 					<button
 						v-if="update.isRepayment"
@@ -165,6 +157,18 @@ const loanStatus = computed(() => {
 const subject = computed(() => update.value?.subject ?? '');
 const body = computed(() => update.value?.body ?? '');
 
+function stripHtmlTags(html) {
+	return html.replace(/<[^>]*>/g, '');
+}
+const displayText = computed(() => {
+	if (update.value?.isRepayment) {
+		return body.value;
+	}
+	if (subject.value) {
+		return stripHtmlTags(`Re: ${subject.value} ${body.value}`);
+	}
+	return body.value;
+});
 const truncatedBody = computed(() => {
 	let truncatedCopy = body.value.split(' ').splice(0, 14).join(' ');
 	if (truncatedCopy.length < body.value.length) {

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -457,9 +457,8 @@ export default {
 					isTransaction: true,
 					status: 'repayment',
 					date: trx.effectiveTime,
-					subject: 'Success!',
 					// eslint-disable-next-line max-len
-					body: `${trx.loan?.name || 'A borrower'} from ${trx.loan?.geocode?.country?.name || 'Unknown country'} repaid you $${trx.amount}! Your new balance is now $${this.userBalance}. Don't let it go unused - `,
+					body: `Success! ${trx.loan?.name || 'A borrower'} from ${trx.loan?.geocode?.country?.name || 'Unknown country'} repaid you $${trx.amount}! Your new balance is now $${this.userBalance}. Don't let it go unused - `,
 					amount: trx.amount,
 					loan: trx.loan,
 					image: trx.loan?.image?.url || null,
@@ -486,9 +485,8 @@ export default {
 				status: 'repayment-summary',
 				date: repayments[0]?.effectiveTime || new Date().toISOString(),
 				title: `${uniqueBorrowers.size} Borrowers`,
-				subject: 'Success!',
 				// eslint-disable-next-line max-len
-				body: `${uniqueBorrowers.size} people from ${uniqueCountries.size} countries repaid you $${totalAmount.toFixed(2)}! Your new balance is now $${this.userBalance}. Don't let it go unused - `,
+				body: `Success! ${uniqueBorrowers.size} people from ${uniqueCountries.size} countries repaid you $${totalAmount.toFixed(2)}! Your new balance is now $${this.userBalance}. Don't let it go unused - `,
 				amount: totalAmount,
 				loan: null,
 				image: null,


### PR DESCRIPTION
Updated MyKiva update cards to align with design guidelines:
– Removed subject lines from transaction updates
– Adjusted repayment cards to keep "Success!" on the same line as repayment info
– For journal updates, replaced “Subject line” with “Re:” formatting
– Matched update card height to recent borrower cards
– Updated truncation rules to unify text length across all update cards