### PR TITLE
fix: refetch communication setting information when going to next steps

### DIFF
--- a/src/pages/MyKiva/MyKivaNextStepsContent.vue
+++ b/src/pages/MyKiva/MyKivaNextStepsContent.vue
@@ -301,7 +301,6 @@ import {
 } from '#src/util/myKiva/myKivaJourneyCardUtils';
 import { checkPostLendingCardCookie, removePostLendingCardCookie } from '#src/util/myKivaUtils';
 import useBreakpoints from '#src/composables/useBreakpoints';
-import useOptIn from '#src/composables/useOptIn';
 
 defineOptions({ name: 'MyKivaNextStepsContent' });
 
@@ -356,7 +355,6 @@ const props = defineProps({
 	},
 });
 
-const apollo = inject('apollo');
 const cookieStore = inject('cookieStore');
 const $kvTrackEvent = inject('$kvTrackEvent');
 const goalData = inject('goalData');
@@ -439,12 +437,13 @@ const topRowHasContent = computed(() => {
 		|| showPostLendingNextStepsCards.value;
 });
 
-const { userHasMailUpdatesOptOut } = useOptIn(apollo, cookieStore);
+const userOptedIn = computed(() => props.userInfo?.communicationSettings?.lenderNews
+	&& props.userInfo?.communicationSettings?.loanUpdates);
 
 const shouldShowEmailMarketingCard = computed(() => checkShouldShowEmailMarketing({
 	showPostLendingNextStepsCards: true,
 	latestLoan: props.latestLoan,
-	hasMailUpdatesOptOut: userHasMailUpdatesOptOut(),
+	hasMailUpdatesOptOut: !userOptedIn.value,
 	loansCount: props.loans.length,
 }));
 

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -129,6 +129,33 @@ export default {
 		regionsData() {
 			return this.lendingStats.regionsData ?? [];
 		},
+		userOptedIn() {
+			return this.userInfo?.communicationSettings?.loanUpdates
+				&& this.userInfo?.communicationSettings?.lenderNews;
+		}
+	},
+	watch: {
+		'$route.path': {
+			async handler() {
+				// No need to fetch communication settings if user has already opted in
+				if (!this.isNextStepsRoute || this.userOptedIn) return;
+				const { data } = await this.apollo.query({
+					query: gql`
+						query UserCommunicationSettings {
+							my {
+								id
+								communicationSettings {
+									lenderNews
+									loanUpdates
+								}
+							}
+						}
+					`,
+					fetchPolicy: 'network-only',
+				});
+				this.userInfo = { ...this.userInfo, communicationSettings: data?.my?.communicationSettings };
+			}
+		}
 	},
 	apollo: {
 		preFetch(_, client, { route }) {


### PR DESCRIPTION
Because of the redirect does not load the page again, created or mounted are not called when going to `/next-steps` from `mykiva`. I added a watcher to get fresh data of communication settings in order to hide marketing card in next steps page.

https://kiva.atlassian.net/browse/MP-2649