### PR TITLE
fix(LoanFigureCarousel): import KvCarousel synchronously AD-234

### DIFF
--- a/src/components/BorrowerProfile/LoanFigureCarousel.vue
+++ b/src/components/BorrowerProfile/LoanFigureCarousel.vue
@@ -49,16 +49,14 @@
 </template>
 
 <script>
-import { defineAsyncComponent } from 'vue';
 import BorrowerImage from '#src/components/BorrowerProfile/BorrowerImage';
+import { KvCarousel } from '@kiva/kv-components';
 
 export default {
 	name: 'LoanFigureCarousel',
 	components: {
 		BorrowerImage,
-		KvCarousel: defineAsyncComponent(() => import(
-			'@kiva/kv-components/vue/KvCarousel'
-		)),
+		KvCarousel,
 	},
 	props: {
 		figures: {


### PR DESCRIPTION
This fixes an issue introduced by #6850 that caused that carousel for multiple images and/or a video to be removed from the page after briefly appearing. The defineAsyncComponent wrapper caused an SSR hydration mismatch that tore down the carousel subtree with null subTree/nodeType errors on the borrower profile. Properly code-splitting this import likely involves importing all of kv-components (`() => import('@kiva/kv-components').then(m => m.KvCarousel)`), making the split not worth it.