### PR TITLE
fix: align edit button at the top of the card

### DIFF
--- a/src/components/MyKiva/GoalProgressRing.vue
+++ b/src/components/MyKiva/GoalProgressRing.vue
@@ -14,7 +14,7 @@
 			</p>
 
 			<button
-				class="tw-flex tw-gap-0.5 tw-items-center tw-text-h5 hover:tw-underline tw-text-action"
+				class="tw-flex tw-gap-0.5 tw-items-center tw-text-h5 hover:tw-underline tw-text-action tw-pt-0.5"
 				v-if="!isModalVariant && goalEditingEnable"
 				@click="handleEditGoal"
 			>
@@ -220,7 +220,7 @@ const containerClass = computed(() => {
 });
 
 const titleContainerClass = computed(() => {
-	return isModalVariant.value ? 'tw-text-center' : 'tw-text-left tw-flex tw-justify-between tw-items-center tw-gap-1';
+	return isModalVariant.value ? 'tw-text-center' : 'tw-text-left tw-flex tw-justify-between tw-items-start tw-gap-1';
 });
 
 const titleClass = computed(() => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2689?focusedCommentId=394323

Adding some extra padding at the top of the  edit button since the title as a paragraph has an intrinsic spacing.

<img width="368" height="221" alt="image" src="https://github.com/user-attachments/assets/e082bc09-5299-4fee-8021-00f6a3eb5afe" />

Without extra spacing in button:
<img width="328" height="63" alt="image" src="https://github.com/user-attachments/assets/1502132f-c746-4a8b-b666-512eb19931a5" />
