### PR TITLE
fix: handle line breaks in team messages [CP-2515]

### DIFF
--- a/src/components/LendingTeams/MyTeams/TeamMessageCard.vue
+++ b/src/components/LendingTeams/MyTeams/TeamMessageCard.vue
@@ -77,7 +77,7 @@ export default {
 			return `/team/${teamPublicId}/messages?msgID=${messageId}#msg_${messageId}`;
 		},
 		formatMessageBody(body, teamPublicId) {
-			const escaped = _escape(body);
+			const escaped = _escape(body).replace(/\r\n|\r|\n/g, '<br>');
 
 			// Replace embedded plain text message IDs (e.g. #123456) with direct links
 			// Use negative lookbehind / lookahead to exclude HTML entities that may have been escaped (e.g., &#39;)

--- a/test/unit/specs/components/LendingTeams/MyTeams/TeamMessageCard.spec.js
+++ b/test/unit/specs/components/LendingTeams/MyTeams/TeamMessageCard.spec.js
@@ -87,6 +87,19 @@ describe('TeamMessageCard', () => {
 		expect(messageBody.innerHTML).toContain('&amp;');
 	});
 
+	it('replaces line breaks in the body with <br> tags', () => {
+		const bodyWithLineBreaks = 'First line\nSecond line\r\nThird line';
+		const { container } = render(TeamMessageCard, {
+			props: {
+				message: mockMessage(1, { body: bodyWithLineBreaks }),
+			},
+			global: globalOptions,
+		});
+
+		const messageBody = container.querySelector('p');
+		expect(messageBody.innerHTML).toContain('First line<br>Second line<br>Third line');
+	});
+
 	it('sender name links to lender profile', () => {
 		const { container } = render(TeamMessageCard, {
 			props: {


### PR DESCRIPTION
Not sure why I didn't notice this before...

Replace line breaks in team message text with `<br>`. If there is a preferred library method way of doing this, please let me know. Otherwise, classic regex replace it is!