### PR TITLE
feat: rm My Teams beta redirect now that it's unnecessary [CP-2628]

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -178,10 +178,6 @@ export default [
 		}
 	},
 	{
-		path: '/teams/my-teams-beta',
-		redirect: '/teams/my-teams'
-	},
-	{
 		path: '/lend-by-category/loans-to-women',
 		redirect: '/lend-by-category/women'
 	},


### PR DESCRIPTION
https://kiva.atlassian.net/browse/CP-2628

Cleanup following https://github.com/kiva/flux/pull/2838, since the beta route is no longer supported in Traefik ingress.