### PR TITLE
feat: donation context fix (including receipt)

### DIFF
--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -22,7 +22,7 @@
 				@continue-clicked="handleContinue(NON_TIERED_BADGE)"
 				class="tw-mb-2.5"
 			/>
-			<!--  Donation opt-in module -->
+			<!--  Start of donation context -->
 			<OptInModule
 				v-if="showDonationOptInModule"
 				data-testid="donation-opt-in-module"
@@ -33,6 +33,21 @@
 				:achievements-completed="achievementsCompleted"
 				class="print:tw-hidden tw-mb-2.5"
 			/>
+			<AccountReceiptShare
+				v-if="onlyDonations"
+				ref="receiptSection"
+				:is-guest="isGuest"
+				:number-of-badges="numberOfBadges"
+				:receipt="receipt"
+				:lender="lender"
+				:loans="loans"
+				:show-receipt="showReceipt"
+				:only-donations="onlyDonations"
+				:guest-username="guestUsername"
+				class="tw-mb-2.5"
+			/>
+			<!--  End of donation context -->
+
 			<!-- Start goal module variations -->
 			<GoalEntrypoint
 				v-if="!isGuest && goalDataInitialized && isEmptyGoal"
@@ -109,6 +124,7 @@
 				@guest-continue="handleContinue"
 			/>
 			<AccountReceiptShare
+				v-if="!onlyDonations"
 				ref="receiptSection"
 				:is-guest="isGuest"
 				:number-of-badges="numberOfBadges"


### PR DESCRIPTION
JIRA Ticket: https://kiva.atlassian.net/jira/software/projects/MP/boards/275?selectedIssue=MP-2670

With original merge, the receipt was not included with the placement change- this ticket addresses it

Donation-Only Context:
<img width="1512" height="902" alt="Screenshot 2026-04-21 at 1 43 16 PM" src="https://github.com/user-attachments/assets/c88f8fad-7005-4334-b774-9a4dcef82f97" />

Nondonation Only Context: 
<img width="1512" height="906" alt="Screenshot 2026-04-21 at 1 44 21 PM" src="https://github.com/user-attachments/assets/80906dd0-d2ae-4ec0-a92c-9e1319ec891d" />
