### PR TITLE
fix: use jpeg image instead of webp to match node-canvas support

### DIFF
--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -161,7 +161,9 @@ async function drawLegacy(loanData) {
 
 		// Borrower Image
 		await trace('borrower-image', async () => {
-			const borrowerImg = await trace('loadImage', async () => loadImage(loanData.image.retina));
+			// Use jpeg version of image as webp is not supported by node-canvas
+			const jpegUrl = loanData?.image?.retina?.replace('webp', 'jpeg') ?? loanData?.image?.retina;
+			const borrowerImg = await trace('loadImage', async () => loadImage(jpegUrl));
 			ctx.drawImage(borrowerImg, 0, 0, cardWidth, cardWidth * borrowerImgAspectRatio);
 		});
 
@@ -222,7 +224,9 @@ async function drawClassic(loanData) {
 
 		// Borrower Image
 		await trace('borrower-image', async () => {
-			const borrowerImg = await trace('loadImage', async () => loadImage(loanData.image.retina));
+			// Use jpeg version of image as webp is not supported by node-canvas
+			const jpegUrl = loanData?.image?.retina?.replace('webp', 'jpeg') ?? loanData?.image?.retina;
+			const borrowerImg = await trace('loadImage', async () => loadImage(jpegUrl));
 			ctx.save();
 			// eslint-disable-next-line max-len
 			roundRect(ctx, borrowerImgMargin, borrowerImgMargin, borrowerImgWidth, borrowerImgHeight, 16 * classicResizeFactor);

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -162,8 +162,8 @@ async function drawLegacy(loanData) {
 		// Borrower Image
 		await trace('borrower-image', async () => {
 			// Use jpeg version of image as webp is not supported by node-canvas
-			const jpegUrl = loanData?.image?.retina?.replace('webp', 'jpeg') ?? loanData?.image?.retina;
-			const borrowerImg = await trace('loadImage', async () => loadImage(jpegUrl));
+			const jpgUrl = loanData?.image?.retina?.replace('webp', 'jpg') ?? loanData?.image?.retina;
+			const borrowerImg = await trace('loadImage', async () => loadImage(jpgUrl));
 			ctx.drawImage(borrowerImg, 0, 0, cardWidth, cardWidth * borrowerImgAspectRatio);
 		});
 
@@ -225,8 +225,8 @@ async function drawClassic(loanData) {
 		// Borrower Image
 		await trace('borrower-image', async () => {
 			// Use jpeg version of image as webp is not supported by node-canvas
-			const jpegUrl = loanData?.image?.retina?.replace('webp', 'jpeg') ?? loanData?.image?.retina;
-			const borrowerImg = await trace('loadImage', async () => loadImage(jpegUrl));
+			const jpgUrl = loanData?.image?.retina?.replace('webp', 'jpg') ?? loanData?.image?.retina;
+			const borrowerImg = await trace('loadImage', async () => loadImage(jpgUrl));
 			ctx.save();
 			// eslint-disable-next-line max-len
 			roundRect(ctx, borrowerImgMargin, borrowerImgMargin, borrowerImgWidth, borrowerImgHeight, 16 * classicResizeFactor);


### PR DESCRIPTION
Fixes broken image loading through node-canvas loadImage which doesn't support webp.