### PR TITLE
feat(MP-2818): remove mykiva_next_steps_redirect flag

### DIFF
--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -1,17 +1,17 @@
 <template>
 	<div
-		:class="{
-			'tw-mb-2': !showLendingNextStepsCards,
-			'next-steps-link': isNextStepsExperimentEnabled,
-			'tw-mb-8': isNextStepsExperimentEnabled && !(showPostLendingNextStepsCards && goalProgressLoading)
-				&& !showRegionExperience && !showLendingNextStepsCards
-		}"
+		:class="[
+			'next-steps-link',
+			{
+				'tw-mb-2': !showLendingNextStepsCards,
+				'tw-mb-8': !(showPostLendingNextStepsCards && goalProgressLoading)
+					&& !showRegionExperience && !showLendingNextStepsCards
+			}]"
 	>
 		<h3 class="tw-text-primary md:tw-mb-1">
 			Next steps recommended for you
 		</h3>
 		<div
-			v-if="isNextStepsExperimentEnabled"
 			class="tw-flex md:tw-gap-1 tw-cursor-pointer tw-w-16 md:tw-w-fit tw-justify-end"
 			@click="handleViewAllClick"
 		>
@@ -194,7 +194,7 @@
 			v-else-if="goalProgressLoading"
 			class="tw-flex tw-gap-2 lg:tw-gap-4 tw-w-full tw-overflow-hidden"
 			:class="{
-				'tw--mt-6': isNextStepsExperimentEnabled && !showPostLendingNextStepsCards
+				'tw--mt-6': !showPostLendingNextStepsCards
 					&& !showLendingNextStepsCards,
 				'tw-mt-1.5': showLendingNextStepsCards
 			}"
@@ -205,8 +205,7 @@
 		</div>
 		<JourneyCardCarousel
 			v-else
-			class="carousel tw--mt-6"
-			:class="{'carousel-spacing': isNextStepsExperimentEnabled}"
+			class="carousel carousel-spacing tw--mt-6"
 			user-in-homepage
 			in-lending-stats
 			controls-top-right
@@ -340,11 +339,6 @@ export default {
 			type: Object,
 			default: () => ({}),
 		},
-		nextStepsExperimentVariant: {
-			type: String,
-			default: 'a',
-			validator: value => ['a', 'b'].includes(value)
-		},
 		goalEditingEnable: {
 			type: Boolean,
 			default: false
@@ -419,9 +413,6 @@ export default {
 		categoriesLoanCount() {
 			const { getAllCategoryLoanCounts } = useBadgeData();
 			return getAllCategoryLoanCounts(this.heroTieredAchievements);
-		},
-		isNextStepsExperimentEnabled() {
-			return this.nextStepsExperimentVariant === 'b';
 		},
 		showLendingNextStepsCards() {
 			return this.lendingNextStepsVariant === 'b' && !this.showPostLendingNextStepsCards;

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -34,7 +34,6 @@
 			:latest-loan="latestLoan"
 			:goal-refresh-key="goalRefreshKey"
 			:show-my-giving-funds-card="showMyGivingFundsCard"
-			:next-steps-experiment-variant="nextStepsExperimentVariant"
 			:goal-editing-enable="goalEditingEnable"
 			:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 			:lending-next-steps-variant="lendingNextStepsExperimentVariant"
@@ -68,7 +67,6 @@ import useBadgeData, {
 import { inject, provide } from 'vue';
 
 const CURRENT_YEAR = new Date().getFullYear();
-const NEXT_STEPS_REDIRECT_EXP_KEY = 'mykiva_next_steps_redirect';
 const GOAL_EDITING_KEY = 'goal_editing_enable';
 const GOAL_TILE_EXPERIMENT_KEY = 'mykiva_goal_tile';
 const LENDING_NEXT_STEPS_EXP_KEY = 'mykiva_lending_next_steps';
@@ -118,7 +116,6 @@ export default {
 			latestLoan: null,
 			goalRefreshKey: 0,
 			showMyGivingFundsCard: false,
-			nextStepsExperimentVariant: null,
 			goalEditingEnable: false,
 			recentTransactionLoans: [],
 			isGoalTileExperimentEnabled: false,
@@ -197,10 +194,6 @@ export default {
 				client.query({
 					query: contentfulEntriesQuery,
 					variables: { contentType: 'challenge', limit: 200 }
-				}),
-				client.query({
-					query: experimentAssignmentQuery,
-					variables: { id: NEXT_STEPS_REDIRECT_EXP_KEY },
 				}),
 				client.query({
 					query: experimentAssignmentQuery,
@@ -348,18 +341,6 @@ export default {
 		} catch (e) {
 			logReadQueryError(e, 'MyKivaPage created');
 		}
-
-		initializeExperiment(
-			this.cookieStore,
-			this.apollo,
-			this.$route,
-			NEXT_STEPS_REDIRECT_EXP_KEY,
-			version => {
-				this.nextStepsExperimentVariant = version;
-			},
-			this.$kvTrackEvent,
-			'EXP-MP-2417-Feb2026'
-		);
 
 		initializeExperiment(
 			this.cookieStore,

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -31,7 +31,6 @@
 				:latest-loan="latestLoan"
 				:goal-refresh-key="goalRefreshKey"
 				:user-info="userInfo"
-				:next-steps-experiment-variant="nextStepsExperimentVariant"
 				:goal-editing-enable="goalEditingEnable"
 				:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 				:lending-next-steps-variant="lendingNextStepsVariant"
@@ -315,11 +314,6 @@ export default {
 		showMyGivingFundsCard: {
 			type: Boolean,
 			default: false
-		},
-		nextStepsExperimentVariant: {
-			type: String,
-			default: 'a',
-			validator: value => ['a', 'b'].includes(value)
 		},
 		goalEditingEnable: {
 			type: Boolean,

--- a/test/unit/specs/components/MyKiva/LendingStats.spec.js
+++ b/test/unit/specs/components/MyKiva/LendingStats.spec.js
@@ -82,4 +82,50 @@ describe('LendingStats', () => {
 			expect(context.loadGoalData).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe('handleViewAllClick', () => {
+		it('tracks the event and navigates to /mykiva/next-steps', () => {
+			const push = vi.fn();
+			const context = {
+				$kvTrackEvent: vi.fn(),
+				$router: { push },
+				showPostLendingNextStepsCards: false,
+			};
+
+			LendingStats.methods.handleViewAllClick.call(context);
+
+			expect(context.$kvTrackEvent).toHaveBeenCalledWith('portfolio', 'click', 'view-all-next-steps');
+			expect(push).toHaveBeenCalledWith('/mykiva/next-steps');
+		});
+
+		it('appends ?postLending=true when showPostLendingNextStepsCards is true', () => {
+			const push = vi.fn();
+			const context = {
+				$kvTrackEvent: vi.fn(),
+				$router: { push },
+				showPostLendingNextStepsCards: true,
+			};
+
+			LendingStats.methods.handleViewAllClick.call(context);
+
+			expect(push).toHaveBeenCalledWith('/mykiva/next-steps?postLending=true');
+		});
+	});
+
+	describe('showLendingNextStepsCards', () => {
+		it('returns true when lendingNextStepsVariant is "b" and showPostLendingNextStepsCards is false', () => {
+			const context = { lendingNextStepsVariant: 'b', showPostLendingNextStepsCards: false };
+			expect(LendingStats.computed.showLendingNextStepsCards.call(context)).toBe(true);
+		});
+
+		it('returns false when lendingNextStepsVariant is not "b"', () => {
+			const context = { lendingNextStepsVariant: 'a', showPostLendingNextStepsCards: false };
+			expect(LendingStats.computed.showLendingNextStepsCards.call(context)).toBe(false);
+		});
+
+		it('returns false when showPostLendingNextStepsCards is true even with variant "b"', () => {
+			const context = { lendingNextStepsVariant: 'b', showPostLendingNextStepsCards: true };
+			expect(LendingStats.computed.showLendingNextStepsCards.call(context)).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
- Remove NEXT_STEPS_REDIRECT_EXP_KEY constant and experiment assignment query from MyKivaPage
- Remove nextStepsExperimentVariant prop from MyKivaPageContent and LendingStats
- Make next steps section permanently visible (variant 'b' becomes default behavior)
- Simplify LendingStats template by removing isNextStepsExperimentEnabled computed property
- Update tests: add coverage for handleViewAllClick navigation and showLendingNextStepsCards logic
- All tests passing (28/28)
- https://kiva.atlassian.net/browse/MP-2818