### PR TITLE
fix: disable loan pill experiment while we run just on combo page

### DIFF
--- a/src/plugins/ai-loan-pills-mixin.js
+++ b/src/plugins/ai-loan-pills-mixin.js
@@ -1,7 +1,15 @@
 import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
-import { HOME_PAGE_EXPERIMENT_KEY as AI_LOAN_PILLS_EXP_KEY } from '#src/util/experiment/fastlyExperimentUtils';
 
-export { AI_LOAN_PILLS_EXP_KEY };
+// Dedicated experiment key for the AI loan pills experiment (MP-2914).
+export const AI_LOAN_PILLS_EXP_KEY = 'ai_loan_pills_combo_page';
+
+// The AI loan pills experiment (MP-2914) is currently being rolled out only on the combo
+// page (lend-category-beta) in the cms-page-server repo, under this dedicated
+// `ai_loan_pills_combo_page` experiment key. It is intentionally disabled here in the ui
+// repo (My Kiva, Checkout) for the initial launch. The enrollment and downstream rendering
+// wiring is left in place so it can be re-enabled on these pages by flipping this flag,
+// without having to re-plumb the components.
+const AI_LOAN_PILLS_ENABLED = false;
 
 export default {
 	data() {
@@ -11,6 +19,13 @@ export default {
 	},
 	methods: {
 		initializeAILoanPills() {
+			// Disabled on ui pages for now — see note above. Skip enrollment entirely so the
+			// experiment is neither assigned nor tracked here while it runs on the combo page.
+			if (!AI_LOAN_PILLS_ENABLED) {
+				this.enableAILoanPills = false;
+				return;
+			}
+
 			const { version } = trackExperimentVersion(
 				this.apollo,
 				this.$kvTrackEvent,

--- a/test/unit/specs/plugins/ai-loan-pills-mixin.spec.js
+++ b/test/unit/specs/plugins/ai-loan-pills-mixin.spec.js
@@ -7,7 +7,9 @@ describe('ai-loan-pills-mixin.js', () => {
 	let context;
 
 	beforeEach(() => {
-		vi.mocked(trackExperimentVersion).mockReturnValue({ version: 'a' });
+		// Default to the treatment variant to prove the feature stays off regardless,
+		// since the experiment is currently disabled in the ui repo.
+		vi.mocked(trackExperimentVersion).mockReturnValue({ version: 'b' });
 
 		// Create a mock context simulating a Vue component
 		context = {
@@ -22,42 +24,25 @@ describe('ai-loan-pills-mixin.js', () => {
 		Object.assign(context, aiLoanPillsMixin.methods);
 	});
 
+	it('exports the experiment key', () => {
+		expect(AI_LOAN_PILLS_EXP_KEY).toBe('ai_loan_pills_combo_page');
+	});
+
 	it('should initialize with enableAILoanPills set to false', () => {
 		expect(context.enableAILoanPills).toBe(false);
 	});
 
-	it('should call trackExperimentVersion with correct parameters in initializeAILoanPills', () => {
-		vi.mocked(trackExperimentVersion).mockReturnValue({ version: 'a' });
-
+	// The experiment is currently disabled in the ui repo — it runs only on the combo
+	// page (lend-category-beta) in cms-page-server. While disabled, the mixin must not
+	// enroll or track users on these pages.
+	it('does not enroll in the experiment while disabled', () => {
 		context.initializeAILoanPills();
 
-		expect(trackExperimentVersion).toHaveBeenCalledWith(
-			context.apollo,
-			context.$kvTrackEvent,
-			'event-tracking',
-			AI_LOAN_PILLS_EXP_KEY,
-			'EXP-MP-2050-Sept2025'
-		);
+		expect(trackExperimentVersion).not.toHaveBeenCalled();
 	});
 
-	it('should set enableAILoanPills to true when version is b', () => {
+	it('keeps enableAILoanPills false while disabled, even for the "b" variant', () => {
 		vi.mocked(trackExperimentVersion).mockReturnValue({ version: 'b' });
-
-		context.initializeAILoanPills();
-
-		expect(context.enableAILoanPills).toBe(true);
-	});
-
-	it('should set enableAILoanPills to false when version is a', () => {
-		vi.mocked(trackExperimentVersion).mockReturnValue({ version: 'a' });
-
-		context.initializeAILoanPills();
-
-		expect(context.enableAILoanPills).toBe(false);
-	});
-
-	it('should set enableAILoanPills to false when version is control', () => {
-		vi.mocked(trackExperimentVersion).mockReturnValue({ version: 'control' });
 
 		context.initializeAILoanPills();
 


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2914

Disable the loan pill experiment in `ui` while it runs just on combo page. Keep code in case we end up running the experiment again and/or roll AI loan pills out permanently.