### PR TITLE
feat: add remaining stats to loans beta page and missing graph bg on rows

### DIFF
--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -50,9 +50,10 @@
 							</td>
 						</tr>
 						<tr
-							v-for="loan in loans"
+							v-for="(loan, index) in loans"
 							:key="loan.id"
 							class="tw-border-b tw-border-tertiary"
+							:class="{ 'tw-bg-gray-50': index % 2 === 1 }"
 						>
 							<td class="tw-px-2 tw-py-2">
 								<div class="tw-flex tw-items-start">

--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -96,19 +96,19 @@ export default {
 			avgStats: {},
 			loading: true,
 			statsRows: [
-				{ label: 'Amount lent', key: 'amount_of_loans', type: 'currency' },
+				{ label: 'Amount lent', key: 'amount_lent', type: 'currency' },
 				{ label: 'Amount repaid', key: 'amount_repaid', type: 'currency' },
-				{ label: 'Amount lost', key: 'amount_defaulted', type: 'currency' },
+				{ label: 'Amount lost', key: 'amount_lost', type: 'currency' },
 				{ label: 'Amount refunded', key: 'amount_refunded', type: 'currency' },
 				{ label: 'Delinquency rate', key: 'arrears_rate', type: 'percentage' },
 				{ label: 'Amount in arrears', key: 'amount_in_arrears', type: 'currency' },
 				{ label: 'Outstanding loans', key: 'amount_outstanding', type: 'currency' },
 				{ label: 'Default rate', key: 'default_rate', type: 'percentage' },
 				{ label: 'Amount defaulted', key: 'amount_defaulted', type: 'currency' },
-				{ label: 'Amount ended', key: 'total_ended', type: 'currency' },
+				{ label: 'Amount ended', key: 'amount_ended', type: 'currency' },
 				{ label: 'Currency loss rate', key: 'currency_loss_rate', type: 'currencyLossRate' },
-				{ label: 'Amount of currency loss', key: 'currency_loss', type: 'currencyNegative' },
-				{ label: 'Currency loss reimbursement', key: 'currency_reimbursement', type: 'currency' }
+				{ label: 'Amount of currency loss', key: 'currency_loss', type: 'currencyLossAmount' },
+				{ label: 'Currency loss reimbursement', key: 'currency_loss_reimbursement', type: 'currency' }
 			],
 			loanCounts: {
 				fundraising: 0,
@@ -136,12 +136,15 @@ export default {
 	},
 	methods: {
 		formatValue(value, type) {
-			if (value === undefined || value === null) {
-				return 'Endpoint TBD';
-			}
+			// Currency-loss rate/amount mirror the legacy page: they read "Not available"
+			// when the backend has no value, instead of falling back to zero.
+			const showsNotAvailable = type === 'currencyLossRate' || type === 'currencyLossAmount';
 
-			if (!value) {
-				return type === 'percentage' || type === 'currencyLossRate' ? '0.00%' : '$0.00';
+			if (value === undefined || value === null) {
+				if (showsNotAvailable) {
+					return 'Not available';
+				}
+				return type === 'percentage' ? '0.00%' : '$0.00';
 			}
 
 			const num = Number(value);
@@ -150,8 +153,8 @@ export default {
 					return `${num.toFixed(2)}%`;
 				case 'percentage':
 					return `${(num * 100).toFixed(2)}%`;
-				case 'currencyNegative':
-					return `$${(num * -1).toFixed(2)}`;
+				case 'currencyLossAmount':
+					return `$${Math.abs(num).toFixed(2)}`;
 				case 'currency':
 				default:
 					return `$${num.toFixed(2)}`;
@@ -161,37 +164,83 @@ export default {
 	apollo: {
 		query: lendingStatsQuery,
 		result({ data }) {
-			this.stats = data?.my?.userStats ?? {};
-			this.$emit('updated-as-of', data?.general?.kivaStats?.avgLenderStatsUpdatedAt ?? null);
+			const userStats = data?.my?.userStats ?? {};
+			const kivaStats = data?.general?.kivaStats ?? {};
+			const num = value => (value === null || value === undefined ? 0 : Number(value));
+
+			this.$emit('updated-as-of', kivaStats.avgLenderStatsUpdatedAt ?? null);
+
+			// The legacy page hides the currency-loss rate/amount together unless both the
+			// rate is present and the loss amount is non-null.
+			const currencyLossAvailable = userStats.currency_loss_rate !== null
+				&& userStats.currency_loss_rate !== undefined
+				&& userStats.currency_loss !== null
+				&& userStats.currency_loss !== undefined;
+
+			// My stats, applying the legacy row formulas.
+			this.stats = {
+				amount_lent: userStats.amount_of_loans,
+				amount_repaid: userStats.amount_repaid,
+				amount_lost: Math.abs(-num(userStats.amount_defaulted) + num(userStats.currency_loss)),
+				amount_refunded: userStats.amount_refunded,
+				arrears_rate: userStats.arrears_rate,
+				amount_in_arrears: userStats.amount_in_arrears,
+				amount_outstanding: userStats.amount_outstanding,
+				default_rate: userStats.default_rate,
+				amount_defaulted: Math.abs(num(userStats.amount_defaulted)),
+				amount_ended: num(userStats.total_ended) + num(userStats.total_defaulted),
+				currency_loss_rate: currencyLossAvailable ? userStats.currency_loss_rate : null,
+				currency_loss: currencyLossAvailable ? userStats.currency_loss : null,
+				currency_loss_reimbursement: userStats.currency_loss_reimbursement
+			};
+
+			// Avg Kiva lender stats come from precomputed kivaStats avg* fields.
 			this.avgStats = {
-				amount_repaid: data?.general?.kivaStats?.avgAmountRepaid ?? null,
-				amount_in_arrears: data?.general?.kivaStats?.avgAmountArrears ?? null,
-				amount_outstanding: data?.general?.kivaStats?.avgAmountOutstanding ?? null,
-				default_rate: data?.general?.kivaStats?.avgDefaultRate ?? null,
-				amount_defaulted: data?.general?.kivaStats?.avgAmountDefaulted ?? null,
-				// The following fields are not yet available in the current API
-				// TODO: Add these values in once backend issues are resolved
-				amount_of_loans: null,
-				arrears_rate: null,
-				amount_refunded: null,
-				total_ended: null,
-				currency_loss_rate: null,
-				currency_loss: null,
-				currency_reimbursement: null
+				amount_lent: kivaStats.avgAmountLent ?? null,
+				amount_repaid: kivaStats.avgAmountRepaid ?? null,
+				amount_lost: kivaStats.avgTotalAmountLost ?? null,
+				amount_refunded: kivaStats.avgAmountRefunded ?? null,
+				arrears_rate: kivaStats.avgDelinquencyRate ?? null,
+				amount_in_arrears: kivaStats.avgAmountArrears ?? null,
+				amount_outstanding: kivaStats.avgAmountOutstanding ?? null,
+				default_rate: kivaStats.avgDefaultRate ?? null,
+				amount_defaulted: kivaStats.avgAmountDefaulted == null
+					? null
+					: Math.abs(Number(kivaStats.avgAmountDefaulted)),
+				amount_ended: kivaStats.avgTotalEnded ?? null,
+				currency_loss_rate: kivaStats.avgCurrencyLossRate ?? null,
+				currency_loss: kivaStats.avgCurrencyLoss ?? null,
+				currency_loss_reimbursement: kivaStats.avgCurrencyLossReimbursement ?? null
 			};
 			this.loading = false;
 
-			// Update loan counts from stats
+			// The ended-with-currency-loss count is not exposed on userStats, so we derive it
+			// from the loans search the way the legacy getStatusCounts() does. The search's
+			// `ended_with_loss` status filter resolves to `defaulted OR (ended AND currency loss)`,
+			// so it also matches every defaulted loan; subtract the defaulted bucket (same search
+			// source) to recover just the ended-with-currency-loss loans. "Repaid" is then the
+			// remaining ended loans: ended total - ended-with-loss.
+			const endedTotal = data?.my?.endedLoans?.totalCount ?? 0;
+			const endedWithLossOrDefaulted = data?.my?.endedWithLossLoans?.totalCount ?? 0;
+			const searchedDefaulted = data?.my?.defaultedLoans?.totalCount ?? 0;
+			const endedWithLoss = Math.max(endedWithLossOrDefaulted - searchedDefaulted, 0);
+
+			// Update loan counts. Note this table mixes two sources: the ended-state rows
+			// (repaid, repaidWithCurrencyLoss, defaulted) are derived together from the loans
+			// search so they reconcile against one snapshot (ended total = repaid + with-loss,
+			// and defaulted shares that source), while the unrelated rows come from userStats
+			// num_* counts. A future backend loanStatusCounts field would let the whole table
+			// come from a single source (see legacy API::user()->getStatusCounts()).
 			this.loanCounts = {
-				fundraising: this.stats.num_fund_raising || 0,
-				funded: this.stats.num_raised || 0,
-				payingBack: this.stats.num_paying_back || 0,
-				payingBackDelinquent: this.stats.number_delinquent || 0,
-				repaid: this.stats.num_ended - (this.stats.currency_loss ? 1 : 0) || 0,
-				repaidWithCurrencyLoss: this.stats.currency_loss ? 1 : 0,
-				defaulted: this.stats.num_defaulted || 0,
-				refunded: this.stats.num_refunded || 0,
-				expired: this.stats.num_expired || 0
+				fundraising: userStats.num_fund_raising || 0,
+				funded: userStats.num_raised || 0,
+				payingBack: userStats.num_paying_back || 0,
+				payingBackDelinquent: userStats.number_delinquent || 0,
+				repaid: Math.max(endedTotal - endedWithLoss, 0),
+				repaidWithCurrencyLoss: endedWithLoss,
+				defaulted: searchedDefaulted,
+				refunded: userStats.num_refunded || 0,
+				expired: userStats.num_expired || 0
 			};
 		}
 	}

--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -36,8 +36,12 @@
 		</tbody>
 
 		<tbody v-else>
-			<tr v-for="row in statsRows" :key="row.key">
-				<td class="tw-p-1">
+			<tr
+				v-for="row in statsRows"
+				:key="row.key"
+				:class="{ 'tw-bg-white': row.showInWhite, 'tw-bg-gray-50': row.showInGray }"
+			>
+				<td class="tw-p-1" :class="{ 'tw-pl-6': row.isTabbed }">
 					{{ row.label }}
 				</td>
 				<td class="tw-text-right tw-p-1">
@@ -95,20 +99,84 @@ export default {
 			stats: {},
 			avgStats: {},
 			loading: true,
+			// isTabbed / showInWhite / showInGray mirror the legacy setupCompareStat() flags
+			// in LoansView.php: tabbed rows indent under their parent metric, and the explicit
+			// white/gray banding groups related rows (replacing the flat migrated grid).
 			statsRows: [
 				{ label: 'Amount lent', key: 'amount_lent', type: 'currency' },
-				{ label: 'Amount repaid', key: 'amount_repaid', type: 'currency' },
+				{
+					label: 'Amount repaid',
+					key: 'amount_repaid',
+					type: 'currency',
+					showInGray: true,
+				},
 				{ label: 'Amount lost', key: 'amount_lost', type: 'currency' },
-				{ label: 'Amount refunded', key: 'amount_refunded', type: 'currency' },
-				{ label: 'Delinquency rate', key: 'arrears_rate', type: 'percentage' },
-				{ label: 'Amount in arrears', key: 'amount_in_arrears', type: 'currency' },
-				{ label: 'Outstanding loans', key: 'amount_outstanding', type: 'currency' },
-				{ label: 'Default rate', key: 'default_rate', type: 'percentage' },
-				{ label: 'Amount defaulted', key: 'amount_defaulted', type: 'currency' },
-				{ label: 'Amount ended', key: 'amount_ended', type: 'currency' },
-				{ label: 'Currency loss rate', key: 'currency_loss_rate', type: 'currencyLossRate' },
-				{ label: 'Amount of currency loss', key: 'currency_loss', type: 'currencyLossAmount' },
-				{ label: 'Currency loss reimbursement', key: 'currency_loss_reimbursement', type: 'currency' }
+				{
+					label: 'Amount refunded',
+					key: 'amount_refunded',
+					type: 'currency',
+					showInGray: true,
+				},
+				{
+					label: 'Delinquency rate',
+					key: 'arrears_rate',
+					type: 'percentage',
+					showInWhite: true,
+				},
+				{
+					label: 'Amount in arrears',
+					key: 'amount_in_arrears',
+					type: 'currency',
+					isTabbed: true,
+					showInWhite: true,
+				},
+				{
+					label: 'Outstanding loans',
+					key: 'amount_outstanding',
+					type: 'currency',
+					isTabbed: true,
+					showInWhite: true,
+				},
+				{
+					label: 'Default rate',
+					key: 'default_rate',
+					type: 'percentage',
+					showInGray: true,
+				},
+				{
+					label: 'Amount defaulted',
+					key: 'amount_defaulted',
+					type: 'currency',
+					isTabbed: true,
+					showInGray: true,
+				},
+				{
+					label: 'Amount ended',
+					key: 'amount_ended',
+					type: 'currency',
+					isTabbed: true,
+					showInGray: true,
+				},
+				{
+					label: 'Currency loss rate',
+					key: 'currency_loss_rate',
+					type: 'currencyLossRate',
+					showInWhite: true,
+				},
+				{
+					label: 'Amount of currency loss',
+					key: 'currency_loss',
+					type: 'currencyLossAmount',
+					isTabbed: true,
+					showInWhite: true,
+				},
+				{
+					label: 'Currency loss reimbursement',
+					key: 'currency_loss_reimbursement',
+					type: 'currency',
+					isTabbed: true,
+					showInWhite: true,
+				}
 			],
 			loanCounts: {
 				fundraising: 0,
@@ -166,7 +234,19 @@ export default {
 		result({ data }) {
 			const userStats = data?.my?.userStats ?? {};
 			const kivaStats = data?.general?.kivaStats ?? {};
-			const num = value => (value === null || value === undefined ? 0 : Number(value));
+			// Money scalar values arrive as legacy number_format strings, so amounts of
+			// $1,000+ carry thousands separators (e.g. "12,500.00"). Strip any grouping or
+			// symbol characters before coercing — otherwise Number() yields NaN and the cell
+			// renders "$NaN". Returns null for missing/unparseable values so the row falls
+			// back to its "$0.00" / "Not available" display.
+			const money = value => {
+				if (value === null || value === undefined || value === '') {
+					return null;
+				}
+				const parsed = Number(String(value).replace(/[^0-9.-]/g, ''));
+				return Number.isNaN(parsed) ? null : parsed;
+			};
+			const num = value => money(value) ?? 0;
 
 			this.$emit('updated-as-of', kivaStats.avgLenderStatsUpdatedAt ?? null);
 
@@ -179,38 +259,37 @@ export default {
 
 			// My stats, applying the legacy row formulas.
 			this.stats = {
-				amount_lent: userStats.amount_of_loans,
-				amount_repaid: userStats.amount_repaid,
+				amount_lent: money(userStats.amount_of_loans),
+				amount_repaid: money(userStats.amount_repaid),
 				amount_lost: Math.abs(-num(userStats.amount_defaulted) + num(userStats.currency_loss)),
-				amount_refunded: userStats.amount_refunded,
+				amount_refunded: money(userStats.amount_refunded),
 				arrears_rate: userStats.arrears_rate,
-				amount_in_arrears: userStats.amount_in_arrears,
-				amount_outstanding: userStats.amount_outstanding,
+				amount_in_arrears: money(userStats.amount_in_arrears),
+				amount_outstanding: money(userStats.amount_outstanding),
 				default_rate: userStats.default_rate,
 				amount_defaulted: Math.abs(num(userStats.amount_defaulted)),
 				amount_ended: num(userStats.total_ended) + num(userStats.total_defaulted),
 				currency_loss_rate: currencyLossAvailable ? userStats.currency_loss_rate : null,
-				currency_loss: currencyLossAvailable ? userStats.currency_loss : null,
-				currency_loss_reimbursement: userStats.currency_loss_reimbursement
+				currency_loss: currencyLossAvailable ? money(userStats.currency_loss) : null,
+				currency_loss_reimbursement: money(userStats.currency_loss_reimbursement)
 			};
 
 			// Avg Kiva lender stats come from precomputed kivaStats avg* fields.
+			const avgDefaulted = money(kivaStats.avgAmountDefaulted);
 			this.avgStats = {
-				amount_lent: kivaStats.avgAmountLent ?? null,
-				amount_repaid: kivaStats.avgAmountRepaid ?? null,
-				amount_lost: kivaStats.avgTotalAmountLost ?? null,
-				amount_refunded: kivaStats.avgAmountRefunded ?? null,
+				amount_lent: money(kivaStats.avgAmountLent),
+				amount_repaid: money(kivaStats.avgAmountRepaid),
+				amount_lost: money(kivaStats.avgTotalAmountLost),
+				amount_refunded: money(kivaStats.avgAmountRefunded),
 				arrears_rate: kivaStats.avgDelinquencyRate ?? null,
-				amount_in_arrears: kivaStats.avgAmountArrears ?? null,
-				amount_outstanding: kivaStats.avgAmountOutstanding ?? null,
+				amount_in_arrears: money(kivaStats.avgAmountArrears),
+				amount_outstanding: money(kivaStats.avgAmountOutstanding),
 				default_rate: kivaStats.avgDefaultRate ?? null,
-				amount_defaulted: kivaStats.avgAmountDefaulted == null
-					? null
-					: Math.abs(Number(kivaStats.avgAmountDefaulted)),
-				amount_ended: kivaStats.avgTotalEnded ?? null,
+				amount_defaulted: avgDefaulted === null ? null : Math.abs(avgDefaulted),
+				amount_ended: money(kivaStats.avgTotalEnded),
 				currency_loss_rate: kivaStats.avgCurrencyLossRate ?? null,
-				currency_loss: kivaStats.avgCurrencyLoss ?? null,
-				currency_loss_reimbursement: kivaStats.avgCurrencyLossReimbursement ?? null
+				currency_loss: money(kivaStats.avgCurrencyLoss),
+				currency_loss_reimbursement: money(kivaStats.avgCurrencyLossReimbursement)
 			};
 			this.loading = false;
 

--- a/src/graphql/query/myPortfolioLoansLendingStats.graphql
+++ b/src/graphql/query/myPortfolioLoansLendingStats.graphql
@@ -14,25 +14,42 @@ query myPortfolioLoansLendingStats {
 			amount_outstanding
 			default_rate
 			total_ended
+			total_defaulted
 			currency_loss_rate
 			currency_loss
+			currency_loss_reimbursement
 			num_fund_raising
 			num_raised
 			num_paying_back
 			number_delinquent
-			num_ended
-			num_defaulted
 			num_refunded
 			num_expired
+		}
+		endedLoans: loans(filters: { status: ended }, limit: 1) {
+			totalCount
+		}
+		endedWithLossLoans: loans(filters: { status: ended_with_loss }, limit: 1) {
+			totalCount
+		}
+		defaultedLoans: loans(filters: { status: defaulted }, limit: 1) {
+			totalCount
 		}
 	}
 	general {
 		kivaStats {
+			avgAmountLent
 			avgAmountRepaid
+			avgTotalAmountLost
+			avgAmountRefunded
+			avgDelinquencyRate
 			avgAmountArrears
 			avgAmountOutstanding
 			avgDefaultRate
 			avgAmountDefaulted
+			avgTotalEnded
+			avgCurrencyLossRate
+			avgCurrencyLoss
+			avgCurrencyLossReimbursement
 			avgLenderStatsUpdatedAt
 		}
 	}

--- a/src/graphql/query/portfolio/myLoans.graphql
+++ b/src/graphql/query/portfolio/myLoans.graphql
@@ -30,7 +30,6 @@ query myLoans(
 				name
 				status
 				statusLabel
-				use
 				image {
 					id
 					url
@@ -46,7 +45,6 @@ query myLoans(
 					id
 					name
 				}
-				loanAmount
 				loanFundraisingInfo {
 					id
 					fundedAmount
@@ -56,9 +54,6 @@ query myLoans(
 				sharedArrearsAmount
 				terms {
 					loanAmount
-					expectedPayments {
-						dueToKivaDate
-					}
 				}
 				userProperties {
 					loanBalance {

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -403,6 +403,21 @@ describe('LoanList — arrears rendering', () => {
 	});
 });
 
+describe('LoanList — row banding', () => {
+	const makeLoans = count => Array.from({ length: count }, (_, i) => makeLoan({ id: 2000 + i }));
+
+	it('applies alternating gray banding to every other data row, starting on the second', () => {
+		const page = renderLoanList({ loans: makeLoans(4) });
+		const rows = [...page.container.querySelectorAll('tbody tr')];
+
+		expect(rows).toHaveLength(4);
+		expect(rows[0].classList.contains('tw-bg-gray-50')).toBe(false);
+		expect(rows[1].classList.contains('tw-bg-gray-50')).toBe(true);
+		expect(rows[2].classList.contains('tw-bg-gray-50')).toBe(false);
+		expect(rows[3].classList.contains('tw-bg-gray-50')).toBe(true);
+	});
+});
+
 describe('LoanList — team cell', () => {
 	it('renders the user-attributed team name and image when present', () => {
 		const page = renderLoanList({

--- a/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
@@ -325,4 +325,104 @@ describe('LoanStatsTable', () => {
 			expect(countRow(container, 'Expired')).toEqual(['Expired', '0']);
 		});
 	});
+
+	describe('locale-formatted Money values', () => {
+		// The Money scalar arrives as legacy number_format strings, so amounts of $1,000+
+		// carry thousands separators (e.g. "12,500.00"). Number() can't parse those, which
+		// rendered "$NaN" for large My-stats and Avg totals (amount lent/repaid/ended).
+		const formatted = () => fullData({
+			userStats: {
+				amount_of_loans: '12,500.00',
+				amount_repaid: '9,800.50',
+				amount_refunded: '1,025.00',
+				amount_defaulted: '50.00',
+				currency_loss: '-12.50',
+				total_ended: '8,200.00',
+				total_defaulted: '1,050.00',
+			},
+			kivaStats: {
+				avgAmountLent: '1,500.00',
+			},
+		});
+
+		it('parses My-stats Money strings that contain thousands separators', () => {
+			const { ctx } = runResult(formatted());
+
+			expect(ctx.stats.amount_lent).toBeCloseTo(12500);
+			expect(ctx.stats.amount_repaid).toBeCloseTo(9800.5);
+			expect(ctx.stats.amount_refunded).toBeCloseTo(1025);
+			// amount_ended = total_ended + total_defaulted = 8200 + 1050
+			expect(ctx.stats.amount_ended).toBeCloseTo(9250);
+		});
+
+		it('parses Avg-column Money strings that contain thousands separators', () => {
+			const { ctx } = runResult(formatted());
+			expect(ctx.avgStats.amount_lent).toBeCloseTo(1500);
+		});
+
+		it('renders parsed dollar amounts instead of $NaN', async () => {
+			const { getVm, container } = renderTable();
+			const vm = getVm();
+			vm.$options.apollo.result.call(vm, { data: formatted() });
+			await nextTick();
+
+			expect(statsRow(container, 'Amount lent')[1]).toBe('$12500.00');
+			expect(statsRow(container, 'Amount repaid')[1]).toBe('$9800.50');
+			expect(statsRow(container, 'Amount ended')[1]).toBe('$9250.00');
+			expect(statsRow(container, 'Amount lent')[2]).toBe('$1500.00');
+		});
+	});
+
+	describe('legacy row banding and indent', () => {
+		// Based on the legacy setupCompareStat($label, ..., $is_tabbed, $show_in_white,
+		// $show_in_gray) flags in LoansView.php (MP-2859), plus product-requested gray banding
+		// on the Amount repaid / Amount refunded rows. `bg` is the expected explicit row
+		// background (null = default); `tabbed` indents the label under its parent metric.
+		const expected = {
+			'Amount lent': { tabbed: false, bg: null },
+			'Amount repaid': { tabbed: false, bg: 'tw-bg-gray-50' },
+			'Amount lost': { tabbed: false, bg: null },
+			'Amount refunded': { tabbed: false, bg: 'tw-bg-gray-50' },
+			'Delinquency rate': { tabbed: false, bg: 'tw-bg-white' },
+			'Amount in arrears': { tabbed: true, bg: 'tw-bg-white' },
+			'Outstanding loans': { tabbed: true, bg: 'tw-bg-white' },
+			'Default rate': { tabbed: false, bg: 'tw-bg-gray-50' },
+			'Amount defaulted': { tabbed: true, bg: 'tw-bg-gray-50' },
+			'Amount ended': { tabbed: true, bg: 'tw-bg-gray-50' },
+			'Currency loss rate': { tabbed: false, bg: 'tw-bg-white' },
+			'Amount of currency loss': { tabbed: true, bg: 'tw-bg-white' },
+			'Currency loss reimbursement': { tabbed: true, bg: 'tw-bg-white' },
+		};
+
+		const renderRows = async () => {
+			const { getVm, container } = renderTable();
+			const vm = getVm();
+			vm.$options.apollo.result.call(vm, { data: fullData() });
+			await nextTick();
+			return container;
+		};
+
+		const trByLabel = (container, label) => [...container.querySelectorAll('tbody tr')]
+			.find(tr => tr.querySelector('td')?.textContent.trim() === label);
+
+		it('applies the legacy white/gray banding per row', async () => {
+			const container = await renderRows();
+			Object.entries(expected).forEach(([label, { bg }]) => {
+				const tr = trByLabel(container, label);
+				expect(tr, `row "${label}" should render`).toBeTruthy();
+				expect(tr.classList.contains('tw-bg-white'), `${label} white banding`)
+					.toBe(bg === 'tw-bg-white');
+				expect(tr.classList.contains('tw-bg-gray-50'), `${label} gray banding`)
+					.toBe(bg === 'tw-bg-gray-50');
+			});
+		});
+
+		it('indents the tabbed rows under their parent metric', async () => {
+			const container = await renderRows();
+			Object.entries(expected).forEach(([label, { tabbed }]) => {
+				const labelCell = trByLabel(container, label).querySelector('td');
+				expect(labelCell.classList.contains('tw-pl-6'), `${label} indent`).toBe(tabbed);
+			});
+		});
+	});
 });

--- a/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
@@ -1,0 +1,328 @@
+import { nextTick } from 'vue';
+import { render } from '@testing-library/vue';
+import LoanStatsTable from '#src/components/Portfolio/LoanStatsTable';
+import { globalOptions } from '../../../specUtils';
+
+// Full backend payload covering both My stats (my.userStats) and Avg Kiva lender
+// (general.kivaStats) columns for all 13 comparison rows.
+const fullData = (overrides = {}) => ({
+	my: {
+		userStats: {
+			amount_of_loans: 1000,
+			amount_repaid: 800,
+			amount_defaulted: 50,
+			amount_refunded: 25,
+			arrears_rate: 0.0123,
+			amount_in_arrears: 10,
+			amount_outstanding: 200,
+			default_rate: 0.05,
+			total_ended: 700,
+			total_defaulted: 50,
+			currency_loss_rate: 1.5,
+			currency_loss: -12.5,
+			currency_loss_reimbursement: 7.25,
+			num_fund_raising: 3,
+			num_raised: 4,
+			num_paying_back: 5,
+			number_delinquent: 1,
+			num_ended: 9,
+			num_defaulted: 2,
+			num_refunded: 1,
+			num_expired: 0,
+			...overrides.userStats,
+		},
+		// endedWithLossLoans is the `ended_with_loss` search bucket, which the backend
+		// resolves to `defaulted OR (ended AND currency loss)` — so it = defaulted (2) +
+		// ended-with-currency-loss (3). The component subtracts defaultedLoans to recover 3.
+		endedLoans: { totalCount: 9, ...overrides.endedLoans },
+		endedWithLossLoans: { totalCount: 5, ...overrides.endedWithLossLoans },
+		defaultedLoans: { totalCount: 2, ...overrides.defaultedLoans },
+	},
+	general: {
+		kivaStats: {
+			avgAmountLent: 1500,
+			avgAmountRepaid: 1200,
+			avgTotalAmountLost: 60,
+			avgAmountRefunded: 30,
+			avgDelinquencyRate: 0.02,
+			avgAmountArrears: 15,
+			avgAmountOutstanding: 250,
+			avgDefaultRate: 0.04,
+			avgAmountDefaulted: 55,
+			avgTotalEnded: 800,
+			avgCurrencyLossRate: 1.1,
+			avgCurrencyLoss: -8,
+			avgCurrencyLossReimbursement: 9,
+			avgLenderStatsUpdatedAt: '2026-05-19T21:30:00.000Z',
+			...overrides.kivaStats,
+		},
+	},
+});
+
+// Invoke the component's apollo result handler against a bare context, the way the
+// rest of the suite tests Options API handlers directly.
+const runResult = (data, context = {}) => {
+	const emit = vi.fn();
+	const ctx = { $emit: emit, ...context };
+	LoanStatsTable.apollo.result.call(ctx, { data });
+	return { ctx, emit };
+};
+
+const renderTable = () => {
+	const childRef = { current: null };
+	const Wrapper = {
+		components: { LoanStatsTable },
+		template: '<LoanStatsTable ref="child" />',
+		mounted() {
+			childRef.current = this.$refs.child;
+		},
+	};
+	const utils = render(Wrapper, {
+		global: {
+			...globalOptions,
+			provide: {
+				...globalOptions.provide,
+				apollo: { ...globalOptions.provide.apollo },
+				cookieStore: {},
+			},
+		},
+	});
+	return { ...utils, getVm: () => childRef.current };
+};
+
+// Read a comparison-table row's cells as [label, myValue, avgValue].
+const statsRow = (container, label) => [...container.querySelectorAll('tbody tr')]
+	.map(tr => [...tr.querySelectorAll('td')].map(td => td.textContent.trim()))
+	.find(cells => cells[0] === label);
+
+// Read a loan-count row's cells as [label, value].
+const countRow = (container, label) => [
+	...container.querySelectorAll('[aria-label="Loan count statistics"] [role="row"]'),
+]
+	.map(row => [...row.querySelectorAll('[role="cell"]')].map(cell => cell.textContent.trim()))
+	.find(cells => cells[0] === label);
+
+describe('LoanStatsTable', () => {
+	describe('formatValue', () => {
+		const { formatValue } = LoanStatsTable.methods;
+
+		it('formats currency, percentage, and currency-loss rate values', () => {
+			expect(formatValue(1234.5, 'currency')).toBe('$1234.50');
+			expect(formatValue(0.0123, 'percentage')).toBe('1.23%');
+			expect(formatValue(1.5, 'currencyLossRate')).toBe('1.50%');
+		});
+
+		it('renders currency-loss amounts as an absolute dollar value', () => {
+			expect(formatValue(-12.5, 'currencyLossAmount')).toBe('$12.50');
+			expect(formatValue(12.5, 'currencyLossAmount')).toBe('$12.50');
+		});
+
+		it('falls back to zero for missing currency and percentage values', () => {
+			expect(formatValue(null, 'currency')).toBe('$0.00');
+			expect(formatValue(undefined, 'currency')).toBe('$0.00');
+			expect(formatValue(0, 'currency')).toBe('$0.00');
+			expect(formatValue(null, 'percentage')).toBe('0.00%');
+		});
+
+		it('renders "Not available" for missing currency-loss rate and amount', () => {
+			expect(formatValue(null, 'currencyLossRate')).toBe('Not available');
+			expect(formatValue(undefined, 'currencyLossAmount')).toBe('Not available');
+		});
+	});
+
+	describe('result mapping', () => {
+		it('applies legacy My-stats formulas', () => {
+			const { ctx } = runResult(fullData());
+
+			// Amount lost = abs(-amount_defaulted + currency_loss) = abs(-50 + -12.5)
+			expect(ctx.stats.amount_lost).toBeCloseTo(62.5);
+			// Amount defaulted = abs(amount_defaulted)
+			expect(ctx.stats.amount_defaulted).toBe(50);
+			// Amount ended = total_ended + total_defaulted
+			expect(ctx.stats.amount_ended).toBe(750);
+			expect(ctx.stats.amount_lent).toBe(1000);
+			expect(ctx.stats.currency_loss_reimbursement).toBe(7.25);
+		});
+
+		it('maps the Avg Kiva lender column to precomputed avg fields', () => {
+			const { ctx } = runResult(fullData());
+
+			expect(ctx.avgStats).toMatchObject({
+				amount_lent: 1500,
+				amount_repaid: 1200,
+				amount_lost: 60,
+				amount_refunded: 30,
+				arrears_rate: 0.02,
+				amount_in_arrears: 15,
+				amount_outstanding: 250,
+				default_rate: 0.04,
+				amount_defaulted: 55,
+				amount_ended: 800,
+				currency_loss_rate: 1.1,
+				currency_loss: -8,
+				currency_loss_reimbursement: 9,
+			});
+		});
+
+		it('hides currency-loss rate and amount when the loss amount is unavailable', () => {
+			const { ctx } = runResult(fullData({
+				userStats: { currency_loss_rate: 1.5, currency_loss: null },
+			}));
+
+			expect(ctx.stats.currency_loss_rate).toBeNull();
+			expect(ctx.stats.currency_loss).toBeNull();
+		});
+
+		it('shows currency-loss rate and amount when both are present', () => {
+			const { ctx } = runResult(fullData());
+
+			expect(ctx.stats.currency_loss_rate).toBe(1.5);
+			expect(ctx.stats.currency_loss).toBe(-12.5);
+		});
+
+		it('maps loan status counts, subtracting defaulted from the ended-with-loss bucket', () => {
+			const { ctx } = runResult(fullData({
+				endedLoans: { totalCount: 9 },
+				endedWithLossLoans: { totalCount: 5 }, // defaulted (2) + ended-with-loss (3)
+				defaultedLoans: { totalCount: 2 },
+			}));
+
+			expect(ctx.loanCounts).toEqual({
+				fundraising: 3,
+				funded: 4,
+				payingBack: 5,
+				payingBackDelinquent: 1,
+				// Repaid = ended total (9) - ended-with-loss-only (5 - 2 = 3)
+				repaid: 6,
+				repaidWithCurrencyLoss: 3,
+				defaulted: 2,
+				refunded: 1,
+				expired: 0,
+			});
+		});
+
+		it('does not count defaulted loans as repaid-with-currency-loss', () => {
+			// The `ended_with_loss` search bucket here is entirely defaulted loans
+			// (no real currency-loss ends), so the split must show zero with-loss.
+			const { ctx } = runResult(fullData({
+				endedLoans: { totalCount: 10 },
+				endedWithLossLoans: { totalCount: 5 },
+				defaultedLoans: { totalCount: 5 },
+			}));
+
+			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(0);
+			expect(ctx.loanCounts.repaid).toBe(10);
+		});
+
+		it('sources the defaulted count from the search, not userStats', () => {
+			const { ctx } = runResult(fullData({
+				userStats: { num_defaulted: 99 },
+				defaultedLoans: { totalCount: 4 },
+				endedWithLossLoans: { totalCount: 4 },
+			}));
+
+			expect(ctx.loanCounts.defaulted).toBe(4);
+		});
+
+		it('derives the ended split from search buckets, not the currency loss amount', () => {
+			const { ctx } = runResult(fullData({
+				userStats: { currency_loss: -99999 },
+				endedLoans: { totalCount: 20 },
+				endedWithLossLoans: { totalCount: 5 },
+				defaultedLoans: { totalCount: 0 },
+			}));
+
+			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(5);
+			expect(ctx.loanCounts.repaid).toBe(15);
+		});
+
+		it('never reports negative repaid or with-loss counts', () => {
+			const { ctx } = runResult(fullData({
+				endedLoans: { totalCount: 0 },
+				endedWithLossLoans: { totalCount: 0 },
+				defaultedLoans: { totalCount: 0 },
+			}));
+
+			expect(ctx.loanCounts.repaid).toBe(0);
+			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(0);
+		});
+
+		it('emits the avg-lender snapshot timestamp as updated-as-of', () => {
+			const { emit } = runResult(fullData());
+			expect(emit).toHaveBeenCalledWith('updated-as-of', '2026-05-19T21:30:00.000Z');
+		});
+
+		it('emits null updated-as-of when no snapshot timestamp is available', () => {
+			const { emit } = runResult(fullData({ kivaStats: { avgLenderStatsUpdatedAt: null } }));
+			expect(emit).toHaveBeenCalledWith('updated-as-of', null);
+		});
+	});
+
+	describe('rendering', () => {
+		it('renders all 13 comparison rows with real values for both columns', async () => {
+			const { getVm, container } = renderTable();
+			const vm = getVm();
+			vm.$options.apollo.result.call(vm, { data: fullData() });
+			await nextTick();
+
+			expect(statsRow(container, 'Amount lent')).toEqual(['Amount lent', '$1000.00', '$1500.00']);
+			expect(statsRow(container, 'Amount repaid')).toEqual(['Amount repaid', '$800.00', '$1200.00']);
+			expect(statsRow(container, 'Amount lost')).toEqual(['Amount lost', '$62.50', '$60.00']);
+			expect(statsRow(container, 'Amount refunded')).toEqual(['Amount refunded', '$25.00', '$30.00']);
+			expect(statsRow(container, 'Delinquency rate')).toEqual(['Delinquency rate', '1.23%', '2.00%']);
+			expect(statsRow(container, 'Amount in arrears')).toEqual(['Amount in arrears', '$10.00', '$15.00']);
+			expect(statsRow(container, 'Outstanding loans')).toEqual(['Outstanding loans', '$200.00', '$250.00']);
+			expect(statsRow(container, 'Default rate')).toEqual(['Default rate', '5.00%', '4.00%']);
+			expect(statsRow(container, 'Amount defaulted')).toEqual(['Amount defaulted', '$50.00', '$55.00']);
+			expect(statsRow(container, 'Amount ended')).toEqual(['Amount ended', '$750.00', '$800.00']);
+			expect(statsRow(container, 'Currency loss rate')).toEqual(['Currency loss rate', '1.50%', '1.10%']);
+			expect(statsRow(container, 'Amount of currency loss'))
+				.toEqual(['Amount of currency loss', '$12.50', '$8.00']);
+			expect(statsRow(container, 'Currency loss reimbursement'))
+				.toEqual(['Currency loss reimbursement', '$7.25', '$9.00']);
+		});
+
+		it('shows "Not available" currency-loss cells and zero fallbacks for missing My stats', async () => {
+			const { getVm, container } = renderTable();
+			const vm = getVm();
+			vm.$options.apollo.result.call(vm, {
+				data: fullData({
+					userStats: {
+						amount_of_loans: null,
+						arrears_rate: null,
+						currency_loss_rate: null,
+						currency_loss: null,
+						amount_defaulted: null,
+						total_ended: null,
+						total_defaulted: null,
+					},
+				}),
+			});
+			await nextTick();
+
+			expect(statsRow(container, 'Amount lent')[1]).toBe('$0.00');
+			expect(statsRow(container, 'Delinquency rate')[1]).toBe('0.00%');
+			expect(statsRow(container, 'Amount lost')[1]).toBe('$0.00');
+			expect(statsRow(container, 'Currency loss rate')[1]).toBe('Not available');
+			expect(statsRow(container, 'Amount of currency loss')[1]).toBe('Not available');
+		});
+
+		it('renders mapped loan status counts', async () => {
+			const { getVm, container } = renderTable();
+			const vm = getVm();
+			vm.$options.apollo.result.call(vm, { data: fullData() });
+			await nextTick();
+
+			expect(countRow(container, 'Fundraising')).toEqual(['Fundraising', '3']);
+			expect(countRow(container, 'Funded')).toEqual(['Funded', '4']);
+			expect(countRow(container, 'Paying back')).toEqual(['Paying back', '5']);
+			expect(countRow(container, 'Paying back delinquent')).toEqual(['Paying back delinquent', '1']);
+			expect(countRow(container, 'Repaid')).toEqual(['Repaid', '6']);
+			expect(countRow(container, 'Repaid with currency loss'))
+				.toEqual(['Repaid with currency loss', '3']);
+			expect(countRow(container, 'Ended in default')).toEqual(['Ended in default', '2']);
+			expect(countRow(container, 'Refunded')).toEqual(['Refunded', '1']);
+			expect(countRow(container, 'Expired')).toEqual(['Expired', '0']);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2731

Adding missing stats that weren't being displayed yet in the loans beta page. Now all fields have data being displayed in the beta page (yay!). Also added some gray background on alternating rows to match legacy (more formatting/style improvements to come in the future).

<img width="789" height="660" alt="image" src="https://github.com/user-attachments/assets/76a383be-ff85-431a-b3a1-010aadd3f3d3" />

<img width="1045" height="550" alt="image" src="https://github.com/user-attachments/assets/dcb7a655-266b-4ea2-90b8-f361b6075842" />
