### PR TITLE
feat(apollo): add lazy query option to Apollo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ $ npm run dev -- --config=local (any context outside of kiva vm)
 # visit localhost:8888/ui-site-map to explore some pages (/styleguide or /lend-by-category may be of interest)
 
 # Alternate configs:
-# use `dev-local` to run localhost mode against development Environments
-# use `dev-vm-mac` to run ui on your mac against the kiva vm
+# use `local-dev` to run localhost mode against development Environments
+# use `dev-custom-host` to run with Caddy at https://kiva-ui.local (enables Auth0)
 
 # COMPILED/PROD MODE
 

--- a/config/local-dev.js
+++ b/config/local-dev.js
@@ -1,0 +1,21 @@
+import merge from 'deepmerge';
+import base from './k8s-local.js';
+
+export default merge(base, {
+	app: {
+		apolloBatching: false, // Remove this once batching is enabled in prod
+		auth0: {
+			enable: false,
+		},
+		graphqlUri: 'https://gateway.development.kiva.org/graphql',
+		host: 'localhost',
+		photoPath: 'https://www.development.kiva.org/img/',
+		publicPath: '/',
+	},
+	server: {
+		graphqlUri: 'https://gateway.development.kiva.org/graphql',
+		gzipEnabled: true,
+		memcachedEnabled: false,
+		memcachedServers: '',
+	},
+});

--- a/config/local-prod.js
+++ b/config/local-prod.js
@@ -1,0 +1,21 @@
+import merge from 'deepmerge';
+import base from './k8s-local.js';
+
+export default merge(base, {
+	app: {
+		apolloBatching: false, // Remove this once batching is enabled in prod
+		auth0: {
+			enable: false,
+		},
+		graphqlUri: 'https://marketplace-api.k1.kiva.org/graphql',
+		host: 'localhost',
+		photoPath: 'https://www.kiva.org/img/',
+		publicPath: '/',
+	},
+	server: {
+		graphqlUri: 'https://marketplace-api.k1.kiva.org/graphql',
+		gzipEnabled: true,
+		memcachedEnabled: false,
+		memcachedServers: '',
+	},
+});

--- a/config/local.js
+++ b/config/local.js
@@ -1,21 +1,3 @@
-import merge from 'deepmerge';
-import base from './k8s-local.js';
+import localProd from './local-prod.js';
 
-export default merge(base, {
-	app: {
-		apolloBatching: false, // Remove this once batching is enabled in prod
-		auth0: {
-			enable: false,
-		},
-		graphqlUri: 'https://marketplace-api.k1.kiva.org/graphql',
-		host: 'localhost',
-		photoPath: 'https://www.kiva.org/img/',
-		publicPath: '/',
-	},
-	server: {
-		graphqlUri: 'https://marketplace-api.k1.kiva.org/graphql',
-		gzipEnabled: true,
-		memcachedEnabled: false,
-		memcachedServers: '',
-	},
-});
+export default localProd;

--- a/src/graphql/README.md
+++ b/src/graphql/README.md
@@ -166,6 +166,69 @@ export default {
 
 If an error occurs during preFetch and no error handler is defined, a warning will be logged to the console containing the error code and message: "Warning: No error handler for error code 'ERROR_CODE': error message".
 
+### Lazy loading queries
+
+When a component is rendered below the fold, we can defer its query until the component is near the viewport by adding the `lazy` option. This avoids fetching data the user may never scroll to.
+
+A basic lazy query uses `lazy: true`, which defers the query until the component's root element is within 500px of the viewport:
+```javascript
+export default {
+	inject: ['apollo', 'cookieStore'],
+	apollo: {
+		lazy: true,
+		query: myQueryName,
+		variables() {
+			return { id: this.myId };
+		},
+		result({ data }) {
+			this.myVar = data?.someProperty;
+		}
+	}
+}
+```
+
+The `lazy` option also accepts an object to override any `IntersectionObserver` option:
+```javascript
+export default {
+	inject: ['apollo', 'cookieStore'],
+	apollo: {
+		lazy: { rootMargin: '200px', threshold: 0.5 },
+		query: myQueryName,
+		result({ data }) {
+			this.myVar = data?.someProperty;
+		}
+	}
+}
+```
+
+By default the observer watches the component's root element (`$el`). To observe a different element, pass a `target` string matching a template `ref`:
+```html
+<template>
+	<div>
+		<p>Always visible content</p>
+		<div ref="lazySection">
+			<!-- content populated by lazy query -->
+		</div>
+	</div>
+</template>
+```
+```javascript
+export default {
+	inject: ['apollo', 'cookieStore'],
+	apollo: {
+		lazy: { target: 'lazySection' },
+		query: myQueryName,
+		result({ data }) {
+			this.myVar = data?.someProperty;
+		}
+	}
+}
+```
+
+When combined with `preFetch: true`, the lazy option is automatically skipped if the data was already prefetched on the server and the watch query is set up immediately with no unnecessary observer. If the prefetch did not run (e.g. `shouldPreFetch` returned `false`), the lazy behavior applies as normal.
+
+The plugin handles cleanup automatically: all intersection observers are disconnected in `beforeUnmount`. If `IntersectionObserver` is not supported by the browser, the query falls back to executing immediately.
+
 ### Multiple queries
 
 When multiple queries are required, we can define the apollo option as an array of objects, each containing a `query` and `result` method, and other options as described above. This allows us to perform multiple queries in a single component, and independently handle prefetching and results for each query.

--- a/src/plugins/apollo-plugin.js
+++ b/src/plugins/apollo-plugin.js
@@ -1,12 +1,48 @@
 import checkInjections from '#src/util/injectionCheck';
 import logReadQueryError from '#src/util/logReadQueryError';
 import { isContentfulQuery } from '#src/util/contentful/isContentfulQuery';
+import { createIntersectionObserver } from '#src/util/observerUtils';
 
 const injections = ['apollo', 'cookieStore'];
 
+function parseLazy(lazy) {
+	if (!lazy) return null;
+	if (lazy === true) return { rootMargin: '500px' };
+	return { rootMargin: '500px', ...lazy };
+}
+
+function setupWatchQuery(vm, operation, commonVars) {
+	const {
+		query,
+		variables = () => {},
+		result = () => {},
+		fetchPolicy,
+	} = operation;
+	const { basketId, isContentfulPreview } = commonVars;
+
+	const observer = vm.apollo.watchQuery({
+		query,
+		...(fetchPolicy && { fetchPolicy }),
+		variables: {
+			...(basketId && { basketId }),
+			...variables.call(vm),
+			...(isContentfulQuery(query) && isContentfulPreview && { preview: true }),
+		},
+	});
+
+	vm.$watch(variables, vars => observer.setVariables({
+		...(basketId && { basketId }),
+		...vars,
+		...(isContentfulQuery(query) && isContentfulPreview && { preview: true }),
+	}), { deep: true });
+
+	observer.subscribe({
+		next: apolloResult => result.call(vm, apolloResult),
+	});
+}
+
 // install method for plugin
 export default app => {
-	// export default {
 	app.mixin({
 		created() {
 			if (this.$options.apollo) {
@@ -19,6 +55,8 @@ export default app => {
 				// $options.apollo is either a single object or an array of objects
 				const operations = Array.isArray(this.$options.apollo) ? this.$options.apollo : [this.$options.apollo];
 
+				this.lazyOperations = [];
+
 				// Load data for each query in the component
 				for (let i = 0; i < operations.length; i += 1) {
 					const operation = operations[i];
@@ -27,7 +65,6 @@ export default app => {
 						preFetch,
 						shouldPreFetch = true,
 						preFetchVariables = () => { },
-						variables = () => { },
 						result = () => { },
 					} = operation;
 
@@ -71,33 +108,50 @@ export default app => {
 							}
 						}
 
-						if (typeof window !== 'undefined') {
-							// Setup an observer to watch for changes to the query result
-							const observer = this.apollo.watchQuery({
-								query,
-								variables: {
-									...(basketId && { basketId }),
-									...variables.call(this),
-									...(isContentfulQuery(query) && isContentfulPreview && { preview: true })
-								}
-							});
-
-							// Use Vue's $watch to reactively update the query variables when the component data changes
-							// This will cause a new query result to be fetched if it is not available in the cache
-							this.$watch(variables, vars => observer.setVariables({
-								...(basketId && { basketId }),
-								...vars,
-								...(isContentfulQuery(query) && isContentfulPreview && { preview: true })
-							}), { deep: true });
-
-							// Subscribe to the observer to see each result
-							observer.subscribe({
-								next: apolloResult => result.call(this, apolloResult)
-							});
+						const lazyConfig = parseLazy(operation.lazy);
+						const commonVars = { basketId, isContentfulPreview };
+						if (lazyConfig && !preFetched) {
+							this.lazyOperations.push({ operation, lazyConfig, commonVars });
+						} else if (typeof window !== 'undefined') {
+							setupWatchQuery(this, operation, commonVars);
 						}
 					}
 				}
 			}
-		}
+		},
+		mounted() {
+			if (!this.lazyOperations?.length) return;
+
+			this.lazyObservers = [];
+
+			for (let i = 0; i < this.lazyOperations.length; i += 1) {
+				const { operation, lazyConfig, commonVars } = this.lazyOperations[i];
+
+				const observer = createIntersectionObserver({
+					targets: [this.$el],
+					options: { rootMargin: lazyConfig.rootMargin },
+					callback: entries => {
+						entries.forEach(entry => {
+							if (entry.intersectionRatio > 0) {
+								setupWatchQuery(this, operation, commonVars);
+								observer.disconnect();
+							}
+						});
+					},
+				});
+
+				if (observer) {
+					this.lazyObservers.push(observer);
+				} else {
+					// IntersectionObserver not supported — fall back to immediate setup
+					setupWatchQuery(this, operation, commonVars);
+				}
+			}
+		},
+		beforeUnmount() {
+			if (this.lazyObservers) {
+				this.lazyObservers.forEach(obs => obs.disconnect());
+			}
+		},
 	});
 };

--- a/src/plugins/apollo-plugin.js
+++ b/src/plugins/apollo-plugin.js
@@ -127,8 +127,20 @@ export default app => {
 			for (let i = 0; i < this.lazyOperations.length; i += 1) {
 				const { operation, lazyConfig, commonVars } = this.lazyOperations[i];
 
+				// In Vue 3 fragment components, $el may be a comment/text node.
+				// Walk siblings to find the first actual Element for observation.
+				let target = this.$el;
+				while (target && !(target instanceof Element)) {
+					target = target.nextSibling;
+				}
+				if (!target) {
+					console.warn('[apollo-plugin] No Element found for IntersectionObserver in', this.$options.name);
+					setupWatchQuery(this, operation, commonVars);
+					continue;
+				}
+
 				const observer = createIntersectionObserver({
-					targets: [this.$el],
+					targets: [target],
 					options: { rootMargin: lazyConfig.rootMargin },
 					callback: entries => {
 						entries.forEach(entry => {

--- a/src/plugins/apollo-plugin.js
+++ b/src/plugins/apollo-plugin.js
@@ -8,7 +8,8 @@ const injections = ['apollo', 'cookieStore'];
 function parseLazy(lazy) {
 	if (!lazy) return null;
 	if (lazy === true) return { rootMargin: '500px' };
-	return { rootMargin: '500px', ...lazy };
+	const { target, ...options } = lazy;
+	return { rootMargin: '500px', ...options, target };
 }
 
 function setupWatchQuery(vm, operation, commonVars) {
@@ -127,9 +128,12 @@ export default app => {
 			for (let i = 0; i < this.lazyOperations.length; i += 1) {
 				const { operation, lazyConfig, commonVars } = this.lazyOperations[i];
 
-				// In Vue 3 fragment components, $el may be a comment/text node.
-				// Walk siblings to find the first actual Element for observation.
-				let target = this.$el;
+				const { target: customTarget, ...observerOptions } = lazyConfig;
+
+				// Resolve the observation target: use a custom target ref if provided,
+				// otherwise default to this.$el. In Vue 3 fragment components, $el may
+				// be a comment/text node — walk siblings to find the first Element.
+				let target = customTarget ? this.$refs[customTarget] : this.$el;
 				while (target && !(target instanceof Element)) {
 					target = target.nextSibling;
 				}
@@ -139,7 +143,7 @@ export default app => {
 				} else {
 					const observer = createIntersectionObserver({
 						targets: [target],
-						options: { rootMargin: lazyConfig.rootMargin },
+						options: observerOptions,
 						callback: entries => {
 							entries.forEach(entry => {
 								if (entry.intersectionRatio > 0) {

--- a/src/plugins/apollo-plugin.js
+++ b/src/plugins/apollo-plugin.js
@@ -136,27 +136,26 @@ export default app => {
 				if (!target) {
 					console.warn('[apollo-plugin] No Element found for IntersectionObserver in', this.$options.name);
 					setupWatchQuery(this, operation, commonVars);
-					continue;
-				}
-
-				const observer = createIntersectionObserver({
-					targets: [target],
-					options: { rootMargin: lazyConfig.rootMargin },
-					callback: entries => {
-						entries.forEach(entry => {
-							if (entry.intersectionRatio > 0) {
-								setupWatchQuery(this, operation, commonVars);
-								observer.disconnect();
-							}
-						});
-					},
-				});
-
-				if (observer) {
-					this.lazyObservers.push(observer);
 				} else {
-					// IntersectionObserver not supported — fall back to immediate setup
-					setupWatchQuery(this, operation, commonVars);
+					const observer = createIntersectionObserver({
+						targets: [target],
+						options: { rootMargin: lazyConfig.rootMargin },
+						callback: entries => {
+							entries.forEach(entry => {
+								if (entry.intersectionRatio > 0) {
+									setupWatchQuery(this, operation, commonVars);
+									observer.disconnect();
+								}
+							});
+						},
+					});
+
+					if (observer) {
+						this.lazyObservers.push(observer);
+					} else {
+						// IntersectionObserver not supported — fall back to immediate setup
+						setupWatchQuery(this, operation, commonVars);
+					}
 				}
 			}
 		},

--- a/test/unit/specs/plugins/apollo-plugin.spec.js
+++ b/test/unit/specs/plugins/apollo-plugin.spec.js
@@ -118,7 +118,9 @@ describe('apollo-plugin', () => {
 		const result = vi.fn();
 		const shouldPreFetch = vi.fn(() => false);
 		const ctx = makeCtx({
-			apolloConfig: { query: 'Q', preFetch: true, shouldPreFetch, result },
+			apolloConfig: {
+				query: 'Q', preFetch: true, shouldPreFetch, result
+			},
 		});
 
 		runCreated(ctx);
@@ -174,7 +176,9 @@ describe('apollo-plugin', () => {
 		const result = vi.fn();
 		const subscribe = vi.fn(({ next }) => { next({ data: 123 }); });
 		const ctx = makeCtx({
-			apolloConfig: { query: 'Q', preFetch: false, variables: () => ({}), result },
+			apolloConfig: {
+				query: 'Q', preFetch: false, variables: () => ({}), result
+			},
 			watchQuery: vi.fn(() => ({ subscribe, setVariables: vi.fn() })),
 			$watch: vi.fn((fn, cb) => cb({})),
 		});
@@ -194,7 +198,9 @@ describe('apollo-plugin', () => {
 		const ctx = makeCtx({
 			apolloConfig: [
 				{ query: 'Q1', preFetch: true, result: result1 },
-				{ query: 'Q2', preFetch: false, variables: () => ({}), result: result2 },
+				{
+					query: 'Q2', preFetch: false, variables: () => ({}), result: result2
+				},
 			],
 			readQuery: vi.fn(() => ({ foo: 'bar' })),
 			watchQuery: vi.fn(() => ({
@@ -213,7 +219,9 @@ describe('apollo-plugin', () => {
 
 	it('should skip observer setup when window is not defined', () => {
 		const ctx = makeCtx({
-			apolloConfig: { query: 'Q', preFetch: false, variables: () => ({}), result: vi.fn() },
+			apolloConfig: {
+				query: 'Q', preFetch: false, variables: () => ({}), result: vi.fn()
+			},
 		});
 
 		runCreated(ctx);
@@ -225,7 +233,9 @@ describe('apollo-plugin', () => {
 	it('should include basketId in preFetchVariables when present', () => {
 		const preFetchVariables = vi.fn(() => ({ foo: 'bar' }));
 		const ctx = makeCtx({
-			apolloConfig: { query: 'Q', preFetch: true, preFetchVariables, result: vi.fn() },
+			apolloConfig: {
+				query: 'Q', preFetch: true, preFetchVariables, result: vi.fn()
+			},
 			cookieStoreGet: vi.fn(() => 'basket123'),
 			readQuery: vi.fn(() => ({ data: 'test' })),
 		});
@@ -240,7 +250,9 @@ describe('apollo-plugin', () => {
 
 	it('should include basketId in watchQuery variables when present', () => {
 		const ctx = makeCtx({
-			apolloConfig: { query: 'Q', preFetch: false, variables: () => ({ foo: 'bar' }), result: vi.fn() },
+			apolloConfig: {
+				query: 'Q', preFetch: false, variables: () => ({ foo: 'bar' }), result: vi.fn()
+			},
 			cookieStoreGet: vi.fn(() => 'basket456'),
 		});
 		setBrowser();
@@ -255,7 +267,9 @@ describe('apollo-plugin', () => {
 
 	it('does not call watchQuery in created() when lazy is true', () => {
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', variables: () => ({}), result: vi.fn() },
+			apolloConfig: {
+				lazy: true, query: 'Q', variables: () => ({}), result: vi.fn()
+			},
 		});
 		setBrowser();
 
@@ -269,7 +283,9 @@ describe('apollo-plugin', () => {
 		const data = { foo: 1 };
 		const result = vi.fn();
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', preFetch: true, variables: () => ({}), result },
+			apolloConfig: {
+				lazy: true, query: 'Q', preFetch: true, variables: () => ({}), result
+			},
 			readQuery: vi.fn(() => data),
 			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
 			$watch: vi.fn(),
@@ -286,8 +302,12 @@ describe('apollo-plugin', () => {
 	it('applies lazy when preFetch is true but shouldPreFetch returns false', () => {
 		const ctx = makeCtx({
 			apolloConfig: {
-				lazy: true, query: 'Q', preFetch: true,
-				shouldPreFetch: () => false, variables: () => ({}), result: vi.fn(),
+				lazy: true,
+				query: 'Q',
+				preFetch: true,
+				shouldPreFetch: () => false,
+				variables: () => ({}),
+				result: vi.fn(),
 			},
 		});
 		setBrowser();
@@ -304,7 +324,9 @@ describe('apollo-plugin', () => {
 		const result2 = vi.fn();
 		const ctx = makeCtx({
 			apolloConfig: [
-				{ lazy: true, query: 'Q1', variables: () => ({}), result: result1 },
+				{
+					lazy: true, query: 'Q1', variables: () => ({}), result: result1
+				},
 				{ query: 'Q2', variables: () => ({}), result: result2 },
 			],
 			watchQuery: vi.fn(() => ({
@@ -326,7 +348,9 @@ describe('apollo-plugin', () => {
 		setBrowser();
 		const result = vi.fn();
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', variables: () => ({ id: 1 }), result },
+			apolloConfig: {
+				lazy: true, query: 'Q', variables: () => ({ id: 1 }), result
+			},
 			watchQuery: vi.fn(() => ({
 				subscribe: ({ next }) => next({ data: 'lazy-result' }),
 				setVariables: vi.fn(),
@@ -356,7 +380,9 @@ describe('apollo-plugin', () => {
 		delete global.IntersectionObserverEntry;
 		const result = vi.fn();
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', variables: () => ({}), result },
+			apolloConfig: {
+				lazy: true, query: 'Q', variables: () => ({}), result
+			},
 			watchQuery: vi.fn(() => ({
 				subscribe: ({ next }) => next({ data: 'fallback' }),
 				setVariables: vi.fn(),
@@ -376,7 +402,9 @@ describe('apollo-plugin', () => {
 	it('uses custom rootMargin from lazy option object', () => {
 		setBrowser();
 		const ctx = makeCtx({
-			apolloConfig: { lazy: { rootMargin: '200px' }, query: 'Q', variables: () => ({}), result: vi.fn() },
+			apolloConfig: {
+				lazy: { rootMargin: '200px' }, query: 'Q', variables: () => ({}), result: vi.fn()
+			},
 			$el: document.createElement('div'),
 		});
 		const mock = mockIntersectionObserver(ctx);
@@ -391,7 +419,9 @@ describe('apollo-plugin', () => {
 	it('disconnects lazy observers on beforeUnmount', () => {
 		setBrowser();
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', variables: () => ({}), result: vi.fn() },
+			apolloConfig: {
+				lazy: true, query: 'Q', variables: () => ({}), result: vi.fn()
+			},
 			$el: document.createElement('div'),
 		});
 		const mock = mockIntersectionObserver(ctx);
@@ -421,7 +451,9 @@ describe('apollo-plugin', () => {
 	it('passes fetchPolicy through to watchQuery for lazy queries', () => {
 		setBrowser();
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', fetchPolicy: 'network-only', variables: () => ({}), result: vi.fn() },
+			apolloConfig: {
+				lazy: true, query: 'Q', fetchPolicy: 'network-only', variables: () => ({}), result: vi.fn()
+			},
 			$el: document.createElement('div'),
 		});
 		const mock = mockIntersectionObserver(ctx);
@@ -441,7 +473,9 @@ describe('apollo-plugin', () => {
 		const setVariables = vi.fn();
 		const watchCallbacks = [];
 		const ctx = makeCtx({
-			apolloConfig: { lazy: true, query: 'Q', variables: () => ({ id: 1 }), result: vi.fn() },
+			apolloConfig: {
+				lazy: true, query: 'Q', variables: () => ({ id: 1 }), result: vi.fn()
+			},
 			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables })),
 			$watch: vi.fn((fn, cb) => watchCallbacks.push(cb)),
 			$el: document.createElement('div'),

--- a/test/unit/specs/plugins/apollo-plugin.spec.js
+++ b/test/unit/specs/plugins/apollo-plugin.spec.js
@@ -36,7 +36,6 @@ function mockIntersectionObserver(ctx) {
 describe('apollo-plugin', () => {
 	let app;
 	let mixin;
-	let ctx;
 
 	function makeApp() {
 		const mixins = [];
@@ -46,11 +45,52 @@ describe('apollo-plugin', () => {
 		};
 	}
 
+	function makeCtx({
+		apolloConfig = { query: 'Q', result: vi.fn() },
+		cookieStoreGet = vi.fn(),
+		readQuery = vi.fn(),
+		watchQuery,
+		$watch = vi.fn(),
+		$el,
+	} = {}) {
+		const defaultWatchQuery = vi.fn(() => ({
+			subscribe: vi.fn(),
+			setVariables: vi.fn(),
+		}));
+
+		const c = {
+			$options: {
+				inject: { apollo: {}, cookieStore: {} },
+				apollo: apolloConfig,
+			},
+			cookieStore: { get: cookieStoreGet },
+			$route: { query: {} },
+			apollo: {
+				readQuery,
+				watchQuery: watchQuery ?? defaultWatchQuery,
+			},
+			$watch,
+			$el,
+		};
+		return c;
+	}
+
+	function runCreated(c) {
+		mixin.created.call(c);
+	}
+
+	function runMounted(c) {
+		mixin.mounted.call(c);
+	}
+
+	function setBrowser() {
+		global.window = {};
+	}
+
 	beforeEach(() => {
 		app = makeApp();
 		apolloPlugin(app);
 		[mixin] = app.getMixins();
-		ctx = {};
 	});
 
 	afterEach(() => {
@@ -64,34 +104,25 @@ describe('apollo-plugin', () => {
 	});
 
 	it('does nothing if $options.apollo is not present', () => {
-		ctx.$options = {};
-		ctx.apollo = { readQuery: vi.fn() };
+		const ctx = { $options: {}, apollo: { readQuery: vi.fn() } };
 		expect(() => mixin.created.call(ctx)).not.toThrow();
 		expect(ctx.apollo.readQuery).not.toHaveBeenCalled();
 	});
 
 	it('throws if required injections are missing', () => {
-		ctx.$options = { apollo: {} };
+		const ctx = { $options: { apollo: {} } };
 		expect(() => mixin.created.call(ctx)).toThrow('Missing required injections');
 	});
 
 	it('does not call result if shouldPreFetch returns false', () => {
 		const result = vi.fn();
 		const shouldPreFetch = vi.fn(() => false);
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: true,
-				shouldPreFetch,
-				result
-			}
-		};
-		ctx.$watch = vi.fn();
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = { readQuery: vi.fn(), watchQuery: vi.fn(() => ({ subscribe: vi.fn() })) };
-		mixin.created.call(ctx);
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: true, shouldPreFetch, result },
+		});
+
+		runCreated(ctx);
+
 		expect(shouldPreFetch).toHaveBeenCalled();
 		expect(ctx.apollo.readQuery).not.toHaveBeenCalled();
 		expect(result).not.toHaveBeenCalled();
@@ -100,94 +131,57 @@ describe('apollo-plugin', () => {
 	it('calls result with cache data if preFetched and data exists', () => {
 		const data = { foo: 1 };
 		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: true,
-				result
-			}
-		};
-		ctx.$watch = vi.fn();
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = { readQuery: vi.fn(() => data), watchQuery: vi.fn(() => ({ subscribe: vi.fn() })) };
-		mixin.created.call(ctx);
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: true, result },
+			readQuery: vi.fn(() => data),
+		});
+
+		runCreated(ctx);
+
 		expect(ctx.apollo.readQuery).toHaveBeenCalled();
 		expect(result).toHaveBeenCalledWith({ data });
 	});
 
 	it('skips result if cache returns null', () => {
 		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: true,
-				result
-			}
-		};
-		ctx.$watch = vi.fn();
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = { readQuery: vi.fn(() => null), watchQuery: vi.fn(() => ({ subscribe: vi.fn() })) };
-		mixin.created.call(ctx);
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: true, result },
+			readQuery: vi.fn(() => null),
+		});
+
+		runCreated(ctx);
+
 		expect(result).not.toHaveBeenCalled();
 	});
 
 	it('handles readQuery errors gracefully and continues with watchQuery', () => {
 		const result = vi.fn();
-		const error = new Error('Cache read error');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
+		const ctx = makeCtx({
+			apolloConfig: {
 				query: { definitions: [{ name: { value: 'TestQuery' } }] },
 				preFetch: true,
-				result
-			}
-		};
-		ctx.$watch = vi.fn();
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(() => { throw error; }),
-			watchQuery: vi.fn(() => ({ subscribe: vi.fn() }))
-		};
-		global.window = {};
+				result,
+			},
+			readQuery: vi.fn(() => { throw new Error('Cache read error'); }),
+		});
+		setBrowser();
 
-		// Should not throw despite readQuery error
-		expect(() => mixin.created.call(ctx)).not.toThrow();
-
-		// Should still set up watchQuery despite cache error
+		expect(() => runCreated(ctx)).not.toThrow();
 		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
 	});
 
 	it('sets up observer and $watch in browser', () => {
 		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: false,
-				variables: () => ({}),
-				result
-			}
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		const subscribe = vi.fn(({ next }) => {
-			next({ data: 123 });
+		const subscribe = vi.fn(({ next }) => { next({ data: 123 }); });
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: false, variables: () => ({}), result },
+			watchQuery: vi.fn(() => ({ subscribe, setVariables: vi.fn() })),
+			$watch: vi.fn((fn, cb) => cb({})),
 		});
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({
-				subscribe,
-				setVariables: vi.fn(),
-			}))
-		};
-		ctx.$watch = vi.fn((fn, cb) => cb({}));
-		global.window = {};
-		mixin.created.call(ctx);
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
 		expect(ctx.$watch).toHaveBeenCalled();
 		expect(subscribe).toHaveBeenCalled();
@@ -197,140 +191,76 @@ describe('apollo-plugin', () => {
 	it('should handle array of apollo configs', () => {
 		const result1 = vi.fn();
 		const result2 = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: [
-				{
-					query: 'Q1',
-					preFetch: true,
-					result: result1
-				},
-				{
-					query: 'Q2',
-					preFetch: false,
-					variables: () => ({}),
-					result: result2
-				}
-			]
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
+		const ctx = makeCtx({
+			apolloConfig: [
+				{ query: 'Q1', preFetch: true, result: result1 },
+				{ query: 'Q2', preFetch: false, variables: () => ({}), result: result2 },
+			],
 			readQuery: vi.fn(() => ({ foo: 'bar' })),
 			watchQuery: vi.fn(() => ({
 				subscribe: ({ next }) => next({ data: 456 }),
-				setVariables: vi.fn()
-			}))
-		};
-		ctx.$watch = (fn, cb) => cb({});
-		global.window = {};
-		mixin.created.call(ctx);
+				setVariables: vi.fn(),
+			})),
+			$watch: (fn, cb) => cb({}),
+		});
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(result1).toHaveBeenCalledWith({ data: { foo: 'bar' } });
 		expect(result2).toHaveBeenCalledWith({ data: 456 });
 	});
 
 	it('should skip observer setup when window is not defined', () => {
-		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: false,
-				variables: () => ({}),
-				result
-			}
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn()
-		};
-		ctx.$watch = vi.fn();
-		global.window = undefined;
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: false, variables: () => ({}), result: vi.fn() },
+		});
 
-		mixin.created.call(ctx);
+		runCreated(ctx);
 
 		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
 		expect(ctx.$watch).not.toHaveBeenCalled();
 	});
 
 	it('should include basketId in preFetchVariables when present', () => {
-		const result = vi.fn();
 		const preFetchVariables = vi.fn(() => ({ foo: 'bar' }));
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: true,
-				preFetchVariables,
-				result
-			}
-		};
-		ctx.$watch = vi.fn();
-		ctx.cookieStore = { get: vi.fn(() => 'basket123') };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: true, preFetchVariables, result: vi.fn() },
+			cookieStoreGet: vi.fn(() => 'basket123'),
 			readQuery: vi.fn(() => ({ data: 'test' })),
-			watchQuery: vi.fn(() => ({ subscribe: vi.fn() }))
-		};
-		mixin.created.call(ctx);
+		});
+
+		runCreated(ctx);
+
 		expect(ctx.apollo.readQuery).toHaveBeenCalledWith({
 			query: 'Q',
-			variables: { basketId: 'basket123', foo: 'bar' }
+			variables: { basketId: 'basket123', foo: 'bar' },
 		});
 	});
 
 	it('should include basketId in watchQuery variables when present', () => {
-		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				preFetch: false,
-				variables: () => ({ foo: 'bar' }),
-				result
-			}
-		};
-		ctx.cookieStore = { get: vi.fn(() => 'basket456') };
-		ctx.$route = { query: {} };
-		const subscribe = vi.fn();
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({
-				subscribe,
-				setVariables: vi.fn()
-			}))
-		};
-		ctx.$watch = vi.fn();
-		global.window = {};
-		mixin.created.call(ctx);
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', preFetch: false, variables: () => ({ foo: 'bar' }), result: vi.fn() },
+			cookieStoreGet: vi.fn(() => 'basket456'),
+		});
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(ctx.apollo.watchQuery).toHaveBeenCalledWith({
 			query: 'Q',
-			variables: { basketId: 'basket456', foo: 'bar' }
+			variables: { basketId: 'basket456', foo: 'bar' },
 		});
 	});
 
 	it('does not call watchQuery in created() when lazy is true', () => {
-		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				variables: () => ({}),
-				result,
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({ subscribe: vi.fn() })),
-		};
-		ctx.$watch = vi.fn();
-		global.window = {};
-		mixin.created.call(ctx);
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', variables: () => ({}), result: vi.fn() },
+		});
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
 		expect(ctx.lazyOperations).toHaveLength(1);
 	});
@@ -338,52 +268,32 @@ describe('apollo-plugin', () => {
 	it('ignores lazy when preFetch is true and shouldPreFetch passes', () => {
 		const data = { foo: 1 };
 		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				preFetch: true,
-				variables: () => ({}),
-				result,
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', preFetch: true, variables: () => ({}), result },
 			readQuery: vi.fn(() => data),
 			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
-		};
-		ctx.$watch = vi.fn();
-		global.window = {};
-		mixin.created.call(ctx);
+			$watch: vi.fn(),
+		});
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(result).toHaveBeenCalledWith({ data });
 		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
 		expect(ctx.lazyOperations).toHaveLength(0);
 	});
 
 	it('applies lazy when preFetch is true but shouldPreFetch returns false', () => {
-		const result = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				preFetch: true,
-				shouldPreFetch: () => false,
-				variables: () => ({}),
-				result,
+		const ctx = makeCtx({
+			apolloConfig: {
+				lazy: true, query: 'Q', preFetch: true,
+				shouldPreFetch: () => false, variables: () => ({}), result: vi.fn(),
 			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({ subscribe: vi.fn() })),
-		};
-		ctx.$watch = vi.fn();
-		global.window = {};
-		mixin.created.call(ctx);
+		});
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(ctx.apollo.readQuery).not.toHaveBeenCalled();
 		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
 		expect(ctx.lazyOperations).toHaveLength(1);
@@ -392,68 +302,44 @@ describe('apollo-plugin', () => {
 	it('handles mixed lazy and non-lazy queries in array form', () => {
 		const result1 = vi.fn();
 		const result2 = vi.fn();
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: [
-				{
-					lazy: true,
-					query: 'Q1',
-					variables: () => ({}),
-					result: result1,
-				},
-				{
-					query: 'Q2',
-					variables: () => ({}),
-					result: result2,
-				},
+		const ctx = makeCtx({
+			apolloConfig: [
+				{ lazy: true, query: 'Q1', variables: () => ({}), result: result1 },
+				{ query: 'Q2', variables: () => ({}), result: result2 },
 			],
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
 			watchQuery: vi.fn(() => ({
 				subscribe: ({ next }) => next({ data: 'immediate' }),
 				setVariables: vi.fn(),
 			})),
-		};
-		ctx.$watch = vi.fn((fn, cb) => cb({}));
-		global.window = {};
-		mixin.created.call(ctx);
+			$watch: vi.fn((fn, cb) => cb({})),
+		});
+		setBrowser();
+
+		runCreated(ctx);
+
 		expect(ctx.lazyOperations).toHaveLength(1);
 		expect(result1).not.toHaveBeenCalled();
 		expect(result2).toHaveBeenCalledWith({ data: 'immediate' });
 	});
 
 	it('sets up watchQuery when IntersectionObserver fires', () => {
-		global.window = {};
-		const mock = mockIntersectionObserver(ctx);
+		setBrowser();
 		const result = vi.fn();
-		ctx.$el = document.createElement('div');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				variables: () => ({ id: 1 }),
-				result,
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', variables: () => ({ id: 1 }), result },
 			watchQuery: vi.fn(() => ({
 				subscribe: ({ next }) => next({ data: 'lazy-result' }),
 				setVariables: vi.fn(),
 			})),
-		};
-		ctx.$watch = vi.fn((fn, cb) => cb({}));
+			$watch: vi.fn((fn, cb) => cb({})),
+			$el: document.createElement('div'),
+		});
+		const mock = mockIntersectionObserver(ctx);
 
-		mixin.created.call(ctx);
+		runCreated(ctx);
 		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
 
-		mixin.mounted.call(ctx);
+		runMounted(ctx);
 		expect(mock.instances).toHaveLength(1);
 		expect(mock.instances[0].options.rootMargin).toBe('500px');
 
@@ -469,85 +355,49 @@ describe('apollo-plugin', () => {
 		delete global.IntersectionObserver;
 		delete global.IntersectionObserverEntry;
 		const result = vi.fn();
-		ctx.$el = document.createElement('div');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				variables: () => ({}),
-				result,
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', variables: () => ({}), result },
 			watchQuery: vi.fn(() => ({
 				subscribe: ({ next }) => next({ data: 'fallback' }),
 				setVariables: vi.fn(),
 			})),
-		};
-		ctx.$watch = vi.fn((fn, cb) => cb({}));
-		global.window = {};
+			$watch: vi.fn((fn, cb) => cb({})),
+			$el: document.createElement('div'),
+		});
+		setBrowser();
 
-		mixin.created.call(ctx);
-		mixin.mounted.call(ctx);
+		runCreated(ctx);
+		runMounted(ctx);
+
 		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
 		expect(result).toHaveBeenCalledWith({ data: 'fallback' });
 	});
 
 	it('uses custom rootMargin from lazy option object', () => {
-		global.window = {};
+		setBrowser();
+		const ctx = makeCtx({
+			apolloConfig: { lazy: { rootMargin: '200px' }, query: 'Q', variables: () => ({}), result: vi.fn() },
+			$el: document.createElement('div'),
+		});
 		const mock = mockIntersectionObserver(ctx);
-		ctx.$el = document.createElement('div');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: { rootMargin: '200px' },
-				query: 'Q',
-				variables: () => ({}),
-				result: vi.fn(),
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
-		};
-		ctx.$watch = vi.fn();
 
-		mixin.created.call(ctx);
-		mixin.mounted.call(ctx);
+		runCreated(ctx);
+		runMounted(ctx);
+
 		expect(mock.instances[0].options.rootMargin).toBe('200px');
-
 		mock.restore();
 	});
 
 	it('disconnects lazy observers on beforeUnmount', () => {
-		global.window = {};
+		setBrowser();
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', variables: () => ({}), result: vi.fn() },
+			$el: document.createElement('div'),
+		});
 		const mock = mockIntersectionObserver(ctx);
-		ctx.$el = document.createElement('div');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				variables: () => ({}),
-				result: vi.fn(),
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
-		};
-		ctx.$watch = vi.fn();
 
-		mixin.created.call(ctx);
-		mixin.mounted.call(ctx);
+		runCreated(ctx);
+		runMounted(ctx);
 		expect(mock.instances[0].disconnect).not.toHaveBeenCalled();
 
 		mixin.beforeUnmount.call(ctx);
@@ -557,100 +407,53 @@ describe('apollo-plugin', () => {
 	});
 
 	it('mounted does nothing when there are no lazy operations', () => {
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				query: 'Q',
-				variables: () => ({}),
-				result: vi.fn(),
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({
-				subscribe: vi.fn(),
-				setVariables: vi.fn(),
-			})),
-		};
-		ctx.$watch = vi.fn();
-		global.window = {};
+		const ctx = makeCtx({
+			apolloConfig: { query: 'Q', variables: () => ({}), result: vi.fn() },
+		});
+		setBrowser();
 
-		mixin.created.call(ctx);
-		expect(() => mixin.mounted.call(ctx)).not.toThrow();
+		runCreated(ctx);
+
+		expect(() => runMounted(ctx)).not.toThrow();
 		expect(() => mixin.beforeUnmount.call(ctx)).not.toThrow();
 	});
 
 	it('passes fetchPolicy through to watchQuery for lazy queries', () => {
-		global.window = {};
+		setBrowser();
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', fetchPolicy: 'network-only', variables: () => ({}), result: vi.fn() },
+			$el: document.createElement('div'),
+		});
 		const mock = mockIntersectionObserver(ctx);
-		ctx.$el = document.createElement('div');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				fetchPolicy: 'network-only',
-				variables: () => ({}),
-				result: vi.fn(),
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({
-				subscribe: vi.fn(),
-				setVariables: vi.fn(),
-			})),
-		};
-		ctx.$watch = vi.fn();
 
-		mixin.created.call(ctx);
-		mixin.mounted.call(ctx);
+		runCreated(ctx);
+		runMounted(ctx);
 		mock.trigger(1);
 
 		expect(ctx.apollo.watchQuery).toHaveBeenCalledWith(
-			expect.objectContaining({ fetchPolicy: 'network-only' })
+			expect.objectContaining({ fetchPolicy: 'network-only' }),
 		);
-
 		mock.restore();
 	});
 
 	it('sets up $watch and calls setVariables after lazy query activates', () => {
-		global.window = {};
-		const mock = mockIntersectionObserver(ctx);
+		setBrowser();
 		const setVariables = vi.fn();
-		ctx.$el = document.createElement('div');
-		ctx.$options = {
-			inject: { apollo: {}, cookieStore: {} },
-			apollo: {
-				lazy: true,
-				query: 'Q',
-				variables: () => ({ id: 1 }),
-				result: vi.fn(),
-			},
-		};
-		ctx.cookieStore = { get: vi.fn() };
-		ctx.$route = { query: {} };
-		ctx.apollo = {
-			readQuery: vi.fn(),
-			watchQuery: vi.fn(() => ({
-				subscribe: vi.fn(),
-				setVariables,
-			})),
-		};
 		const watchCallbacks = [];
-		ctx.$watch = vi.fn((fn, cb) => watchCallbacks.push(cb));
+		const ctx = makeCtx({
+			apolloConfig: { lazy: true, query: 'Q', variables: () => ({ id: 1 }), result: vi.fn() },
+			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables })),
+			$watch: vi.fn((fn, cb) => watchCallbacks.push(cb)),
+			$el: document.createElement('div'),
+		});
+		const mock = mockIntersectionObserver(ctx);
 
-		mixin.created.call(ctx);
-		mixin.mounted.call(ctx);
+		runCreated(ctx);
+		runMounted(ctx);
 		mock.trigger(1);
 
 		expect(ctx.$watch).toHaveBeenCalled();
 
-		// Simulate variable change
 		watchCallbacks[0]({ id: 2 });
 		expect(setVariables).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
 

--- a/test/unit/specs/plugins/apollo-plugin.spec.js
+++ b/test/unit/specs/plugins/apollo-plugin.spec.js
@@ -1,5 +1,38 @@
 import apolloPlugin from '#src/plugins/apollo-plugin';
 
+function mockIntersectionObserver(ctx) {
+	const instances = [];
+	const MockObserver = vi.fn((callback, options) => {
+		const instance = {
+			callback,
+			options,
+			observe: vi.fn(),
+			disconnect: vi.fn(),
+		};
+		instances.push(instance);
+		return instance;
+	});
+	global.IntersectionObserver = MockObserver;
+	global.IntersectionObserverEntry = { prototype: { intersectionRatio: 0 } };
+	// Also set on window object for checkIntersectionObserverSupport
+	if (typeof global.window === 'object' && global.window !== null) {
+		global.window.IntersectionObserver = MockObserver;
+		global.window.IntersectionObserverEntry = global.IntersectionObserverEntry;
+	}
+	return {
+		get instances() { return instances; },
+		trigger(intersectionRatio = 1) {
+			instances.forEach(inst => {
+				inst.callback([{ target: ctx.$el, intersectionRatio }]);
+			});
+		},
+		restore() {
+			delete global.IntersectionObserver;
+			delete global.IntersectionObserverEntry;
+		},
+	};
+}
+
 describe('apollo-plugin', () => {
 	let app;
 	let mixin;
@@ -18,6 +51,12 @@ describe('apollo-plugin', () => {
 		apolloPlugin(app);
 		[mixin] = app.getMixins();
 		ctx = {};
+	});
+
+	afterEach(() => {
+		global.window = undefined;
+		delete global.IntersectionObserver;
+		delete global.IntersectionObserverEntry;
 	});
 
 	it('registers a mixin with a created hook', () => {
@@ -270,5 +309,351 @@ describe('apollo-plugin', () => {
 			query: 'Q',
 			variables: { basketId: 'basket456', foo: 'bar' }
 		});
+	});
+
+	it('does not call watchQuery in created() when lazy is true', () => {
+		const result = vi.fn();
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				variables: () => ({}),
+				result,
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({ subscribe: vi.fn() })),
+		};
+		ctx.$watch = vi.fn();
+		global.window = {};
+		mixin.created.call(ctx);
+		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
+		expect(ctx.lazyOperations).toHaveLength(1);
+	});
+
+	it('ignores lazy when preFetch is true and shouldPreFetch passes', () => {
+		const data = { foo: 1 };
+		const result = vi.fn();
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				preFetch: true,
+				variables: () => ({}),
+				result,
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(() => data),
+			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
+		};
+		ctx.$watch = vi.fn();
+		global.window = {};
+		mixin.created.call(ctx);
+		expect(result).toHaveBeenCalledWith({ data });
+		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
+		expect(ctx.lazyOperations).toHaveLength(0);
+	});
+
+	it('applies lazy when preFetch is true but shouldPreFetch returns false', () => {
+		const result = vi.fn();
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				preFetch: true,
+				shouldPreFetch: () => false,
+				variables: () => ({}),
+				result,
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({ subscribe: vi.fn() })),
+		};
+		ctx.$watch = vi.fn();
+		global.window = {};
+		mixin.created.call(ctx);
+		expect(ctx.apollo.readQuery).not.toHaveBeenCalled();
+		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
+		expect(ctx.lazyOperations).toHaveLength(1);
+	});
+
+	it('handles mixed lazy and non-lazy queries in array form', () => {
+		const result1 = vi.fn();
+		const result2 = vi.fn();
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: [
+				{
+					lazy: true,
+					query: 'Q1',
+					variables: () => ({}),
+					result: result1,
+				},
+				{
+					query: 'Q2',
+					variables: () => ({}),
+					result: result2,
+				},
+			],
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({
+				subscribe: ({ next }) => next({ data: 'immediate' }),
+				setVariables: vi.fn(),
+			})),
+		};
+		ctx.$watch = vi.fn((fn, cb) => cb({}));
+		global.window = {};
+		mixin.created.call(ctx);
+		expect(ctx.lazyOperations).toHaveLength(1);
+		expect(result1).not.toHaveBeenCalled();
+		expect(result2).toHaveBeenCalledWith({ data: 'immediate' });
+	});
+
+	it('sets up watchQuery when IntersectionObserver fires', () => {
+		global.window = {};
+		const mock = mockIntersectionObserver(ctx);
+		const result = vi.fn();
+		ctx.$el = document.createElement('div');
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				variables: () => ({ id: 1 }),
+				result,
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({
+				subscribe: ({ next }) => next({ data: 'lazy-result' }),
+				setVariables: vi.fn(),
+			})),
+		};
+		ctx.$watch = vi.fn((fn, cb) => cb({}));
+
+		mixin.created.call(ctx);
+		expect(ctx.apollo.watchQuery).not.toHaveBeenCalled();
+
+		mixin.mounted.call(ctx);
+		expect(mock.instances).toHaveLength(1);
+		expect(mock.instances[0].options.rootMargin).toBe('500px');
+
+		mock.trigger(1);
+		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
+		expect(result).toHaveBeenCalledWith({ data: 'lazy-result' });
+		expect(mock.instances[0].disconnect).toHaveBeenCalled();
+
+		mock.restore();
+	});
+
+	it('falls back to immediate watchQuery when IntersectionObserver is unavailable', () => {
+		delete global.IntersectionObserver;
+		delete global.IntersectionObserverEntry;
+		const result = vi.fn();
+		ctx.$el = document.createElement('div');
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				variables: () => ({}),
+				result,
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({
+				subscribe: ({ next }) => next({ data: 'fallback' }),
+				setVariables: vi.fn(),
+			})),
+		};
+		ctx.$watch = vi.fn((fn, cb) => cb({}));
+		global.window = {};
+
+		mixin.created.call(ctx);
+		mixin.mounted.call(ctx);
+		expect(ctx.apollo.watchQuery).toHaveBeenCalled();
+		expect(result).toHaveBeenCalledWith({ data: 'fallback' });
+	});
+
+	it('uses custom rootMargin from lazy option object', () => {
+		global.window = {};
+		const mock = mockIntersectionObserver(ctx);
+		ctx.$el = document.createElement('div');
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: { rootMargin: '200px' },
+				query: 'Q',
+				variables: () => ({}),
+				result: vi.fn(),
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
+		};
+		ctx.$watch = vi.fn();
+
+		mixin.created.call(ctx);
+		mixin.mounted.call(ctx);
+		expect(mock.instances[0].options.rootMargin).toBe('200px');
+
+		mock.restore();
+	});
+
+	it('disconnects lazy observers on beforeUnmount', () => {
+		global.window = {};
+		const mock = mockIntersectionObserver(ctx);
+		ctx.$el = document.createElement('div');
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				variables: () => ({}),
+				result: vi.fn(),
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({ subscribe: vi.fn(), setVariables: vi.fn() })),
+		};
+		ctx.$watch = vi.fn();
+
+		mixin.created.call(ctx);
+		mixin.mounted.call(ctx);
+		expect(mock.instances[0].disconnect).not.toHaveBeenCalled();
+
+		mixin.beforeUnmount.call(ctx);
+		expect(mock.instances[0].disconnect).toHaveBeenCalled();
+
+		mock.restore();
+	});
+
+	it('mounted does nothing when there are no lazy operations', () => {
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				query: 'Q',
+				variables: () => ({}),
+				result: vi.fn(),
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({
+				subscribe: vi.fn(),
+				setVariables: vi.fn(),
+			})),
+		};
+		ctx.$watch = vi.fn();
+		global.window = {};
+
+		mixin.created.call(ctx);
+		expect(() => mixin.mounted.call(ctx)).not.toThrow();
+		expect(() => mixin.beforeUnmount.call(ctx)).not.toThrow();
+	});
+
+	it('passes fetchPolicy through to watchQuery for lazy queries', () => {
+		global.window = {};
+		const mock = mockIntersectionObserver(ctx);
+		ctx.$el = document.createElement('div');
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				fetchPolicy: 'network-only',
+				variables: () => ({}),
+				result: vi.fn(),
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({
+				subscribe: vi.fn(),
+				setVariables: vi.fn(),
+			})),
+		};
+		ctx.$watch = vi.fn();
+
+		mixin.created.call(ctx);
+		mixin.mounted.call(ctx);
+		mock.trigger(1);
+
+		expect(ctx.apollo.watchQuery).toHaveBeenCalledWith(
+			expect.objectContaining({ fetchPolicy: 'network-only' })
+		);
+
+		mock.restore();
+	});
+
+	it('sets up $watch and calls setVariables after lazy query activates', () => {
+		global.window = {};
+		const mock = mockIntersectionObserver(ctx);
+		const setVariables = vi.fn();
+		ctx.$el = document.createElement('div');
+		ctx.$options = {
+			inject: { apollo: {}, cookieStore: {} },
+			apollo: {
+				lazy: true,
+				query: 'Q',
+				variables: () => ({ id: 1 }),
+				result: vi.fn(),
+			},
+		};
+		ctx.cookieStore = { get: vi.fn() };
+		ctx.$route = { query: {} };
+		ctx.apollo = {
+			readQuery: vi.fn(),
+			watchQuery: vi.fn(() => ({
+				subscribe: vi.fn(),
+				setVariables,
+			})),
+		};
+		const watchCallbacks = [];
+		ctx.$watch = vi.fn((fn, cb) => watchCallbacks.push(cb));
+
+		mixin.created.call(ctx);
+		mixin.mounted.call(ctx);
+		mock.trigger(1);
+
+		expect(ctx.$watch).toHaveBeenCalled();
+
+		// Simulate variable change
+		watchCallbacks[0]({ id: 2 });
+		expect(setVariables).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
+
+		mock.restore();
 	});
 });

--- a/test/unit/specs/plugins/apollo-plugin.spec.js
+++ b/test/unit/specs/plugins/apollo-plugin.spec.js
@@ -416,6 +416,57 @@ describe('apollo-plugin', () => {
 		mock.restore();
 	});
 
+	it('passes all IntersectionObserver options through from lazy config', () => {
+		setBrowser();
+		const ctx = makeCtx({
+			apolloConfig: {
+				lazy: { rootMargin: '100px', threshold: 0.5 },
+				query: 'Q',
+				variables: () => ({}),
+				result: vi.fn(),
+			},
+			$el: document.createElement('div'),
+		});
+		const mock = mockIntersectionObserver(ctx);
+
+		runCreated(ctx);
+		runMounted(ctx);
+
+		expect(mock.instances[0].options).toEqual({ rootMargin: '100px', threshold: 0.5 });
+		mock.restore();
+	});
+
+	it('observes a custom target element via $refs when target is specified', () => {
+		setBrowser();
+		const customEl = document.createElement('section');
+		const result = vi.fn();
+		const ctx = makeCtx({
+			apolloConfig: {
+				lazy: { target: 'lazyRoot' },
+				query: 'Q',
+				variables: () => ({}),
+				result,
+			},
+			watchQuery: vi.fn(() => ({
+				subscribe: ({ next }) => next({ data: 'custom-target' }),
+				setVariables: vi.fn(),
+			})),
+			$watch: vi.fn((fn, cb) => cb({})),
+			$el: document.createElement('div'),
+		});
+		ctx.$refs = { lazyRoot: customEl };
+		const mock = mockIntersectionObserver(ctx);
+
+		runCreated(ctx);
+		runMounted(ctx);
+
+		expect(mock.instances[0].observe).toHaveBeenCalledWith(customEl);
+
+		mock.trigger(1);
+		expect(result).toHaveBeenCalledWith({ data: 'custom-target' });
+		mock.restore();
+	});
+
 	it('disconnects lazy observers on beforeUnmount', () => {
 		setBrowser();
 		const ctx = makeCtx({


### PR DESCRIPTION
## Summary
- Add `lazy` option to Apollo operation config that defers query execution until the component enters the viewport via `IntersectionObserver`, reducing unnecessary data fetching for below-the-fold content
- Handle Vue 3 fragment components where `$el` may be a comment/text node by walking siblings to find the first actual `Element`
- Extract `setupWatchQuery` helper for reuse across eager and lazy paths
- Split `config/local.js` into `local-prod.js` and `local-dev.js` for clearer local dev configuration

## Usage

Add `lazy: true` to any Apollo operation to defer it until the component is near the viewport (default 500px root margin):

```js
apollo: {
  lazy: true,
  query: myQuery,
  variables() { return { id: this.id }; },
  result({ data }) { this.myData = data; },
}
```

Custom `IntersectionObserver` options (any valid option can be overridden):

```js
apollo: {
  lazy: { rootMargin: '200px', threshold: 0.5 },
  query: myQuery,
  // ...
}
```

Custom observation target via `$refs` (defaults to `$el`):

```js
apollo: {
  lazy: { target: 'lazyRoot' },
  query: myQuery,
  // ...
}
```
```html
<template>
  <div ref="lazyRoot">...</div>
</template>
```
If the operation has `preFetch: true` and data was already fetched server-side, the lazy option is skipped and the watch query is set up immediately so no observer is created.

## Example refactor

Here's what a refactor looks like using `WhySpecial.vue` as an example (pulled from the [feature/borrower-profile-migration-ui](https://github.com/kiva/ui/tree/feature/borrower-profile-migration-ui) branch):

**Before:** manual observer setup, teardown, and a separate `loadData` method:

```vue
<script>
import { gql } from 'graphql-tag';
import { createIntersectionObserver } from '#src/util/observerUtils';

export default {
  name: 'WhySpecial',
  inject: ['apollo', 'cookieStore'],
  // ...
  apollo: {
    query: gql`query whySpecial($loanId: Int!) { ... }`,
    variables() { return { loanId: this.loanId }; },
    result(result) {
      this.whySpecial = result?.data?.lend?.loan?.whySpecial ?? '';
    },
  },
  methods: {
    createObserver() {
      this.observer = createIntersectionObserver({
        targets: [this.$el],
        rootMargin: '500px',
        callback: entries => {
          entries.forEach(entry => {
            if (entry.target === this.$el && entry.intersectionRatio > 0) {
              this.loadData();
            }
          });
        }
      });
      if (!this.observer) {
        this.loadData();
      }
    },
    destroyObserver() {
      if (this.observer) {
        this.observer.disconnect();
      }
    },
    loadData() {
      this.apollo.query({
        query: gql`query whySpecial($loanId: Int!) { ... }`,
        variables: { loanId: this.loanId },
      }).then(result => {
        this.whySpecial = result?.data?.lend?.loan?.whySpecial ?? '';
        this.loading = false;
      });
    },
  },
  mounted() { this.createObserver(); },
  beforeUnmount() { this.destroyObserver(); },
};
</script>
```

**After:** one `lazy: true` declaration replaces observer setup, teardown, loadData, and the duplicated query:

```vue
<script>
import { gql } from 'graphql-tag';

export default {
  name: 'WhySpecial',
  inject: ['apollo', 'cookieStore'],
  // ...
  apollo: {
    lazy: true,
    query: gql`query whySpecial($loanId: Int!) { ... }`,
    variables() { return { loanId: this.loanId }; },
    result(result) {
      this.whySpecial = result?.data?.lend?.loan?.whySpecial ?? '';
      this.loading = false;
    },
  },
  // No methods, mounted, or beforeUnmount needed for lazy loading
};
</script>
```

This eliminates the `createIntersectionObserver` import, three methods, two lifecycle hooks, and a duplicated query definition per component.