### PR TITLE
fix: use top category according to achievement progress

### DIFF
--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -590,26 +590,24 @@ export default function useBadgeData() {
 	};
 
 	/**
-	 * Get top category
+	 * Redesign to work with userAchievementProgressWithLoans.tieredLendingAchievements
 	 *
-	 * @param loans The loans to filter
-	 * @returns Top category by loans
+	 * @param tieredLendingAchievements The tiered lending achievements with loans
+	 * @returns The top category with loans
 	 */
-	const getTopCategoryByLoans = loans => {
-		const groupedLoans = [];
-		Object.keys(CATEGORIES).forEach(category => {
-			const filteredLoans = getFilteredLoansByJourney({ id: category }, loans);
-			if (filteredLoans.length > 0) {
-				groupedLoans.push({
-					category,
-					loans: filteredLoans,
-				});
-			}
+	const getTopCategoryWithLoans = tieredLendingAchievements => {
+		const categories = tieredLendingAchievements.map(c => {
+			return {
+				category: c.id,
+				loansCount: c.totalProgressToAchievement ?? 0,
+				loans: c.matchingLoans?.loans?.values ?? [],
+				target: CATEGORY_TARGETS[c.id] ?? '',
+			};
 		});
 
-		groupedLoans.sort((a, b) => b.loans.length - a.loans.length);
-		if (groupedLoans.length > 0) {
-			return groupedLoans[0];
+		categories.sort((a, b) => b.loansCount - a.loansCount);
+		if (categories.length > 0) {
+			return categories[0];
 		}
 		return null;
 	};
@@ -699,6 +697,6 @@ export default function useBadgeData() {
 		isBadgeKeyValid,
 		getLevelCaption,
 		getJourneysByLoan,
-		getTopCategoryByLoans,
+		getTopCategoryWithLoans,
 	};
 }

--- a/src/graphql/query/userAchievementProgressWithLoans.graphql
+++ b/src/graphql/query/userAchievementProgressWithLoans.graphql
@@ -1,0 +1,41 @@
+query UserAchievementProgressWithLoans($publicId: String) {
+  userAchievementProgress(publicId: $publicId) {
+    id
+    lendingAchievements {
+      id
+      description
+      milestoneProgress {
+        earnedAtDate
+        id
+        milestoneStatus
+        progress
+        target
+      }
+    }
+    tieredLendingAchievements {
+      id
+	  description
+      totalProgressToAchievement
+      matchingLoans {
+        id
+        filters
+		loans {
+			values {
+				id
+				name
+				image {
+					id
+					hash
+				}
+			}
+		}
+      }
+      tiers {
+        target
+        tierStatement
+        completedDate
+        learnMoreURL
+      }
+    }
+  }
+}

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -14,6 +14,7 @@ import useBadgeData, {
 	ID_2BB,
 	FILTERS,
 	CATEGORIES,
+	CATEGORY_TARGETS,
 } from '#src/composables/useBadgeData';
 import { defaultBadges } from '#src/util/achievementUtils';
 import {
@@ -951,43 +952,113 @@ describe('useBadgeData.js', () => {
 		});
 	});
 
-	describe('getTopCategoryByLoans', () => {
-		const { getTopCategoryByLoans } = useBadgeData();
+	describe('getTopCategoryWithLoans', () => {
+		const { getTopCategoryWithLoans } = useBadgeData();
 
-		it('should return null if no loans are provided', () => {
-			const loans = [];
-			expect(getTopCategoryByLoans(loans)).toEqual(null);
+		it('should return null if no tiered lending achievements are provided', () => {
+			const tieredLendingAchievements = [];
+			expect(getTopCategoryWithLoans(tieredLendingAchievements)).toEqual(null);
 		});
 
-		it('should return most repeated category object', () => {
-			const loans = [
+		it('should return the category with the highest loan count', () => {
+			const tieredLendingAchievements = [
 				{
-					id: 1,
-					gender: 'female'
-				},
-				{
-					id: 2,
-					gender: 'female'
-				},
-				{
-					gender: 'male',
-					geocode: {
-						country: {
-							isoCode: 'PE'
+					id: ID_WOMENS_EQUALITY,
+					totalProgressToAchievement: 5,
+					matchingLoans: {
+						loans: {
+							values: [
+								{ id: 1, name: 'Loan 1' },
+								{ id: 2, name: 'Loan 2' },
+								{ id: 3, name: 'Loan 3' },
+								{ id: 4, name: 'Loan 4' },
+								{ id: 5, name: 'Loan 5' }
+							]
 						}
-					},
-					sector: {
-						id: 2
-					},
-					themes: [
-						'Education'
-					],
-					tags: [
-						'#Agriculture'
-					]
+					}
+				},
+				{
+					id: ID_CLIMATE_ACTION,
+					totalProgressToAchievement: 3,
+					matchingLoans: {
+						loans: {
+							values: [
+								{ id: 6, name: 'Loan 6' },
+								{ id: 7, name: 'Loan 7' },
+								{ id: 8, name: 'Loan 8' }
+							]
+						}
+					}
+				},
+				{
+					id: ID_BASIC_NEEDS,
+					totalProgressToAchievement: 2,
+					matchingLoans: {
+						loans: {
+							values: [
+								{ id: 9, name: 'Loan 9' },
+								{ id: 10, name: 'Loan 10' }
+							]
+						}
+					}
 				}
 			];
-			expect(getTopCategoryByLoans(loans)).toEqual({ category: 'womens-equality', loans: [loans[0], loans[1]] });
+
+			const expected = {
+				category: ID_WOMENS_EQUALITY,
+				loansCount: 5,
+				loans: [
+					{ id: 1, name: 'Loan 1' },
+					{ id: 2, name: 'Loan 2' },
+					{ id: 3, name: 'Loan 3' },
+					{ id: 4, name: 'Loan 4' },
+					{ id: 5, name: 'Loan 5' }
+				],
+				target: CATEGORY_TARGETS[ID_WOMENS_EQUALITY]
+			};
+
+			expect(getTopCategoryWithLoans(tieredLendingAchievements)).toEqual(expected);
+		});
+
+		it('should handle achievements with no matching loans', () => {
+			const tieredLendingAchievements = [
+				{
+					id: ID_WOMENS_EQUALITY,
+					totalProgressToAchievement: 0,
+					matchingLoans: {
+						loans: {
+							values: []
+						}
+					}
+				}
+			];
+
+			const expected = {
+				category: ID_WOMENS_EQUALITY,
+				loansCount: 0,
+				loans: [],
+				target: CATEGORY_TARGETS[ID_WOMENS_EQUALITY]
+			};
+
+			expect(getTopCategoryWithLoans(tieredLendingAchievements)).toEqual(expected);
+		});
+
+		it('should handle achievements with missing matchingLoans structure', () => {
+			const tieredLendingAchievements = [
+				{
+					id: ID_CLIMATE_ACTION,
+					totalProgressToAchievement: 3
+				}
+			];
+
+			const expected = {
+				category: ID_CLIMATE_ACTION,
+				loansCount: 3,
+				loans: [],
+				target: CATEGORY_TARGETS[ID_CLIMATE_ACTION]
+			};
+
+			expect(getTopCategoryWithLoans(tieredLendingAchievements)).toEqual(expected);
 		});
 	});
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1897
https://kiva.atlassian.net/browse/MP-1903

- Previously we were choosing the "top category" and getting the loan count based on the loans query that has a limit
- Now the data is being pulled from the achievement service data, which we are already using on MyKiva, I just created a new extended query
- Fixed a bug where we were displaying "persons" instead of "people"

<img width="1066" height="429" alt="image" src="https://github.com/user-attachments/assets/22d4eb8d-bc4e-4939-a0cd-7e9bf9e9b5ff" />
