### PR TITLE
feat: utilize new My Teams page at standard teams/my-teams route [CP-2628]

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -171,6 +171,13 @@ export default [
 		component: () => import('#src/pages/LendingTeams/LendingTeams')
 	},
 	{
+		path: '/teams/my-teams',
+		component: () => import('#src/pages/LendingTeams/MyTeamsPage'),
+		meta: {
+			authenticationRequired: true,
+		}
+	},
+	{
 		path: '/teams/my-teams-beta',
 		component: () => import('#src/pages/LendingTeams/MyTeamsPage'),
 		meta: {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -179,11 +179,7 @@ export default [
 	},
 	{
 		path: '/teams/my-teams-beta',
-		component: () => import('#src/pages/LendingTeams/MyTeamsPage'),
-		meta: {
-			authenticationRequired: true,
-			excludeFromStaticSitemap: true,
-		}
+		redirect: '/teams/my-teams'
 	},
 	{
 		path: '/lend-by-category/loans-to-women',


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CP-2628

In coordination with CS, we sent out the teams/my-teams-beta page to team captains and gathered feedback. Feedback was generally positive, so we are now ready to roll out this in non-beta form in production!

Once this route update releases, we'll follow up with Flux ingress updates as well.