### PR TITLE
fix: guard against failed live loan image fetch, allow render of card…

### DIFF
--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -163,8 +163,12 @@ async function drawLegacy(loanData) {
 		await trace('borrower-image', async () => {
 			// Use jpeg version of image as webp is not supported by node-canvas
 			const jpgUrl = loanData?.image?.retina?.replace('webp', 'jpg') ?? loanData?.image?.retina;
-			const borrowerImg = await trace('loadImage', async () => loadImage(jpgUrl));
-			ctx.drawImage(borrowerImg, 0, 0, cardWidth, cardWidth * borrowerImgAspectRatio);
+			try {
+				const borrowerImg = await trace('loadImage', async () => loadImage(jpgUrl));
+				ctx.drawImage(borrowerImg, 0, 0, cardWidth, cardWidth * borrowerImgAspectRatio);
+			} catch (error) {
+				console.error('Error loading image:', error);
+			}
 		});
 
 		// Add a border around everything
@@ -226,13 +230,17 @@ async function drawClassic(loanData) {
 		await trace('borrower-image', async () => {
 			// Use jpeg version of image as webp is not supported by node-canvas
 			const jpgUrl = loanData?.image?.retina?.replace('webp', 'jpg') ?? loanData?.image?.retina;
-			const borrowerImg = await trace('loadImage', async () => loadImage(jpgUrl));
-			ctx.save();
-			// eslint-disable-next-line max-len
-			roundRect(ctx, borrowerImgMargin, borrowerImgMargin, borrowerImgWidth, borrowerImgHeight, 16 * classicResizeFactor);
-			ctx.clip();
-			ctx.drawImage(borrowerImg, borrowerImgMargin, borrowerImgMargin, borrowerImgWidth, borrowerImgHeight);
-			ctx.restore();
+			try {
+				const borrowerImg = await trace('loadImage', async () => loadImage(jpgUrl));
+				ctx.save();
+				// eslint-disable-next-line max-len
+				roundRect(ctx, borrowerImgMargin, borrowerImgMargin, borrowerImgWidth, borrowerImgHeight, 16 * classicResizeFactor);
+				ctx.clip();
+				ctx.drawImage(borrowerImg, borrowerImgMargin, borrowerImgMargin, borrowerImgWidth, borrowerImgHeight);
+				ctx.restore();
+			} catch (error) {
+				console.error('Error loading image:', error);
+			}
 		});
 
 		// Borrower country


### PR DESCRIPTION
… without image.

If the image fetch fails, we can still render the rest of the card without it.

Here's how the card renders if that try throws and error:
<img width="504" height="797" alt="image" src="https://github.com/user-attachments/assets/fe29380f-750e-41ab-a8da-dd9236941342" />
