### PR TITLE
fix: use tailwind classes for placeholder dimensions rather than style [CP-2515]

### DIFF
--- a/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
@@ -10,20 +10,28 @@
 				:key="n"
 				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
 			>
-				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-items-start tw-mb-1">
-					<kv-loading-placeholder
-						class="tw-flex-none tw-mr-1 tw-rounded-full"
-						:style="{width: '1.5rem', height: '1.5rem'}"
-					/>
+					<div class="tw-flex-none tw-mr-1 tw-rounded-full tw-w-6 tw-h-6 tw-overflow-hidden">
+						<kv-loading-placeholder />
+					</div>
 					<div class="tw-flex-1">
-						<kv-loading-placeholder class="tw-mb-0.5" :style="{width: '50%', height: '1rem'}" />
-						<kv-loading-placeholder :style="{width: '35%', height: '0.75rem'}" />
+						<div class="tw-w-1/2 tw-h-2 tw-mb-1">
+							<kv-loading-placeholder />
+						</div>
+						<div class="tw-w-[35%] tw-h-1.5">
+							<kv-loading-placeholder />
+						</div>
 					</div>
 				</div>
-				<kv-loading-placeholder class="tw-mb-1" :style="{width: '95%', height: '1rem'}" />
-				<kv-loading-placeholder class="tw-mb-1" :style="{width: '90%', height: '1rem'}" />
-				<kv-loading-placeholder :style="{width: '60%', height: '1rem'}" />
+				<div class="tw-w-[95%] tw-h-2 tw-mb-1">
+					<kv-loading-placeholder />
+				</div>
+				<div class="tw-w-[90%] tw-h-2 tw-mb-1">
+					<kv-loading-placeholder />
+				</div>
+				<div class="tw-w-3/5 tw-h-2">
+					<kv-loading-placeholder />
+				</div>
 			</div>
 		</template>
 

--- a/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
@@ -10,28 +10,20 @@
 				:key="n"
 				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
 			>
+				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-items-start tw-mb-1">
-					<div class="tw-flex-none tw-mr-1 tw-rounded-full tw-w-6 tw-h-6 tw-overflow-hidden">
-						<kv-loading-placeholder />
-					</div>
+					<kv-loading-placeholder
+						class="tw-flex-none tw-mr-1 tw-rounded-full"
+						:style="{width: '1.5rem', height: '1.5rem'}"
+					/>
 					<div class="tw-flex-1">
-						<div class="tw-w-1/2 tw-h-2 tw-mb-1">
-							<kv-loading-placeholder />
-						</div>
-						<div class="tw-w-[35%] tw-h-1.5">
-							<kv-loading-placeholder />
-						</div>
+						<kv-loading-placeholder class="tw-mb-0.5" :style="{width: '50%', height: '1rem'}" />
+						<kv-loading-placeholder :style="{width: '35%', height: '0.75rem'}" />
 					</div>
 				</div>
-				<div class="tw-w-[95%] tw-h-2 tw-mb-1">
-					<kv-loading-placeholder />
-				</div>
-				<div class="tw-w-[90%] tw-h-2 tw-mb-1">
-					<kv-loading-placeholder />
-				</div>
-				<div class="tw-w-3/5 tw-h-2">
-					<kv-loading-placeholder />
-				</div>
+				<kv-loading-placeholder class="tw-mb-1" :style="{width: '95%', height: '1rem'}" />
+				<kv-loading-placeholder class="tw-mb-1" :style="{width: '90%', height: '1rem'}" />
+				<kv-loading-placeholder :style="{width: '60%', height: '1rem'}" />
 			</div>
 		</template>
 

--- a/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamMessagesList.vue
@@ -8,22 +8,18 @@
 			<div
 				v-for="n in 3"
 				:key="n"
-				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
+				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg tw-h-min-12"
 			>
-				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-items-start tw-mb-1">
-					<kv-loading-placeholder
-						class="tw-flex-none tw-mr-1 tw-rounded-full"
-						:style="{width: '1.5rem', height: '1.5rem'}"
-					/>
+					<kv-loading-placeholder class="!tw-h-6 !tw-w-6 tw-flex-none tw-mr-1 !tw-rounded-full" />
 					<div class="tw-flex-1">
-						<kv-loading-placeholder class="tw-mb-0.5" :style="{width: '50%', height: '1rem'}" />
-						<kv-loading-placeholder :style="{width: '35%', height: '0.75rem'}" />
+						<kv-loading-placeholder class="!tw-h-2 !tw-w-1/2 tw-mb-1" />
+						<kv-loading-placeholder class="!tw-h-1.5 !tw-w-1/3" />
 					</div>
 				</div>
-				<kv-loading-placeholder class="tw-mb-1" :style="{width: '95%', height: '1rem'}" />
-				<kv-loading-placeholder class="tw-mb-1" :style="{width: '90%', height: '1rem'}" />
-				<kv-loading-placeholder :style="{width: '60%', height: '1rem'}" />
+				<kv-loading-placeholder class="!tw-h-2 !tw-w-4/5 tw-mb-1" />
+				<kv-loading-placeholder class="!tw-h-2 !tw-w-9/10 tw-mb-1" />
+				<kv-loading-placeholder class="!tw-h-2 !tw-w-3/5" />
 			</div>
 		</template>
 

--- a/src/components/LendingTeams/MyTeams/MyTeamsList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamsList.vue
@@ -22,13 +22,18 @@
 				:key="n"
 				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
 			>
-				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-flex-row tw-items-center">
-					<kv-loading-placeholder class="tw-flex-none tw-mr-1" :style="{height: '3rem', width: '3rem'}" />
-					<div class="tw-flex-1 tw-min-w-0">
-						<kv-loading-placeholder class="tw-mb-1" :style="{width: '70%', height: '1.25rem'}" />
+					<div class="tw-flex-none tw-mr-1 tw-w-6 tw-h-6">
+						<kv-loading-placeholder />
 					</div>
-					<kv-loading-placeholder class="tw-flex-none tw-ml-1" :style="{width: '1.5rem', height: '1.5rem'}" />
+					<div class="tw-flex-1 tw-min-w-0">
+						<div class="tw-w-[70%] tw-h-2.5 tw-mb-1">
+							<kv-loading-placeholder />
+						</div>
+					</div>
+					<div class="tw-flex-none tw-ml-1 tw-w-3 tw-h-3">
+						<kv-loading-placeholder />
+					</div>
 				</div>
 			</div>
 		</template>

--- a/src/components/LendingTeams/MyTeams/MyTeamsList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamsList.vue
@@ -22,18 +22,13 @@
 				:key="n"
 				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
 			>
+				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-flex-row tw-items-center">
-					<div class="tw-flex-none tw-mr-1 tw-w-6 tw-h-6">
-						<kv-loading-placeholder />
-					</div>
+					<kv-loading-placeholder class="tw-flex-none tw-mr-1" :style="{height: '3rem', width: '3rem'}" />
 					<div class="tw-flex-1 tw-min-w-0">
-						<div class="tw-w-[70%] tw-h-2.5 tw-mb-1">
-							<kv-loading-placeholder />
-						</div>
+						<kv-loading-placeholder class="tw-mb-1" :style="{width: '70%', height: '1.25rem'}" />
 					</div>
-					<div class="tw-flex-none tw-ml-1 tw-w-3 tw-h-3">
-						<kv-loading-placeholder />
-					</div>
+					<kv-loading-placeholder class="tw-flex-none tw-ml-1" :style="{width: '1.5rem', height: '1.5rem'}" />
 				</div>
 			</div>
 		</template>

--- a/src/components/LendingTeams/MyTeams/MyTeamsList.vue
+++ b/src/components/LendingTeams/MyTeams/MyTeamsList.vue
@@ -20,15 +20,14 @@
 			<div
 				v-for="n in 3"
 				:key="n"
-				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg"
+				class="tw-mb-4 tw-bg-primary tw-rounded tw-p-2 tw-shadow-lg tw-h-min-6"
 			>
-				<!-- @todo Can we use tailwind classes here and still get the placeholder gradient animation? -->
 				<div class="tw-flex tw-flex-row tw-items-center">
-					<kv-loading-placeholder class="tw-flex-none tw-mr-1" :style="{height: '3rem', width: '3rem'}" />
+					<kv-loading-placeholder class="!tw-h-6 !tw-w-6 tw-flex-none tw-mr-1" />
 					<div class="tw-flex-1 tw-min-w-0">
-						<kv-loading-placeholder class="tw-mb-1" :style="{width: '70%', height: '1.25rem'}" />
+						<kv-loading-placeholder class="!tw-h-2.5 !tw-w-7/10" />
 					</div>
-					<kv-loading-placeholder class="tw-flex-none tw-ml-1" :style="{width: '1.5rem', height: '1.5rem'}" />
+					<kv-loading-placeholder class="!tw-h-3 !tw-w-3 tw-flex-none tw-ml-1" />
 				</div>
 			</div>
 		</template>


### PR DESCRIPTION
One technique for using tailwind classes with kv-loading-placeholder elements is to define the dimensions via a wrapper div.

Claude Code identified that `kv-loading-placeholder` elements are defined to have `tw-w-full/tw-h-full`, so if tailwind classes are applied to that same element, they would have identical specificity and so which dimension wins depends on how the final CSS output is compiled. So if `tw-w-full/tw-h-full` wins and the parent has no height defined, this will collapse the element -- which is what I was seeing.

Setting the style inline gets around this issues since it will have a higher CSS specificity.

The other route Claude suggested is what you see here: wrapping the `kv-loading-placeholder` in outer divs that have dimensions applied. That way the `kv-loading-placeholder` with its default `tw-w-full/tw-h-full` will fill the container and things will work as intended.

If you see other solutions, or prefer the inline style approach vs the wrapper approach, please let me know!

# Updated

<img width="1189" height="585" alt="Screenshot 2026-04-07 at 10 57 36 AM" src="https://github.com/user-attachments/assets/82a3f6cb-3449-4861-bce0-e47b8273bf6b" />
