### PR TITLE
fix: [MP-2046] issues with experiment header for nav with cache

### DIFF
--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -104,7 +104,7 @@ export default function createMiddleware({ config, vite }) {
 
 		// Handle a single home page experiment
 		if (homePageHeader) {
-			forceHeader = true;
+			forceHeader = homePageHeader;
 		}
 
 		// Setup rendering context

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -105,9 +105,6 @@ export default function createMiddleware({ config, vite }) {
 		// Handle a single home page experiment
 		if (homePageHeader) {
 			forceHeader = true;
-			res.setHeader(VARY_HEADER, headers.vary
-				? `${headers.vary}, ${HOME_PAGE_EXPERIMENT_HEADER}`
-				: HOME_PAGE_EXPERIMENT_HEADER);
 		}
 
 		// Setup rendering context

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -3,7 +3,7 @@ import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import Bowser from 'bowser';
 import cookie from 'cookie';
-import { HOME_PAGE_EXPERIMENT_HEADER, VARY_HEADER } from '../src/util/experiment/fastlyExperimentUtils.js';
+import { HOME_PAGE_EXPERIMENT_HEADER } from '../src/util/experiment/fastlyExperimentUtils.js';
 import vueWorkerPool from './vue-worker-pool.js';
 import vueRender from './vue-render.js';
 import protectedRoutes from './util/protectedRoutes.js';

--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -96,17 +96,6 @@ export default function createMiddleware({ config, vite }) {
 			// If not simulating CDN, check Fastly header
 			: req.get('Fastly-Noted-Logged-In') === 'true';
 
-		let forceHeader = false;
-		const { headers } = req;
-		// We currently support running one and only one experiment at a time on cached pages
-		// The experiment is named "home page" but can be used for any page and experiment
-		const homePageHeader = headers[HOME_PAGE_EXPERIMENT_HEADER.toLowerCase()]; // Node lowercases header keys
-
-		// Handle a single home page experiment
-		if (homePageHeader) {
-			forceHeader = homePageHeader;
-		}
-
 		// Setup rendering context
 		const context = {
 			url: req.url,
@@ -118,7 +107,7 @@ export default function createMiddleware({ config, vite }) {
 			locale: req.locale,
 			device,
 			cdnNotedLoggedIn,
-			forceHeader,
+			forceHeader: req.headers[HOME_PAGE_EXPERIMENT_HEADER.toLowerCase()],
 		};
 
 		// set html response headers

--- a/server/vue-render.js
+++ b/server/vue-render.js
@@ -3,6 +3,7 @@ import { getCookieHeader } from './util/cookies.js';
 import initCache from './util/initCache.js';
 import { info } from './util/log.js';
 import getGqlPossibleTypes from './util/getGqlPossibleTypes.js';
+import { HOME_PAGE_EXPERIMENT_HEADER, VARY_HEADER } from '../src/util/experiment/fastlyExperimentUtils.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -53,6 +54,7 @@ export default async function render({
 			headers: {
 				Cookie: getCookieHeader(context.cookies),
 				'Fastly-Top-Url': context.url,
+				...(context.forceHeader && { [`${VARY_HEADER}`]: HOME_PAGE_EXPERIMENT_HEADER })
 			},
 		}) : html;
 

--- a/server/vue-render.js
+++ b/server/vue-render.js
@@ -3,7 +3,6 @@ import { getCookieHeader } from './util/cookies.js';
 import initCache from './util/initCache.js';
 import { info } from './util/log.js';
 import getGqlPossibleTypes from './util/getGqlPossibleTypes.js';
-import { HOME_PAGE_EXPERIMENT_HEADER, VARY_HEADER } from '../src/util/experiment/fastlyExperimentUtils.js';
 
 const isProd = process.env.NODE_ENV === 'production';
 
@@ -54,7 +53,6 @@ export default async function render({
 			headers: {
 				Cookie: getCookieHeader(context.cookies),
 				'Fastly-Top-Url': context.url,
-				...(context.forceHeader && { [`${VARY_HEADER}`]: HOME_PAGE_EXPERIMENT_HEADER })
 			},
 		}) : html;
 

--- a/src/api/apollo.js
+++ b/src/api/apollo.js
@@ -18,6 +18,7 @@ export default function createApolloClient({
 	userAgent,
 	fetch,
 	route,
+	forceHeader,
 }) {
 	const cache = new InMemoryCache({
 		possibleTypes: types,
@@ -36,6 +37,7 @@ export default function createApolloClient({
 		cookieStore,
 		kvAuth0,
 		route,
+		forceHeader,
 	});
 
 	const client = new ApolloClient({

--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -16,7 +16,7 @@ import logFormatter from '#src/util/logFormatter';
  *
  * @param {Object} param0.cookieStore The cookie mixin
  * @param {Object} param0.route The initial route resolved by the Vue router
- * @param {boolean} param0.forceHeader Force new navigation header
+ * @param {boolean|string} param0.forceHeader Force new navigation header
  * @returns {Object} The local resolvers
  */
 export default ({ cookieStore, route, forceHeader }) => {

--- a/src/api/localResolvers/experiment.js
+++ b/src/api/localResolvers/experiment.js
@@ -16,9 +16,10 @@ import logFormatter from '#src/util/logFormatter';
  *
  * @param {Object} param0.cookieStore The cookie mixin
  * @param {Object} param0.route The initial route resolved by the Vue router
+ * @param {boolean} param0.forceHeader Force new navigation header
  * @returns {Object} The local resolvers
  */
-export default ({ cookieStore, route }) => {
+export default ({ cookieStore, route, forceHeader }) => {
 	if (!cookieStore) {
 		return {};
 	}
@@ -33,10 +34,9 @@ export default ({ cookieStore, route }) => {
 				 * @param {String} param1.id The ID of the experiment
 				 * @param {Object} param2.cache The Apollo cache
 				 * @param {Object} param2.client The Apollo client
-				 * @param {Object} param2.headers The Request headers
 				 * @returns The active experiment assignment
 				 */
-				async experiment(_, { id = '' }, { cache, client, headers }) {
+				async experiment(_, { id = '' }, { cache, client }) {
 					// Get the list of active experiments
 					const activeExperiments = await getActiveExperiments(cache, client);
 					if (!activeExperiments?.length) {
@@ -57,9 +57,14 @@ export default ({ cookieStore, route }) => {
 						return Experiment({ id });
 					}
 
-					console.log('HP - incoming headers in resolver: ', JSON.stringify(headers));
 					// Get forced assignment if there's an assignment in "setuiab" query string param or "uiab" cookie
-					const forcedAssignment = getForcedAssignment(cookieStore, route, id, experimentSetting, headers);
+					const forcedAssignment = getForcedAssignment(
+						cookieStore,
+						route,
+						id,
+						experimentSetting,
+						forceHeader
+					);
 
 					// Create initial current assignment object
 					let currentAssignment = { ...(forcedAssignment || { id }) };

--- a/src/esiTags/head.js
+++ b/src/esiTags/head.js
@@ -59,6 +59,7 @@ export default async function renderESIHead({
 	const {
 		config,
 		kivaUserAgent,
+		forceHeader,
 	} = context;
 	const { topUrl } = context.esi;
 	const topUrlObj = new URL(topUrl, `${config.transport}://${config.host}`);
@@ -72,6 +73,7 @@ export default async function renderESIHead({
 		userAgent: kivaUserAgent,
 		uri: config.graphqlUri,
 		types: config.graphqlPossibleTypes,
+		forceHeader,
 	});
 
 	// Set the visitor id cookie before other cookies or requests

--- a/src/main.js
+++ b/src/main.js
@@ -22,6 +22,7 @@ export default async function createApp({
 	router,
 	cdnNotedLoggedIn = false,
 	isServer = false,
+	forceHeader = false,
 } = {}) {
 	const renderConfig = {
 		cdnNotedLoggedIn,
@@ -74,6 +75,7 @@ export default async function createApp({
 		fetch,
 		userAgent: kivaUserAgent,
 		route,
+		forceHeader
 	});
 
 	if (!useCDNCaching || !isServer) {

--- a/src/server-app-render.js
+++ b/src/server-app-render.js
@@ -35,6 +35,7 @@ export default async function renderPage({
 		device,
 		ssrManifest,
 		template,
+		forceHeader,
 	} = context;
 
 	// Create a new router instance. This will set the initial route and potentially redirect or 404.
@@ -61,6 +62,7 @@ export default async function renderPage({
 		kivaUserAgent,
 		router,
 		isServer: true,
+		forceHeader,
 	});
 
 	try {

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -275,7 +275,7 @@ export const setCookieAssignments = (cookieStore, assignments) => {
  * @param {Object} route The initial route resolved by the Vue router
  * @param {string} id The ID of the assignment to check
  * @param {Object} experimentSetting The experiment settings
- * @param {boolean} should force the new header experiment if was setted by fastly header
+ * @param {boolean|string} should force the new header experiment if was setted by fastly header otherwise false
  * @returns The forced experiment assignment
  */
 export const getForcedAssignment = (cookieStore, route, id, experimentSetting, forceHeader = false) => {
@@ -289,7 +289,7 @@ export const getForcedAssignment = (cookieStore, route, id, experimentSetting, f
 
 	if (forceHeader && id === HOME_PAGE_EXPERIMENT_KEY) {
 		headerForced = true;
-		forcedVersion = 'b';
+		forcedVersion = forceHeader;
 	} else {
 		// Look through setuiab assignments
 		const setuiabQuery = route?.query?.setuiab;

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import logFormatter from '#src/util/logFormatter';
 import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
 import Alea from './Alea';
+import { HOME_PAGE_EXPERIMENT_HEADER, HOME_PAGE_EXPERIMENT_KEY } from './fastlyExperimentUtils';
 
 /**
  * The name of the cookie for storing assignments
@@ -274,26 +275,34 @@ export const setCookieAssignments = (cookieStore, assignments) => {
  * @param {Object} route The initial route resolved by the Vue router
  * @param {string} id The ID of the assignment to check
  * @param {Object} experimentSetting The experiment settings
+ * @param {Object} The headers of the request
  * @returns The forced experiment assignment
  */
-export const getForcedAssignment = (cookieStore, route, id, experimentSetting) => {
+export const getForcedAssignment = (cookieStore, route, id, experimentSetting, headers = {}) => {
 	// Get previous cookie assignment
 	const cookieAssignment = getCookieAssignments(cookieStore)[id];
 	const cookieQueryForced = !!cookieAssignment?.queryForced;
 
 	let queryForced;
+	let headerForced = false;
 	let forcedVersion = cookieAssignment?.version;
 
-	// Look through setuiab assignments
-	const setuiabQuery = route?.query?.setuiab;
-	// Route query param will be an array if more than one instance in URL
-	const setuiab = typeof setuiabQuery === 'string' ? [setuiabQuery] : (setuiabQuery ?? []);
-	for (let i = 0; i < setuiab.length; i += 1) {
-		const forcedExp = setuiab[i]?.split('.') ?? [];
-		if (forcedExp[0] === id) {
-			queryForced = !!forcedExp[1];
-			forcedVersion = (queryForced && encodeURIComponent(forcedExp[1])) || forcedVersion;
-			break;
+	const homePageHeader = headers?.[HOME_PAGE_EXPERIMENT_HEADER.toLowerCase()];
+	if (id === HOME_PAGE_EXPERIMENT_KEY && homePageHeader) {
+		headerForced = true;
+		forcedVersion = homePageHeader;
+	} else {
+		// Look through setuiab assignments
+		const setuiabQuery = route?.query?.setuiab;
+		// Route query param will be an array if more than one instance in URL
+		const setuiab = typeof setuiabQuery === 'string' ? [setuiabQuery] : (setuiabQuery ?? []);
+		for (let i = 0; i < setuiab.length; i += 1) {
+			const forcedExp = setuiab[i]?.split('.') ?? [];
+			if (forcedExp[0] === id) {
+				queryForced = !!forcedExp[1];
+				forcedVersion = (queryForced && encodeURIComponent(forcedExp[1])) || forcedVersion;
+				break;
+			}
 		}
 	}
 
@@ -305,6 +314,7 @@ export const getForcedAssignment = (cookieStore, route, id, experimentSetting) =
 			...experimentSetting,
 			version: forcedVersion,
 			...(forcedHash && { hash: forcedHash }),
+			...(headerForced && { headerForced }),
 			queryForced: queryForced || cookieQueryForced,
 		};
 	}

--- a/src/util/experiment/experimentUtils.js
+++ b/src/util/experiment/experimentUtils.js
@@ -7,7 +7,7 @@ import { v4 as uuidv4 } from 'uuid';
 import logFormatter from '#src/util/logFormatter';
 import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
 import Alea from './Alea';
-import { HOME_PAGE_EXPERIMENT_HEADER, HOME_PAGE_EXPERIMENT_KEY } from './fastlyExperimentUtils';
+import { HOME_PAGE_EXPERIMENT_KEY } from './fastlyExperimentUtils';
 
 /**
  * The name of the cookie for storing assignments
@@ -275,10 +275,10 @@ export const setCookieAssignments = (cookieStore, assignments) => {
  * @param {Object} route The initial route resolved by the Vue router
  * @param {string} id The ID of the assignment to check
  * @param {Object} experimentSetting The experiment settings
- * @param {Object} The headers of the request
+ * @param {boolean} should force the new header experiment if was setted by fastly header
  * @returns The forced experiment assignment
  */
-export const getForcedAssignment = (cookieStore, route, id, experimentSetting, headers = {}) => {
+export const getForcedAssignment = (cookieStore, route, id, experimentSetting, forceHeader = false) => {
 	// Get previous cookie assignment
 	const cookieAssignment = getCookieAssignments(cookieStore)[id];
 	const cookieQueryForced = !!cookieAssignment?.queryForced;
@@ -287,10 +287,9 @@ export const getForcedAssignment = (cookieStore, route, id, experimentSetting, h
 	let headerForced = false;
 	let forcedVersion = cookieAssignment?.version;
 
-	const homePageHeader = headers?.[HOME_PAGE_EXPERIMENT_HEADER.toLowerCase()];
-	if (id === HOME_PAGE_EXPERIMENT_KEY && homePageHeader) {
+	if (forceHeader && id === HOME_PAGE_EXPERIMENT_KEY) {
 		headerForced = true;
-		forcedVersion = homePageHeader;
+		forcedVersion = 'b';
 	} else {
 		// Look through setuiab assignments
 		const setuiabQuery = route?.query?.setuiab;

--- a/src/util/experiment/fastlyExperimentUtils.js
+++ b/src/util/experiment/fastlyExperimentUtils.js
@@ -1,2 +1,3 @@
 export const HOME_PAGE_EXPERIMENT_HEADER = 'Fastly-ABTest-HomePage';
 export const HOME_PAGE_EXPERIMENT_KEY = 'home_page';
+export const VARY_HEADER = 'Vary';

--- a/src/util/experiment/fastlyExperimentUtils.js
+++ b/src/util/experiment/fastlyExperimentUtils.js
@@ -1,0 +1,2 @@
+export const HOME_PAGE_EXPERIMENT_HEADER = 'Fastly-ABTest-HomePage';
+export const HOME_PAGE_EXPERIMENT_KEY = 'home_page';

--- a/src/util/experiment/fastlyExperimentUtils.js
+++ b/src/util/experiment/fastlyExperimentUtils.js
@@ -1,3 +1,2 @@
 export const HOME_PAGE_EXPERIMENT_HEADER = 'Fastly-ABTest-HomePage';
 export const HOME_PAGE_EXPERIMENT_KEY = 'home_page';
-export const VARY_HEADER = 'Vary';

--- a/test/unit/specs/api/localResolvers/experiment.spec.js
+++ b/test/unit/specs/api/localResolvers/experiment.spec.js
@@ -449,7 +449,7 @@ describe('experiment.js', () => {
 			expect(result).toEqual(Experiment({ id: EXP_ID, version: undefined }));
 			expect(getActiveExperiments).toHaveBeenCalledTimes(1);
 			expect(getExperimentSetting).toHaveBeenCalledTimes(1);
-			expect(getForcedAssignment).toHaveBeenCalledWith(cookieStore, route, EXP_ID, experiment);
+			expect(getForcedAssignment).toHaveBeenCalledWith(cookieStore, route, EXP_ID, experiment, undefined);
 			expect(calculateHash).toHaveBeenCalledTimes(1);
 			expect(assignVersionForLoginId).toHaveBeenCalledTimes(1);
 			expect(getLoginId).toHaveBeenCalledTimes(1);

--- a/test/unit/specs/server/vueMiddleware.spec.js
+++ b/test/unit/specs/server/vueMiddleware.spec.js
@@ -1,0 +1,112 @@
+import {
+	describe, it, expect, beforeEach, vi
+} from 'vitest';
+import * as mockTrace from '#server/util/mockTrace';
+import createMiddleware from '#server/vue-middleware';
+import * as vueRender from '#server/vue-render';
+import { HOME_PAGE_EXPERIMENT_HEADER } from '#src/util/experiment/fastlyExperimentUtils';
+
+describe('vue-middleware.js', () => {
+	let req; let res; let next; let config; let vite; let middleware;
+	let vueRenderSpy;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		vueRenderSpy = vi.spyOn(vueRender, 'default');
+		req = {
+			url: '/test',
+			get: vi.fn(header => {
+				if (header === 'Cookie') return 'kvls=testcookie';
+				if (header === 'User-Agent') return 'TestAgent';
+				if (header === 'Fastly-Top-Url') return 'https://test.com';
+				if (header === 'Fastly-Noted-Logged-In') return 'true';
+				return undefined;
+			}),
+			headers: { [`${HOME_PAGE_EXPERIMENT_HEADER.toLowerCase()}`]: 'b' },
+			user: {},
+			locale: 'en',
+			session: {},
+		};
+		res = {
+			setHeader: vi.fn(),
+			append: vi.fn(),
+			send: vi.fn(),
+		};
+		next = vi.fn();
+
+		config = {
+			app: {
+				locale: {
+					supported: ['en'],
+					default: 'en',
+				},
+			},
+			server: {
+				simulateCDN: false,
+				userAgent: 'TestUserAgent',
+				vueWorkerIdleTimeout: 1000,
+				minVueWorkers: 1,
+				maxVueWorkers: 2,
+				vueWorkerRecordTiming: false,
+			},
+		};
+
+		vite = {
+			transformIndexHtml: vi.fn().mockResolvedValue('<html></html>'),
+			ssrLoadModule: vi.fn().mockResolvedValue({ default: vi.fn() }),
+		};
+
+		vi.spyOn(mockTrace, 'wrap').mockImplementation((name, fn) => {
+			// eslint-disable-next-line func-names
+			return async function (_req, _res, _next) {
+				return fn(_req, _res, _next);
+			};
+		});
+
+		middleware = createMiddleware({ config, vite });
+	});
+
+	it(`should persist fastly "${HOME_PAGE_EXPERIMENT_HEADER}" header`, async () => {
+		vueRenderSpy.mockReturnValueOnce({
+			html: '<html>Test</html>',
+			setCookies: ['cookie1=value1'],
+		});
+
+		await middleware(req, res, next);
+
+		expect(vueRenderSpy).toHaveBeenCalledTimes(1);
+		expect(vueRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
+			context: expect.objectContaining({
+				forceHeader: 'b'
+			})
+		}));
+		expect(res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html');
+		expect(res.append).toHaveBeenCalledWith('Set-Cookie', 'cookie1=value1');
+		expect(res.send).toHaveBeenCalledWith('<html>Test</html>');
+	});
+
+	it(
+		`should not forward forceHeader if fastly "${HOME_PAGE_EXPERIMENT_HEADER}" header is not coming`,
+		async () => {
+			vueRenderSpy.mockReturnValueOnce({
+				html: '<html>Test</html>',
+				setCookies: ['cookie1=value1'],
+			});
+			req = {
+				...req,
+				headers: {},
+			};
+
+			await middleware(req, res, next);
+
+			expect(vueRenderSpy).toHaveBeenCalledTimes(1);
+			expect(vueRenderSpy).toHaveBeenCalledWith(expect.objectContaining({
+				context: expect.objectContaining({
+					forceHeader: undefined
+				})
+			}));
+		}
+	);
+
+	// TODO: Add more tests (as our code coverage is low at the moment)
+});


### PR DESCRIPTION
Sync experiment handler with CPS logic, following the order:

1. fastly header variant/value 
2. query param from `setuiab` cookie
3. cookieStore