### PR TITLE
chore: rm App Gallery link from build page [CP-2190]

### DIFF
--- a/src/pages/Build/BuildPage.vue
+++ b/src/pages/Build/BuildPage.vue
@@ -24,11 +24,6 @@
 			<p>
 				Check out our <a href="https://gateway.production.kiva.org/graphql"> GraphQL API methods</a>.
 			</p>
-			<h2>Share your app </h2>
-			<p>
-				Let the world experience microlending through
-				<a href="http://pages.kiva.org/apps">the applications you've built</a>!
-			</p>
 			<h2>Discussion</h2>
 			<p>
 				Here are recent topics from our developer forum.


### PR DESCRIPTION
cf https://kiva.atlassian.net/browse/CP-2190 and https://github.com/kiva/ui/pull/6260

Business stakeholders Sophie M and Emily W have no issue dropping this link. The App Gallery page content was last updated in 2019, and it's not clear that the content in its unmaintained state provides net value. We can always add back a link to a new page with updated content when and if we decide to pursue it.