### PR TITLE
feat: change bundle size based on balance

### DIFF
--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -4,15 +4,26 @@ import { getFromCache, setToCache } from './util/memJsUtils.js';
 import drawLoanCard from './util/live-loan/live-loan-draw.js';
 import fetchLoansByType, { QUERY_TYPE } from './util/live-loan/live-loan-fetch.js';
 import { trace } from './util/mockTrace.js';
+import { resolveBundleSize, DEFAULT_BUNDLE_COUNT } from './util/live-loan/bundle-size.js';
 
-async function fetchRecommendedLoans(type, id, cache, queryType = QUERY_TYPE.DEFAULT) {
+async function fetchRecommendedLoans(type, id, cache, queryType = QUERY_TYPE.DEFAULT, count = DEFAULT_BUNDLE_COUNT) {
 	const queryTypeSuffix = queryType !== QUERY_TYPE.DEFAULT ? `-${queryType}` : '';
 	const loanCachedName = `recommendations-by-${type}-id-${id}${queryTypeSuffix}`;
-	// If we have loan data in memjscache return that quickly
+	// If we have loan data in memjscache return it quickly. For counts up to the default
+	// (4), serve any cached array — matches pre-MP-2713 behavior so legacy URL/IMG and
+	// no-balance bundle routes keep their original cache hit rate even if GraphQL
+	// returned fewer than 4 loans. For counts above the default (balance-bearing bundle
+	// requests), require the cache to hold at least `count` loans so the bundle isn't
+	// short-served from a stale smaller entry.
 	try {
 		const cachedLoanData = await getFromCache(loanCachedName, cache);
 		if (cachedLoanData) {
-			return JSON.parse(cachedLoanData);
+			const parsed = JSON.parse(cachedLoanData);
+			if (Array.isArray(parsed)) {
+				if (count <= DEFAULT_BUNDLE_COUNT || parsed.length >= count) {
+					return parsed;
+				}
+			}
 		}
 	} catch (err) {
 		error(`Error reading from memjs, ${err}`, { error: err });
@@ -22,7 +33,7 @@ async function fetchRecommendedLoans(type, id, cache, queryType = QUERY_TYPE.DEF
 	const loanData = await trace(
 		'fetchLoansByType',
 		{ resource: type },
-		async () => fetchLoansByType(type, id, queryType)
+		async () => fetchLoansByType(type, id, queryType, count)
 	);
 
 	// Set the loan data in memcache, return the loan data
@@ -39,14 +50,14 @@ async function fetchRecommendedLoans(type, id, cache, queryType = QUERY_TYPE.DEF
 	throw new Error('No loans returned');
 }
 
-async function getLoanForRequest(type, cache, req, queryType = QUERY_TYPE.DEFAULT) {
+async function getLoanForRequest(type, cache, req, queryType = QUERY_TYPE.DEFAULT, count = DEFAULT_BUNDLE_COUNT) {
 	// Use default values for id and offset if they are not numeric
 	const id = req.params?.id || 0;
 	const offset = req.params?.offset || 1;
 
 	const loanData = await trace(
 		'fetchRecommendedLoans',
-		async () => fetchRecommendedLoans(type, id, cache, queryType)
+		async () => fetchRecommendedLoans(type, id, cache, queryType, count)
 	);
 
 	// if there are fewer loan results than the offset, return the last result
@@ -82,13 +93,24 @@ async function redirectToUrl(type, cache, req, res, queryType = QUERY_TYPE.DEFAU
 
 async function redirectToBundleUrl(type, cache, req, res, queryType = QUERY_TYPE.DEFAULT) {
 	try {
+		const size = resolveBundleSize(req.query?.balance);
+		if (size.redirect) {
+			res.redirect(302, size.redirect);
+			return;
+		}
+
 		const id = req.params?.id || 0;
+		const { count } = size;
 		const loanData = await trace(
 			'fetchRecommendedLoans',
-			async () => fetchRecommendedLoans(type, id, cache, queryType)
+			async () => fetchRecommendedLoans(type, id, cache, queryType, count)
 		);
 
-		const loanIds = loanData.map(loan => loan.id).filter(Boolean).join(',');
+		const loanIds = loanData
+			.slice(0, count)
+			.map(loan => loan.id)
+			.filter(Boolean)
+			.join(',');
 		if (!loanIds) {
 			res.redirect(302, '/lend-by-category/');
 			return;
@@ -96,11 +118,12 @@ async function redirectToBundleUrl(type, cache, req, res, queryType = QUERY_TYPE
 
 		let redirect = `/add-loan-bundle?loanIds=${loanIds}`;
 
-		// Forward any original query params
+		// Forward original query params, stripping `balance`
 		const requestUrl = new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
-		const queryParams = new URLSearchParams(requestUrl.search);
-		if (queryParams.toString()) {
-			redirect += `&${queryParams}`;
+		const forwarded = new URLSearchParams(requestUrl.search);
+		forwarded.delete('balance');
+		if (forwarded.toString()) {
+			redirect += `&${forwarded}`;
 		}
 
 		res.redirect(302, redirect);
@@ -320,6 +343,8 @@ export default function liveLoanRouter(cache) {
 
 	// User Bundle URL Router
 	// Example: /live-loan/u/12345/bundle-url -> redirects to /add-loan-bundle?loanIds=101,202,303,404
+	// With balance: /live-loan/u/12345/bundle-url?balance=75 -> 3 loans (/add-loan-bundle?loanIds=101,202,303)
+	// Balance > 150: /live-loan/u/12345/bundle-url?balance=200 -> redirects to /lend/filter
 	router.use('/u/:id(\\d{0,})/bundle-url', async (req, res) => {
 		await trace('live-loan.user.redirectToBundleUrl', { resource: req.path }, async () => {
 			await redirectToBundleUrl('user', cache, req, res);
@@ -328,6 +353,9 @@ export default function liveLoanRouter(cache) {
 
 	// User Bundle URL Router FLSS
 	// Example: /live-loan/flss/u/12345/bundle-url -> redirects to /add-loan-bundle?loanIds=101,202,303,404
+	// eslint-disable-next-line max-len
+	// With balance: /live-loan/flss/u/12345/bundle-url?balance=125 -> 5 loans (/add-loan-bundle?loanIds=101,202,303,404,505)
+	// Balance > 150: /live-loan/flss/u/12345/bundle-url?balance=500 -> redirects to /lend/filter
 	router.use('/flss/u/:id(\\d{0,})/bundle-url', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToBundleUrl', { resource: req.path }, async () => {
 			await redirectToBundleUrl('user', cache, req, res, QUERY_TYPE.FLSS);
@@ -336,6 +364,8 @@ export default function liveLoanRouter(cache) {
 
 	// User Bundle URL Router Recommendations
 	// Example: /live-loan/recommendations/u/12345/bundle-url -> redirects to /add-loan-bundle?loanIds=101,202,303,404
+	// With balance: /live-loan/recommendations/u/12345/bundle-url?balance=25 -> 1 loan (/add-loan-bundle?loanIds=101)
+	// Balance > 150: /live-loan/recommendations/u/12345/bundle-url?balance=300 -> redirects to /lend/filter
 	router.use('/recommendations/u/:id(\\d{0,})/bundle-url', async (req, res) => {
 		await trace('live-loan.recommendations.user.redirectToBundleUrl', { resource: req.path }, async () => {
 			await redirectToBundleUrl('user', cache, req, res, QUERY_TYPE.RECOMMENDATIONS);

--- a/server/util/live-loan/bundle-size.js
+++ b/server/util/live-loan/bundle-size.js
@@ -1,0 +1,39 @@
+export const DEFAULT_BUNDLE_COUNT = 4;
+
+const REDIRECT_PATH = '/lend/filter';
+const MAX_BALANCE = 150;
+const TIER_STEP = 25;
+const MIN_LOANS = 1;
+const MAX_LOANS = 6;
+
+/**
+ * Resolves how many loans should be included in a live-loan email bundle, based on the
+ * recipient's account balance. Tiers: $25.01–$50 → 2 loans, $50.01–$75 → 3, $75.01–$100 → 4,
+ * $100.01–$125 → 5, $125.01–$150 → 6. Balance ≤ $25 → 1 loan. Balance > $150 → redirect to
+ * `/lend/filter` (combo page) so the user can curate a larger bundle themselves.
+ *
+ * Falsy, malformed, non-string/non-number, or negative input returns the 4-loan default so
+ * that pre-MP-2713 email links without a `?balance=` parameter keep their original behavior.
+ *
+ * @param {string|number} balanceInput Raw `?balance=` query value from the request.
+ * @returns {{ count: number } | { redirect: string }} Either a count in [1, 6] or a redirect path.
+ */
+export function resolveBundleSize(balanceInput) {
+	if (typeof balanceInput !== 'string' && typeof balanceInput !== 'number') {
+		return { count: DEFAULT_BUNDLE_COUNT };
+	}
+	const normalized = typeof balanceInput === 'string' ? balanceInput.trim() : balanceInput;
+	if (normalized === '') {
+		return { count: DEFAULT_BUNDLE_COUNT };
+	}
+	const balance = Number(normalized);
+	if (!Number.isFinite(balance) || balance < 0) {
+		return { count: DEFAULT_BUNDLE_COUNT };
+	}
+	if (balance > MAX_BALANCE) {
+		return { redirect: REDIRECT_PATH };
+	}
+	const raw = Math.ceil(balance / TIER_STEP);
+	const count = Math.min(Math.max(raw, MIN_LOANS), MAX_LOANS);
+	return { count };
+}

--- a/server/util/live-loan/live-loan-fetch.js
+++ b/server/util/live-loan/live-loan-fetch.js
@@ -7,8 +7,8 @@ export const QUERY_TYPE = {
 	RECOMMENDATIONS: 'recommendations'
 };
 
-// Number of loans to fetch
-const loanCount = 4;
+// Default number of loans to fetch when caller doesn't specify
+const DEFAULT_LOAN_COUNT = 4;
 
 // Which loan properties to fetch
 const loanData = `
@@ -90,14 +90,14 @@ async function fetchLoansFromGraphQL(request, resultPath) {
 }
 
 // Get per-user recommended loans from the ML service
-async function fetchRecommendationsByLoginId(id, queryType = QUERY_TYPE.DEFAULT) {
+async function fetchRecommendationsByLoginId(id, queryType = QUERY_TYPE.DEFAULT, count = DEFAULT_LOAN_COUNT) {
 	if (queryType === QUERY_TYPE.RECOMMENDATIONS) {
 		return fetchLoansFromGraphQL(
 			{
 				query: `query($userId: Int) {
 					loanRecommendations(
 						userId: $userId,
-						limit: ${loanCount},
+						limit: ${count},
 						origin: "email:live-loans"
 					) {
 						${loanValues}
@@ -115,7 +115,7 @@ async function fetchRecommendationsByLoginId(id, queryType = QUERY_TYPE.DEFAULT)
 				query: `query($userId: Int) {
 					fundraisingLoans(
 						pageNumber: 0,
-						limit: ${loanCount},
+						limit: ${count},
 						userId: $userId,
 						origin: "email:live-loans"
 					) {
@@ -137,7 +137,7 @@ async function fetchRecommendationsByLoginId(id, queryType = QUERY_TYPE.DEFAULT)
 						segment: all
 							loginId: ${id}
 							offset: 0
-							limit: ${loanCount}
+							limit: ${count}
 					) {
 						${loanValues}
 					}
@@ -149,7 +149,7 @@ async function fetchRecommendationsByLoginId(id, queryType = QUERY_TYPE.DEFAULT)
 }
 
 // Get loan-to-loan recommended loans from the ML service
-async function fetchRecommendationsByLoanId(id) {
+async function fetchRecommendationsByLoanId(id, count = DEFAULT_LOAN_COUNT) {
 	return fetchLoansFromGraphQL(
 		{
 			query: `{
@@ -158,7 +158,7 @@ async function fetchRecommendationsByLoanId(id) {
 						loanId: ${id},
 						offset: 0,
 						topics: [story]
-						limit: ${loanCount},
+						limit: ${count},
 					) {
 						${loanValues}
 					}
@@ -390,7 +390,7 @@ const parseFilterStringFLSS = async filterString => {
 };
 
 // Get loans from the Fundraising Loan Search Service matching a set of filters
-async function fetchRecommendationsByFilter(filterString) {
+async function fetchRecommendationsByFilter(filterString, count = DEFAULT_LOAN_COUNT) {
 	const filters = await parseFilterStringFLSS(filterString);
 	const sortOptions = await fetchFLSSSorts();
 	const sortBy = parseSortString(filterString, sortOptions);
@@ -399,7 +399,7 @@ async function fetchRecommendationsByFilter(filterString) {
 			query: `query($filters: [FundraisingLoanSearchFilterInput!], $sortBy: SortEnum) {
 				fundraisingLoans(
 					pageNumber: 0,
-					limit: ${loanCount},
+					limit: ${count},
 					filters: $filters,
 					sortBy: $sortBy,
 					origin: "email:live-loans"
@@ -488,7 +488,7 @@ async function parseFilterStringLegacy(filterString) {
 }
 
 // Get loans from legacy lend search matching a set of filters
-async function fetchRecommendationsByLegacyFilter(filterString) {
+async function fetchRecommendationsByLegacyFilter(filterString, count = DEFAULT_LOAN_COUNT) {
 	const [filters, sortOptions] = await Promise.all([
 		parseFilterStringLegacy(filterString),
 		fetchSorts(),
@@ -498,7 +498,7 @@ async function fetchRecommendationsByLegacyFilter(filterString) {
 		{
 			query: `query($filters: LoanSearchFiltersInput, $sort: LoanSearchSortByEnum) {
 				lend {
-					loans(limit: ${loanCount}, offset: 0, filters: $filters, sortBy: $sort) {
+					loans(limit: ${count}, offset: 0, filters: $filters, sortBy: $sort) {
 						${loanValues}
 					}
 				}
@@ -558,17 +558,17 @@ const shouldUseFLSS = async filterString => {
 };
 
 // Export a function that will fetch loans by live-loan type and id
-export default async function fetchLoansByType(type, id, queryType = QUERY_TYPE.DEFAULT) {
+export default async function fetchLoansByType(type, id, queryType = QUERY_TYPE.DEFAULT, count = DEFAULT_LOAN_COUNT) {
 	if (type === 'user') {
-		return fetchRecommendationsByLoginId(id, queryType);
+		return fetchRecommendationsByLoginId(id, queryType, count);
 	} if (type === 'loan') {
-		return fetchRecommendationsByLoanId(id);
+		return fetchRecommendationsByLoanId(id, count);
 	} if (type === 'filter') {
 		if (await shouldUseFLSS(id)) {
-			return fetchRecommendationsByFilter(id);
+			return fetchRecommendationsByFilter(id, count);
 		}
 		warn(`Using legacy loan search for filter "${id}"`);
-		return fetchRecommendationsByLegacyFilter(id);
+		return fetchRecommendationsByLegacyFilter(id, count);
 	}
 	if (type === 'loanid') {
 		return fetchLoanById(id);

--- a/test/unit/specs/server/bundle-size.spec.js
+++ b/test/unit/specs/server/bundle-size.spec.js
@@ -1,0 +1,100 @@
+// @vitest-environment node
+import { resolveBundleSize } from '#server/util/live-loan/bundle-size';
+
+describe('resolveBundleSize', () => {
+	describe('tier boundaries', () => {
+		it.each([
+			[0, { count: 1 }],
+			[25.00, { count: 1 }],
+			[25.01, { count: 2 }],
+			[50.00, { count: 2 }],
+			[50.01, { count: 3 }],
+			[75.00, { count: 3 }],
+			[75.01, { count: 4 }],
+			[100.00, { count: 4 }],
+			[100.01, { count: 5 }],
+			[125.00, { count: 5 }],
+			[125.01, { count: 6 }],
+			[150.00, { count: 6 }],
+			[150.01, { redirect: '/lend/filter' }],
+			[500.00, { redirect: '/lend/filter' }],
+		])('balance %s resolves to %o', (balance, expected) => {
+			expect(resolveBundleSize(String(balance))).toEqual(expected);
+		});
+	});
+
+	describe('normal cases per tier', () => {
+		it('balance 35 -> 2 loans', () => {
+			expect(resolveBundleSize('35')).toEqual({ count: 2 });
+		});
+		it('balance 60 -> 3 loans', () => {
+			expect(resolveBundleSize('60')).toEqual({ count: 3 });
+		});
+		it('balance 90 -> 4 loans', () => {
+			expect(resolveBundleSize('90')).toEqual({ count: 4 });
+		});
+		it('balance 110 -> 5 loans', () => {
+			expect(resolveBundleSize('110')).toEqual({ count: 5 });
+		});
+		it('balance 140 -> 6 loans', () => {
+			expect(resolveBundleSize('140')).toEqual({ count: 6 });
+		});
+		it('balance 1000 -> redirect', () => {
+			expect(resolveBundleSize('1000')).toEqual({ redirect: '/lend/filter' });
+		});
+	});
+
+	describe('fallbacks to 4-loan default', () => {
+		it.each([
+			undefined,
+			null,
+			'',
+			'abc',
+			'NaN',
+			'-25',
+			'-0.01',
+		])('input %o resolves to { count: 4 }', input => {
+			expect(resolveBundleSize(input)).toEqual({ count: 4 });
+		});
+	});
+
+	describe('accepts numeric input too', () => {
+		it('numeric 75 -> 3 loans', () => {
+			expect(resolveBundleSize(75)).toEqual({ count: 3 });
+		});
+		it('numeric 0 -> 1 loan', () => {
+			expect(resolveBundleSize(0)).toEqual({ count: 1 });
+		});
+		it('numeric -5 -> fallback 4 loans', () => {
+			expect(resolveBundleSize(-5)).toEqual({ count: 4 });
+		});
+	});
+
+	describe('strict numeric validation', () => {
+		it('rejects trailing garbage: "75abc" -> fallback', () => {
+			expect(resolveBundleSize('75abc')).toEqual({ count: 4 });
+		});
+		it('accepts scientific notation: "1e10" -> redirect', () => {
+			expect(resolveBundleSize('1e10')).toEqual({ redirect: '/lend/filter' });
+		});
+		it('trims surrounding whitespace: " 75 " -> 3 loans', () => {
+			expect(resolveBundleSize(' 75 ')).toEqual({ count: 3 });
+		});
+		it('whitespace-only string -> fallback', () => {
+			expect(resolveBundleSize('   ')).toEqual({ count: 4 });
+		});
+	});
+
+	describe('rejects non-string, non-number inputs', () => {
+		it.each([
+			[true],
+			[false],
+			[[]],
+			[['75', '100']],
+			[{}],
+			[{ balance: 75 }],
+		])('input %o resolves to { count: 4 }', input => {
+			expect(resolveBundleSize(input)).toEqual({ count: 4 });
+		});
+	});
+});

--- a/test/unit/specs/server/live-loan-fetch.spec.js
+++ b/test/unit/specs/server/live-loan-fetch.spec.js
@@ -199,4 +199,52 @@ describe('live-loan-fetch', () => {
 			expect(fetch.mock.results[0].value).toBeDefined();
 		});
 	});
+
+	describe('count parameter threading', () => {
+		beforeEach(() => {
+			fetch.mockClear();
+			fetch.mockResolvedValue({ json: () => ({}) });
+		});
+
+		async function queryForCall(callIndex) {
+			return JSON.parse(fetch.mock.calls[callIndex][1].body).query;
+		}
+
+		it('passes count into recommendationsByLoginId (DEFAULT) limit', async () => {
+			await fetchLoansByType('user', 42, 'default', 6);
+			const query = await queryForCall(0);
+			expect(query).toMatch(/recommendationsByLoginId\s*\([^)]*limit\s*:\s*6/);
+		});
+
+		it('passes count into fundraisingLoans (FLSS) limit', async () => {
+			await fetchLoansByType('user', 42, 'flss', 3);
+			const query = await queryForCall(0);
+			expect(query).toMatch(/fundraisingLoans\s*\([^)]*limit\s*:\s*3/);
+		});
+
+		it('passes count into loanRecommendations limit', async () => {
+			await fetchLoansByType('user', 42, 'recommendations', 5);
+			const query = await queryForCall(0);
+			expect(query).toMatch(/loanRecommendations\s*\([^)]*limit\s*:\s*5/);
+		});
+
+		it('defaults count to 4 when not provided (DEFAULT)', async () => {
+			await fetchLoansByType('user', 42);
+			const query = await queryForCall(0);
+			expect(query).toMatch(/recommendationsByLoginId\s*\([^)]*limit\s*:\s*4/);
+		});
+
+		it('passes count into filter (FLSS fundraisingLoans with filters) limit', async () => {
+			await fetchLoansByType('filter', 'sector_arts', 'default', 6);
+			const query = await queryForCall(0);
+			expect(query).toMatch(/fundraisingLoans\s*\([^)]*limit\s*:\s*6/);
+		});
+
+		it('passes count into legacy filter (lend.loans) limit', async () => {
+			// Using sort_random forces legacy loan search
+			await fetchLoansByType('filter', 'sort_random,sector_arts', 'default', 2);
+			const query = await queryForCall(0);
+			expect(query).toMatch(/loans\s*\([^)]*limit\s*:\s*2/);
+		});
+	});
 });

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -167,7 +167,8 @@ describe('live-loan-router bundle-url routes', () => {
 			expect(liveLoanFetch.default).toHaveBeenCalledWith(
 				'user',
 				'42',
-				liveLoanFetch.QUERY_TYPE.FLSS
+				liveLoanFetch.QUERY_TYPE.FLSS,
+				4,
 			);
 		});
 	});
@@ -194,8 +195,179 @@ describe('live-loan-router bundle-url routes', () => {
 			expect(liveLoanFetch.default).toHaveBeenCalledWith(
 				'user',
 				'42',
-				liveLoanFetch.QUERY_TYPE.RECOMMENDATIONS
+				liveLoanFetch.QUERY_TYPE.RECOMMENDATIONS,
+				4,
 			);
+		});
+	});
+
+	describe('balance-aware bundle size', () => {
+		it('balance=75 on /u/:id/bundle-url returns 3 loans', async () => {
+			const fresh = [{ id: 11 }, { id: 12 }, { id: 13 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url?balance=75');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=11,12,13');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'default', 3);
+		});
+
+		it('balance=130 returns 6 loans', async () => {
+			const fresh = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url?balance=130');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=1,2,3,4,5,6');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'default', 6);
+		});
+
+		it('balance=200 redirects to /lend/filter without fetching loans', async () => {
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url?balance=200');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/lend/filter');
+			expect(liveLoanFetch.default).not.toHaveBeenCalled();
+			expect(memJsUtils.getFromCache).not.toHaveBeenCalled();
+		});
+
+		it('no balance preserves 4-loan default behavior', async () => {
+			const fresh = [{ id: 100 }, { id: 200 }, { id: 300 }, { id: 400 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=100,200,300,400');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'default', 4);
+		});
+
+		it('strips balance from forwarded query params, keeps others', async () => {
+			const fresh = [{ id: 1 }, { id: 2 }, { id: 3 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(
+				app,
+				'/live-loan/u/42/bundle-url?balance=75&utm_source=email&utm_campaign=weekly',
+			);
+
+			expect(result.statusCode).toBe(302);
+			const loc = new URL(`http://x${result.location}`);
+			expect(loc.pathname).toBe('/add-loan-bundle');
+			expect(loc.searchParams.get('loanIds')).toBe('1,2,3');
+			expect(loc.searchParams.get('utm_source')).toBe('email');
+			expect(loc.searchParams.get('utm_campaign')).toBe('weekly');
+			expect(loc.searchParams.has('balance')).toBe(false);
+		});
+
+		it('invalid balance (non-numeric) falls back to 4 loans', async () => {
+			const fresh = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url?balance=abc');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=1,2,3,4');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'default', 4);
+		});
+
+		it('balance=75 on /flss/u/:id/bundle-url returns 3 loans with FLSS query type', async () => {
+			const fresh = [{ id: 1 }, { id: 2 }, { id: 3 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/flss/u/42/bundle-url?balance=75');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=1,2,3');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'flss', 3);
+		});
+
+		it('balance=200 on /flss/u/:id/bundle-url redirects to /lend/filter', async () => {
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/flss/u/42/bundle-url?balance=200');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/lend/filter');
+			expect(liveLoanFetch.default).not.toHaveBeenCalled();
+		});
+
+		it('balance=130 on /recommendations route returns 6 loans', async () => {
+			const fresh = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/recommendations/u/42/bundle-url?balance=130');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=1,2,3,4,5,6');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'recommendations', 6);
+		});
+
+		it('balance=200 on /recommendations/u/:id/bundle-url redirects to /lend/filter', async () => {
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/recommendations/u/42/bundle-url?balance=200');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/lend/filter');
+			expect(liveLoanFetch.default).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('length-aware cache for bundle-url', () => {
+		it('serves cached array when cached.length >= requested count', async () => {
+			const cached = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+			memJsUtils.getFromCache.mockResolvedValue(JSON.stringify(cached));
+
+			const app = createApp(cache);
+			// balance=50 -> 2 loans; cache has 4 -> sufficient; slice to 2
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url?balance=50');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=1,2');
+			expect(liveLoanFetch.default).not.toHaveBeenCalled();
+		});
+
+		it('refetches and overwrites when cached.length < requested count', async () => {
+			const cached = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+			memJsUtils.getFromCache.mockResolvedValue(JSON.stringify(cached));
+			const fresh = [{ id: 11 }, { id: 12 }, { id: 13 }, { id: 14 }, { id: 15 }, { id: 16 }];
+			liveLoanFetch.default.mockResolvedValue(fresh);
+
+			const app = createApp(cache);
+			// balance=130 -> 6 loans; cache has 4 -> insufficient
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url?balance=130');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=11,12,13,14,15,16');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith('user', '42', 'default', 6);
+			expect(memJsUtils.setToCache).toHaveBeenCalledWith(
+				'recommendations-by-user-id-42',
+				JSON.stringify(fresh),
+				10 * 60,
+				cache,
+			);
+		});
+
+		it('slices cached array to count when cache has more than requested', async () => {
+			const cached = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }];
+			memJsUtils.getFromCache.mockResolvedValue(JSON.stringify(cached));
+
+			const app = createApp(cache);
+			// No balance -> default 4 loans; cache has 6 -> slice
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-url');
+
+			expect(result.statusCode).toBe(302);
+			expect(result.location).toBe('/add-loan-bundle?loanIds=1,2,3,4');
+			expect(liveLoanFetch.default).not.toHaveBeenCalled();
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2713

An optional `balance` parameter that allows live loan bundles to be up to 6, existing live loan usage untouched functionally (and cache-wise).