### PR TITLE
feat: mp-2576-lower-equity

### DIFF
--- a/src/components/Thanks/SingleVersion/BadgeMilestone.vue
+++ b/src/components/Thanks/SingleVersion/BadgeMilestone.vue
@@ -52,7 +52,7 @@ import {
 	onMounted,
 } from 'vue';
 import { mdiArrowRight } from '@mdi/js';
-import useBadgeData, { ID_EQUITY } from '#src/composables/useBadgeData';
+import useBadgeData from '#src/composables/useBadgeData';
 import {
 	KvMaterialIcon, KvButton, KvLoadingPlaceholder
 } from '@kiva/kv-components';
@@ -108,6 +108,8 @@ const {
 	getHighestPriorityDisplayBadge,
 	getLastCompletedBadgeLevelData,
 	getTierBadgeDataByLevel,
+	getNonEquityBadgeOverride,
+	getPreferredFallbackBadge,
 } = useBadgeData();
 
 const badgeDataAchieved = ref();
@@ -150,6 +152,10 @@ const displayedBadgeData = computed(() => {
 			return badgeDataAchieved.value[0];
 		}
 		const displayedBadge = getHighestPriorityDisplayBadge(badgeDataAchieved.value);
+		// Contentful-only badges (non-equity badges not in achievement service) have no achievementData
+		if (!displayedBadge.achievementData) {
+			return displayedBadge;
+		}
 		return getLastCompletedBadgeLevelData(displayedBadge);
 	}
 	return {};
@@ -182,23 +188,39 @@ onMounted(async () => {
 });
 
 watch(() => badgeContentfulData.value, () => {
-	// Guests don't have access to achievement data, so we only show the equity badge
+	// Guests don't have access to achievement data, so we fall back to contentful only.
+	// Prefers an earned non-equity badge over equity.
 	if (showEqualityBadge.value && badgeContentfulData.value?.length) {
-		const equityBadge = badgeContentfulData.value.find(b => b.id === ID_EQUITY);
-		if (equityBadge) {
+		const badgeToShow = getPreferredFallbackBadge(props.badgeAchievedIds, badgeContentfulData.value);
+		if (badgeToShow) {
 			badgeDataAchieved.value = [
 				{
-					levelName: equityBadge.challengeName,
-					contentfulData: { ...equityBadge },
+					levelName: badgeToShow.challengeName,
+					contentfulData: { ...badgeToShow },
 				},
 			];
 		}
 	}
 });
 
-watch(() => badgeData.value, () => {
-	if (!showEqualityBadge.value && badgeData.value.length) {
-		badgeDataAchieved.value = badgeData.value.filter(b => props.badgeAchievedIds.includes(b.id));
+watch([() => badgeData.value, () => badgeContentfulData.value], ([newBadgeData]) => {
+	if (!showEqualityBadge.value && newBadgeData.length) {
+		const filteredBadges = newBadgeData.filter(b => props.badgeAchievedIds.includes(b.id));
+		const nonEquityBadgeOverride = getNonEquityBadgeOverride(
+			filteredBadges,
+			props.badgeAchievedIds,
+			badgeContentfulData.value,
+		);
+
+		if (nonEquityBadgeOverride) {
+			badgeDataAchieved.value = [
+				nonEquityBadgeOverride,
+				...filteredBadges.filter(b => b.id !== nonEquityBadgeOverride.id),
+			];
+			return;
+		}
+
+		badgeDataAchieved.value = filteredBadges;
 	}
 }, { immediate: true });
 </script>

--- a/src/components/Thanks/SingleVersion/BadgeMilestone.vue
+++ b/src/components/Thanks/SingleVersion/BadgeMilestone.vue
@@ -52,7 +52,7 @@ import {
 	onMounted,
 } from 'vue';
 import { mdiArrowRight } from '@mdi/js';
-import useBadgeData from '#src/composables/useBadgeData';
+import useBadgeData, { ID_EQUITY } from '#src/composables/useBadgeData';
 import {
 	KvMaterialIcon, KvButton, KvLoadingPlaceholder
 } from '@kiva/kv-components';
@@ -109,7 +109,6 @@ const {
 	getLastCompletedBadgeLevelData,
 	getTierBadgeDataByLevel,
 	getNonEquityBadgeOverride,
-	getPreferredFallbackBadge,
 } = useBadgeData();
 
 const badgeDataAchieved = ref();
@@ -188,15 +187,14 @@ onMounted(async () => {
 });
 
 watch(() => badgeContentfulData.value, () => {
-	// Guests don't have access to achievement data, so we fall back to contentful only.
-	// Prefers an earned non-equity badge over equity.
+	// Guests don't have access to achievement data, so we only show the equity badge
 	if (showEqualityBadge.value && badgeContentfulData.value?.length) {
-		const badgeToShow = getPreferredFallbackBadge(props.badgeAchievedIds, badgeContentfulData.value);
-		if (badgeToShow) {
+		const equityBadge = badgeContentfulData.value.find(b => b.id === ID_EQUITY);
+		if (equityBadge) {
 			badgeDataAchieved.value = [
 				{
-					levelName: badgeToShow.challengeName,
-					contentfulData: { ...badgeToShow },
+					levelName: equityBadge.challengeName,
+					contentfulData: { ...equityBadge },
 				},
 			];
 		}

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -808,46 +808,26 @@ export default function useBadgeData() {
 	};
 
 	/**
-	 * Returns the contentful badge entry to show when full achievement data isn't available
-	 * (e.g. guests). Prefers an earned non-equity badge over equity.
-	 *
-	 * @param badgeAchievedIds IDs of all badges earned during checkout
-	 * @param allContentfulData All contentful badge data
-	 * @returns The contentful entry to display, or null
-	 */
-	const getPreferredFallbackBadge = (badgeAchievedIds, allContentfulData) => {
-		if (!allContentfulData?.length) return null;
-		const hasEquity = badgeAchievedIds.includes(ID_EQUITY);
-		const earnedNonEquityBadge = allContentfulData.find(
-			b => b.id !== ID_EQUITY && badgeAchievedIds.includes(b.id)
-		);
-		if (hasEquity && earnedNonEquityBadge) {
-			return earnedNonEquityBadge;
-		}
-		return allContentfulData.find(b => b.id === ID_EQUITY) ?? null;
-	};
-
-	/**
-	 * If equity and another badge were both earned but the other badge is missing from the
-	 * achievement service data, returns the badge built from contentful so it can be
-	 * prioritized over equity. Returns null if no override is needed.
+	 * If equity and a non-tiered milestone badge were both earned but the milestone badge is
+	 * missing from achievement service data, return a contentful-only override so it can be
+	 * prioritized over equity. Tiered badges should not override equity.
 	 *
 	 * @param filteredBadges Badges already filtered to those earned during checkout
 	 * @param badgeAchievedIds IDs of all badges earned during checkout
 	 * @param allContentfulData All contentful badge data
-	 * @returns The non-equity badge override object, or null
+	 * @returns The non-equity milestone badge override object, or null
 	 */
 	const getNonEquityBadgeOverride = (filteredBadges, badgeAchievedIds, allContentfulData) => {
-		const hasEquity = filteredBadges.some(b => b.id === ID_EQUITY);
-		const earnedNonEquityBadgeId = badgeAchievedIds.find(id => id !== ID_EQUITY);
-		const badgeMissingFromData = earnedNonEquityBadgeId
-			&& !filteredBadges.some(b => b.id === earnedNonEquityBadgeId);
+		const hasEquity = badgeAchievedIds.includes(ID_EQUITY);
+		const earnedMilestoneBadgeId = badgeAchievedIds.find(id => id !== ID_EQUITY && !defaultBadges.includes(id));
+		const milestoneMissingFromData = earnedMilestoneBadgeId
+			&& !filteredBadges.some(b => b.id === earnedMilestoneBadgeId);
 
-		if (hasEquity && badgeMissingFromData) {
-			const contentfulEntry = allContentfulData?.find(b => b.id === earnedNonEquityBadgeId);
+		if (hasEquity && milestoneMissingFromData) {
+			const contentfulEntry = allContentfulData?.find(b => b.id === earnedMilestoneBadgeId);
 			if (contentfulEntry) {
 				return {
-					id: earnedNonEquityBadgeId,
+					id: earnedMilestoneBadgeId,
 					challengeName: contentfulEntry.challengeName,
 					contentfulData: { ...contentfulEntry },
 				};
@@ -901,6 +881,5 @@ export default function useBadgeData() {
 		getAllCategoryLoanCounts,
 		allAchievementsCompleted,
 		getNonEquityBadgeOverride,
-		getPreferredFallbackBadge,
 	};
 }

--- a/src/composables/useBadgeData.js
+++ b/src/composables/useBadgeData.js
@@ -808,6 +808,55 @@ export default function useBadgeData() {
 	};
 
 	/**
+	 * Returns the contentful badge entry to show when full achievement data isn't available
+	 * (e.g. guests). Prefers an earned non-equity badge over equity.
+	 *
+	 * @param badgeAchievedIds IDs of all badges earned during checkout
+	 * @param allContentfulData All contentful badge data
+	 * @returns The contentful entry to display, or null
+	 */
+	const getPreferredFallbackBadge = (badgeAchievedIds, allContentfulData) => {
+		if (!allContentfulData?.length) return null;
+		const hasEquity = badgeAchievedIds.includes(ID_EQUITY);
+		const earnedNonEquityBadge = allContentfulData.find(
+			b => b.id !== ID_EQUITY && badgeAchievedIds.includes(b.id)
+		);
+		if (hasEquity && earnedNonEquityBadge) {
+			return earnedNonEquityBadge;
+		}
+		return allContentfulData.find(b => b.id === ID_EQUITY) ?? null;
+	};
+
+	/**
+	 * If equity and another badge were both earned but the other badge is missing from the
+	 * achievement service data, returns the badge built from contentful so it can be
+	 * prioritized over equity. Returns null if no override is needed.
+	 *
+	 * @param filteredBadges Badges already filtered to those earned during checkout
+	 * @param badgeAchievedIds IDs of all badges earned during checkout
+	 * @param allContentfulData All contentful badge data
+	 * @returns The non-equity badge override object, or null
+	 */
+	const getNonEquityBadgeOverride = (filteredBadges, badgeAchievedIds, allContentfulData) => {
+		const hasEquity = filteredBadges.some(b => b.id === ID_EQUITY);
+		const earnedNonEquityBadgeId = badgeAchievedIds.find(id => id !== ID_EQUITY);
+		const badgeMissingFromData = earnedNonEquityBadgeId
+			&& !filteredBadges.some(b => b.id === earnedNonEquityBadgeId);
+
+		if (hasEquity && badgeMissingFromData) {
+			const contentfulEntry = allContentfulData?.find(b => b.id === earnedNonEquityBadgeId);
+			if (contentfulEntry) {
+				return {
+					id: earnedNonEquityBadgeId,
+					challengeName: contentfulEntry.challengeName,
+					contentfulData: { ...contentfulEntry },
+				};
+			}
+		}
+		return null;
+	};
+
+	/**
 	 * Check if all achievements are completed
 	 *
 	 * @param badges The badges to check
@@ -851,5 +900,7 @@ export default function useBadgeData() {
 		getLevelCaption,
 		getAllCategoryLoanCounts,
 		allAchievementsCompleted,
+		getNonEquityBadgeOverride,
+		getPreferredFallbackBadge,
 	};
 }

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -502,36 +502,8 @@ describe('useBadgeData.js', () => {
 		});
 	});
 
-	describe('getPreferredFallbackBadge', () => {
-		it('should prefer non-equity earned badges over equity for fallback display', () => {
-			const { getPreferredFallbackBadge } = useBadgeData();
-			const fallbackContentfulData = [
-				{ id: ID_EQUITY, challengeName: 'Equity' },
-				{ id: ID_EARTH_DAY_24, challengeName: 'Earth Day 2024' },
-			];
-
-			expect(getPreferredFallbackBadge(
-				[ID_EQUITY, ID_EARTH_DAY_24],
-				fallbackContentfulData,
-			)).toEqual(fallbackContentfulData[1]);
-		});
-
-		it('should fall back to equity when only equity is earned', () => {
-			const { getPreferredFallbackBadge } = useBadgeData();
-			const fallbackContentfulData = [
-				{ id: ID_EQUITY, challengeName: 'Equity' },
-				{ id: ID_WOMENS_EQUALITY, challengeName: 'Women' },
-			];
-
-			expect(getPreferredFallbackBadge(
-				[ID_EQUITY],
-				fallbackContentfulData,
-			)).toEqual(fallbackContentfulData[0]);
-		});
-	});
-
 	describe('getNonEquityBadgeOverride', () => {
-		it('should return a non-equity badge override when a non-equity badge is missing from achievement data', () => {
+		it('should return a non-equity milestone override when a milestone badge is missing from achievement data', () => {
 			const { getNonEquityBadgeOverride } = useBadgeData();
 			const filteredBadges = [
 				{ id: ID_EQUITY },
@@ -549,6 +521,22 @@ describe('useBadgeData.js', () => {
 				challengeName: 'IWD 2024',
 				contentfulData: { ...overrideContentfulData[0] },
 			});
+		});
+
+		it('should not override equity with tiered badges', () => {
+			const { getNonEquityBadgeOverride } = useBadgeData();
+			const filteredBadges = [
+				{ id: ID_EQUITY },
+			];
+			const overrideContentfulData = [
+				{ id: ID_WOMENS_EQUALITY, challengeName: 'Women' },
+			];
+
+			expect(getNonEquityBadgeOverride(
+				filteredBadges,
+				[ID_EQUITY, ID_WOMENS_EQUALITY],
+				overrideContentfulData,
+			)).toEqual(null);
 		});
 
 		it('should not override when only non-equity badges are already in achievement data', () => {

--- a/test/unit/specs/composables/useBadgeData.spec.js
+++ b/test/unit/specs/composables/useBadgeData.spec.js
@@ -502,6 +502,73 @@ describe('useBadgeData.js', () => {
 		});
 	});
 
+	describe('getPreferredFallbackBadge', () => {
+		it('should prefer non-equity earned badges over equity for fallback display', () => {
+			const { getPreferredFallbackBadge } = useBadgeData();
+			const fallbackContentfulData = [
+				{ id: ID_EQUITY, challengeName: 'Equity' },
+				{ id: ID_EARTH_DAY_24, challengeName: 'Earth Day 2024' },
+			];
+
+			expect(getPreferredFallbackBadge(
+				[ID_EQUITY, ID_EARTH_DAY_24],
+				fallbackContentfulData,
+			)).toEqual(fallbackContentfulData[1]);
+		});
+
+		it('should fall back to equity when only equity is earned', () => {
+			const { getPreferredFallbackBadge } = useBadgeData();
+			const fallbackContentfulData = [
+				{ id: ID_EQUITY, challengeName: 'Equity' },
+				{ id: ID_WOMENS_EQUALITY, challengeName: 'Women' },
+			];
+
+			expect(getPreferredFallbackBadge(
+				[ID_EQUITY],
+				fallbackContentfulData,
+			)).toEqual(fallbackContentfulData[0]);
+		});
+	});
+
+	describe('getNonEquityBadgeOverride', () => {
+		it('should return a non-equity badge override when a non-equity badge is missing from achievement data', () => {
+			const { getNonEquityBadgeOverride } = useBadgeData();
+			const filteredBadges = [
+				{ id: ID_EQUITY },
+			];
+			const overrideContentfulData = [
+				{ id: ID_IWD_24, challengeName: 'IWD 2024' },
+			];
+
+			expect(getNonEquityBadgeOverride(
+				filteredBadges,
+				[ID_EQUITY, ID_IWD_24],
+				overrideContentfulData,
+			)).toEqual({
+				id: ID_IWD_24,
+				challengeName: 'IWD 2024',
+				contentfulData: { ...overrideContentfulData[0] },
+			});
+		});
+
+		it('should not override when only non-equity badges are already in achievement data', () => {
+			const { getNonEquityBadgeOverride } = useBadgeData();
+			const filteredBadges = [
+				{ id: ID_EQUITY },
+				{ id: ID_WOMENS_EQUALITY },
+			];
+			const overrideContentfulData = [
+				{ id: ID_WOMENS_EQUALITY, challengeName: 'Women' },
+			];
+
+			expect(getNonEquityBadgeOverride(
+				filteredBadges,
+				[ID_EQUITY, ID_WOMENS_EQUALITY],
+				overrideContentfulData,
+			)).toEqual(null);
+		});
+	});
+
 	describe('getCompletedBadges', () => {
 		it('should return the completed badges', () => {
 			const { getCompletedBadges } = useBadgeData();


### PR DESCRIPTION
Jira ticket 
[MP-2576](https://kiva.atlassian.net/browse/MP-2576)


Updated Thanks badge selection so equity is treated as a fallback, and any earned non-equity badge is preferred for display when both are present.
Added composable helpers to pick the fallback badge and to override equity when non-equity badge metadata is only available from Contentful.
Adjusted BadgeMilestone wiring and tests to cover guest fallback, override behavior, and naming consistency with the new non-equity-first logic.

[MP-2576]: https://kiva.atlassian.net/browse/MP-2576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ