### PR TITLE
fix: resolve issue with incorrect loan status in borrower carousel

### DIFF
--- a/src/components/MyKiva/BorrowerStatusCard.vue
+++ b/src/components/MyKiva/BorrowerStatusCard.vue
@@ -1,7 +1,10 @@
 <template>
 	<div class="card-container">
-		<div class="tw-bg-white tw-absolute tw-top-1 tw-left-1 tw-rounded tw-px-1 tw-py-0.5 tw-font-medium">
-			🎉 {{ loanStatus }}
+		<div
+			v-if="loanStatus"
+			class="tw-bg-white tw-absolute tw-top-1 tw-left-1 tw-rounded tw-px-1 tw-py-0.5 tw-font-medium"
+		>
+			{{ loanStatus }}
 		</div>
 		<div
 			v-if="showMenu"
@@ -108,6 +111,7 @@ import {
 	watch,
 } from 'vue';
 import {
+	DEFAULTED,
 	FUNDRAISING,
 	REFUNDED,
 	EXPIRED,
@@ -179,19 +183,21 @@ const stepsCopy = computed(() => {
 const loanStatus = computed(() => {
 	switch (loan.value?.status) {
 		case FUNDRAISING:
-			return 'Fundraising';
+			return '🎉 Fundraising';
 		case FUNDED:
-			return 'Funded';
+			return '🎉 Funded';
 		case PAYING_BACK:
-			return 'Repaying';
+			return '🎉 Repaying';
 		case REFUNDED:
 			return 'Refunded';
 		case EXPIRED:
 			return 'Expired';
-		case ENDED:
+		case DEFAULTED:
 			return 'Ended in default';
+		case ENDED:
+			return '🎉 Repaid';
 		default:
-			return 'Repaid';
+			return '';
 	}
 });
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1937
https://kiva.atlassian.net/browse/MP-1954

- Fixes to borrower carousel in portfolio and mykiva
- We were incorrectly showing emoji for "failed" loan statuses
- We were incorrectly called "ended" loans "defaulted"