### PR TITLE
feat: integrate goal row in my kiva while adjusting next steps logic

### DIFF
--- a/src/components/MyKiva/FeaturedGoalCard.vue
+++ b/src/components/MyKiva/FeaturedGoalCard.vue
@@ -1,7 +1,7 @@
 <template>
 	<KvLoadingPlaceholder
 		v-if="loading"
-		class="featured-goal-card__loading tw-rounded-lg tw-w-full"
+		class="featured-goal-card__loading !tw-rounded-lg tw-w-full"
 		aria-busy="true"
 	/>
 	<div
@@ -149,13 +149,14 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 import {
 	KvButton, KvLoadingPlaceholder, KvProgressCircle, KvUtilityMenu,
 } from '@kiva/kv-components';
 import KvIcon from '#src/components/Kv/KvIcon';
 import goalCopy from '#src/util/goalCopy';
 import { GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
+import { showConfetti } from '#src/util/animation/confettiUtils';
 
 const HALF_GOAL_THRESHOLD = 50;
 const COMPLETED_GOAL_THRESHOLD = 100;
@@ -193,6 +194,10 @@ const props = defineProps({
 	userName: {
 		type: String,
 		default: '',
+	},
+	suppressCompletionConfetti: {
+		type: Boolean,
+		default: false,
 	},
 });
 
@@ -258,6 +263,27 @@ const activeGoalCta = computed(() => {
 const onSelect = action => {
 	if (action.value === 'edit-goal') emit('edit-click');
 };
+
+const hasFiredCompletionConfetti = ref(false);
+
+const fireCompletionConfettiIfReady = () => {
+	if (
+		hasFiredCompletionConfetti.value
+		|| props.loading
+		|| props.suppressCompletionConfetti
+		|| clampedPercentage.value !== COMPLETED_GOAL_THRESHOLD
+	) {
+		return;
+	}
+	hasFiredCompletionConfetti.value = true;
+	showConfetti();
+};
+
+watch(
+	() => [props.loading, props.suppressCompletionConfetti, clampedPercentage.value],
+	fireCompletionConfettiIfReady,
+	{ immediate: true }
+);
 </script>
 
 <style lang="postcss" scoped>

--- a/src/components/MyKiva/FeaturedGoalCard.vue
+++ b/src/components/MyKiva/FeaturedGoalCard.vue
@@ -58,6 +58,7 @@
 						</h5>
 					</div>
 					<KvUtilityMenu
+						v-if="!goalCompleted"
 						menu-position="right-aligned"
 						button-size="small"
 						menu-border-class="tw-border tw-border-tertiary tw-rounded-md"
@@ -204,7 +205,7 @@ const props = defineProps({
 const emit = defineEmits(['set-goal-click', 'cta-click', 'edit-click']);
 
 const menuActions = [
-	{ label: 'Edit goal', value: 'edit-goal' },
+	{ label: 'Edit', value: 'edit-goal' },
 ];
 
 const resolvedState = computed(() => (
@@ -371,10 +372,6 @@ watch(
 	.featured-goal-card__cta--active-goal {
 		width: 286px;
 	}
-}
-
-.featured-goal-card__cta :deep(span) {
-	@apply !tw-min-h-4.5 md:tw-h-auto;
 }
 
 .featured-goal-card__cta :deep(span > span) {

--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -55,7 +55,10 @@
 			/>
 		</template>
 		<template v-else-if="showRegionExperience && !showLendingNextStepsCards">
-			<div class="goal-card-container">
+			<div
+				class="goal-card-container"
+				:class="{ 'tw-order-last': goalsRowEnabled }"
+			>
 				<JourneyCardCarousel
 					class="carousel carousel-single"
 					user-in-homepage
@@ -251,7 +254,7 @@
 </template>
 
 <script>
-import { inject } from 'vue';
+import { computed, inject } from 'vue';
 import { KvMaterialIcon, KvCheckbox, KvLoadingPlaceholder } from '@kiva/kv-components';
 import { mdiArrowTopRight, mdiArrowRight } from '@mdi/js';
 
@@ -355,7 +358,11 @@ export default {
 		basketItems: {
 			type: Array,
 			default: () => ([]),
-		}
+		},
+		goalsRowEnabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -411,11 +418,17 @@ export default {
 			return this.lendingNextStepsVariant === 'b' && !this.showPostLendingNextStepsCards;
 		},
 	},
-	setup() {
+	setup(props) {
 		const goalData = inject('goalData');
 
+		// When the featured-goal-slot experiment is on, the in-carousel goal tile is
+		// suppressed in favor of the slot rendered above LendingStats.
+		const hideCompletedGoalCard = computed(
+			() => props.goalsRowEnabled || Boolean(goalData.hideGoalCard?.value)
+		);
+
 		return {
-			hideCompletedGoalCard: goalData.hideGoalCard,
+			hideCompletedGoalCard,
 			goalProgress: goalData.goalProgress,
 			goalProgressLoading: goalData.loading,
 			loadGoalData: goalData.loadGoalData,

--- a/src/components/MyKiva/MyKivaFeaturedSlot.vue
+++ b/src/components/MyKiva/MyKivaFeaturedSlot.vue
@@ -117,7 +117,6 @@ watch(
 );
 
 const handleSetGoalClick = () => {
-	// Parent (MyKivaPageContent) opens the existing GoalSettingModal mounted in LendingStats.
 	emit('set-goal-click');
 };
 
@@ -144,7 +143,6 @@ const handleCtaClick = () => {
 };
 
 const handleEditClick = () => {
-	// Parent (MyKivaPageContent) opens the existing GoalSettingModal in edit mode.
 	emit('edit-click');
 };
 </script>

--- a/src/components/MyKiva/MyKivaFeaturedSlot.vue
+++ b/src/components/MyKiva/MyKivaFeaturedSlot.vue
@@ -1,0 +1,150 @@
+<template>
+	<section
+		v-if="shouldRender"
+		class="!tw-mt-1"
+	>
+		<KvLoadingPlaceholder
+			v-if="cardLoading"
+			class="!tw-h-5 tw-mb-2"
+			:style="{ width: '15rem'}"
+		/>
+		<h3 v-else class="tw-text-title tw-mb-2">
+			{{ slotTitle }}
+		</h3>
+		<FeaturedGoalCard
+			:state="slotState"
+			:loading="cardLoading"
+			:goal-target="goalTarget"
+			:goal-progress="goalProgressValue"
+			:goal-progress-percentage="goalProgressPercentageValue"
+			:category-name="categoryName"
+			:user-name="userFirstName"
+			:suppress-completion-confetti="suppressCompletionConfetti"
+			@set-goal-click="handleSetGoalClick"
+			@cta-click="handleCtaClick"
+			@edit-click="handleEditClick"
+		/>
+	</section>
+</template>
+
+<script setup>
+import {
+	computed, inject, ref, watch,
+} from 'vue';
+import { useRouter } from 'vue-router';
+import FeaturedGoalCard from '#src/components/MyKiva/FeaturedGoalCard';
+import {
+	GOAL_STATUS,
+	GOALS_CURRENT_YEAR,
+	COMPLETED_GOAL_THRESHOLD,
+} from '#src/composables/useGoalData';
+import logReadQueryError from '#src/util/logReadQueryError';
+import { KvLoadingPlaceholder } from '@kiva/kv-components';
+
+const STATE_NO_GOAL = 'no-goal';
+const STATE_ACTIVE_GOAL = 'active-goal';
+
+const SLOT_TITLES = {
+	[STATE_NO_GOAL]: 'Start by setting an impact goal',
+	inProgress: 'Continue making progress on your impact goal',
+	completed: 'Goal Achieved!',
+};
+
+defineProps({
+	userFirstName: {
+		type: String,
+		default: '',
+	},
+});
+
+const emit = defineEmits(['set-goal-click', 'cta-click', 'edit-click']);
+
+const router = useRouter();
+const goalData = inject('goalData');
+
+const cardLoading = computed(() => Boolean(goalData?.loading?.value));
+const goalStatus = computed(() => goalData?.userGoal?.value?.status || null);
+const goalTarget = computed(() => goalData?.userGoal?.value?.target || 0);
+const goalProgressValue = computed(() => goalData?.goalProgress?.value || 0);
+const goalProgressPercentageValue = computed(() => goalData?.goalProgressPercentage?.value || 0);
+
+const categoryName = computed(() => {
+	const target = goalData?.userGoal?.value?.target;
+	const category = goalData?.userGoal?.value?.category;
+	if (!target || !category || !goalData?.getGoalDisplayName) return '';
+	return goalData.getGoalDisplayName(target, category);
+});
+
+// Snapshot of the viewedGoalComplete flag taken once when we first see a COMPLETED status.
+// Sticky so the slot does not disappear mid-view after we persist the flag.
+const alreadyViewedSnapshot = ref(null);
+
+const slotState = computed(() => {
+	if (cardLoading.value) return STATE_NO_GOAL;
+	if (goalStatus.value === GOAL_STATUS.COMPLETED) {
+		if (alreadyViewedSnapshot.value === true) return null;
+		return STATE_ACTIVE_GOAL;
+	}
+	if (goalStatus.value === GOAL_STATUS.IN_PROGRESS) return STATE_ACTIVE_GOAL;
+	return STATE_NO_GOAL;
+});
+
+const shouldRender = computed(() => slotState.value !== null);
+
+const slotTitle = computed(() => {
+	if (slotState.value === STATE_NO_GOAL) return SLOT_TITLES[STATE_NO_GOAL];
+	if (goalStatus.value === GOAL_STATUS.COMPLETED) return SLOT_TITLES.completed;
+	return SLOT_TITLES.inProgress;
+});
+
+const suppressCompletionConfetti = computed(() => alreadyViewedSnapshot.value === true);
+
+watch(
+	() => [cardLoading.value, goalStatus.value],
+	() => {
+		if (alreadyViewedSnapshot.value !== null) return;
+		if (cardLoading.value) return;
+		if (goalStatus.value !== GOAL_STATUS.COMPLETED) return;
+		const viewed = Boolean(goalData?.hasViewedCompletedGoalForYear?.(GOALS_CURRENT_YEAR));
+		alreadyViewedSnapshot.value = viewed;
+		if (!viewed) {
+			goalData.setViewedGoalCompletePreference(GOALS_CURRENT_YEAR).catch(error => {
+				logReadQueryError(error, 'MyKivaFeaturedSlot setViewedGoalComplete');
+			});
+		}
+	},
+	{ immediate: true }
+);
+
+const handleSetGoalClick = () => {
+	// Parent (MyKivaPageContent) opens the existing GoalSettingModal mounted in LendingStats.
+	emit('set-goal-click');
+};
+
+const handleCtaClick = () => {
+	emit('cta-click');
+	if (goalProgressPercentageValue.value >= COMPLETED_GOAL_THRESHOLD) {
+		const el = typeof document !== 'undefined'
+			? document.querySelector('#mykiva-achievements')
+			: null;
+		if (el) {
+			el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		}
+		return;
+	}
+	const href = goalData?.getCtaHref?.(
+		goalData?.userGoal?.value?.target,
+		goalData?.userGoal?.value?.category,
+		router,
+		goalProgressValue.value,
+	);
+	if (href && typeof window !== 'undefined') {
+		window.location.href = href;
+	}
+};
+
+const handleEditClick = () => {
+	// Parent (MyKivaPageContent) opens the existing GoalSettingModal in edit mode.
+	emit('edit-click');
+};
+</script>

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -662,6 +662,30 @@ export default function useGoalData({ apollo } = {}) {
 		// MyKiva renders the completed card once, then hides it on the next page load.
 	}
 
+	const viewedGoalCompleteByYear = computed(() => {
+		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
+		return parsedPrefs.viewedGoalComplete || {};
+	});
+
+	function hasViewedCompletedGoalForYear(year) {
+		return Boolean(viewedGoalCompleteByYear.value?.[year]);
+	}
+
+	async function setViewedGoalCompletePreference(year = GOALS_CURRENT_YEAR) {
+		if (!year) return;
+		const parsedPrefs = await loadPreferences('network-only');
+		const prev = parsedPrefs?.viewedGoalComplete || {};
+		// Year-keyed flag so next year's celebration is not suppressed by a prior year's view.
+		if (prev[year]) return;
+		const updatedPreference = { viewedGoalComplete: { ...prev, [year]: true } };
+		await updateUserPreferences(
+			apolloClient,
+			userPreferences.value,
+			parsedPrefs,
+			updatedPreference
+		);
+	}
+
 	async function checkCompletedGoal({
 		currentGoalProgress = 0,
 		category = 'post-checkout',
@@ -999,6 +1023,9 @@ export default function useGoalData({ apollo } = {}) {
 		renewAnnualGoal,
 		hideGoalCard,
 		setHideGoalCardPreference,
+		viewedGoalCompleteByYear,
+		hasViewedCompletedGoalForYear,
+		setViewedGoalCompletePreference,
 		getSupportAllLoanCountByYear,
 		setGoalState,
 		removeGoalFromPreferences,

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -18,8 +18,16 @@
 				:user-id="userInfo?.id"
 			/>
 		</section>
+		<MyKivaFeaturedSlot
+			v-if="goalsRowEnabled"
+			:key="`featured-slot-${goalRefreshKey}`"
+			:user-first-name="userInfo?.userAccount?.firstName"
+			@set-goal-click="openGoalSettingModal"
+			@edit-click="openEditGoalSettingModal"
+		/>
 		<section v-if="clientRendered" class="!tw-mt-2">
 			<LendingStats
+				ref="lendingStatsRef"
 				:regions-data="lendingStats.regionsData"
 				:user-lent-to-all-regions="userLentToAllRegions"
 				:hero-slides="heroSlides"
@@ -34,6 +42,7 @@
 				:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 				:lending-next-steps-variant="lendingNextStepsVariant"
 				:goal-recommended-loan-enable="goalRecommendedLoanEnable"
+				:goals-row-enabled="goalsRowEnabled"
 				:basket-items="basketItems"
 				:is-adding="isAdding"
 				@add-to-basket="addToBasket"
@@ -206,6 +215,7 @@ import LendingCategorySection from '#src/components/LoanFinding/LendingCategoryS
 import JourneySideSheet from '#src/components/Badges/JourneySideSheet';
 import KvAtbModalContainer from '#src/components/WwwFrame/Header/KvAtbModalContainer';
 import LendingStats from '#src/components/MyKiva/LendingStats';
+import MyKivaFeaturedSlot from '#src/components/MyKiva/MyKivaFeaturedSlot';
 import BailoutChips from '#src/components/MyKiva/BailoutChips';
 import borrowerProfileExpMixin from '#src/plugins/borrower-profile-exp-mixin';
 import smoothScrollMixin from '#src/plugins/smooth-scroll-mixin';
@@ -248,6 +258,7 @@ export default {
 		MyGivingFundsCard,
 		MyKivaStats,
 		LendingStats,
+		MyKivaFeaturedSlot,
 		BailoutChips,
 		BadgesSectionV2,
 		KvMaterialIcon,
@@ -421,6 +432,13 @@ export default {
 		},
 	},
 	methods: {
+		openGoalSettingModal() {
+			// Reuses the GoalSettingModal already mounted inside LendingStats.
+			this.$refs.lendingStatsRef?.openGoalModal?.();
+		},
+		openEditGoalSettingModal() {
+			this.$refs.lendingStatsRef?.openGoalModal?.({ updating: true });
+		},
 		navigateToLoanFindingUrl(id) {
 			const loanFindingUrl = this.getLoanFindingUrl(id, this.$router.currentRoute.value);
 			if (loanFindingUrl) {

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -73,7 +73,9 @@
 						@tool-tip-visible="handleToolTipVisible"
 					>
 						<template #title>
-							<h5 class="tw-text-label">Annual goals and achievements</h5>
+							<h5 class="tw-text-label">
+								Annual goals and achievements
+							</h5>
 						</template>
 						<p class="tw-text-small">
 							<!-- eslint-disable-next-line max-len -->
@@ -433,7 +435,6 @@ export default {
 	},
 	methods: {
 		openGoalSettingModal() {
-			// Reuses the GoalSettingModal already mounted inside LendingStats.
 			this.$refs.lendingStatsRef?.openGoalModal?.();
 		},
 		openEditGoalSettingModal() {

--- a/test/unit/specs/components/MyKiva/FeaturedGoalCard.spec.js
+++ b/test/unit/specs/components/MyKiva/FeaturedGoalCard.spec.js
@@ -1,0 +1,271 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import FeaturedGoalCard from '#src/components/MyKiva/FeaturedGoalCard';
+import { GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
+
+vi.mock('#src/util/animation/confettiUtils', () => ({
+	showConfetti: vi.fn(),
+}));
+
+// Stub the @kiva/kv-components primitives this spec touches so copy assertions
+// don't drag in SVG rendering (KvProgressCircle) or menu interaction logic
+// (KvUtilityMenu) that are irrelevant here — matches sibling MyKiva specs like
+// NextYearGoalCard.
+vi.mock('@kiva/kv-components', () => ({
+	KvButton: {
+		name: 'KvButton',
+		template: '<button class="kv-button-stub"><slot /></button>',
+	},
+	KvLoadingPlaceholder: {
+		name: 'KvLoadingPlaceholder',
+		template: '<div data-testid="loading-placeholder" />',
+	},
+	KvProgressCircle: {
+		name: 'KvProgressCircle',
+		props: ['value', 'max', 'rotate', 'color', 'strokeWidth'],
+		template: '<div data-testid="progress-ring" :data-value="value" :data-max="max" />',
+	},
+	KvUtilityMenu: {
+		name: 'KvUtilityMenu',
+		template: '<div data-testid="utility-menu"><slot /></div>',
+	},
+}));
+
+vi.mock('#src/components/Kv/KvIcon', () => ({
+	default: {
+		name: 'KvIcon',
+		props: ['name'],
+		template: '<i :data-icon="name" />',
+	},
+}));
+
+const mountCard = (props = {}) => mount(FeaturedGoalCard, {
+	props: {
+		state: 'no-goal',
+		loading: false,
+		goalTarget: 0,
+		goalProgress: 0,
+		goalProgressPercentage: 0,
+		categoryName: '',
+		userName: '',
+		suppressCompletionConfetti: false,
+		...props,
+	},
+	global: {
+		directives: {
+			kvTrackEvent: () => ({}),
+		},
+	},
+});
+
+describe('FeaturedGoalCard copy', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('loading state', () => {
+		it('renders the loading placeholder when loading=true and no body content', () => {
+			const wrapper = mountCard({ loading: true });
+			expect(wrapper.find('[data-testid="loading-placeholder"]').exists()).toBe(true);
+			expect(wrapper.text()).not.toContain('How many loans');
+		});
+	});
+
+	describe('no-goal state', () => {
+		const buildNoGoal = () => mountCard({ state: 'no-goal' });
+
+		it('renders the "3 women" title from goalCopy.titleNoHistoryWomensDefault', () => {
+			const wrapper = buildNoGoal();
+			expect(wrapper.html()).toContain('Lenders like you help');
+			expect(wrapper.html()).toContain('3 women');
+			expect(wrapper.html()).toContain('a year!');
+		});
+
+		it('renders the generic loans-this-year subtitle', () => {
+			expect(buildNoGoal().text()).toContain('How many loans will you make this year?');
+		});
+
+		it('renders the year-stamped Set Goal CTA', () => {
+			expect(buildNoGoal().text()).toContain(`Set ${GOALS_CURRENT_YEAR} goal`);
+		});
+
+		it('does not render any active-goal copy', () => {
+			const text = buildNoGoal().text();
+			expect(text).not.toContain('Work toward your goal');
+			expect(text).not.toContain('View your achievements');
+			expect(text).not.toContain('Your ');
+		});
+	});
+
+	describe('active-goal heading', () => {
+		it('renders "Your {year} goal to support {category}"', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 5,
+				goalProgress: 2,
+				goalProgressPercentage: 40,
+				categoryName: 'US entrepreneurs',
+			});
+			expect(wrapper.text()).toContain(`Your ${GOALS_CURRENT_YEAR} goal to support US entrepreneurs`);
+		});
+	});
+
+	describe('active-goal progress label', () => {
+		it('shows visibleProgress / goalTarget and the "Loans" label', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 10,
+				goalProgress: 3,
+				goalProgressPercentage: 30,
+			});
+			expect(wrapper.text()).toContain('3');
+			expect(wrapper.text()).toContain('/10');
+			expect(wrapper.text()).toContain('Loans');
+		});
+
+		it('clamps visibleProgress to goalTarget when overshot', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 5,
+				goalProgress: 12,
+				goalProgressPercentage: 100,
+				userName: 'Ada',
+			});
+			// Visible progress should clamp at goalTarget, never showing the raw 12.
+			expect(wrapper.text()).toContain('/5');
+			expect(wrapper.text()).not.toContain('12');
+		});
+	});
+
+	describe('activeGoalTitle by percentage', () => {
+		const titleAt = pct => mountCard({
+			state: 'active-goal',
+			goalTarget: 4,
+			goalProgress: Math.round((pct / 100) * 4),
+			goalProgressPercentage: pct,
+			userName: 'Ada',
+		}).text();
+
+		it('at 0%: "Start with your first loan"', () => {
+			expect(titleAt(0)).toContain('Start with your first loan');
+		});
+
+		it('below 50%: "You\'ve started something powerful."', () => {
+			expect(titleAt(25)).toContain('You\'ve started something powerful.');
+		});
+
+		it('exactly 50%: "You\'re half way there!"', () => {
+			expect(titleAt(50)).toContain('You\'re half way there!');
+		});
+
+		it('between 50% and 100%: "You\'re close to the impact you imagined"', () => {
+			expect(titleAt(75)).toContain('You\'re close to the impact you imagined');
+		});
+
+		it('at 100%: includes the user\'s name in the celebration', () => {
+			expect(titleAt(100)).toContain('You did it, Ada! You made it happen');
+		});
+
+		it('at 100% with empty userName: still renders the rest of the celebration', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 4,
+				goalProgress: 4,
+				goalProgressPercentage: 100,
+				userName: '',
+			});
+			expect(wrapper.text()).toContain('You did it');
+			expect(wrapper.text()).toContain('You made it happen');
+		});
+	});
+
+	describe('activeGoalDescription by percentage', () => {
+		const descAt = (pct, extra = {}) => mountCard({
+			state: 'active-goal',
+			goalTarget: 4,
+			goalProgress: Math.round((pct / 100) * 4),
+			goalProgressPercentage: pct,
+			userName: 'Ada',
+			...extra,
+		}).text();
+
+		it('at 0%: "Turn your intention into consistent impact."', () => {
+			expect(descAt(0)).toContain('Turn your intention into consistent impact.');
+		});
+
+		it('below 50%: "Let\'s keep it growing together."', () => {
+			expect(descAt(25)).toContain('Let\'s keep it growing together.');
+		});
+
+		it('exactly 50%: "You\'ve made real progress and real impact. Keep it going."', () => {
+			expect(descAt(50)).toContain('You\'ve made real progress and real impact. Keep it going.');
+		});
+
+		it('between 50% and 100%: "Continue creating opportunity for others. Finish strong!"', () => {
+			expect(descAt(75)).toContain('Continue creating opportunity for others. Finish strong!');
+		});
+
+		it('at 100%: "Achieving your goal means you\'ve changed {target} lives this year"', () => {
+			expect(descAt(100, { goalTarget: 7, goalProgress: 7 }))
+				.toContain('Achieving your goal means you\'ve changed 7 lives this year');
+		});
+	});
+
+	describe('activeGoalCta', () => {
+		it('not completed: "Work toward your goal"', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 5,
+				goalProgress: 2,
+				goalProgressPercentage: 40,
+			});
+			expect(wrapper.text()).toContain('Work toward your goal');
+			expect(wrapper.text()).not.toContain('View your achievements');
+		});
+
+		it('completed: "View your achievements"', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 5,
+				goalProgress: 5,
+				goalProgressPercentage: 100,
+				userName: 'Ada',
+			});
+			expect(wrapper.text()).toContain('View your achievements');
+			expect(wrapper.text()).not.toContain('Work toward your goal');
+		});
+	});
+
+	describe('utility menu visibility and content', () => {
+		it('renders the "Edit" action when goal is in progress', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 5,
+				goalProgress: 2,
+				goalProgressPercentage: 40,
+			});
+			const menu = wrapper.find('[data-testid="utility-menu"]');
+			expect(menu.exists()).toBe(true);
+			expect(menu.html()).toContain('>Edit<');
+		});
+
+		it('hides the utility menu entirely when the goal is completed', () => {
+			const wrapper = mountCard({
+				state: 'active-goal',
+				goalTarget: 5,
+				goalProgress: 5,
+				goalProgressPercentage: 100,
+				userName: 'Ada',
+			});
+			expect(wrapper.find('[data-testid="utility-menu"]').exists()).toBe(false);
+		});
+	});
+
+	describe('state validator fallback', () => {
+		it('renders no-goal copy when an unrecognized state value is passed', () => {
+			const wrapper = mountCard({ state: 'something-unsupported' });
+			expect(wrapper.text()).toContain('How many loans will you make this year?');
+			expect(wrapper.text()).toContain(`Set ${GOALS_CURRENT_YEAR} goal`);
+		});
+	});
+});

--- a/test/unit/specs/components/MyKiva/MyKivaFeaturedSlot.spec.js
+++ b/test/unit/specs/components/MyKiva/MyKivaFeaturedSlot.spec.js
@@ -1,0 +1,219 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import { nextTick, ref } from 'vue';
+import MyKivaFeaturedSlot from '#src/components/MyKiva/MyKivaFeaturedSlot';
+import { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
+import { ID_US_ECONOMIC_EQUALITY } from '#src/composables/useBadgeData';
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({}),
+}));
+
+vi.mock('#src/util/logReadQueryError', () => ({
+	default: vi.fn(),
+}));
+
+const FEATURED_CARD_STUB = {
+	name: 'FeaturedGoalCard',
+	props: ['state', 'loading', 'suppressCompletionConfetti'],
+	template: '<div data-testid="featured-goal-card" :data-state="state" '
+		+ ':data-suppress-confetti="String(suppressCompletionConfetti)" />',
+};
+
+const buildGoalData = ({
+	status = null,
+	hasViewedCompletedGoal = false,
+	loading = false,
+	target = 5,
+	progress = 0,
+	percentage = 0,
+} = {}) => ({
+	loading: ref(loading),
+	userGoal: ref(status ? { category: ID_US_ECONOMIC_EQUALITY, target, status } : null),
+	goalProgress: ref(progress),
+	goalProgressPercentage: ref(percentage),
+	getGoalDisplayName: vi.fn(() => 'US entrepreneurs'),
+	getCtaHref: vi.fn(() => '/lend'),
+	hasViewedCompletedGoalForYear: vi.fn(() => hasViewedCompletedGoal),
+	setViewedGoalCompletePreference: vi.fn(() => Promise.resolve()),
+});
+
+const mountSlot = ({ goalData = buildGoalData(), props = {} } = {}) => {
+	const wrapper = mount(MyKivaFeaturedSlot, {
+		props: {
+			userFirstName: 'Ada',
+			...props,
+		},
+		global: {
+			provide: {
+				goalData,
+				$kvTrackEvent: vi.fn(),
+			},
+			stubs: {
+				FeaturedGoalCard: FEATURED_CARD_STUB,
+				KvLoadingPlaceholder: { template: '<div data-testid="loading-placeholder" />' },
+			},
+		},
+	});
+	return { wrapper, goalData };
+};
+
+describe('MyKivaFeaturedSlot', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('state resolution', () => {
+		it('renders no-goal state when the lender has no goal', () => {
+			const { wrapper } = mountSlot({ goalData: buildGoalData({ status: null }) });
+			const card = wrapper.find('[data-testid="featured-goal-card"]');
+			expect(card.exists()).toBe(true);
+			expect(card.attributes('data-state')).toBe('no-goal');
+		});
+
+		it('renders active-goal state when the lender has an in-progress goal', () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({ status: GOAL_STATUS.IN_PROGRESS, progress: 2, percentage: 40 }),
+			});
+			const card = wrapper.find('[data-testid="featured-goal-card"]');
+			expect(card.attributes('data-state')).toBe('active-goal');
+		});
+
+		it('renders active-goal state when the lender has a completed goal not yet viewed', () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({
+					status: GOAL_STATUS.COMPLETED,
+					hasViewedCompletedGoal: false,
+					progress: 5,
+					percentage: 100,
+				}),
+			});
+			expect(wrapper.find('[data-testid="featured-goal-card"]').exists()).toBe(true);
+		});
+
+		it('renders nothing when the lender has already viewed the completed goal this year', () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({
+					status: GOAL_STATUS.COMPLETED,
+					hasViewedCompletedGoal: true,
+					progress: 5,
+					percentage: 100,
+				}),
+			});
+			expect(wrapper.find('[data-testid="featured-goal-card"]').exists()).toBe(false);
+		});
+	});
+
+	describe('viewedGoalComplete persistence', () => {
+		it('persists the flag exactly once when first showing the completed state', async () => {
+			const { goalData } = mountSlot({
+				goalData: buildGoalData({
+					status: GOAL_STATUS.COMPLETED,
+					hasViewedCompletedGoal: false,
+					percentage: 100,
+				}),
+			});
+			await nextTick();
+			expect(goalData.setViewedGoalCompletePreference).toHaveBeenCalledTimes(1);
+			expect(goalData.setViewedGoalCompletePreference).toHaveBeenCalledWith(GOALS_CURRENT_YEAR);
+		});
+
+		it('does not persist the flag when the user has already viewed the completion', async () => {
+			const { goalData } = mountSlot({
+				goalData: buildGoalData({
+					status: GOAL_STATUS.COMPLETED,
+					hasViewedCompletedGoal: true,
+					percentage: 100,
+				}),
+			});
+			await nextTick();
+			expect(goalData.setViewedGoalCompletePreference).not.toHaveBeenCalled();
+		});
+
+		it('does not persist the flag for in-progress goals', async () => {
+			const { goalData } = mountSlot({
+				goalData: buildGoalData({ status: GOAL_STATUS.IN_PROGRESS, percentage: 50 }),
+			});
+			await nextTick();
+			expect(goalData.setViewedGoalCompletePreference).not.toHaveBeenCalled();
+		});
+
+		it('snapshot is sticky — the slot stays visible if the underlying flag flips after mount', async () => {
+			// Mount in COMPLETED + not-viewed state — slot renders, persistence kicks in.
+			const goalData = buildGoalData({
+				status: GOAL_STATUS.COMPLETED,
+				hasViewedCompletedGoal: false,
+				percentage: 100,
+			});
+			const { wrapper } = mountSlot({ goalData });
+
+			expect(wrapper.find('[data-testid="featured-goal-card"]').exists()).toBe(true);
+
+			// Simulate the mutation completing: hasViewedCompletedGoalForYear would now return true.
+			goalData.hasViewedCompletedGoalForYear.mockReturnValue(true);
+			// Trigger a reactive cycle by toggling loading — watcher re-runs but bails because the
+			// snapshot was already taken on mount.
+			goalData.loading.value = true;
+			await nextTick();
+			goalData.loading.value = false;
+			await nextTick();
+
+			expect(wrapper.find('[data-testid="featured-goal-card"]').exists()).toBe(true);
+		});
+	});
+
+	describe('confetti suppression prop', () => {
+		it('passes suppressCompletionConfetti=false when first viewing the completed state', () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({
+					status: GOAL_STATUS.COMPLETED,
+					hasViewedCompletedGoal: false,
+					percentage: 100,
+				}),
+			});
+			const card = wrapper.find('[data-testid="featured-goal-card"]');
+			expect(card.attributes('data-suppress-confetti')).toBe('false');
+		});
+	});
+
+	describe('event emission', () => {
+		it('emits set-goal-click without navigating', async () => {
+			const { wrapper } = mountSlot();
+			await wrapper.findComponent(FEATURED_CARD_STUB).vm.$emit('set-goal-click');
+			expect(wrapper.emitted('set-goal-click')).toHaveLength(1);
+		});
+
+		it('emits edit-click without navigating', async () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({ status: GOAL_STATUS.IN_PROGRESS, percentage: 25 }),
+			});
+			await wrapper.findComponent(FEATURED_CARD_STUB).vm.$emit('edit-click');
+			expect(wrapper.emitted('edit-click')).toHaveLength(1);
+		});
+	});
+
+	describe('title copy', () => {
+		it('renders "Start by setting an impact goal" in the no-goal state', () => {
+			const { wrapper } = mountSlot({ goalData: buildGoalData({ status: null }) });
+			expect(wrapper.text()).toContain('Start by setting an impact goal');
+		});
+
+		it('renders "Continue making progress on your impact goal" in the in-progress state', () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({ status: GOAL_STATUS.IN_PROGRESS, percentage: 40 }),
+			});
+			expect(wrapper.text()).toContain('Continue making progress on your impact goal');
+		});
+
+		it('renders "Goal Achieved!" in the completed (first-view) state', () => {
+			const { wrapper } = mountSlot({
+				goalData: buildGoalData({
+					status: GOAL_STATUS.COMPLETED,
+					hasViewedCompletedGoal: false,
+					percentage: 100,
+				}),
+			});
+			expect(wrapper.text()).toContain('Goal Achieved!');
+		});
+	});
+});

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -4411,4 +4411,93 @@ describe('useGoalData', () => {
 			expect(result).toEqual([{ id: 999 }]);
 		});
 	});
+
+	describe('viewedGoalComplete flag', () => {
+		// `setViewedGoalCompletePreference` internally calls `loadPreferences('network-only')`
+		// before writing, so the apollo mock must return the same response on every call —
+		// not just once — or the function's own load will hit an empty mock and treat prefs
+		// as cleared.
+		const loadPrefsOnce = async prefsObject => {
+			mockApollo.query = vi.fn().mockResolvedValue({
+				data: {
+					my: {
+						userPreferences: {
+							id: 'pref-vgc',
+							preferences: JSON.stringify(prefsObject),
+						},
+						loans: { totalCount: 0 },
+					},
+				},
+			});
+			await composable.loadPreferences('network-only');
+		};
+
+		it('hasViewedCompletedGoalForYear returns false when key missing', async () => {
+			await loadPrefsOnce({ goals: [] });
+			expect(composable.hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR)).toBe(false);
+		});
+
+		it('hasViewedCompletedGoalForYear returns true when year flag is set', async () => {
+			await loadPrefsOnce({ viewedGoalComplete: { [GOALS_CURRENT_YEAR]: true } });
+			expect(composable.hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR)).toBe(true);
+		});
+
+		it('hasViewedCompletedGoalForYear is year-keyed (no cross-year leakage)', async () => {
+			await loadPrefsOnce({ viewedGoalComplete: { [GOALS_CURRENT_YEAR - 1]: true } });
+			expect(composable.hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR - 1)).toBe(true);
+			expect(composable.hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR)).toBe(false);
+		});
+
+		it('setViewedGoalCompletePreference persists a year-keyed flag', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await loadPrefsOnce({ goals: [], hideGoalCard: false });
+			await composable.setViewedGoalCompletePreference(GOALS_CURRENT_YEAR);
+
+			expect(updateUserPreferences).toHaveBeenCalledTimes(1);
+			const [, , , updatedPreference] = updateUserPreferences.mock.calls[0];
+			expect(updatedPreference).toEqual({
+				viewedGoalComplete: { [GOALS_CURRENT_YEAR]: true },
+			});
+		});
+
+		it('setViewedGoalCompletePreference merges with existing year entries', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await loadPrefsOnce({
+				viewedGoalComplete: { [GOALS_CURRENT_YEAR - 1]: true },
+			});
+			await composable.setViewedGoalCompletePreference(GOALS_CURRENT_YEAR);
+
+			expect(updateUserPreferences).toHaveBeenCalledTimes(1);
+			const [, , , updatedPreference] = updateUserPreferences.mock.calls[0];
+			expect(updatedPreference).toEqual({
+				viewedGoalComplete: {
+					[GOALS_CURRENT_YEAR - 1]: true,
+					[GOALS_CURRENT_YEAR]: true,
+				},
+			});
+		});
+
+		it('setViewedGoalCompletePreference is idempotent — no write when year already set', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await loadPrefsOnce({ viewedGoalComplete: { [GOALS_CURRENT_YEAR]: true } });
+			await composable.setViewedGoalCompletePreference(GOALS_CURRENT_YEAR);
+
+			expect(updateUserPreferences).not.toHaveBeenCalled();
+		});
+
+		it('setViewedGoalCompletePreference is a no-op when called with a falsy year', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await composable.setViewedGoalCompletePreference(0);
+
+			expect(updateUserPreferences).not.toHaveBeenCalled();
+		});
+	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2869

<img width="1147" height="322" alt="image" src="https://github.com/user-attachments/assets/b805ed1f-73a1-4fc7-99ff-2f031bcd1f7b" />

- Add Goal Row to My Kiva
- Handles scenarios where Goal Row is active so Goal Card should not be visible in next steps, but the logic in the card sort should remain.
