### PR TITLE
fix: show fundraising meter for active funds, improve visibilty checks

### DIFF
--- a/src/pages/GivingFunds/GivingFundsManagementPage.vue
+++ b/src/pages/GivingFunds/GivingFundsManagementPage.vue
@@ -270,11 +270,3 @@ onMounted(() => {
 	fetchUserId();
 });
 </script>
-
-<style lang="postcss" scoped>
-.utility-menu-link {
-	@apply tw-block tw-p-1.5 hover:tw-bg-secondary tw-text-primary hover:tw-text-action-highlight tw-font-medium;
-	@apply tw-no-underline active:tw-no-underline;
-	@apply visited:tw-no-underline hover:tw-no-underline focus:tw-no-underline;
-}
-</style>


### PR DESCRIPTION
- Adds fundraising meter and copy to mgmt card when fund is active
- Improve fund active checks to include both NONE + IN_PROGRESS statues as well as a date check
- Hide the "Start a fundraiser" button if one is already active
- Fix utility menu styles

New:
<img width="875" height="509" alt="image" src="https://github.com/user-attachments/assets/b0e73d1a-8bf5-4471-badb-cfd52d6ad7b6" />

Previously:
<img width="838" height="532" alt="image" src="https://github.com/user-attachments/assets/10522029-33c8-45e8-aa5e-2fff626b1c8e" />
