### PR TITLE
build(dependabot): group related dependencies AD-255

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,90 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "13:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: vue-instantsearch
-    versions:
-    - ">= 2.7.a"
-  - dependency-name: vue-svg-loader
-    versions:
-    - ">= 0.15.0"
-  # clipboard-copy v4 drops IE11 support
-  - dependency-name: clipboard-copy
-    versions:
-    - ">= 3.2.0"
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    open-pull-requests-limit: 10
+    groups:
+      kiva-internal:
+        patterns:
+          - "@kiva/*"
+      cypress:
+        patterns:
+          - "cypress"
+          - "cypress-*"
+          - "@testing-library/cypress"
+          - "eslint-plugin-cypress"
+      testing-library:
+        patterns:
+          - "@testing-library/*"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      opentelemetry:
+        patterns:
+          - "@opentelemetry/*"
+      babel:
+        patterns:
+          - "@babel/*"
+          - "babel-*"
+      apollo-and-graphql:
+        patterns:
+          - "@apollo/*"
+          - "apollo-*"
+          - "apollo3-*"
+          - "graphql"
+          - "graphql-tag"
+          - "@graphql-tools/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+      stylelint:
+        patterns:
+          - "stylelint"
+          - "stylelint-*"
+      postcss-and-tailwind:
+        patterns:
+          - "tailwindcss"
+          - "postcss"
+          - "postcss-*"
+          - "autoprefixer"
+          - "cssnano"
+      vue:
+        patterns:
+          - "vue"
+          - "vue-*"
+          - "@vue/*"
+          - "vuelidate"
+          - "@vuelidate/*"
+      vite-and-vitest:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+          - "vitest"
+          - "@vitest/*"
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+      minor-patch-other:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: vue-instantsearch
+        versions:
+          - ">= 2.7.a"
+      - dependency-name: vue-svg-loader
+        versions:
+          - ">= 0.15.0"
+      # clipboard-copy v4 drops IE11 support
+      - dependency-name: clipboard-copy
+        versions:
+          - ">= 3.2.0"


### PR DESCRIPTION
This groups related dependency updates to reduce dependabot PR noise and simplify ecosystem updates. This includes a catch-all group for minor and patch updates that aren't placed in another group first. My hope is that this will unclog the backlog of updates and make it easier to review updates going forward.

Related to https://github.com/kiva/cms-page-server/pull/3000

https://kiva.atlassian.net/browse/AD-255