### PR TITLE
fix: use tw-shadow-lg so dropdown menus are not buried under subsequent team cards [CP-2515]

### DIFF
--- a/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
@@ -8,7 +8,7 @@
 			<div
 				v-for="n in 3"
 				:key="n"
-				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-drop-shadow-lg"
+				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
 			>
 				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-items-start tw-mb-1">

--- a/src/components/LendingTeams/MyTeams/MyTeamsList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamsList.vue
@@ -20,7 +20,7 @@
 			<div
 				v-for="n in 3"
 				:key="n"
-				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-drop-shadow-lg"
+				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
 			>
 				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-flex-row tw-items-center">

--- a/src/components/LendingTeams/MyTeams/TeamCard.vue
+++ b/src/components/LendingTeams/MyTeams/TeamCard.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-drop-shadow-lg">
+	<div class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg">
 		<div class="tw-flex tw-flex-row tw-items-center">
 			<img
 				:src="team.imageUrl"
@@ -18,7 +18,6 @@
 					{{ team.name }}
 				</router-link>
 			</div>
-			<!-- @todo Dropdown menu displays beneath team cards below it -->
 			<kv-utility-menu
 				class="tw-rounded-full"
 				menu-position="right-aligned"

--- a/src/components/LendingTeams/MyTeams/TeamMessageCard.vue
+++ b/src/components/LendingTeams/MyTeams/TeamMessageCard.vue
@@ -1,6 +1,6 @@
 <template>
 	<div
-		class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-drop-shadow-lg tw-overflow-hidden"
+		class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg tw-overflow-hidden"
 	>
 		<div class="tw-flex tw-items-start tw-mb-1">
 			<img


### PR DESCRIPTION
Using `tw-shadow-lg` instead of `tw-drop-shadow-lg` allows the drop-down menu on team cards to display above subsequent team cards. This changes the opacity of the shadow to be a little lighter but otherwise the aesthetic changes are minimal.

Claude Code identified that `tw-drop-shadow-lg` on the card wrapper creates a CSS stacking context via the filter property, so that the dropdowns cannot escape that stacking context. Thus subsequent cards render over the dropdown no matter what the pertinent z-index is.

# Before
<img width="1290" height="580" alt="Screenshot 2026-04-07 at 9 54 02 AM" src="https://github.com/user-attachments/assets/25b6aa2d-36de-4fe4-bdf6-e7cdd821d1d3" />

# After
<img width="1314" height="597" alt="Screenshot 2026-04-07 at 9 54 25 AM" src="https://github.com/user-attachments/assets/00af697d-af32-4e7b-becb-25da83284da2" />
