### PR TITLE
fix: ensure goal card still appears once on mykiva after completing

### DIFF
--- a/src/components/MyKiva/NextYearGoalCard.vue
+++ b/src/components/MyKiva/NextYearGoalCard.vue
@@ -111,10 +111,10 @@ const {
 	getCtaHref,
 	getGoalDisplayName,
 	goalProgressPercentage,
-	setHideGoalCardPreference,
 } = goalData;
 
 const isUpdatingGoal = ref(false);
+const hasHandledGoalCompletion = ref(false);
 
 const userHasGoal = computed(() => !!props.userGoal && Object.keys(props.userGoal).length > 0);
 
@@ -177,12 +177,29 @@ const handleEditClick = () => {
 	emit('open-goal-modal', { updating: true });
 };
 
+const showCompletedGoalConfetti = () => {
+	if (
+		hasHandledGoalCompletion.value
+		|| props.loading
+		|| props.hideGoalCard
+		|| !userHasGoal.value
+		|| goalProgressPercentage.value !== COMPLETED_GOAL_THRESHOLD
+	) {
+		return;
+	}
+
+	hasHandledGoalCompletion.value = true;
+	showConfetti();
+};
+
+watch(
+	() => [props.loading, props.hideGoalCard, goalProgressPercentage.value, userHasGoal.value],
+	showCompletedGoalConfetti,
+	{ immediate: true }
+);
+
 watch(() => [props.loading, props.hideGoalCard], ([newLoading, newHideGoalCard], [oldLoading]) => {
 	if (!newLoading && oldLoading && !newHideGoalCard) {
-		if (goalProgressPercentage.value === COMPLETED_GOAL_THRESHOLD) {
-			showConfetti();
-			setHideGoalCardPreference();
-		}
 		if (!userHasGoal.value) {
 			$kvTrackEvent(
 				'portfolio',

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -658,10 +658,8 @@ export default function useGoalData({ apollo } = {}) {
 			parsedPrefs,
 			updatedPreference
 		);
-		userPreferences.value = {
-			...userPreferences.value,
-			preferences: JSON.stringify({ ...parsedPrefs, ...updatedPreference }),
-		};
+		// Persist only; do not copy the hidden preference into local state.
+		// MyKiva renders the completed card once, then hides it on the next page load.
 	}
 
 	async function checkCompletedGoal({
@@ -693,6 +691,7 @@ export default function useGoalData({ apollo } = {}) {
 				status: GOAL_STATUS.COMPLETED
 			};
 			await storeGoalPreferences({ ...userGoal.value });
+			await setHideGoalCardPreference();
 			$kvTrackEvent(
 				category,
 				'show',

--- a/src/pages/MyKiva/MyKivaNextStepsContent.vue
+++ b/src/pages/MyKiva/MyKivaNextStepsContent.vue
@@ -38,7 +38,7 @@
 					:user-goal-achieved="userGoalAchieved"
 					:user-goal="userGoal"
 					:categories-loan-count="categoriesLoanCount"
-					:hide-goal-card="hideCompletedGoalCard"
+					:hide-goal-card="hideGoalCardInNextSteps"
 					:user-info="userInfo"
 					:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
 					:show-lending-next-steps-cards="true"
@@ -63,7 +63,7 @@
 							:user-goal-achieved="userGoalAchieved"
 							:user-goal="userGoal"
 							:categories-loan-count="categoriesLoanCount"
-							:hide-goal-card="hideCompletedGoalCard"
+							:hide-goal-card="hideGoalCardInNextSteps"
 							:user-info="userInfo"
 							:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
 							:goal-editing-enable="goalEditingEnable"
@@ -101,7 +101,7 @@
 					:pre-built-achievement-slides="sortedAchievementSlides"
 					:user-goal-achieved="userGoalAchieved"
 					:user-goal="userGoal"
-					:hide-goal-card="hideCompletedGoalCard"
+					:hide-goal-card="hideGoalCardInNextSteps"
 					:latest-loan="latestLoan"
 					:user-info="userInfo"
 					:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
@@ -518,10 +518,12 @@ const hideRecommendedForYouSection = computed(() => {
 		&& allAchievementsCompleted(props.heroTieredAchievements);
 });
 
+const hideGoalCardInNextSteps = computed(() => hideCompletedGoalCard.value || userGoalAchieved.value);
+
 // Hide the top row carousel when there is nothing to show (no active goal card,
 // no incomplete achievements, and no post-lending cards). Applies to the fully-completed superlender case.
 const topRowHasContent = computed(() => {
-	return !hideCompletedGoalCard.value
+	return !hideGoalCardInNextSteps.value
 		|| achievementSlides.value.length > 0
 		|| showPostLendingNextStepsCards.value;
 });
@@ -553,7 +555,7 @@ const nonBadgesSlides = computed(() => filterNonBadgesSlides(props.heroSlides));
 const topRowPriorityCards = computed(() => getTopRowPriorityCards({
 	showRegionExperienceInFirstRow: showRegionExperienceInFirstRow.value,
 	showPostLendingNextStepsCards: showPostLendingNextStepsCards.value,
-	hideCompletedGoalCard: hideCompletedGoalCard.value,
+	hideCompletedGoalCard: hideGoalCardInNextSteps.value,
 	shouldShowEmailMarketingCard: shouldShowEmailMarketingCard.value,
 	showLatestLoan: showLatestLoan.value,
 	showSurveyCard: showSurveyCard.value,
@@ -566,7 +568,7 @@ const topRowPriorityCards = computed(() => getTopRowPriorityCards({
 const topRowAchievementKeys = computed(() => getTopRowAchievementKeys({
 	showRegionExperienceInFirstRow: showRegionExperienceInFirstRow.value,
 	showPostLendingNextStepsCards: showPostLendingNextStepsCards.value,
-	hideCompletedGoalCard: hideCompletedGoalCard.value,
+	hideCompletedGoalCard: hideGoalCardInNextSteps.value,
 	topRowPriorityCards: topRowPriorityCards.value,
 	sortedAchievementSlides: sortedAchievementSlides.value,
 	showLendingNextStepsCards: showLendingNextStepsCards.value,

--- a/test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js
+++ b/test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js
@@ -1,0 +1,75 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import confetti from 'canvas-confetti';
+import NextYearGoalCard from '#src/components/MyKiva/NextYearGoalCard';
+import { COMPLETED_GOAL_THRESHOLD, GOAL_STATUS } from '#src/composables/useGoalData';
+import { ID_US_ECONOMIC_EQUALITY } from '#src/composables/useBadgeData';
+
+vi.mock('canvas-confetti', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({}),
+}));
+
+vi.mock('@kiva/kv-components', () => ({
+	KvButton: {
+		template: '<button><slot /></button>',
+	},
+	KvLoadingPlaceholder: {
+		template: '<div />',
+	},
+}));
+
+describe('NextYearGoalCard', () => {
+	const createGoalData = () => ({
+		getCtaHref: vi.fn(() => '/lend'),
+		getGoalDisplayName: vi.fn(() => 'US entrepreneurs'),
+		goalProgressPercentage: ref(COMPLETED_GOAL_THRESHOLD),
+		setHideGoalCardPreference: vi.fn(),
+	});
+
+	const mountCard = ({ goalData = createGoalData(), props = {} } = {}) => {
+		const wrapper = mount(NextYearGoalCard, {
+			props: {
+				userGoal: {
+					category: ID_US_ECONOMIC_EQUALITY,
+					target: 5,
+					status: GOAL_STATUS.COMPLETED,
+				},
+				goalProgress: 5,
+				loading: false,
+				hideGoalCard: false,
+				...props,
+			},
+			global: {
+				provide: {
+					goalData,
+					$kvTrackEvent: vi.fn(),
+				},
+				directives: {
+					kvTrackEvent: () => ({}),
+				},
+				stubs: {
+					GoalProgressRing: {
+						template: '<div data-testid="goal-progress-ring" />',
+					},
+				},
+			},
+		});
+		return { wrapper, goalData };
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('shows confetti when mounted with a completed visible goal', () => {
+		const { goalData } = mountCard();
+
+		expect(confetti).toHaveBeenCalledTimes(1);
+		expect(goalData.setHideGoalCardPreference).not.toHaveBeenCalled();
+	});
+});

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -1328,6 +1328,9 @@ describe('useGoalData', () => {
 
 	describe('checkCompletedGoal', () => {
 		it('should mark goal as completed and track event', async () => {
+			const {
+				updateUserPreferences,
+			} = await import('#src/util/userPreferenceUtils');
 			const currentYear = new Date().getFullYear();
 			const mockPrefs = {
 				goals: [{
@@ -1379,8 +1382,19 @@ describe('useGoalData', () => {
 				});
 
 			await composable.loadGoalData();
+			updateUserPreferences.mockClear();
 			await composable.checkCompletedGoal({ currentGoalProgress: 20 });
 
+			expect(updateUserPreferences).toHaveBeenCalledWith(
+				mockApollo,
+				expect.objectContaining({ id: 'pref-123' }),
+				expect.objectContaining({
+					goals: [
+						expect.objectContaining({ status: GOAL_STATUS.COMPLETED }),
+					],
+				}),
+				{ hideGoalCard: true },
+			);
 			expect(mockKvTrackEvent).toHaveBeenCalledWith(
 				'post-checkout',
 				'show',
@@ -1498,7 +1512,7 @@ describe('useGoalData', () => {
 			expect(composable.userGoalAchievedNow.value).toBe(false);
 		});
 
-		it('should hide an already completed current-year goal when progress is complete', async () => {
+		it('persists hide preference for completed goal without hiding it immediately', async () => {
 			const {
 				setMyKivaGoal,
 				updateUserPreferences,
@@ -1563,7 +1577,7 @@ describe('useGoalData', () => {
 				mockPrefs,
 				{ hideGoalCard: true },
 			);
-			expect(composable.hideGoalCard.value).toBe(true);
+			expect(composable.hideGoalCard.value).toBe(false);
 		});
 
 		it('should not mark completed if goal not achieved', async () => {
@@ -3509,32 +3523,6 @@ describe('useGoalData', () => {
 					fetchPolicy: 'network-only',
 				})
 			);
-		});
-
-		it('should update local hideGoalCard state after setting the preference', async () => {
-			mockApollo.query = vi.fn().mockResolvedValue({
-				data: {
-					my: {
-						userPreferences: {
-							id: 'hide-goal-id',
-							preferences: JSON.stringify({
-								goals: [{
-									goalName: 'goal-us-economic-equality-2026',
-									category: ID_US_ECONOMIC_EQUALITY,
-									target: 5,
-									status: GOAL_STATUS.COMPLETED,
-									dateStarted: '2026-04-03T18:59:12.628Z',
-								}],
-							}),
-						},
-						loans: { totalCount: 5 },
-					},
-				},
-			});
-
-			await composable.setHideGoalCardPreference(true);
-
-			expect(composable.hideGoalCard.value).toBe(true);
 		});
 	});
 

--- a/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
@@ -30,6 +30,10 @@ const MyKivaContainerStub = defineComponent({
 const JourneyCardCarouselStub = defineComponent({
 	name: 'JourneyCardCarousel',
 	props: {
+		hideGoalCard: {
+			type: Boolean,
+			default: false,
+		},
 		showLendingNextStepsCards: {
 			type: Boolean,
 			default: false,
@@ -43,24 +47,30 @@ const KvLoadingPlaceholderStub = defineComponent({
 	template: '<div class="kv-loading-placeholder-stub" />',
 });
 
-const buildGoalData = ({ loading = false } = {}) => ({
+const buildGoalData = ({
+	hideGoalCard = false,
+	loading = false,
+	userGoalAchieved = false,
+} = {}) => ({
 	checkCompletedGoal: vi.fn().mockResolvedValue(),
 	goalProgress: ref(0),
-	hideGoalCard: ref(false),
+	hideGoalCard: ref(hideGoalCard),
 	loading: ref(loading),
 	loadGoalData: vi.fn().mockResolvedValue(),
 	loadPreferences: vi.fn().mockResolvedValue(),
 	storeGoalPreferences: vi.fn().mockResolvedValue(),
 	updateCurrentGoal: vi.fn().mockResolvedValue(),
 	userGoal: ref(null),
-	userGoalAchieved: ref(false),
+	userGoalAchieved: ref(userGoalAchieved),
 });
 
 const createWrapper = ({
 	goalLoading = false,
+	hideGoalCard = false,
 	cookieValue,
 	query = {},
 	props = {},
+	userGoalAchieved = false,
 } = {}) => {
 	routeRef.value = { query };
 	const cookieStore = {
@@ -68,7 +78,7 @@ const createWrapper = ({
 		remove: vi.fn(),
 	};
 
-	const goalData = buildGoalData({ loading: goalLoading });
+	const goalData = buildGoalData({ hideGoalCard, loading: goalLoading, userGoalAchieved });
 
 	const wrapper = mount(MyKivaNextStepsContent, {
 		props: {
@@ -137,5 +147,15 @@ describe('MyKivaNextStepsContent', () => {
 		expect(carousels).toHaveLength(1);
 		expect(carousels[0].props('showLendingNextStepsCards')).toBe(false);
 		expect(cookieStore.remove).toHaveBeenCalledWith(POST_LENDING_NEXT_STEPS_COOKIE);
+	});
+
+	it('hides the goal card in next steps when the goal is achieved for this page view', () => {
+		const { wrapper } = createWrapper({
+			goalLoading: false,
+			userGoalAchieved: true,
+		});
+
+		const carousels = wrapper.findAllComponents({ name: 'JourneyCardCarousel' });
+		expect(carousels[0].props('hideGoalCard')).toBe(true);
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2824

Encountered some more interesting edge cases for the goal card on MyKiva while testing my previous PR.

Here it's ensuring the goal card appears once on MyKiva when completed, gets hidden, and doesn't have a pop-in situation on the next steps page.

Moving the setting of the hidden status to the composable is also a good consolidation of goal changing code.