### PR TITLE
feat: [MP-2747] - extra changes requested in QaVA

### DIFF
--- a/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalFooter.vue
+++ b/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalFooter.vue
@@ -108,7 +108,7 @@ const primaryTo = computed(() => (
 ));
 
 const primaryButtonVariant = computed(() => (
-	props.isInBasket ? 'secondary' : 'primary'
+	props.isInBasket && !props.isAdding ? 'secondary' : 'primary'
 ));
 
 const onPrimaryCtaClick = event => {

--- a/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
+++ b/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
@@ -205,7 +205,6 @@ const onSubmit = async () => {
 			amount: numeral(totalDue.value).format('0.00'),
 			transactionInfo: transactionResult?.data?.checkoutStatus,
 		});
-		closeLightbox();
 	} catch (e) {
 		if (e?.code === 'shop.failedCheckoutValidation') {
 			closeLightbox();
@@ -221,10 +220,9 @@ const onSubmit = async () => {
 		} else if (e?.message && e?.code !== 'shop.dropinRequired') {
 			errorMsg = e.message;
 		}
+		paying.value = false;
 		$showTipMsg(errorMsg, 'error');
 		closeLightbox();
-	} finally {
-		paying.value = false;
 	}
 };
 

--- a/src/composables/useExpressCheckoutModal.js
+++ b/src/composables/useExpressCheckoutModal.js
@@ -119,10 +119,10 @@ export default function useExpressCheckoutModal({
 				if (empty) {
 					kvTrackEvent?.(EVENT_CATEGORY, 'open', 'open-express-checkout');
 					expressCheckoutLoan.value = payload.loan ?? null;
-					expressCheckoutModalRef.value?.openLightbox();
-				} else {
-					router.push('/basket');
+					return expressCheckoutModalRef.value?.openLightbox();
 				}
+				router.push('/basket');
+				return undefined;
 			},
 			onError: () => {
 				isRedirecting.value = false;

--- a/src/plugins/borrower-profile-exp-mixin.js
+++ b/src/plugins/borrower-profile-exp-mixin.js
@@ -168,7 +168,7 @@ export default {
 					}).then(({ data }) => {
 						this.basketItems = data?.shop?.basket?.items?.values;
 						this.basketSize = data?.shop?.nonTrivialItemCount || 0;
-						onSuccess?.();
+						return onSuccess?.();
 					});
 				}
 			}).catch(error => {

--- a/test/unit/specs/composables/useExpressCheckoutModal.spec.js
+++ b/test/unit/specs/composables/useExpressCheckoutModal.spec.js
@@ -116,6 +116,25 @@ describe('useExpressCheckoutModal', () => {
 				expect(mockPush).not.toHaveBeenCalled();
 			});
 
+			it('returns the openLightbox promise from the addToBasket onSuccess callback', async () => {
+				basketItems.value = [];
+				const openLightboxPromise = Promise.resolve(true);
+				const modalMock = { openLightbox: vi.fn(() => openLightboxPromise) };
+				composable.expressCheckoutModalRef.value = modalMock;
+				let addToBasketOnSuccess;
+				mockAddToBasket.mockImplementation(({ onSuccess }) => {
+					addToBasketOnSuccess = onSuccess;
+				});
+
+				await composable.handleAddRecommendedLoanToBasket({
+					loanId: 999,
+					lendAmount: '25',
+					loan: { id: 999 },
+				});
+
+				expect(addToBasketOnSuccess()).toBe(openLightboxPromise);
+			});
+
 			it('does not flip isRedirecting in the empty path', async () => {
 				basketItems.value = [];
 				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());

--- a/test/unit/specs/plugins/borrower-profile-exp-mixin.spec.js
+++ b/test/unit/specs/plugins/borrower-profile-exp-mixin.spec.js
@@ -594,6 +594,39 @@ describe('borrower-profile-exp-mixin', () => {
 			expect(onSuccess).toHaveBeenCalled();
 		});
 
+		it('should keep isAdding true until an async onSuccess resolves', async () => {
+			createComponent();
+			mockApollo.mutate.mockResolvedValue({ errors: null });
+			mockApollo.query.mockResolvedValue({
+				data: {
+					shop: {
+						basket: { items: { values: [] } },
+						nonTrivialItemCount: 1,
+					},
+				},
+			});
+			let resolveOnSuccess;
+			const onSuccess = vi.fn(() => new Promise(resolve => {
+				resolveOnSuccess = resolve;
+			}));
+
+			component.addToBasket({
+				loanId: 123,
+				lendAmount: 25,
+				loan: { id: 123 },
+				onSuccess,
+			});
+			await flushPromises();
+
+			expect(onSuccess).toHaveBeenCalled();
+			expect(component.isAdding).toBe(true);
+
+			resolveOnSuccess();
+			await flushPromises();
+
+			expect(component.isAdding).toBe(false);
+		});
+
 		it('should not call onSuccess when the add to basket fails', async () => {
 			createComponent();
 			const { hasBasketExpired } = await import('#src/util/basketUtils');


### PR DESCRIPTION
- prevent double event recording when we are redirecting to new ty page
- keep primary CTA text until express checkout modal is opened

## Before

[Thank you! | Kiva - 11 June 2026](https://www.loom.com/share/f329baa91a8d4004ace1416e2d782842)

## After

https://github.com/user-attachments/assets/74240f88-49dd-4bb1-ac3d-9d48e1947038

