### PR TITLE
feat: mp-2821-fixing the apply credit at checkout

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -224,7 +224,8 @@ export default {
 		appliedPromoCredits() {
 			if (this.creditsUsed.length) {
 				const appliedCredits = this.creditsUsed.filter(credit => {
-					return credit.creditType !== 'kiva_credit';
+					return credit.creditType !== 'kiva_credit'
+						&& (credit.applied === null || parseFloat(credit.applied) > 0);
 				});
 				return appliedCredits.length ? appliedCredits : [];
 			}

--- a/src/components/Checkout/LoanPromoCredits.vue
+++ b/src/components/Checkout/LoanPromoCredits.vue
@@ -35,7 +35,7 @@ export default {
 		formattedPromoCredits() {
 			return this.appliedPromoCredits.map(credit => {
 				return {
-					amount: credit?.amount ?? 0,
+					amount: credit?.applied ?? credit?.amount ?? 0,
 					displayName: credit?.promoFund?.displayName ?? null
 				};
 			});

--- a/test/unit/specs/components/Checkout/BasketItem.spec.js
+++ b/test/unit/specs/components/Checkout/BasketItem.spec.js
@@ -93,6 +93,63 @@ describe('BasketItem loan', () => {
 		expect(within(LoanPromoCredit).getByText('Sponsored by:'));
 	});
 
+	it('should not show a promo credit badge when applied is 0', () => {
+		const loan = {
+			...loanReservation,
+			creditsUsed: [{
+				...loanReservation.creditsUsed[0],
+				applied: '0.00',
+			}]
+		};
+		const { queryByTestId } = render(
+			BasketItem,
+			{
+				global: {
+					...globalOptions,
+					stubs: { LoanReservation: { ...emptyComponent } },
+					plugins: [router],
+				},
+				props: {
+					disableRedirects: false,
+					loan,
+					teams: [],
+				},
+			}
+		);
+
+		expect(queryByTestId('basket-loan-promo-credit')).toBeNull();
+	});
+
+	it('should show the applied amount on the promo credit badge, not the total amount', () => {
+		const loan = {
+			...loanReservation,
+			creditsUsed: [{
+				...loanReservation.creditsUsed[0],
+				amount: '25.00',
+				applied: '15.00',
+			}]
+		};
+		const { getByTestId } = render(
+			BasketItem,
+			{
+				global: {
+					...globalOptions,
+					stubs: { LoanReservation: { ...emptyComponent } },
+					plugins: [router],
+				},
+				props: {
+					disableRedirects: false,
+					loan,
+					teams: [],
+				},
+			}
+		);
+
+		const LoanPromoCredit = getByTestId('basket-loan-promo-credit');
+		expect(within(LoanPromoCredit).getByText('15.00 credit applied'));
+		expect(within(LoanPromoCredit).queryByText('25.00 credit applied')).toBeNull();
+	});
+
 	it('should show amounts 1,000 and over for logged in user and huge amount enabled', () => {
 		loanReservation.expiryTime = '2050-09-19T19:02:10Z';
 		render(


### PR DESCRIPTION
[MP-2821](https://kiva.atlassian.net/browse/MP-2821 )

The checkout basket was showing incorrect credit badges on loan items because the component was reading the amount field (the total credit pool size) instead of applied (what's actually allocated to that specific loan), and wasn't filtering out credits with zero applied — so in a multi-loan basket, every loan could show badges for credits not funding it, with wrong amounts. The fix is two small changes: filter credits to only those where applied is non-zero, and display applied instead of amount, falling back to amount when applied is null (which the API returns in the single-loan case). Tests were added to cover both the zero-applied case and the applied-vs-amount display case.

[MP-2821]: https://kiva.atlassian.net/browse/MP-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ