### PR TITLE
chore: update aws cred handling for build/deploy stage

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -21,9 +21,9 @@ jobs:
       cancel-in-progress: true
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
-    env:
-      AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-      AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -59,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     # Run on merges to development (main)
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -53,11 +53,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     if: ${{ !cancelled() && needs.create-release.outputs.published == 'true' }}
+    permissions:
+      contents: read
+      id-token: write
     env:
       GITHUB_PAT: "${{ secrets.KIVA_ROBOT_GITHUB_PAT }}"
       AWS_REGION: "us-west-2"
-      AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
-      AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
       SLACK_BOT_TOKEN: "${{ secrets.SLACK_TOKEN }}"
       SLACK_CHANNEL: "eng-build-failures"
     steps:


### PR DESCRIPTION
Should get things working again but I'm wondering if the upload assets action is already in shape... ref. https://github.com/kiva/github-actions/blob/main/actions/upload-static-assets/action.yaml. I'm guessing it is and I thought all assets were uploaded and CPS is resolving in dev...