### PR TITLE
fix: remove background size prop from lending stats cards that is no longer needed

### DIFF
--- a/src/components/Contentful/JourneyCardCarousel.vue
+++ b/src/components/Contentful/JourneyCardCarousel.vue
@@ -41,7 +41,6 @@
 				<MyKivaCard
 					v-else
 					class="tw-w-full tw-h-full"
-					:background-size="backgroundSize"
 					:bg-image="backgroundImg(slide)"
 					:is-bg-top-aligned="isNonBadgeSlide(slide)"
 					:has-gradient="!isNonBadgeSlide(slide)"
@@ -102,10 +101,6 @@ const {
 const emit = defineEmits(['update-journey']);
 
 const props = defineProps({
-	backgroundSize: {
-		type: String,
-		default: 'tw-bg-cover',
-	},
 	userInfo: {
 		type: Object,
 		default: () => ({}),

--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -132,7 +132,6 @@
 			class="carousel"
 			user-in-homepage
 			in-lending-stats
-			background-size="tw-bg-contain"
 			:lender="lender"
 			:slides-number="3"
 			:slides="allRegionsLentSlides"

--- a/src/components/MyKiva/MyKivaCard.vue
+++ b/src/components/MyKiva/MyKivaCard.vue
@@ -2,8 +2,7 @@
 	<div
 		:class="[
 			// eslint-disable-next-line max-len
-			'tw-w-full tw-relative tw-rounded tw-bg-center tw-select-none tw-bg-white journey-card tw-flex tw-flex-col tw-h-full',
-			backgroundSize,
+			'tw-w-full tw-relative tw-rounded tw-bg-center tw-select-none tw-bg-white journey-card tw-flex tw-flex-col tw-h-full tw-bg-cover',
 			{ 'tw-bg-top tw-bg-no-repeat': isBgTopAligned },
 			{ 'single-image': hasSingleBorrowerImage }
 		]"
@@ -159,14 +158,6 @@ const TrophyIcon = defineAsyncComponent(() => import('#src/assets/images/my-kiva
 const emit = defineEmits(['secondary-cta-clicked', 'primary-cta-clicked']);
 
 const props = defineProps({
-	/**
-	 * Background size class for the card.
-	 * This should be a string of Tailwind CSS classes.
-	 */
-	backgroundSize: {
-		type: String,
-		default: 'tw-bg-cover',
-	},
 	/**
 	 * Classes to apply to the content area of the card.
 	 * This should be a string of Tailwind CSS classes.


### PR DESCRIPTION
Turns out other recent sizing fixes made this prop an issue and obsolete.