### PR TITLE
feat: admin reward tip helper

### DIFF
--- a/src/graphql/query/checkout/initializeCheckout.graphql
+++ b/src/graphql/query/checkout/initializeCheckout.graphql
@@ -31,6 +31,10 @@ query initializeCheckout($basketId: String) {
 			value
 			description
 		}
+		admin_reward_tip_flag: uiConfigSetting(key: "enable_tip_for_admin_reward_lc") {
+			key
+			value
+		}
 	}
 	shop (basketId: $basketId) {
 		id

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -493,6 +493,7 @@ export default {
 			isBanditUpsellExpEnabled: false,
 			isExpiringSoonExpEnabled: false,
 			isKivaCreditReplacementExpEnabled: false,
+			enableAdminRewardTipFlag: false,
 		};
 	},
 	apollo: {
@@ -568,6 +569,9 @@ export default {
 			this.isFtdMessageEnable = readBoolSetting(data, 'general.ftd_message_enable.value');
 			this.ftdCreditAmount = data?.general?.ftd_message_amount?.value ?? '';
 			this.ftdValidDate = data?.general?.ftd_message_valid_date?.value ?? '';
+
+			// Enable admin reward tip flag from settings
+			this.enableAdminRewardTipFlag = readBoolSetting(data, 'general.admin_reward_tip_flag.value');
 
 			// Deposit incentive experiment MP-72
 			this.depositIncentiveAmountToLend = numeral(data?.my?.depositIncentiveAmountToLend ?? 0).value();

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -495,7 +495,6 @@ export default {
 			isExpiringSoonExpEnabled: false,
 			isKivaCreditReplacementExpEnabled: false,
 			enableAdminRewardTipFlag: false,
-			apolloData: null,
 		};
 	},
 	apollo: {
@@ -830,7 +829,7 @@ export default {
 			return this.promoData?.managedAccount?.id ?? null;
 		},
 		adminRewardTipEligible() {
-			return isAdminRewardTipEligible(this.apolloData, this.enableAdminRewardTipFlag);
+			return isAdminRewardTipEligible(this.promoData, this.enableAdminRewardTipFlag);
 		},
 		promoFundId() {
 			return this.promoData?.promoFund?.id ?? null;
@@ -1064,7 +1063,6 @@ export default {
 		getPromoInformationFromBasket() {
 			getPromoFromBasket(this.derivedPromoFund?.id, this.apollo).then(({ data }) => {
 				this.promoData = data?.shop?.promoCampaign;
-				this.apolloData = data;
 
 				this.$nextTick(() => {
 					if (

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -315,6 +315,7 @@ import _get from 'lodash/get';
 import _filter from 'lodash/filter';
 import numeral from 'numeral';
 import { readBoolSetting } from '#src/util/settingsUtils';
+import { isAdminRewardTipEligible } from '#src/util/promoCredit';
 import { preFetchAll } from '#src/util/apolloPreFetch';
 import syncDate from '#src/util/syncDate';
 import { myFTDQuery, formatTransactionData } from '#src/util/checkoutUtils';
@@ -494,6 +495,7 @@ export default {
 			isExpiringSoonExpEnabled: false,
 			isKivaCreditReplacementExpEnabled: false,
 			enableAdminRewardTipFlag: false,
+			apolloData: null,
 		};
 	},
 	apollo: {
@@ -827,6 +829,9 @@ export default {
 		managedAccountId() {
 			return this.promoData?.managedAccount?.id ?? null;
 		},
+		adminRewardTipEligible() {
+			return isAdminRewardTipEligible(this.apolloData, this.enableAdminRewardTipFlag);
+		},
 		promoFundId() {
 			return this.promoData?.promoFund?.id ?? null;
 		},
@@ -1059,6 +1064,7 @@ export default {
 		getPromoInformationFromBasket() {
 			getPromoFromBasket(this.derivedPromoFund?.id, this.apollo).then(({ data }) => {
 				this.promoData = data?.shop?.promoCampaign;
+				this.apolloData = data;
 
 				this.$nextTick(() => {
 					if (

--- a/src/util/promoCredit.js
+++ b/src/util/promoCredit.js
@@ -114,6 +114,24 @@ export function hasPromoSession(data) {
 }
 
 /**
+ * Determine whether the optional tip section is eligible to be shown for an
+ * Admin Reward lending-credit checkout.
+ *
+ * Returns true only when ALL of the following are true:
+ *   1. The `enable_tip_for_admin_reward_lc` feature flag is enabled.
+ *   2. The current checkout's promoCampaign managed account has a
+ *      `managementType` of exactly `'Admin Reward'`.
+ *
+ * @param {Object} data - GraphQL result with `shop.promoCampaign.managedAccount.managementType`.
+ * @param {boolean} flagEnabled - The resolved boolean value of the feature flag.
+ * @returns {boolean}
+ */
+export function isAdminRewardTipEligible(data, flagEnabled) {
+	if (flagEnabled !== true) return false;
+	return data?.shop?.promoCampaign?.managedAccount?.managementType === 'Admin Reward';
+}
+
+/**
  * Determine if the route or URL indicates that the user is coming from the Impact Dashboard.
  *
  * @param {Object|URL} routeOrUrl - The route object or URL to check.

--- a/src/util/promoCredit.js
+++ b/src/util/promoCredit.js
@@ -122,13 +122,13 @@ export function hasPromoSession(data) {
  *   2. The current checkout's promoCampaign managed account has a
  *      `managementType` of exactly `'Admin Reward'`.
  *
- * @param {Object} data - GraphQL result with `shop.promoCampaign.managedAccount.managementType`.
+ * @param {Object} promoData - The `shop.promoCampaign` sub-tree from a checkout query.
  * @param {boolean} flagEnabled - The resolved boolean value of the feature flag.
  * @returns {boolean}
  */
-export function isAdminRewardTipEligible(data, flagEnabled) {
+export function isAdminRewardTipEligible(promoData, flagEnabled) {
 	if (flagEnabled !== true) return false;
-	return data?.shop?.promoCampaign?.managedAccount?.managementType === 'Admin Reward';
+	return promoData?.managedAccount?.managementType === 'Admin Reward';
 }
 
 /**

--- a/test/unit/specs/util/promoCredit.spec.js
+++ b/test/unit/specs/util/promoCredit.spec.js
@@ -1,4 +1,9 @@
-import { isFromImpactDashboard, bonusBalance, hasPromoSession } from '#src/util/promoCredit';
+import {
+	isFromImpactDashboard,
+	bonusBalance,
+	hasPromoSession,
+	isAdminRewardTipEligible,
+} from '#src/util/promoCredit';
 
 describe('promoCredit', () => {
 	describe('isFromImpactDashboard', () => {
@@ -155,6 +160,40 @@ describe('promoCredit', () => {
 			expect(hasPromoSession({})).toBe(false);
 			expect(hasPromoSession({ my: {} })).toBe(false);
 			expect(hasPromoSession({ shop: {} })).toBe(false);
+		});
+	});
+
+	describe('isAdminRewardTipEligible', () => {
+		const adminRewardData = {
+			shop: { promoCampaign: { managedAccount: { managementType: 'Admin Reward' } } },
+		};
+		const otherTypeData = {
+			shop: { promoCampaign: { managedAccount: { managementType: 'lending_reward' } } },
+		};
+		const noPromoData = { shop: {} };
+
+		it('returns true when flag is on and managementType is Admin Reward', () => {
+			expect(isAdminRewardTipEligible(adminRewardData, true)).toBe(true);
+		});
+
+		it('returns false when flag is off, even for Admin Reward', () => {
+			expect(isAdminRewardTipEligible(adminRewardData, false)).toBe(false);
+		});
+
+		it('returns false for other managementType values when flag is on', () => {
+			expect(isAdminRewardTipEligible(otherTypeData, true)).toBe(false);
+		});
+
+		it('returns false for non-promotional checkouts (no promoCampaign) when flag is on', () => {
+			expect(isAdminRewardTipEligible(noPromoData, true)).toBe(false);
+		});
+
+		it('returns false when flag is null (setting absent)', () => {
+			expect(isAdminRewardTipEligible(adminRewardData, null)).toBe(false);
+		});
+
+		it('returns false when data is undefined', () => {
+			expect(isAdminRewardTipEligible(undefined, true)).toBe(false);
 		});
 	});
 });

--- a/test/unit/specs/util/promoCredit.spec.js
+++ b/test/unit/specs/util/promoCredit.spec.js
@@ -164,36 +164,28 @@ describe('promoCredit', () => {
 	});
 
 	describe('isAdminRewardTipEligible', () => {
-		const adminRewardData = {
-			shop: { promoCampaign: { managedAccount: { managementType: 'Admin Reward' } } },
-		};
-		const otherTypeData = {
-			shop: { promoCampaign: { managedAccount: { managementType: 'lending_reward' } } },
-		};
-		const noPromoData = { shop: {} };
+		const adminRewardPromo = { managedAccount: { managementType: 'Admin Reward' } };
+		const otherTypePromo = { managedAccount: { managementType: 'lending_reward' } };
 
 		it('returns true when flag is on and managementType is Admin Reward', () => {
-			expect(isAdminRewardTipEligible(adminRewardData, true)).toBe(true);
+			expect(isAdminRewardTipEligible(adminRewardPromo, true)).toBe(true);
 		});
 
 		it('returns false when flag is off, even for Admin Reward', () => {
-			expect(isAdminRewardTipEligible(adminRewardData, false)).toBe(false);
+			expect(isAdminRewardTipEligible(adminRewardPromo, false)).toBe(false);
 		});
 
 		it('returns false for other managementType values when flag is on', () => {
-			expect(isAdminRewardTipEligible(otherTypeData, true)).toBe(false);
+			expect(isAdminRewardTipEligible(otherTypePromo, true)).toBe(false);
 		});
 
-		it('returns false for non-promotional checkouts (no promoCampaign) when flag is on', () => {
-			expect(isAdminRewardTipEligible(noPromoData, true)).toBe(false);
+		it('returns false for non-promotional checkouts (no promoData) when flag is on', () => {
+			expect(isAdminRewardTipEligible(undefined, true)).toBe(false);
+			expect(isAdminRewardTipEligible({}, true)).toBe(false);
 		});
 
 		it('returns false when flag is null (setting absent)', () => {
-			expect(isAdminRewardTipEligible(adminRewardData, null)).toBe(false);
-		});
-
-		it('returns false when data is undefined', () => {
-			expect(isAdminRewardTipEligible(undefined, true)).toBe(false);
+			expect(isAdminRewardTipEligible(adminRewardPromo, null)).toBe(false);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Foundational helper for epic [MP-2829](https://kiva.atlassian.net/browse/MP-2829), unblocks UI ticket [MP-2840](https://kiva.atlassian.net/browse/MP-2840). Adds a feature-flagged `isAdminRewardTipEligible` helper so the optional tip section can later be shown on Admin Reward lending-credit checkouts.

Ticket: [MP-2839](https://kiva.atlassian.net/browse/MP-2839)

## What changed

- **Flag plumbing** — adds `uiConfigSetting(key: "enable_tip_for_admin_reward_lc")` to `initializeCheckout.graphql` and surfaces it on `CheckoutPage` as `enableAdminRewardTipFlag` via `readBoolSetting`.
- **Helper** — new `isAdminRewardTipEligible(promoData, flagEnabled)` in `src/util/promoCredit.js` next to `hasPromoSession`. Returns `true` only when the flag is `=== true` **and** `promoData.managedAccount.managementType === 'Admin Reward'`.
- **Computed** — `CheckoutPage.vue` exposes `adminRewardTipEligible` so MP-2840 reads a single boolean to gate the UI.
- **No schema change** — `managementType` is already on `ManagedAccount` (already requested by `promoCampaign.graphql`).

[MP-2829]: https://kiva.atlassian.net/browse/MP-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2840]: https://kiva.atlassian.net/browse/MP-2840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2839]: https://kiva.atlassian.net/browse/MP-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ