### PR TITLE
feat: [MP-2744] - integrate recommended loan experience after set a goal on goal setting page

### DIFF
--- a/.storybook/stories/RecommendLoanForGoalContainer.stories.js
+++ b/.storybook/stories/RecommendLoanForGoalContainer.stories.js
@@ -30,6 +30,7 @@ export default {
 		expressCheckoutEnabled: { control: 'boolean' },
 		isAdding: { control: 'boolean' },
 		isInBasket: { control: 'boolean' },
+		loadedSetData: { control: 'boolean' },
 		footerProps: { control: 'object' },
 	},
 };
@@ -42,6 +43,7 @@ const story = (overrides = {}) => {
 		expressCheckoutEnabled: false,
 		isAdding: false,
 		isInBasket: false,
+		loadedSetData: true,
 		footerProps: {},
 		...overrides,
 	};
@@ -81,4 +83,8 @@ export const AddingToBasket = story({
 
 export const CheckoutReady = story({
 	isInBasket: true,
+});
+
+export const Loading = story({
+	loadedSetData: false,
 });

--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -431,8 +431,9 @@ const setGoal = async preferences => {
 	} catch (e) {
 		logFormatter('GoalSettingContainer: failed to setting up this goal', 'error', { error: e });
 		$showTipMsg('There was a problem setting up this goal', 'error');
+	} finally {
+		loading.value = false;
 	}
-	loading.value = false;
 };
 
 const handleCategorySelected = categoryId => {

--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -345,8 +345,9 @@ const categories = getCategories(props.categoriesLoanCount, props.totalLoans);
 
 const selectedCategory = ref(categories[0]);
 
-// Composable for recommended loan state (shared logic with GoalSettingModal)
-const showPage = ref(true);
+// This container doesn't have the same multi-step flow as the modal,
+// so we can always show the recommended loan section when enabled
+const showPage = true;
 const loadedSetData = ref(false);
 const {
 	showRecommendLoanAfterGoalView,

--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -45,7 +45,21 @@
 			style="max-width: 644px; min-height: 495px;"
 		/>
 		<template v-else>
+			<RecommendLoanForGoalContainer
+				v-if="showRecommendLoanAfterGoalView"
+				class="tw-mx-auto"
+				style="max-width: 700px;"
+				header-title="Goal set!"
+				:header-details="recommendLoanHeaderDetails"
+				:content-card-props="recommendLoanCardProps"
+				:is-adding="isAdding"
+				:is-in-basket="recommendLoanIsInBasket"
+				:loaded-set-data="loadedSetData"
+				@primary-cta-click="addToBasket"
+				@secondary-cta-click="handleExploreMoreLoans"
+			/>
 			<div
+				v-else
 				class="tw-mx-auto"
 				style="max-width: 644px;"
 			>
@@ -150,7 +164,11 @@ import {
 	KvUtilityMenu
 } from '@kiva/kv-components';
 import GoalSelector from '#src/components/MyKiva/GoalSetting/GoalSelector';
+import RecommendLoanForGoalContainer from
+	'#src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContainer';
 import useGoalData, { GOAL_STATUS } from '#src/composables/useGoalData';
+import useGoalSettingRecommendedLoan from
+	'#src/composables/useGoalSettingRecommendedLoan';
 import { buildEmailFlowGoalData } from '#src/util/goalEmailFlow';
 import logFormatter from '#src/util/logFormatter';
 import {
@@ -165,6 +183,7 @@ import useTipMessage from '#src/composables/useTipMessage';
 
 const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');
+const $appConfig = inject('$appConfig', {});
 const router = useRouter();
 
 const { $showTipMsg } = useTipMessage(apollo);
@@ -182,6 +201,7 @@ const {
 	removeGoalFromPreferences,
 	updateCurrentGoal,
 	userGoalAchieved,
+	getRecommendedLoans,
 } = useGoalData({ apollo });
 
 const props = defineProps({
@@ -230,7 +250,23 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	/**
+	 * Array of basket items for recommended loan exclusion and in-basket checks
+	 */
+	basketItems: {
+		type: Array,
+		default: () => ([]),
+	},
+	/**
+	 * True while add-to-basket mutation is in flight (provided by parent mixin)
+	 */
+	isAdding: {
+		type: Boolean,
+		default: false,
+	},
 });
+
+const emit = defineEmits(['add-to-basket']);
 
 const isGoalSet = ref(false);
 // Variable used to create/update the goal target based on user selection
@@ -306,6 +342,37 @@ const categories = getCategories(props.categoriesLoanCount, props.totalLoans);
 
 const selectedCategory = ref(categories[0]);
 
+// Composable for recommended loan state (shared logic with GoalSettingModal)
+const showPage = ref(true);
+const loadedSetData = ref(false);
+const {
+	showRecommendLoanAfterGoalView,
+	recommendLoanHeaderDetails,
+	recommendLoanCardProps,
+	recommendLoanIsInBasket,
+	enterRecommendedLoanStepAfterGoalSave,
+	handleExploreMoreLoans,
+} = useGoalSettingRecommendedLoan({
+	emit: () => {},
+	props,
+	selectedGoalNumber: goalSelectorLoanTarget,
+	selectedCategory,
+	show: showPage,
+	goalProgress,
+	getRecommendedLoans,
+	getCtaHref,
+	userGoal,
+	kvTrackEvent: $kvTrackEvent,
+	appConfig: $appConfig,
+});
+
+const addToBasket = () => {
+	const { loanId } = recommendLoanCardProps.value;
+	if (!loanId) return;
+	// Delegate to parent (GoalSetting.vue) which uses borrower-profile-exp-mixin
+	emit('add-to-basket', { loanId, lendAmount: 25 });
+};
+
 const contentComponent = computed(() => {
 	switch (formStep.value) {
 		case 2: return NumberChoice;
@@ -350,9 +417,13 @@ const updateGoal = async preferences => {
 };
 
 const setGoal = async preferences => {
+	loading.value = true;
 	try {
 		await storeGoalPreferences(preferences);
 		await recalculateGoalInformation();
+		enterRecommendedLoanStepAfterGoalSave();
+		loadedSetData.value = true;
+		loading.value = false;
 	} catch (e) {
 		logFormatter('GoalSettingContainer: failed to setting up this goal', 'error', { error: e });
 		$showTipMsg('There was a problem setting up this goal', 'error');
@@ -456,6 +527,7 @@ async function handleEmailFlow() {
 				category,
 				validEmailTarget.value
 			);
+			enterRecommendedLoanStepAfterGoalSave();
 		} catch (e) {
 			logFormatter('GoalSettingContainer: failed to store email goal', 'error', { error: e });
 			$showTipMsg('There was a problem setting up this goal', 'error');

--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -150,6 +150,7 @@
 <script setup>
 import {
 	ref,
+	toRef,
 	inject,
 	onMounted,
 	computed,
@@ -356,7 +357,8 @@ const {
 	handleExploreMoreLoans,
 } = useGoalSettingRecommendedLoan({
 	emit: () => {},
-	props,
+	goalRecommendedLoanEnable: toRef(props, 'goalRecommendedLoanEnable'),
+	basketItems: toRef(props, 'basketItems'),
 	selectedGoalNumber: goalSelectorLoanTarget,
 	selectedCategory,
 	show: showPage,
@@ -426,11 +428,11 @@ const setGoal = async preferences => {
 		await recalculateGoalInformation();
 		enterRecommendedLoanStepAfterGoalSave();
 		loadedSetData.value = true;
-		loading.value = false;
 	} catch (e) {
 		logFormatter('GoalSettingContainer: failed to setting up this goal', 'error', { error: e });
 		$showTipMsg('There was a problem setting up this goal', 'error');
 	}
+	loading.value = false;
 };
 
 const handleCategorySelected = categoryId => {

--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -47,6 +47,7 @@
 		<template v-else>
 			<RecommendLoanForGoalContainer
 				v-if="showRecommendLoanAfterGoalView"
+				ref="recommendLoanForGoalRef"
 				class="tw-mx-auto"
 				style="max-width: 700px;"
 				header-title="Goal set!"
@@ -125,7 +126,7 @@
 		<!-- Goal Actions modal -->
 		<KvLightbox
 			:visible="isDeleteGoalModalVisible"
-			title="Delete your 2026 impact goal?"
+			:title="`Delete your ${GOALS_CURRENT_YEAR} impact goal?`"
 			@lightbox-closed="handleKeepGoal"
 		>
 			<!-- eslint-disable-next-line max-len -->
@@ -166,7 +167,7 @@ import {
 import GoalSelector from '#src/components/MyKiva/GoalSetting/GoalSelector';
 import RecommendLoanForGoalContainer from
 	'#src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContainer';
-import useGoalData, { GOAL_STATUS } from '#src/composables/useGoalData';
+import useGoalData, { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
 import useGoalSettingRecommendedLoan from
 	'#src/composables/useGoalSettingRecommendedLoan';
 import { buildEmailFlowGoalData } from '#src/util/goalEmailFlow';
@@ -282,6 +283,7 @@ const isDeleting = ref(false);
 const fetchedCurrentYearLoans = ref(0);
 // This loading state is specifically for goal options
 const loadingCurrentYear = ref(false);
+const recommendLoanForGoalRef = ref(null);
 
 // Email flow — set during creation so the loading placeholder renders on the first tick
 const emailLoading = ref(props.emailTarget != null);
@@ -369,8 +371,9 @@ const {
 const addToBasket = () => {
 	const { loanId } = recommendLoanCardProps.value;
 	if (!loanId) return;
+	const lendAmount = recommendLoanForGoalRef.value?.getSelectedAmount();
 	// Delegate to parent (GoalSetting.vue) which uses borrower-profile-exp-mixin
-	emit('add-to-basket', { loanId, lendAmount: 25 });
+	emit('add-to-basket', { loanId, lendAmount });
 };
 
 const contentComponent = computed(() => {

--- a/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContainer.vue
+++ b/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContainer.vue
@@ -6,6 +6,7 @@
 			:loaded-set-data="loadedSetData"
 		/>
 		<RecommendLoanForGoalContent
+			ref="recommendLoanForGoalContentRef"
 			:heading="contentHeading"
 			v-bind="contentCardProps"
 			:is-adding="isAdding"
@@ -26,6 +27,7 @@
 </template>
 
 <script setup>
+import { ref } from 'vue';
 import RecommendLoanForGoalContent from '#src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContent';
 import RecommendLoanForGoalFooter from '#src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalFooter';
 import RecommendLoanForGoalHeader from '#src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalHeader';
@@ -93,4 +95,12 @@ defineEmits([
 	'checkout-click',
 	'secondary-cta-click',
 ]);
+
+const recommendLoanForGoalContentRef = ref(null);
+
+// Bridge the inner content's selected lend amount so parents using the
+// container (not the content directly) can still read what the user picked.
+defineExpose({
+	getSelectedAmount: () => recommendLoanForGoalContentRef.value?.getSelectedAmount(),
+});
 </script>

--- a/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContainer.vue
+++ b/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalContainer.vue
@@ -3,6 +3,7 @@
 		<RecommendLoanForGoalHeader
 			:title="headerTitle"
 			:details="headerDetails"
+			:loaded-set-data="loadedSetData"
 		/>
 		<RecommendLoanForGoalContent
 			:heading="contentHeading"
@@ -73,6 +74,13 @@ defineProps({
 	isInBasket: {
 		type: Boolean,
 		default: false,
+	},
+	/**
+	 * Whether goal/loan data has finished loading; controls header loading placeholder.
+	 */
+	loadedSetData: {
+		type: Boolean,
+		default: true,
 	},
 });
 

--- a/src/components/MyKiva/GoalSettingModal.vue
+++ b/src/components/MyKiva/GoalSettingModal.vue
@@ -409,7 +409,9 @@ const props = defineProps({
 	},
 });
 
-const { numberOfLoans, isGoalSet, show } = toRefs(props);
+const {
+	numberOfLoans, isGoalSet, show, goalRecommendedLoanEnable, basketItems,
+} = toRefs(props);
 
 const formStep = ref(1);
 const showCategories = ref(false);
@@ -440,7 +442,8 @@ const {
 	onAddToBasketError,
 } = useGoalSettingRecommendedLoan({
 	emit,
-	props,
+	goalRecommendedLoanEnable,
+	basketItems,
 	selectedGoalNumber,
 	selectedCategory,
 	show,

--- a/src/composables/useGoalSettingRecommendedLoan.js
+++ b/src/composables/useGoalSettingRecommendedLoan.js
@@ -1,27 +1,25 @@
 import {
 	computed,
 	ref,
-	toRef,
 	watch,
 } from 'vue';
 import { useRouter } from 'vue-router';
 import useTipMessage from '#src/composables/useTipMessage';
 
 /**
- * Recommended-loan step state for {@link GoalSettingModal.vue}.
+ * Recommended-loan step state shared by {@link GoalSettingModal.vue} and
+ * {@link GoalSettingContainer.vue}.
  *
- * The modal owns refs and passes them in; this composable does not call `defineProps` itself.
+ * The host component owns refs and passes them in; this composable does not call `defineProps`.
  *
  * @param {object} options
- * @param {Function} options.emit — Modal emit function (`defineEmits`), e.g. `set-goal`.
- * @param {object} options.props — GoalSettingModal’s full `defineProps` object; this composable only
- *   reads two keys via `toRef` (pass the same reactive reference the modal uses).
- *   - **`goalRecommendedLoanEnable`** (`boolean`): feature flag; when false the recommend-loan step
- *     and related fetch never activate.
- *   - **`basketItems`** (`Array`): shop/basket line items; each entry’s **`id`** is passed to
- *     `getRecommendedLoans` as exclusions (`loanIds.none`). Same array is forwarded on loan card
- *     props. Entries may include GraphQL fields such as **`__typename`** (e.g. `LoanReservation`) for
- *     “recommended loan already in basket” checks.
+ * @param {Function} options.emit — Host emit function (`defineEmits`), e.g. `set-goal`.
+ * @param {object} options.goalRecommendedLoanEnable — Vue ref; `.value` is the feature-flag boolean.
+ *   When false the recommend-loan step and related fetch never activate.
+ * @param {object} options.basketItems — Vue ref; `.value` is the shop/basket line items array.
+ *   `LoanReservation` entries’ **`id`** (the loan id) are sent to `getRecommendedLoans` as
+ *   exclusions (`loanIds.none`) and drive the “recommended loan already in basket” check via
+ *   **`__typename`**. The array is also forwarded on the loan card props.
  * @param {object} options.selectedGoalNumber — Vue ref from the modal; `.value` is goal target (loan count).
  * @param {object} options.selectedCategory — Vue ref from the modal; `.value` has `name`, `badgeId`.
  * @param {object} options.show — Vue ref from the modal; `.value` is whether the lightbox is open.
@@ -35,7 +33,8 @@ import useTipMessage from '#src/composables/useTipMessage';
  */
 export default function useGoalSettingRecommendedLoan({
 	emit,
-	props,
+	goalRecommendedLoanEnable,
+	basketItems,
 	selectedGoalNumber,
 	selectedCategory,
 	show,
@@ -50,15 +49,13 @@ export default function useGoalSettingRecommendedLoan({
 	const router = useRouter();
 	const { $showTipMsg } = useTipMessage(apollo);
 
-	const basketItems = toRef(props, 'basketItems');
-
 	const showPostGoalLoanRecommendation = ref(false);
 	const recommendedLoans = ref([]);
 	const recommendedLoanIndex = ref(0);
 	const recommendedLoan = ref(null);
 
 	const showRecommendLoanAfterGoalView = computed(() => (
-		props.goalRecommendedLoanEnable && showPostGoalLoanRecommendation.value
+		goalRecommendedLoanEnable.value && showPostGoalLoanRecommendation.value
 	));
 
 	const recommendLoanHeaderDetails = computed(() => {
@@ -115,7 +112,7 @@ export default function useGoalSettingRecommendedLoan({
 	};
 
 	const enterRecommendedLoanStepAfterGoalSave = () => {
-		if (props.goalRecommendedLoanEnable) {
+		if (goalRecommendedLoanEnable.value) {
 			showPostGoalLoanRecommendation.value = true;
 		}
 	};
@@ -139,7 +136,12 @@ export default function useGoalSettingRecommendedLoan({
 	};
 
 	const filteredLoanIds = computed(() => {
-		return basketItems.value?.map(item => item.id) ?? [];
+		// Only LoanReservation entries carry a loan id; other basket item types
+		// (donations, Kiva Cards, etc.) must not be sent as loan exclusions.
+		return (basketItems.value ?? [])
+			// eslint-disable-next-line no-underscore-dangle
+			.filter(item => item.__typename === 'LoanReservation')
+			.map(item => item.id);
 	});
 
 	watch(show, visible => {

--- a/src/pages/GoalSetting.vue
+++ b/src/pages/GoalSetting.vue
@@ -88,7 +88,9 @@ export default {
 
 		// Get feature flag for goal recommended loan
 		this.goalRecommendedLoanEnable = readBoolSetting(goalSettingPageResult, 'general.goal_recommended_loan_enable.value') ?? false; // eslint-disable-line max-len
-		await this.loadInitialBasketItems();
+		if (this.goalRecommendedLoanEnable) {
+			await this.loadInitialBasketItems();
+		}
 
 		// Fetch tiered achievements - try cache first, then network
 		const achievementsResult = this.apollo.readQuery({

--- a/src/pages/GoalSetting.vue
+++ b/src/pages/GoalSetting.vue
@@ -8,6 +8,9 @@
 				:email-target="$route.query.target || null"
 				:email-category="$route.query.category || null"
 				:goal-recommended-loan-enable="goalRecommendedLoanEnable"
+				:basket-items="basketItems"
+				:is-adding="isAdding"
+				@add-to-basket="addToBasket"
 			/>
 		</KvPageContainer>
 	</WwwPage>
@@ -24,10 +27,12 @@ import WwwPage from '#src/components/WwwFrame/WwwPage';
 import GoalSettingContainer from '#src/components/GoalSetting/GoalSettingContainer';
 import { LAST_YEAR_KEY } from '#src/composables/useGoalData';
 import { readBoolSetting } from '#src/util/settingsUtils';
+import borrowerProfileExpMixin from '#src/plugins/borrower-profile-exp-mixin';
 
 export default {
 	name: 'GoalSetting',
 	inject: ['apollo', 'cookieStore'],
+	mixins: [borrowerProfileExpMixin],
 	components: {
 		WwwPage,
 		KvPageContainer,
@@ -83,6 +88,7 @@ export default {
 
 		// Get feature flag for goal recommended loan
 		this.goalRecommendedLoanEnable = readBoolSetting(goalSettingPageResult, 'general.goal_recommended_loan_enable.value') ?? false; // eslint-disable-line max-len
+		await this.loadInitialBasketItems();
 
 		// Fetch tiered achievements - try cache first, then network
 		const achievementsResult = this.apollo.readQuery({

--- a/test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js
+++ b/test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js
@@ -1,5 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies -- devDependency used only in tests */
-import { createApp, reactive, ref } from 'vue';
+import {
+	createApp, reactive, ref, toRef,
+} from 'vue';
 import { flushPromises } from '@vue/test-utils';
 import useGoalSettingRecommendedLoan from '#src/composables/useGoalSettingRecommendedLoan';
 
@@ -48,7 +50,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			setup() {
 				composable = useGoalSettingRecommendedLoan({
 					emit,
-					props,
+					goalRecommendedLoanEnable: toRef(props, 'goalRecommendedLoanEnable'),
+					basketItems: toRef(props, 'basketItems'),
 					selectedGoalNumber,
 					selectedCategory,
 					show,
@@ -275,12 +278,27 @@ describe('useGoalSettingRecommendedLoan', () => {
 
 		it('should pass basket item ids as filteredLoanIds to getRecommendedLoans', async () => {
 			props.goalRecommendedLoanEnable = true;
-			props.basketItems = [{ id: 900 }, { id: 901 }];
+			props.basketItems = [
+				{ __typename: 'LoanReservation', id: 900 },
+				{ __typename: 'LoanReservation', id: 901 },
+			];
 			composable.enterRecommendedLoanStepAfterGoalSave();
 			getRecommendedLoans.mockResolvedValue([{ id: 2, name: 'Next' }]);
 			await flushPromises();
 			expect(getRecommendedLoans).toHaveBeenCalledWith('women-badge', [900, 901]);
 			expect(composable.recommendLoanCardProps.value.loanId).toBe(2);
+		});
+
+		it('should exclude non-LoanReservation basket items from filteredLoanIds', async () => {
+			props.goalRecommendedLoanEnable = true;
+			props.basketItems = [
+				{ __typename: 'LoanReservation', id: 900 },
+				{ __typename: 'Donation', id: 901 },
+			];
+			composable.enterRecommendedLoanStepAfterGoalSave();
+			getRecommendedLoans.mockResolvedValue([{ id: 2, name: 'Next' }]);
+			await flushPromises();
+			expect(getRecommendedLoans).toHaveBeenCalledWith('women-badge', [900]);
 		});
 
 		it('should set recommendedLoan to null when fetch returns empty', async () => {


### PR DESCRIPTION
# MP-2744

## Summary

updates the Goals page so that after a lender sets a goal, they see the new "start your goal" experience instead of the current confirmation page; adding a new storybook

https://kiva.atlassian.net/browse/MP-2744

## Evidences

https://github.com/user-attachments/assets/f58c308a-6e69-41e3-bd33-f3fc9ccbea2b
