### PR TITLE
feat: add pagination to loans-beta page

### DIFF
--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -39,7 +39,7 @@
 											`tw-col-span-${placeholder.span}`,
 											placeholder.marginLeft && 'tw-ml-auto'
 										]"
-										style="height: 16px;"
+										style="height: 50px;"
 									/>
 								</div>
 							</td>

--- a/src/graphql/query/portfolio/myLoans.graphql
+++ b/src/graphql/query/portfolio/myLoans.graphql
@@ -1,7 +1,13 @@
-query myLoans {
+query myLoans(
+	$offset: Int = 0,
+	$limit: Int = 20
+) {
 	my {
 		id
-		loans {
+		loans(
+			offset: $offset,
+			limit: $limit
+		) {
 			values {
 				id
 				name

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -50,13 +50,12 @@
 import WwwPage from '#src/components/WwwFrame/WwwPage';
 import TheMyKivaSecondaryMenu from '#src/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import ThePortfolioTertiaryMenu from '#src/components/WwwFrame/Menus/ThePortfolioTertiaryMenu';
-import { KvPageContainer, KvGrid } from '@kiva/kv-components';
+import { KvPageContainer, KvGrid, KvPagination } from '@kiva/kv-components';
 
 import logFormatter from '#src/util/logFormatter';
 import LoanStatsTable from '#src/components/Portfolio/LoanStatsTable';
 import LoanFilterBar from '#src/components/Portfolio/LoanFilterBar';
 import LoanList from '#src/components/Portfolio/LoanList';
-import KvPagination from '#src/components/Kv/KvPagination';
 import myLoansQuery from '#src/graphql/query/portfolio/myLoans.graphql';
 
 const PAGE_LIMIT = 20;

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -23,8 +23,23 @@
 				<div
 					class="tw-col-span-12"
 				>
-					<loan-filter-bar :total-loans="totalLoans" />
-					<loan-list :loans="loans" :loading="loading" />
+					<loan-filter-bar
+						:total-loans="totalLoans"
+					/>
+					<div ref="loanTableTop">
+						<loan-list :loans="loans" :loading="loading" />
+					</div>
+					<kv-pagination
+						v-if="showPagination"
+						class="tw-mt-3"
+						:class="{ 'tw-pointer-events-none tw-opacity-low': loading }"
+						:limit="loanState.limit"
+						:offset="loanState.offset"
+						:aria-disabled="loading ? 'true' : undefined"
+						:scroll-to-top="false"
+						:total="totalLoans"
+						@page-changed="handlePageChange"
+					/>
 				</div>
 			</kv-grid>
 		</kv-page-container>
@@ -41,7 +56,10 @@ import logFormatter from '#src/util/logFormatter';
 import LoanStatsTable from '#src/components/Portfolio/LoanStatsTable';
 import LoanFilterBar from '#src/components/Portfolio/LoanFilterBar';
 import LoanList from '#src/components/Portfolio/LoanList';
+import KvPagination from '#src/components/Kv/KvPagination';
 import myLoansQuery from '#src/graphql/query/portfolio/myLoans.graphql';
+
+const PAGE_LIMIT = 20;
 
 export default {
 	name: 'LoansPage',
@@ -52,6 +70,7 @@ export default {
 		ThePortfolioTertiaryMenu,
 		KvGrid,
 		KvPageContainer,
+		KvPagination,
 		LoanStatsTable,
 		LoanFilterBar,
 		LoanList
@@ -62,6 +81,10 @@ export default {
 			loans: [],
 			totalLoans: 0,
 			loading: true,
+			loanState: {
+				offset: 0,
+				limit: PAGE_LIMIT,
+			},
 			stats: {
 				loanStatuses: {
 					fundraising: 0,
@@ -77,20 +100,55 @@ export default {
 			}
 		};
 	},
+	computed: {
+		showPagination() {
+			return this.totalLoans > this.loanState.limit;
+		},
+	},
 	mounted() {
-		this.apollo.query({
-			query: myLoansQuery,
-			fetchPolicy: 'network-only'
-		}).then(({ data }) => {
-			if (data?.my?.loans) {
-				this.loans = data.my.loans.values || [];
-				this.totalLoans = data.my.loans.totalCount;
+		this.fetchLoans();
+	},
+	methods: {
+		fetchLoans({ clearLoans = false } = {}) {
+			this.loading = true;
+			if (clearLoans) {
+				this.loans = [];
 			}
-		}).catch(error => {
-			logFormatter(`Error fetching loans: ${error}`, 'error');
-		}).finally(() => {
-			this.loading = false;
-		});
+			return this.apollo.query({
+				query: myLoansQuery,
+				variables: {
+					offset: this.loanState.offset,
+					limit: this.loanState.limit,
+				},
+				fetchPolicy: 'network-only'
+			}).then(({ data }) => {
+				if (data?.my?.loans) {
+					this.loans = data.my.loans.values || [];
+					this.totalLoans = data.my.loans.totalCount;
+				}
+			}).catch(error => {
+				logFormatter(`Error fetching loans: ${error}`, 'error');
+			}).finally(() => {
+				this.loading = false;
+			});
+		},
+		handlePageChange({ pageOffset }) {
+			if (this.loading) {
+				return undefined;
+			}
+			this.loanState = {
+				...this.loanState,
+				offset: pageOffset,
+			};
+			this.scrollToLoanTable();
+			return this.fetchLoans({ clearLoans: true });
+		},
+		scrollToLoanTable() {
+			this.$refs.loanTableTop?.scrollIntoView({
+				behavior: 'smooth',
+				block: 'start',
+			});
+		},
 	}
 };
 </script>

--- a/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
@@ -1,0 +1,205 @@
+import { render, fireEvent, waitFor } from '@testing-library/vue';
+import LoansPage from '#src/pages/Portfolio/Loans/LoansPage';
+
+const deferred = () => {
+	let resolve;
+	const promise = new Promise(resolvePromise => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+};
+
+const loansResponse = (loanId = '101', totalCount = 45) => ({
+	my: {
+		id: 'my-id',
+		loans: {
+			totalCount,
+			values: [
+				{ id: loanId, name: 'Maria' },
+			],
+		},
+	},
+});
+
+const scrollIntoView = vi.fn();
+
+Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+	configurable: true,
+	value: scrollIntoView,
+});
+
+const renderLoansPage = ({ apollo = null, router = null } = {}) => {
+	const query = vi.fn().mockResolvedValue({ data: loansResponse() });
+	const push = vi.fn();
+
+	return {
+		query,
+		push,
+		...render(LoansPage, {
+			global: {
+				provide: {
+					apollo: apollo || { query },
+					cookieStore: {},
+				},
+				mocks: {
+					$router: router || { push },
+				},
+				stubs: {
+					WwwPage: { template: '<div><slot name="secondary" /><slot /></div>' },
+					TheMyKivaSecondaryMenu: { template: '<div />' },
+					ThePortfolioTertiaryMenu: { template: '<div />' },
+					KvPageContainer: { template: '<div><slot /></div>' },
+					KvGrid: { template: '<div><slot /></div>' },
+					LoanStatsTable: { template: '<div />' },
+					LoanList: {
+						props: ['loans', 'loading'],
+						template: `
+							<div data-testid="loan-list">
+								loading:{{ loading }} loans:{{ loans.map(loan => loan.id).join(",") }}
+							</div>
+						`,
+					},
+					LoanFilterBar: {
+						props: ['filters', 'queryString', 'countries', 'partners', 'totalLoans'],
+						emits: ['filters-changed'],
+						template: `
+							<button
+								type="button"
+								data-testid="filter"
+								@click="$emit('filters-changed', { status: 'delinquent' })"
+							>
+								filter
+							</button>
+						`,
+					},
+					KvPagination: {
+						props: ['limit', 'total', 'offset', 'scrollToTop'],
+						emits: ['page-changed'],
+						template: `
+							<div
+								data-testid="pagination"
+								:data-scroll-to-top="scrollToTop"
+							>
+								<button
+									type="button"
+									data-testid="first-page"
+									@click="$emit('page-changed', { pageOffset: 0 })"
+								>
+									first {{ offset }} {{ total }}
+								</button>
+								<button
+									type="button"
+									data-testid="middle-page"
+									@click="$emit('page-changed', { pageOffset: 20 })"
+								>
+									middle
+								</button>
+								<button
+									type="button"
+									data-testid="later-page"
+									@click="$emit('page-changed', { pageOffset: 40 })"
+								>
+									later
+								</button>
+							</div>
+						`,
+					},
+				},
+			},
+		}),
+	};
+};
+
+describe('LoansPage', () => {
+	beforeEach(() => {
+		scrollIntoView.mockClear();
+	});
+
+	it('queries my loans with first page paging variables', async () => {
+		const { query } = renderLoansPage();
+
+		await waitFor(() => expect(query).toHaveBeenCalled());
+
+		expect(query.mock.calls[0][0]).toEqual(expect.objectContaining({
+			fetchPolicy: 'network-only',
+			variables: {
+				offset: 0,
+				limit: 20,
+			},
+		}));
+	});
+
+	it('queries selected pages without adding query strings and scrolls to the table', async () => {
+		const page = renderLoansPage();
+
+		await waitFor(() => expect(page.query).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(page.getByTestId('pagination').getAttribute('aria-disabled')).toBeNull());
+		expect(page.getByTestId('pagination').getAttribute('class')).not.toContain('tw-pointer-events-none');
+		await fireEvent.click(await page.findByTestId('middle-page'));
+		await waitFor(() => expect(page.query).toHaveBeenCalledTimes(2));
+		await waitFor(() => expect(page.getByTestId('pagination').getAttribute('aria-disabled')).toBeNull());
+		await fireEvent.click(await page.findByTestId('later-page'));
+		await waitFor(() => expect(page.query).toHaveBeenCalledTimes(3));
+
+		expect(page.push).not.toHaveBeenCalled();
+		expect(page.query.mock.calls[1][0].variables).toEqual({
+			offset: 20,
+			limit: 20,
+		});
+		expect(page.query.mock.calls[2][0].variables).toEqual({
+			offset: 40,
+			limit: 20,
+		});
+		expect(page.getByTestId('pagination').getAttribute('data-scroll-to-top')).toBe('false');
+		expect(scrollIntoView).toHaveBeenCalledWith({
+			behavior: 'smooth',
+			block: 'start',
+		});
+	});
+
+	it('hides pagination for a single page of results', async () => {
+		const query = vi.fn().mockResolvedValue({
+			data: loansResponse('101', 20),
+		});
+
+		const { queryByTestId } = renderLoansPage({ apollo: { query } });
+
+		await waitFor(() => expect(query).toHaveBeenCalled());
+
+		expect(queryByTestId('first-page')).toBeNull();
+	});
+
+	it('clears previous page loans while the next page is loading', async () => {
+		const nextRequest = deferred();
+		const query = vi.fn()
+			.mockResolvedValueOnce({ data: loansResponse('101') })
+			.mockReturnValueOnce(nextRequest.promise);
+		const page = renderLoansPage({ apollo: { query } });
+
+		await waitFor(() => expect(page.getByTestId('loan-list').textContent).toContain('loans:101'));
+
+		await fireEvent.click(await page.findByTestId('later-page'));
+
+		expect(page.getByTestId('loan-list').textContent).toContain('loading:true loans:');
+		expect(page.getByTestId('loan-list').textContent).not.toContain('101');
+	});
+
+	it('disables pagination while the next page is loading', async () => {
+		const nextRequest = deferred();
+		const query = vi.fn()
+			.mockResolvedValueOnce({ data: loansResponse('101') })
+			.mockReturnValueOnce(nextRequest.promise);
+		const page = renderLoansPage({ apollo: { query } });
+
+		await waitFor(() => expect(page.getByTestId('loan-list').textContent).toContain('loans:101'));
+		await fireEvent.click(await page.findByTestId('later-page'));
+
+		expect(page.getByTestId('pagination').getAttribute('aria-disabled')).toBe('true');
+		expect(page.getByTestId('pagination').getAttribute('class')).toContain('tw-pointer-events-none');
+		expect(page.getByTestId('pagination').getAttribute('class')).toContain('tw-opacity-low');
+
+		await fireEvent.click(await page.findByTestId('middle-page'));
+
+		expect(query).toHaveBeenCalledTimes(2);
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2734

Previously the loans table in `loans-beta` was pulling all loans for a user (or falling to default in backend). Paging is now implemented using existing offset/limit logic and adding shared pagination component.

<img width="1003" height="743" alt="image" src="https://github.com/user-attachments/assets/fe277ee1-ac67-4205-bcbc-c92777110b3e" />
