### PR TITLE
perf: only allow batching for stellate

### DIFF
--- a/src/api/HttpLink.js
+++ b/src/api/HttpLink.js
@@ -63,7 +63,7 @@ export default ({
 		},
 		// eslint-disable-next-line max-len
 		(!apolloBatching ? new HttpLink(stellateOptions) : new BatchHttpLink(stellateOptions)), // function returns TRUE use this
-		(!apolloBatching ? new HttpLink(options) : new BatchHttpLink(options)), // function returns FALSE use this
+		new HttpLink(options), // function returns FALSE use this
 	);
 
 	return link;


### PR DESCRIPTION
Stellate supports query batching out-of-the-box without any additional configuration https://stellate.co/docs/graphql-edge-cache/query-batching, so this makes the apollo client use a regular http link for Kiva API operations so that stellate operations can be controlled with the activateBatching flag value.