### PR TITLE
feat: borrower profile image & video carousel AD-234

### DIFF
--- a/.storybook/stories/LoanFigureCarousel.stories.js
+++ b/.storybook/stories/LoanFigureCarousel.stories.js
@@ -1,38 +1,39 @@
+import ContentContainer from '#src/components/BorrowerProfile/ContentContainer';
 import LoanFigureCarousel from '#src/components/BorrowerProfile/LoanFigureCarousel';
 
 export default {
-	title: 'BorrowerProfile/LoanFigureCarousel',
+	title: 'Components/BorrowerProfile/LoanFigureCarousel',
 	component: LoanFigureCarousel,
 };
 
 const IMAGE_A = {
 	__typename: 'Image',
 	id: 1,
-	hash: '4d844ac2c0b77a8a522741b908ea5c32',
+	hash: '9673d0722a7675b9b8d11f90849d9b44',
 };
 const IMAGE_B = {
 	__typename: 'Image',
 	id: 2,
-	hash: '7a39b55d6c72e12c0a06a1d9e5f9b0d1',
+	hash: '6638894152e5ea6f0e65423b7b6cd9bb',
 };
 const IMAGE_C = {
 	__typename: 'Image',
 	id: 3,
-	hash: 'c44a3d1fa7a3e8e8f3b2a9c0d5e6f7a8',
+	hash: '131e7cc9d0de32daad20d90b3a39c8a8',
 };
 const VIDEO = {
 	__typename: 'Video',
-	youtubeId: 'dQw4w9WgXcQ',
+	youtubeId: '_vikEQ3pWqo',
 };
 
 const story = (args) => {
 	const template = () => ({
-		components: { LoanFigureCarousel },
+		components: { ContentContainer, LoanFigureCarousel },
 		setup() { return { args }; },
 		template: `
-			<div style="max-width: 420px;">
+			<content-container>
 				<loan-figure-carousel v-bind="args" />
-			</div>
+			</content-container>
 		`,
 	});
 	template.args = args;
@@ -44,11 +45,6 @@ export const SingleImage = story({
 	figures: [IMAGE_A],
 });
 
-export const SingleVideo = story({
-	name: 'Maria',
-	figures: [VIDEO],
-});
-
 export const MultipleImages = story({
 	name: 'Maria',
 	figures: [IMAGE_A, IMAGE_B, IMAGE_C],
@@ -56,5 +52,5 @@ export const MultipleImages = story({
 
 export const MixedImagesAndVideo = story({
 	name: 'Maria',
-	figures: [IMAGE_A, VIDEO, IMAGE_B],
+	figures: [VIDEO, IMAGE_A],
 });

--- a/.storybook/stories/LoanFigureCarousel.stories.js
+++ b/.storybook/stories/LoanFigureCarousel.stories.js
@@ -1,0 +1,60 @@
+import LoanFigureCarousel from '#src/components/BorrowerProfile/LoanFigureCarousel';
+
+export default {
+	title: 'BorrowerProfile/LoanFigureCarousel',
+	component: LoanFigureCarousel,
+};
+
+const IMAGE_A = {
+	__typename: 'Image',
+	id: 1,
+	hash: '4d844ac2c0b77a8a522741b908ea5c32',
+};
+const IMAGE_B = {
+	__typename: 'Image',
+	id: 2,
+	hash: '7a39b55d6c72e12c0a06a1d9e5f9b0d1',
+};
+const IMAGE_C = {
+	__typename: 'Image',
+	id: 3,
+	hash: 'c44a3d1fa7a3e8e8f3b2a9c0d5e6f7a8',
+};
+const VIDEO = {
+	__typename: 'Video',
+	youtubeId: 'dQw4w9WgXcQ',
+};
+
+const story = (args) => {
+	const template = () => ({
+		components: { LoanFigureCarousel },
+		setup() { return { args }; },
+		template: `
+			<div style="max-width: 420px;">
+				<loan-figure-carousel v-bind="args" />
+			</div>
+		`,
+	});
+	template.args = args;
+	return template;
+};
+
+export const SingleImage = story({
+	name: 'Maria',
+	figures: [IMAGE_A],
+});
+
+export const SingleVideo = story({
+	name: 'Maria',
+	figures: [VIDEO],
+});
+
+export const MultipleImages = story({
+	name: 'Maria',
+	figures: [IMAGE_A, IMAGE_B, IMAGE_C],
+});
+
+export const MixedImagesAndVideo = story({
+	name: 'Maria',
+	figures: [IMAGE_A, VIDEO, IMAGE_B],
+});

--- a/src/components/BorrowerProfile/LoanFigureCarousel.vue
+++ b/src/components/BorrowerProfile/LoanFigureCarousel.vue
@@ -1,0 +1,93 @@
+<template>
+	<div v-if="figures.length === 1" class="loan-figure-carousel">
+		<iframe
+			v-if="figures[0].__typename === 'Video'"
+			class="tw-aspect-video tw-mx-auto tw-rounded tw-w-full"
+			width="560"
+			height="315"
+			:src="`https://www.youtube.com/embed/${figures[0].youtubeId}?rel=0`"
+			title="YouTube video player"
+			frameborder="0"
+			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; web-share"
+			allowfullscreen
+		></iframe>
+		<borrower-image
+			v-else
+			class="tw-w-full tw-bg-black tw-rounded"
+			data-testid="bp-story-borrower-image"
+			:alt="name"
+			:aspect-ratio="16 / 25"
+			:default-image="{ width: 612 }"
+			:hash="figures[0].hash"
+			:images="imagePreset"
+		/>
+	</div>
+	<kv-carousel
+		v-else-if="figures.length > 1"
+		:embla-options="{ loop: false }"
+		class="loan-figure-carousel"
+	>
+		<template
+			v-for="(figure, index) in figures"
+			#[`slide${index}`]
+			:key="figure.id ?? index"
+		>
+			<iframe
+				v-if="figure.__typename === 'Video'"
+				class="tw-aspect-video tw-mx-auto tw-rounded tw-w-full"
+				width="560"
+				height="315"
+				:src="`https://www.youtube.com/embed/${figure.youtubeId}?rel=0`"
+				title="YouTube video player"
+				frameborder="0"
+				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; web-share"
+				allowfullscreen
+			></iframe>
+			<borrower-image
+				v-else
+				class="tw-w-full tw-bg-black tw-rounded"
+				data-testid="bp-story-borrower-image"
+				:alt="name"
+				:aspect-ratio="16 / 25"
+				:default-image="{ width: 612 }"
+				:hash="figure.hash"
+				:images="imagePreset"
+			/>
+		</template>
+	</kv-carousel>
+</template>
+
+<script>
+import { KvCarousel } from '@kiva/kv-components';
+import BorrowerImage from '#src/components/BorrowerProfile/BorrowerImage';
+
+export default {
+	name: 'LoanFigureCarousel',
+	components: {
+		BorrowerImage,
+		KvCarousel,
+	},
+	props: {
+		figures: {
+			type: Array,
+			default: () => [],
+		},
+		name: {
+			type: String,
+			default: '',
+		},
+	},
+	data() {
+		return {
+			imagePreset: [
+				{ width: 612, viewSize: 1024 },
+				{ width: 580, viewSize: 768 },
+				{ width: 416, viewSize: 480 },
+				{ width: 374, viewSize: 414 },
+				{ width: 335, viewSize: 375 },
+				{ width: 280 },
+			],
+		};
+	},
+};
+</script>

--- a/src/components/BorrowerProfile/LoanFigureCarousel.vue
+++ b/src/components/BorrowerProfile/LoanFigureCarousel.vue
@@ -1,27 +1,14 @@
 <template>
-	<div v-if="figures.length === 1" class="loan-figure-carousel">
-		<iframe
-			v-if="figures[0].__typename === 'Video'"
-			class="tw-aspect-video tw-mx-auto tw-rounded tw-w-full"
-			width="560"
-			height="315"
-			:src="`https://www.youtube.com/embed/${figures[0].youtubeId}?rel=0`"
-			title="YouTube video player"
-			frameborder="0"
-			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; web-share"
-			allowfullscreen
-		></iframe>
-		<borrower-image
-			v-else
-			class="tw-w-full tw-bg-black tw-rounded"
-			data-testid="bp-story-borrower-image"
-			:alt="name"
-			:aspect-ratio="16 / 25"
-			:default-image="{ width: 612 }"
-			:hash="figures[0].hash"
-			:images="imagePreset"
-		/>
-	</div>
+	<borrower-image
+		v-if="figures.length === 1"
+		class="tw-w-full tw-bg-black tw-rounded"
+		data-testid="bp-story-borrower-image"
+		:alt="name"
+		:aspect-ratio="aspectRatio"
+		:default-image="{ width: 612 }"
+		:hash="figures[0].hash"
+		:images="imagePreset"
+	/>
 	<kv-carousel
 		v-else-if="figures.length > 1"
 		:embla-options="{ loop: false }"
@@ -32,23 +19,27 @@
 			#[`slide${index}`]
 			:key="figure.id ?? index"
 		>
-			<iframe
+			<div
 				v-if="figure.__typename === 'Video'"
-				class="tw-aspect-video tw-mx-auto tw-rounded tw-w-full"
-				width="560"
-				height="315"
-				:src="`https://www.youtube.com/embed/${figure.youtubeId}?rel=0`"
-				title="YouTube video player"
-				frameborder="0"
-				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; web-share"
-				allowfullscreen
-			></iframe>
+				class="tw-relative tw-w-full tw-bg-black tw-rounded"
+				:style="`padding-bottom: ${aspectRatio * 100}%;`"
+			>
+				<iframe
+					class="tw-absolute tw-top-1/2 tw-left-0 tw-w-full tw-aspect-video tw--translate-y-1/2"
+					data-testid="bp-story-borrower-video"
+					:src="`https://www.youtube.com/embed/${figure.youtubeId}?rel=0`"
+					title="YouTube video player"
+					frameborder="0"
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; web-share"
+					allowfullscreen
+				></iframe>
+			</div>
 			<borrower-image
 				v-else
 				class="tw-w-full tw-bg-black tw-rounded"
 				data-testid="bp-story-borrower-image"
 				:alt="name"
-				:aspect-ratio="16 / 25"
+				:aspect-ratio="aspectRatio"
 				:default-image="{ width: 612 }"
 				:hash="figure.hash"
 				:images="imagePreset"
@@ -58,14 +49,16 @@
 </template>
 
 <script>
-import { KvCarousel } from '@kiva/kv-components';
+import { defineAsyncComponent } from 'vue';
 import BorrowerImage from '#src/components/BorrowerProfile/BorrowerImage';
 
 export default {
 	name: 'LoanFigureCarousel',
 	components: {
 		BorrowerImage,
-		KvCarousel,
+		KvCarousel: defineAsyncComponent(() => import(
+			'@kiva/kv-components/vue/KvCarousel'
+		)),
 	},
 	props: {
 		figures: {
@@ -79,6 +72,7 @@ export default {
 	},
 	data() {
 		return {
+			aspectRatio: 16 / 25,
 			imagePreset: [
 				{ width: 612, viewSize: 1024 },
 				{ width: 580, viewSize: 768 },

--- a/src/components/BorrowerProfile/LoanStory.vue
+++ b/src/components/BorrowerProfile/LoanStory.vue
@@ -1,38 +1,9 @@
 <template>
 	<article>
-		<iframe
-			v-if="youtubeId"
-			class="tw-aspect-video tw-mx-auto tw-rounded tw-w-full tw--mb-1.5 md:tw--mb-1"
-			width="560"
-			height="315"
-			:src="`https://www.youtube.com/embed/${youtubeId}?rel=0`"
-			title="YouTube video player"
-			frameborder="0"
-			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; web-share"
-			allowfullscreen
-		></iframe>
-		<borrower-image
-			v-else
-			class="
-				tw-w-full
-				tw-bg-black
-				tw-rounded
-				tw--mb-1.5
-				md:tw--mb-1
-			"
-			data-testid="bp-story-borrower-image"
-			:alt="name"
-			:aspect-ratio="16 / 25"
-			:default-image="{ width: 612 }"
-			:hash="hash"
-			:images="[
-				{ width: 612, viewSize: 1024 },
-				{ width: 580, viewSize: 768 },
-				{ width: 416, viewSize: 480 },
-				{ width: 374, viewSize: 414 },
-				{ width: 335, viewSize: 375 },
-				{ width: 280 },
-			]"
+		<loan-figure-carousel
+			class="tw--mb-1.5 md:tw--mb-1"
+			:figures="figures"
+			:name="name"
 		/>
 		<loan-description
 			class="tw-pt-4"
@@ -48,43 +19,20 @@
 			:story-description="description"
 			:previous-loan-id="previousLoanId"
 		/>
-		<borrower-image
-			v-if="youtubeId"
-			class="
-				tw-w-full
-				tw-bg-black
-				tw-rounded
-				tw--mb-1.5
-				md:tw--mb-1
-			"
-			data-testid="bp-story-borrower-image"
-			:alt="name"
-			:aspect-ratio="16 / 25"
-			:default-image="{ width: 612 }"
-			:hash="hash"
-			:images="[
-				{ width: 612, viewSize: 1024 },
-				{ width: 580, viewSize: 768 },
-				{ width: 416, viewSize: 480 },
-				{ width: 374, viewSize: 414 },
-				{ width: 335, viewSize: 375 },
-				{ width: 280 },
-			]"
-		/>
 	</article>
 </template>
 
 <script>
 import { gql } from 'graphql-tag';
-import BorrowerImage from './BorrowerImage';
 import LoanDescription from './LoanDescription';
+import LoanFigureCarousel from './LoanFigureCarousel';
 
 export default {
 	name: 'LoanStory',
 	inject: ['apollo', 'cookieStore'],
 	components: {
-		BorrowerImage,
 		LoanDescription,
+		LoanFigureCarousel,
 	},
 	props: {
 		loanId: {
@@ -98,14 +46,13 @@ export default {
 			borrowerCount: 0,
 			borrowers: [],
 			name: '',
-			hash: '',
+			figures: [],
 			description: '',
 			descriptionInOriginalLanguage: '',
 			originalLanguage: {},
 			partnerName: '',
 			reviewer: {},
 			previousLoanId: 0,
-			youtubeId: ''
 		};
 	},
 	apollo: {
@@ -123,12 +70,15 @@ export default {
 					description
 					previousLoanId
 					descriptionInOriginalLanguage
-					image {
-						id
-						hash
-					}
-					video {
-						youtubeId
+					figures {
+						__typename
+						... on Image {
+							id
+							hash
+						}
+						... on Video {
+							youtubeId
+						}
 					}
 					name
 					originalLanguage {
@@ -163,13 +113,12 @@ export default {
 			this.borrowers = loan?.borrowers ?? [];
 			this.description = loan?.description ?? '';
 			this.descriptionInOriginalLanguage = loan?.descriptionInOriginalLanguage ?? '';
-			this.hash = loan?.image?.hash ?? '';
+			this.figures = loan?.figures ?? [];
 			this.name = loan?.name ?? '';
 			this.originalLanguage = loan?.originalLanguage ?? {};
 			this.partnerName = loan?.partnerName ?? '';
 			this.reviewer = loan?.reviewer ?? {};
 			this.previousLoanId = loan?.previousLoanId ?? 0;
-			this.youtubeId = loan?.video?.youtubeId ?? '';
 		},
 	},
 };


### PR DESCRIPTION
This uses the new `LoanBasic.figures` field to provide a carousel of all the media for a loan in one place. Loans with multiple images previously did not display anything other than the primary image, and loans with a video displayed the video before the loan story and the primary image after the loan story. This changes it so that the video and all images are displayed in one carousel before the loan story, as approved by product and design.

See the comments on https://kiva.atlassian.net/browse/AD-234 for before/after screenshots and demo video.