### PR TITLE
fix: convert /lend/:category guard to redirect

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -322,10 +322,6 @@ export default [
 		}
 	},
 	{
-		path: '/lending-home',
-		redirect: '/lend-by-category',
-	},
-	{
 		name: 'lenderProfile',
 		path: '/lender/:publicId',
 		component: () => import('#src/pages/LenderProfile/LenderProfile'),

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -347,17 +347,18 @@ export default [
 	},
 	{
 		path: '/lend/:category',
-		beforeEnter(to) {
-			const url = to.params.category
-				? `/lend-by-category/${to.params.category}`
-				: '/lend-by-category';
-			if (typeof window !== 'undefined') {
-				window.location.href = url;
-			} else {
+		// /lend-by-category is served externally, so we hand off via a full browser
+		// navigation on the client and a server-side 301 on SSR rather than a
+		// router-level redirect.
+		redirect: to => {
+			const url = `/lend-by-category/${to.params.category}`;
+			if (typeof window === 'undefined') {
 				// SSR: triggers res.redirect in server/vue-middleware.js
 				// eslint-disable-next-line no-throw-literal
 				throw { url, code: 301 };
 			}
+			window.location.href = url;
+			return url;
 		}
 	},
 	{


### PR DESCRIPTION
**Guard update to test on dev**

The previous `beforeEnter` guard on `/lend/:category` set `window.location.href` on the client and threw `{ url, code: 301 }` on SSR to hand off to `/lend-by-category/:category` (which is served externally). On SSR this was broken: Vue Router invokes `beforeEnter` during `router.push(url)`, and the rejection was swallowed by the `.catch(() => {})` in `src/router/index.js`. The route then resolved with no component, producing a 404 instead of the intended 301.

Switching to a `redirect` function moves the hook into the matcher path (`handleRedirectRecord`), which is called synchronously inside `pushWithRedirect`. The SSR throw now propagates out of `router.push()` before any `.then/.catch` and surfaces in `server/vue-middleware.js`'s `handleError`, which issues the 301.

On the client the function returns `url` so Vue Router has a valid redirect target. Without a return value, `handleRedirectRecord` would read `.path` on `undefined` and throw "Invalid redirect" (dev) or a TypeError (prod) right after `window.location.href` is set — a spurious error captured by Sentry even though the browser navigation succeeds.

Also removed the unreachable `: '/lend-by-category'` fallback (the `:category` param is required for the route to match) and added a comment explaining why this entry uses a side-effect handoff instead of the declarative string redirect used elsewhere in the file.

https://kiva.atlassian.net/browse/MP-2906