### PR TITLE
fix: change nav experiment key to match cps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^6.50.4",
+				"@kiva/kv-components": "^6.52.2",
 				"@kiva/kv-shop": "^3.3.15",
 				"@kiva/kv-tokens": "^3.4.1",
 				"@mdi/js": "^7.4.47",

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -598,7 +598,7 @@ import SearchBar from './SearchBar';
 import PromoCreditBanner from './PromotionalBanner/Banners/PromoCreditBanner';
 
 const COMMS_OPT_IN_EXP_KEY = 'opt_in_comms';
-const NAV_UPDATE_EXP_KEY = 'kiva_nav_update';
+const NAV_UPDATE_EXP_KEY = 'home_page'; // Key aligns with key used in Fastly experimentation for cached CPS pages
 
 export default {
 	name: 'TheHeader',


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2024

- CPS now uses key from fastly experimentation, so UI needs to be updated to match