### PR TITLE
fix: resolve errors in mfa page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^6.57.5",
+				"@kiva/kv-components": "^6.57.7",
 				"@kiva/kv-shop": "^3.3.38",
 				"@kiva/kv-tokens": "^3.4.1",
 				"@mdi/js": "^7.4.47",

--- a/src/components/Kv/KvPhoneInput.vue
+++ b/src/components/Kv/KvPhoneInput.vue
@@ -139,7 +139,7 @@ export default {
 				return val.replace('(', '');
 			}
 
-			const asYouTypeFormatter = new AsYouType(this.selectedCountry.code);
+			const asYouTypeFormatter = new AsYouType(this.selectedCountry?.code);
 			return asYouTypeFormatter.input(val);
 		},
 		onInputCountry() {

--- a/src/components/Settings/AppAuthentication.vue
+++ b/src/components/Settings/AppAuthentication.vue
@@ -177,12 +177,14 @@ export default {
 				this.$router.push('/settings/security/mfa'); // return to MFA settings page
 				this.lightboxVisible = false;
 			}
-			this.enrollmentError = '';
-			this.barcodeURI = '';
-			this.secret = '';
-			this.step = 0;
-			this.userVerificationCode = '';
-			this.verificationError = '';
+			setTimeout(() => {
+				this.enrollmentError = '';
+				this.barcodeURI = '';
+				this.secret = '';
+				this.step = 0;
+				this.userVerificationCode = '';
+				this.verificationError = '';
+			}, 300); // Allow time for lightbox to close before resetting state
 		},
 		confirmRecoveryCode() {
 			this.recoveryCode = '';
@@ -228,7 +230,8 @@ export default {
 				this.fetchingEnrollment = false;
 			}).catch(err => {
 				console.error(err);
-				this.enrollmentError = 'There was an error. Please refresh the page and try again.';
+				// eslint-disable-next-line max-len
+				this.enrollmentError = err?.[0]?.message || 'There was an error. Please refresh the page and try again.';
 				this.fetchingEnrollment = false;
 				try {
 					Sentry.captureException(err?.[0]?.extensions?.exception || err);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-1938

A user reported issues with MFA, and while testing I encountered a couple issues that meant the page was just broken (mainly for phone mfa). Not sure if this will solve the user's issue specifically, but the page now works... I also surfaced the mfa error in the dialog, since it's much more useful for new users than the default error.

Here's an example of trying to turn on mfa as a new user with the real error now surfaced:

<img width="623" height="273" alt="Screenshot 2025-10-07 at 9 11 08 AM" src="https://github.com/user-attachments/assets/394ea636-85e7-4aa4-be3f-83788a2adbe9" />
