### PR TITLE
fix: missing recommended loan query filters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3763,9 +3763,9 @@
 			"peer": true
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.13.0.tgz",
-			"integrity": "sha512-yKyrUHRa8AmsU0zuxDdLxjmdNnxigbnhGqkmR+VAytsXzSxdA8Yp7xoEwUoM4NZ0o7+4/Sh3vb6g9L4NUdgoOQ==",
+			"version": "8.13.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.13.1.tgz",
+			"integrity": "sha512-jBUeElSn2xEO8UlP+Ad8m3jsQnisV1rE0MlMuqrSv6osa4wczPcjlVBmZXhNl9dsV1qeWs/BdJFxMwAOsEXD+g==",
 			"bundleDependencies": [
 				"aria-hidden",
 				"embla-carousel",
@@ -32961,9 +32961,9 @@
 			"peer": true
 		},
 		"@kiva/kv-components": {
-			"version": "8.13.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.13.0.tgz",
-			"integrity": "sha512-yKyrUHRa8AmsU0zuxDdLxjmdNnxigbnhGqkmR+VAytsXzSxdA8Yp7xoEwUoM4NZ0o7+4/Sh3vb6g9L4NUdgoOQ==",
+			"version": "8.13.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.13.1.tgz",
+			"integrity": "sha512-jBUeElSn2xEO8UlP+Ad8m3jsQnisV1rE0MlMuqrSv6osa4wczPcjlVBmZXhNl9dsV1qeWs/BdJFxMwAOsEXD+g==",
 			"requires": {
 				"aria-hidden": "*",
 				"embla-carousel": "*",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
-		"@kiva/kv-components": "^8.13.0",
+		"@kiva/kv-components": "^8.13.1",
 		"@kiva/kv-shop": "^3.7.74",
 		"@kiva/kv-tokens": "^4.0.3",
 		"@mdi/js": "^7.4.47",

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -962,7 +962,7 @@ export default function useGoalData({ apollo } = {}) {
 		const filterObject = {
 			...flssFilter,
 			...(filteredLoanIds.length > 0 ? { loanIds: { none: filteredLoanIds } } : {}),
-			amountLeft: { min: MIN_CATEGORY_LOANS_AMOUNT },
+			amountLeft: { range: { gte: MIN_CATEGORY_LOANS_AMOUNT } },
 			pageLimit: RECOMMENDED_LOANS_LIMIT,
 			sortBy: 'personalized',
 		};

--- a/src/util/loanSearch/filterConfig.js
+++ b/src/util/loanSearch/filterConfig.js
@@ -1,5 +1,7 @@
 import pageOffset from '#src/util/loanSearch/filters/pageOffset';
 import pageLimit from '#src/util/loanSearch/filters/pageLimit';
+import amountLeft from '#src/util/loanSearch/filters/amountLeft';
+import loanIds from '#src/util/loanSearch/filters/loanIds';
 import genders from '#src/util/loanSearch/filters/genders';
 import isIndividual from '#src/util/loanSearch/filters/isIndividual';
 import keywordSearch from '#src/util/loanSearch/filters/keywordSearch';
@@ -71,6 +73,8 @@ const config = {
 	activities,
 	isMatchable,
 	flexibleFundraisingEnabled,
+	amountLeft,
+	loanIds,
 };
 
 /**

--- a/src/util/loanSearch/filters/amountLeft.js
+++ b/src/util/loanSearch/filters/amountLeft.js
@@ -1,0 +1,31 @@
+export default {
+	uiConfig: {
+		type: undefined,
+		hasAccordion: undefined,
+		topLine: false,
+		bottomLine: false,
+		title: undefined,
+		itemHeaderKey: undefined,
+		placeholder: undefined,
+		facetsKey: undefined,
+		stateKey: 'amountLeft',
+		eventAction: undefined,
+		allOptionsTitle: undefined,
+		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
+	},
+	getOptions: () => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: loanSearchState => ({
+		...(loanSearchState?.amountLeft && { amountLeft: loanSearchState.amountLeft })
+	}),
+	getValidatedSearchState: loanSearchState => ({
+		amountLeft: loanSearchState?.amountLeft ?? null
+	}),
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/src/util/loanSearch/filters/loanIds.js
+++ b/src/util/loanSearch/filters/loanIds.js
@@ -1,0 +1,31 @@
+export default {
+	uiConfig: {
+		type: undefined,
+		hasAccordion: undefined,
+		topLine: false,
+		bottomLine: false,
+		title: undefined,
+		itemHeaderKey: undefined,
+		placeholder: undefined,
+		facetsKey: undefined,
+		stateKey: 'loanIds',
+		eventAction: undefined,
+		allOptionsTitle: undefined,
+		valueMap: undefined,
+		isPercentage: false,
+		displayedUnit: undefined,
+	},
+	getOptions: () => ([]),
+	showSavedSearch: () => (false),
+	getFilterChips: () => ([]),
+	getRemovedFacet: () => ({}),
+	getSavedSearch: () => ({}),
+	getFlssFilter: loanSearchState => ({
+		...(loanSearchState?.loanIds && { loanIds: loanSearchState.loanIds })
+	}),
+	getValidatedSearchState: loanSearchState => ({
+		loanIds: loanSearchState?.loanIds ?? null
+	}),
+	getFilterFromQuery: () => ({}),
+	getQueryFromFilter: () => ({}),
+};

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -4146,7 +4146,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				gender: ['female'],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4176,7 +4176,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				tagId: [8, 9],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4205,7 +4205,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				sectorId: [6, 10, 20, 21],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4233,7 +4233,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				themeId: [28],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4262,7 +4262,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				countryIsoCode: ['PR', 'US'],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4290,7 +4290,7 @@ describe('useGoalData', () => {
 			await composable.getRecommendedLoans(ID_WOMENS_EQUALITY);
 
 			const filterArg = mockRunLoansQuery.mock.calls[0][1];
-			expect(filterArg).toHaveProperty('amountLeft', { min: 100 });
+			expect(filterArg).toHaveProperty('amountLeft', { range: { gte: 100 } });
 			expect(filterArg).toHaveProperty('pageLimit', 4);
 			expect(filterArg).toHaveProperty('sortBy', 'personalized');
 		});
@@ -4303,7 +4303,7 @@ describe('useGoalData', () => {
 			const filterArg = mockRunLoansQuery.mock.calls[0][1];
 			expect(filterArg).toEqual({
 				tagId: [8, 9],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			});
@@ -4362,7 +4362,7 @@ describe('useGoalData', () => {
 			await composable.getRecommendedLoans(ID_SUPPORT_ALL);
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4377,7 +4377,7 @@ describe('useGoalData', () => {
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				gender: ['female'],
 				loanIds: { none: filteredLoanIds },
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4390,7 +4390,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				tagId: [8, 9],
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');
@@ -4404,7 +4404,7 @@ describe('useGoalData', () => {
 
 			expect(mockRunLoansQuery).toHaveBeenCalledWith(mockApollo, {
 				loanIds: { none: filteredLoanIds },
-				amountLeft: { min: 100 },
+				amountLeft: { range: { gte: 100 } },
 				pageLimit: 4,
 				sortBy: 'personalized',
 			}, 'web:goal-recommended-loan');


### PR DESCRIPTION
- Update compact loan card component.
- Fix `amountLeft` and `loanIds` filters not present in the recommended loan query.

<img width="1519" height="752" alt="image" src="https://github.com/user-attachments/assets/a0dd1993-3679-4b8a-9c8a-62f8f94a36f4" />
