### PR TITLE
feat: mp-2808-loaders-next-steps

### DIFF
--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -28,7 +28,7 @@
 		ref="loanRegionsElement"
 		:class="{ 'tw-flex tw-flex-col md:tw-flex-row tw-gap-4': showRegionExperience }"
 	>
-		<template v-if="showLendingNextStepsCards">
+		<template v-if="showLendingNextStepsCards && !goalProgressLoading">
 			<JourneyCardCarousel
 				class="carousel carousel-lending-next-steps tw-w-full"
 				user-in-homepage
@@ -55,7 +55,7 @@
 				@open-impact-insight-modal="showImpactInsightsModal = true"
 			/>
 		</template>
-		<template v-else-if="showRegionExperience">
+		<template v-else-if="showRegionExperience && !showLendingNextStepsCards">
 			<div class="goal-card-container">
 				<JourneyCardCarousel
 					class="carousel carousel-single"

--- a/src/pages/MyKiva/MyKivaNextStepsContent.vue
+++ b/src/pages/MyKiva/MyKivaNextStepsContent.vue
@@ -21,7 +21,7 @@
 				}"
 			>
 				<JourneyCardCarousel
-					v-if="showLendingNextStepsCards"
+					v-if="showLendingNextStepsCards && !goalProgressLoading"
 					class="carousel tw-w-full"
 					user-in-homepage
 					in-lending-stats
@@ -46,7 +46,7 @@
 					@open-goal-modal="openGoalModal($event)"
 					@open-impact-insight-modal="showImpactInsightsModal = true"
 				/>
-				<template v-else-if="showRegionExperienceInFirstRow">
+				<template v-else-if="showRegionExperienceInFirstRow && !showLendingNextStepsCards">
 					<div class="goal-card-container">
 						<JourneyCardCarousel
 							class="carousel carousel-single"
@@ -422,6 +422,9 @@ const $kvTrackEvent = inject('$kvTrackEvent');
 const goalData = inject('goalData');
 const router = useRouter();
 const { isMobile } = useBreakpoints();
+const postLendingQueryExists = router.currentRoute.value.query.postLending === 'true';
+const hasPostLendingCookie = checkPostLendingCardCookie(cookieStore);
+const shouldShowPostLendingNextStepsCards = hasPostLendingCookie || postLendingQueryExists;
 
 // Goal data from parent-provided composable
 const {
@@ -452,7 +455,7 @@ const newGoalPrefs = ref(null);
 const isUpdatingGoal = ref(false);
 const isSharingModalVisible = ref(false);
 const acceptedEmailMarketingUpdates = ref(false);
-const showPostLendingNextStepsCards = ref(false);
+const showPostLendingNextStepsCards = ref(shouldShowPostLendingNextStepsCards);
 
 // Computed
 const categoriesLoanCount = computed(() => getAllCategoryLoanCounts(props.heroTieredAchievements));
@@ -675,9 +678,7 @@ watch(() => props.goalRefreshKey, async (newVal, oldVal) => {
 
 onMounted(async () => {
 	await checkCompletedGoal({ category: 'portfolio' });
-	const postLendingQueryExists = router.currentRoute.value.query.postLending === 'true';
-	if (checkPostLendingCardCookie(cookieStore) || postLendingQueryExists) {
-		showPostLendingNextStepsCards.value = true;
+	if (shouldShowPostLendingNextStepsCards) {
 		removePostLendingCardCookie(cookieStore);
 	}
 });

--- a/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
@@ -1,0 +1,141 @@
+/* eslint-disable import/no-extraneous-dependencies, vue/one-component-per-file */
+import { flushPromises, mount } from '@vue/test-utils';
+import { defineComponent, h, ref } from 'vue';
+import MyKivaNextStepsContent from '#src/pages/MyKiva/MyKivaNextStepsContent';
+import { POST_LENDING_NEXT_STEPS_COOKIE } from '#src/util/myKivaUtils';
+
+const mockPush = vi.fn();
+const routeRef = ref({ query: {} });
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({
+		push: mockPush,
+		currentRoute: routeRef,
+	}),
+}));
+
+vi.mock('#src/composables/useBreakpoints', () => ({
+	default: () => ({
+		isMobile: ref(false),
+	}),
+}));
+
+const MyKivaContainerStub = defineComponent({
+	name: 'MyKivaContainer',
+	setup(_, { slots }) {
+		return () => h('div', slots.default?.());
+	},
+});
+
+const JourneyCardCarouselStub = defineComponent({
+	name: 'JourneyCardCarousel',
+	props: {
+		showLendingNextStepsCards: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	template: '<div class="journey-card-carousel-stub" />',
+});
+
+const KvLoadingPlaceholderStub = defineComponent({
+	name: 'KvLoadingPlaceholder',
+	template: '<div class="kv-loading-placeholder-stub" />',
+});
+
+const buildGoalData = ({ loading = false } = {}) => ({
+	checkCompletedGoal: vi.fn().mockResolvedValue(),
+	goalProgress: ref(0),
+	hideGoalCard: ref(false),
+	loading: ref(loading),
+	loadGoalData: vi.fn().mockResolvedValue(),
+	loadPreferences: vi.fn().mockResolvedValue(),
+	storeGoalPreferences: vi.fn().mockResolvedValue(),
+	updateCurrentGoal: vi.fn().mockResolvedValue(),
+	userGoal: ref(null),
+	userGoalAchieved: ref(false),
+});
+
+const createWrapper = ({
+	goalLoading = false,
+	cookieValue,
+	query = {},
+	props = {},
+} = {}) => {
+	routeRef.value = { query };
+	const cookieStore = {
+		get: vi.fn(name => (name === POST_LENDING_NEXT_STEPS_COOKIE ? cookieValue : undefined)),
+		remove: vi.fn(),
+	};
+
+	const goalData = buildGoalData({ loading: goalLoading });
+
+	const wrapper = mount(MyKivaNextStepsContent, {
+		props: {
+			lendingNextStepsVariant: 'b',
+			userInfo: {
+				userPreferences: {
+					preferences: '{}',
+				},
+				communicationSettings: {
+					lenderNews: false,
+					loanUpdates: false,
+				},
+			},
+			...props,
+		},
+		global: {
+			provide: {
+				cookieStore,
+				$kvTrackEvent: vi.fn(),
+				goalData,
+			},
+			stubs: {
+				MyKivaContainer: MyKivaContainerStub,
+				JourneyCardCarousel: JourneyCardCarouselStub,
+				MyKivaRegionExperience: true,
+				GoalSettingModal: true,
+				MyKivaImpactInsightModal: true,
+				MyKivaSharingModal: true,
+				MyKivaCard: true,
+				MyKivaEmailUpdatesTransition: true,
+				MyKivaLatestLoanCard: true,
+				MyKivaSurveyCard: true,
+				KvMaterialIcon: true,
+				KvButton: true,
+				KvLoadingPlaceholder: KvLoadingPlaceholderStub,
+			},
+		},
+	});
+
+	return {
+		wrapper,
+		cookieStore,
+	};
+};
+
+describe('MyKivaNextStepsContent', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		routeRef.value = { query: {} };
+	});
+
+	it('shows loading placeholders instead of lending-focused carousel while goal data is loading', () => {
+		const { wrapper } = createWrapper({ goalLoading: true });
+
+		expect(wrapper.findAll('.journey-card-carousel-stub')).toHaveLength(0);
+	});
+
+	it('initializes post-lending mode before first render when post-lending cookie exists', async () => {
+		const { wrapper, cookieStore } = createWrapper({
+			cookieValue: 'true',
+			goalLoading: false,
+		});
+		await flushPromises();
+
+		const carousels = wrapper.findAllComponents({ name: 'JourneyCardCarousel' });
+		expect(carousels).toHaveLength(1);
+		expect(carousels[0].props('showLendingNextStepsCards')).toBe(false);
+		expect(cookieStore.remove).toHaveBeenCalledWith(POST_LENDING_NEXT_STEPS_COOKIE);
+	});
+});


### PR DESCRIPTION
Added loader coverage for the missing cards in both places:

Next Steps page: lending-focused cards now respect the same loading condition, so missing cards show skeletons until data is ready.
MyKiva dashboard: applied the same loader condition, so those missing lending-focused cards also render as placeholders during load.
So both views now use the same loading behavior instead of showing partial card sets.