### PR TITLE
feat: loans-beta updated as of timestamp

### DIFF
--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -89,6 +89,7 @@ export default {
 		KvLoadingPlaceholder
 	},
 	inject: ['apollo', 'cookieStore'],
+	emits: ['updated-as-of'],
 	data() {
 		return {
 			stats: {},
@@ -161,6 +162,7 @@ export default {
 		query: lendingStatsQuery,
 		result({ data }) {
 			this.stats = data?.my?.userStats ?? {};
+			this.$emit('updated-as-of', data?.general?.kivaStats?.avgLenderStatsUpdatedAt ?? null);
 			this.avgStats = {
 				amount_repaid: data?.general?.kivaStats?.avgAmountRepaid ?? null,
 				amount_in_arrears: data?.general?.kivaStats?.avgAmountArrears ?? null,

--- a/src/graphql/query/myPortfolioLoansLendingStats.graphql
+++ b/src/graphql/query/myPortfolioLoansLendingStats.graphql
@@ -33,6 +33,7 @@ query myPortfolioLoansLendingStats {
 			avgAmountOutstanding
 			avgDefaultRate
 			avgAmountDefaulted
+			avgLenderStatsUpdatedAt
 		}
 	}
 }

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -14,10 +14,10 @@
 						My loans
 					</h1>
 					<div class="tw-mb-2">
-						<p class="tw-text-right tw-text-tertiary tw-text-small">
+						<p v-if="lastUpdated" class="tw-text-right tw-text-tertiary tw-text-small">
 							*Updated as of {{ lastUpdated }}
 						</p>
-						<loan-stats-table />
+						<loan-stats-table @updated-as-of="handleUpdatedAsOf" />
 					</div>
 				</div>
 				<div
@@ -83,7 +83,7 @@ export default {
 	},
 	data() {
 		return {
-			lastUpdated: '(Endpoint TBD)',
+			lastUpdated: '',
 			loans: [],
 			totalLoans: 0,
 			loading: true,
@@ -187,6 +187,28 @@ export default {
 			};
 			this.scrollToLoanTable();
 			return this.fetchLoans({ clearLoans: true });
+		},
+		handleUpdatedAsOf(iso) {
+			if (!iso) {
+				this.lastUpdated = '';
+				return;
+			}
+			const d = new Date(iso);
+			if (Number.isNaN(d.getTime())) {
+				this.lastUpdated = '';
+				return;
+			}
+			const datePart = d.toLocaleDateString('en-US', {
+				month: 'short',
+				day: 'numeric',
+				year: 'numeric',
+			});
+			const timePart = d.toLocaleTimeString('en-US', {
+				hour: '2-digit',
+				minute: '2-digit',
+				hour12: true,
+			}).toLowerCase();
+			this.lastUpdated = `${datePart} ${timePart}`;
 		},
 		handleFiltersChanged({ filters = {}, keywordSearch = null }) {
 			this.loanState = {

--- a/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
@@ -69,7 +69,27 @@ const renderLoansPage = ({ apollo = null, router = null } = {}) => {
 					ThePortfolioTertiaryMenu: { template: '<div />' },
 					KvPageContainer: { template: '<div><slot /></div>' },
 					KvGrid: { template: '<div><slot /></div>' },
-					LoanStatsTable: { template: '<div />' },
+					LoanStatsTable: {
+						emits: ['updated-as-of'],
+						template: `
+							<div>
+								<button
+									type="button"
+									data-testid="emit-updated-as-of"
+									@click="$emit('updated-as-of', '2026-05-19T21:30:00.000Z')"
+								>
+									emit
+								</button>
+								<button
+									type="button"
+									data-testid="emit-null-updated-as-of"
+									@click="$emit('updated-as-of', null)"
+								>
+									emit null
+								</button>
+							</div>
+						`,
+					},
 					LoanList: {
 						props: ['loans', 'loading'],
 						template: `
@@ -321,6 +341,27 @@ describe('LoansPage', () => {
 
 		expect(page.getByTestId('loan-list').textContent).toContain('loading:true loans:');
 		expect(page.getByTestId('loan-list').textContent).not.toContain('101');
+	});
+
+	it('hides the "Updated as of" line until the stats table emits a timestamp', async () => {
+		const page = renderLoansPage();
+
+		expect(page.queryByText(/Updated as of/)).toBeNull();
+
+		await fireEvent.click(page.getByTestId('emit-updated-as-of'));
+
+		await waitFor(() => expect(page.queryByText(/Updated as of/)).not.toBeNull());
+		expect(page.queryByText(/Updated as of/).textContent).toContain('2026');
+	});
+
+	it('hides the "Updated as of" line when the stats table emits null', async () => {
+		const page = renderLoansPage();
+
+		await fireEvent.click(page.getByTestId('emit-updated-as-of'));
+		await waitFor(() => expect(page.queryByText(/Updated as of/)).not.toBeNull());
+
+		await fireEvent.click(page.getByTestId('emit-null-updated-as-of'));
+		await waitFor(() => expect(page.queryByText(/Updated as of/)).toBeNull());
 	});
 
 	it('disables pagination while the next page is loading', async () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2721

Connected to new API data for loans-beta updated at timestamp.

<img width="831" height="642" alt="image" src="https://github.com/user-attachments/assets/ecd0e2fc-2a5b-4cc0-881c-9f0b516fa548" />
