### PR TITLE
chore(storybook): borrower profile storybook baseline AD-267

### DIFF
--- a/.storybook/mixins/apollo-story-mixin.js
+++ b/.storybook/mixins/apollo-story-mixin.js
@@ -30,6 +30,7 @@ export default ({
 							}
 							return { unsubscribe: () => {} };
 						},
+						setVariables() {},
 					};
 				},
 				query() {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -23,14 +23,14 @@ import config from '../config/local';
 
 setup((app) => {
 	// Create a new router instance
-	// Memory history keeps route changes in-memory instead of modifying the
-	// browser URL. Without this, stories that call $router.replace() or
-	// $router.push() navigate the iframe away from Storybook's URL.
-	// The catch-all route ensures vue-router can resolve any path/query
-	// combination without throwing "No match found" errors.
 	const router = createRouter({
+		// Memory history keeps route changes in-memory instead of modifying the
+		// browser URL. Without this, stories that call $router.replace() or
+		// $router.push() navigate the iframe away from Storybook's URL.
 		history: createMemoryHistory(),
 		routes: [
+			// The catch-all route ensures vue-router can resolve any path/query
+			// combination without throwing "No match found" errors.
 			{ path: '/:catchAll(.*)*', component: { template: '' } },
 		],
 	});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 import { setup } from '@storybook/vue3';
 import { MINIMAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { VueHeadMixin, createHead } from '@unhead/vue';
-import { createRouter, createWebHistory } from 'vue-router';
+import { createRouter, createMemoryHistory } from 'vue-router';
 import { KvThemeProvider } from '@kiva/kv-components';
 import { defaultTheme } from '@kiva/kv-tokens';
 import changeCaseFilter from '../src/plugins/change-case-filter';
@@ -23,9 +23,16 @@ import config from '../config/local';
 
 setup((app) => {
 	// Create a new router instance
+	// Memory history keeps route changes in-memory instead of modifying the
+	// browser URL. Without this, stories that call $router.replace() or
+	// $router.push() navigate the iframe away from Storybook's URL.
+	// The catch-all route ensures vue-router can resolve any path/query
+	// combination without throwing "No match found" errors.
 	const router = createRouter({
-		history: createWebHistory(),
-		routes: [],
+		history: createMemoryHistory(),
+		routes: [
+			{ path: '/:catchAll(.*)*', component: { template: '' } },
+		],
 	});
 	app.use(router);
 

--- a/.storybook/stories/BorrowerProfile/BorrowerCountry.stories.js
+++ b/.storybook/stories/BorrowerProfile/BorrowerCountry.stories.js
@@ -1,0 +1,59 @@
+import BorrowerCountry from '#src/components/BorrowerProfile/BorrowerCountry';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/BorrowerCountry',
+	component: BorrowerCountry,
+};
+
+const loanWithGeocode = {
+	...fundraisingPartnerLoan,
+	geocode: {
+		...fundraisingPartnerLoan.geocode,
+		latitude: 41.5,
+		longitude: 75.8,
+	},
+};
+
+const loanMissingGeocode = {
+	...fundraisingPartnerLoan,
+	geocode: {
+		...fundraisingPartnerLoan.geocode,
+		latitude: null,
+		longitude: null,
+	},
+};
+
+export const WithLoanGeocode = () => ({
+	components: { BorrowerCountry },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(loanWithGeocode) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<borrower-country :loan-id="${loanWithGeocode.id}" />`,
+});
+
+export const FallsBackToCountryGeocode = () => ({
+	components: { BorrowerCountry },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(loanMissingGeocode) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<borrower-country :loan-id="${loanMissingGeocode.id}" />`,
+});
+
+export const Loading = () => ({
+	components: { BorrowerCountry },
+	mixins: [
+		apolloStoryMixin({ queryResult: new Promise(() => {}) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<borrower-country :loan-id="${fundraisingPartnerLoan.id}" />`,
+});

--- a/.storybook/stories/BorrowerProfile/BorrowerCountry.stories.js
+++ b/.storybook/stories/BorrowerProfile/BorrowerCountry.stories.js
@@ -51,7 +51,7 @@ export const FallsBackToCountryGeocode = () => ({
 export const Loading = () => ({
 	components: { BorrowerCountry },
 	mixins: [
-		apolloStoryMixin({ queryResult: new Promise(() => {}) }),
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan), loading: true }),
 		cookieStoreStoryMixin(),
 		kvAuth0StoryMixin,
 	],

--- a/.storybook/stories/BorrowerProfile/BorrowerSideSheetContent.stories.js
+++ b/.storybook/stories/BorrowerProfile/BorrowerSideSheetContent.stories.js
@@ -1,0 +1,30 @@
+import BorrowerSideSheetContent from '#src/components/BorrowerProfile/BorrowerSideSheetContent';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/BorrowerSideSheetContent',
+	component: BorrowerSideSheetContent,
+};
+
+export const Default = () => ({
+	components: { BorrowerSideSheetContent },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	provide: {
+		$kvTrackEvent: () => {},
+	},
+	template: `
+		<borrower-side-sheet-content
+			:loan-id="${fundraisingPartnerLoan.id}"
+			:is-adding="false"
+			:basket-items="[]"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/BorrowerSideSheetWrapper.stories.js
+++ b/.storybook/stories/BorrowerProfile/BorrowerSideSheetWrapper.stories.js
@@ -1,0 +1,51 @@
+import BorrowerSideSheetWrapper from '#src/components/BorrowerProfile/BorrowerSideSheetWrapper';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/BorrowerSideSheetWrapper',
+	component: BorrowerSideSheetWrapper,
+};
+
+export const Default = () => ({
+	components: { BorrowerSideSheetWrapper },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	provide: {
+		$kvTrackEvent: () => {},
+	},
+	template: `
+		<borrower-side-sheet-wrapper
+			:selected-loan-id="${fundraisingPartnerLoan.id}"
+			:show-side-sheet="true"
+			:is-adding="false"
+			:basket-items="[]"
+		/>
+	`,
+});
+
+export const Closed = () => ({
+	components: { BorrowerSideSheetWrapper },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	provide: {
+		$kvTrackEvent: () => {},
+	},
+	template: `
+		<borrower-side-sheet-wrapper
+			:selected-loan-id="${fundraisingPartnerLoan.id}"
+			:show-side-sheet="false"
+			:is-adding="false"
+			:basket-items="[]"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/CommentsAndWhySpecial.stories.js
+++ b/.storybook/stories/BorrowerProfile/CommentsAndWhySpecial.stories.js
@@ -1,0 +1,53 @@
+import CommentsAndWhySpecial from '#src/components/BorrowerProfile/CommentsAndWhySpecial';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/CommentsAndWhySpecial',
+	component: CommentsAndWhySpecial,
+};
+
+export const WithComments = () => ({
+	components: { CommentsAndWhySpecial },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+	],
+	template: `
+		<comments-and-why-special
+			:loan-id="${fundraisingPartnerLoan.id}"
+		/>
+	`,
+});
+
+export const AdminWithDeleteButton = () => ({
+	components: { CommentsAndWhySpecial },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+	],
+	template: `
+		<comments-and-why-special
+			:loan-id="${fundraisingPartnerLoan.id}"
+			:is-admin="true"
+			:is-logged-in="true"
+		/>
+	`,
+});
+
+export const WithSubscribeToggle = () => ({
+	components: { CommentsAndWhySpecial },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+	],
+	template: `
+		<comments-and-why-special
+			:loan-id="${fundraisingPartnerLoan.id}"
+			:is-logged-in="true"
+			:is-subscribed="true"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/CountryInfo.stories.js
+++ b/.storybook/stories/BorrowerProfile/CountryInfo.stories.js
@@ -1,0 +1,37 @@
+import CountryInfo from '#src/components/BorrowerProfile/CountryInfo';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/CountryInfo',
+	component: CountryInfo,
+};
+
+const loanWithParityFields = {
+	...fundraisingPartnerLoan,
+	terms: {
+		...fundraisingPartnerLoan.terms,
+		currency: 'KGS',
+		currencyFullName: 'Kyrgyzstani Som',
+	},
+	geocode: {
+		...fundraisingPartnerLoan.geocode,
+		country: {
+			...fundraisingPartnerLoan.geocode.country,
+			fundsLentInCountry: 12450000,
+		},
+	},
+};
+
+export const Default = () => ({
+	components: { CountryInfo },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(loanWithParityFields) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<country-info :loan-id="${loanWithParityFields.id}" />`,
+});

--- a/.storybook/stories/BorrowerProfile/DescriptionListItem.stories.js
+++ b/.storybook/stories/BorrowerProfile/DescriptionListItem.stories.js
@@ -1,0 +1,50 @@
+import DescriptionListItem from '#src/components/BorrowerProfile/DescriptionListItem';
+
+export default {
+	title: 'Components/BorrowerProfile/DescriptionListItem',
+	component: DescriptionListItem,
+};
+
+export const Default = () => ({
+	components: { DescriptionListItem },
+	template: `
+		<dl>
+			<description-list-item
+				term="Loan length"
+				details="14 months"
+			/>
+		</dl>
+	`,
+});
+
+export const NumericDetails = () => ({
+	components: { DescriptionListItem },
+	template: `
+		<dl>
+			<description-list-item
+				term="Repayment schedule"
+				:details="12"
+			/>
+		</dl>
+	`,
+});
+
+export const MultipleItems = () => ({
+	components: { DescriptionListItem },
+	template: `
+		<dl>
+			<description-list-item
+				term="Loan length"
+				details="14 months"
+			/>
+			<description-list-item
+				term="Repayment schedule"
+				details="Monthly"
+			/>
+			<description-list-item
+				term="Disbursed date"
+				details="March 15, 2026"
+			/>
+		</dl>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/DetailsTabs.stories.js
+++ b/.storybook/stories/BorrowerProfile/DetailsTabs.stories.js
@@ -1,0 +1,42 @@
+import DetailsTabs from '#src/components/BorrowerProfile/DetailsTabs';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import {
+	createQueryResult,
+	fundraisingPartnerLoan,
+	fundraisingDirectLoan,
+	directLoanWithTrustee,
+} from './mockLoanFixtures';
+
+function detailsTabsStory(loan) {
+	return () => ({
+		components: { DetailsTabs },
+		mixins: [
+			apolloStoryMixin({ queryResult: createQueryResult(loan) }),
+			cookieStoreStoryMixin(),
+			kvAuth0StoryMixin,
+		],
+		template: `
+			<details-tabs
+				:loan-id="${loan.id}"
+				name="${loan.name}"
+			/>
+		`,
+	});
+}
+
+export default {
+	title: 'Components/BorrowerProfile/DetailsTabs',
+	component: DetailsTabs,
+};
+
+export const PartnerLoan = detailsTabsStory(fundraisingPartnerLoan);
+PartnerLoan.storyName = 'Partner Loan (Lending Partner Tab)';
+
+export const DirectLoanWithTrustee = detailsTabsStory(directLoanWithTrustee);
+DirectLoanWithTrustee.storyName = 'Direct Loan (Trustee Tab)';
+
+export const DirectLoanNoTrustee = detailsTabsStory(fundraisingDirectLoan);
+DirectLoanNoTrustee.storyName = 'Direct Loan (No Trustee)';

--- a/.storybook/stories/BorrowerProfile/FieldPartnerDetails.stories.js
+++ b/.storybook/stories/BorrowerProfile/FieldPartnerDetails.stories.js
@@ -1,0 +1,56 @@
+import FieldPartnerDetails from '#src/components/BorrowerProfile/FieldPartnerDetails';
+
+export default {
+	title: 'Components/BorrowerProfile/FieldPartnerDetails',
+	component: FieldPartnerDetails,
+};
+
+const basePartner = {
+	partnerId: 100,
+	partnerName: 'Bai Tushum Bank',
+	avgBorrowerCost: 35,
+	avgBorrowerCostType: 'interest',
+	avgProfitability: 2.5,
+	arrearsRate: 0.02,
+	loansAtRiskRate: 3,
+	defaultRate: 1.25,
+	riskRating: 3.5,
+	currencyExchangeLossRate: 0.05,
+	startDate: '2018-06-01',
+	loansPosted: 12450,
+	totalAmountRaised: 18500000,
+	avgLoanSizePercentPerCapitaIncome: 42.5,
+};
+
+function monthsAgoIso(months) {
+	const d = new Date();
+	d.setMonth(d.getMonth() - months);
+	return d.toISOString().slice(0, 10);
+}
+
+export const AllMetrics = () => ({
+	components: { FieldPartnerDetails },
+	data: () => ({ ...basePartner }),
+	template: '<field-partner-details v-bind="$data" />',
+});
+
+export const LessThanOneYear = () => ({
+	components: { FieldPartnerDetails },
+	data: () => ({
+		...basePartner,
+		startDate: monthsAgoIso(3),
+	}),
+	template: '<field-partner-details v-bind="$data" />',
+});
+
+export const MissingOptionalFields = () => ({
+	components: { FieldPartnerDetails },
+	data: () => ({
+		...basePartner,
+		startDate: '',
+		loansPosted: 0,
+		totalAmountRaised: 0,
+		avgLoanSizePercentPerCapitaIncome: 0,
+	}),
+	template: '<field-partner-details v-bind="$data" />',
+});

--- a/.storybook/stories/BorrowerProfile/FieldPartnerDetails.stories.js
+++ b/.storybook/stories/BorrowerProfile/FieldPartnerDetails.stories.js
@@ -5,6 +5,8 @@ export default {
 	component: FieldPartnerDetails,
 };
 
+// Only props the component actually renders. (It does not accept startDate,
+// loansPosted, totalAmountRaised or avgLoanSizePercentPerCapitaIncome.)
 const basePartner = {
 	partnerId: 100,
 	partnerName: 'Bai Tushum Bank',
@@ -16,17 +18,7 @@ const basePartner = {
 	defaultRate: 1.25,
 	riskRating: 3.5,
 	currencyExchangeLossRate: 0.05,
-	startDate: '2018-06-01',
-	loansPosted: 12450,
-	totalAmountRaised: 18500000,
-	avgLoanSizePercentPerCapitaIncome: 42.5,
 };
-
-function monthsAgoIso(months) {
-	const d = new Date();
-	d.setMonth(d.getMonth() - months);
-	return d.toISOString().slice(0, 10);
-}
 
 export const AllMetrics = () => ({
 	components: { FieldPartnerDetails },
@@ -34,23 +26,16 @@ export const AllMetrics = () => ({
 	template: '<field-partner-details v-bind="$data" />',
 });
 
-export const LessThanOneYear = () => ({
+// avgBorrowerCost of 0 makes the "Average cost to borrower" metric render as "N/A".
+export const NoAverageCost = () => ({
 	components: { FieldPartnerDetails },
-	data: () => ({
-		...basePartner,
-		startDate: monthsAgoIso(3),
-	}),
+	data: () => ({ ...basePartner, avgBorrowerCost: 0 }),
 	template: '<field-partner-details v-bind="$data" />',
 });
 
-export const MissingOptionalFields = () => ({
+// riskRating drives the star rating display (5 full stars vs the default 3.5).
+export const HighRiskRating = () => ({
 	components: { FieldPartnerDetails },
-	data: () => ({
-		...basePartner,
-		startDate: '',
-		loansPosted: 0,
-		totalAmountRaised: 0,
-		avgLoanSizePercentPerCapitaIncome: 0,
-	}),
+	data: () => ({ ...basePartner, riskRating: 5 }),
 	template: '<field-partner-details v-bind="$data" />',
 });

--- a/.storybook/stories/BorrowerProfile/JournalUpdates.stories.js
+++ b/.storybook/stories/BorrowerProfile/JournalUpdates.stories.js
@@ -1,0 +1,40 @@
+import JournalUpdates from '#src/components/BorrowerProfile/JournalUpdates';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import {
+	fundraisingPartnerLoan,
+	createMockLoan,
+	createQueryResult,
+} from './mockLoanFixtures';
+
+const noUpdatesLoan = createMockLoan({
+	id: 2000099,
+	updates: { totalCount: 0, values: [], __typename: 'UpdateCollection' },
+});
+
+export default {
+	title: 'Components/BorrowerProfile/JournalUpdates',
+	component: JournalUpdates,
+};
+
+export const Default = () => ({
+	components: { JournalUpdates },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<journal-updates :loan-id="${fundraisingPartnerLoan.id}" />`,
+});
+
+export const NoUpdates = () => ({
+	components: { JournalUpdates },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(noUpdatesLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<journal-updates :loan-id="${noUpdatesLoan.id}" />`,
+});

--- a/.storybook/stories/BorrowerProfile/LendCta.stories.js
+++ b/.storybook/stories/BorrowerProfile/LendCta.stories.js
@@ -1,0 +1,46 @@
+import LendCta from '#src/components/BorrowerProfile/LendCta';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import {
+	fundraisingPartnerLoan,
+	fullyFundedLoan,
+	payingBackLoan,
+	createQueryResult,
+} from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/LendCta',
+	component: LendCta,
+};
+
+export const Fundraising = () => ({
+	components: { LendCta },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<lend-cta :loan-id="${fundraisingPartnerLoan.id}" />`,
+});
+
+export const FullyFunded = () => ({
+	components: { LendCta },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fullyFundedLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<lend-cta :loan-id="${fullyFundedLoan.id}" />`,
+});
+
+export const PostFundraising = () => ({
+	components: { LendCta },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(payingBackLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<lend-cta :loan-id="${payingBackLoan.id}" />`,
+});

--- a/.storybook/stories/BorrowerProfile/LendersAndTeams.stories.js
+++ b/.storybook/stories/BorrowerProfile/LendersAndTeams.stories.js
@@ -1,0 +1,109 @@
+import LendersAndTeams from '#src/components/BorrowerProfile/LendersAndTeams';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/LendersAndTeams',
+	component: LendersAndTeams,
+};
+
+const lendersLoan = {
+	...fundraisingPartnerLoan,
+	lenders: {
+		totalCount: 23,
+		values: [
+			{
+				id: 201,
+				name: 'Sarah',
+				publicId: 'sarah123',
+				image: { id: 'img1', hash: 'abc123' },
+				lenderPage: { id: 'lp1', whereabouts: 'Portland, OR' },
+			},
+			{
+				id: 202,
+				name: 'Miguel',
+				publicId: 'miguel456',
+				image: { id: 'img2', hash: 'def456' },
+				lenderPage: { id: 'lp2', whereabouts: 'Madrid, Spain' },
+			},
+			{
+				id: 203,
+				name: 'Emma',
+				publicId: 'emma789',
+				image: { id: 'img3', hash: 'ghi789' },
+				lenderPage: { id: 'lp3', whereabouts: 'London, UK' },
+			},
+		],
+		__typename: 'LenderCollection',
+	},
+};
+
+const teamsLoan = {
+	...fundraisingPartnerLoan,
+	teams: {
+		totalCount: 5,
+		values: [
+			{
+				id: 1,
+				name: 'Kiva Lending Team',
+				teamPublicId: 'kiva',
+				category: 'Common Interest',
+				image: { id: 't1', hash: 'team1' },
+				lenderCount: 500,
+				lenderCountForLoan: 3,
+			},
+			{
+				id: 2,
+				name: 'Women Empowerment',
+				teamPublicId: 'women',
+				category: 'Causes',
+				image: { id: 't2', hash: 'team2' },
+				lenderCount: 200,
+				lenderCountForLoan: 1,
+			},
+		],
+		__typename: 'TeamCollection',
+	},
+};
+
+const emptyLendersLoan = {
+	...fundraisingPartnerLoan,
+	lenders: {
+		totalCount: 0,
+		values: [],
+		__typename: 'LenderCollection',
+	},
+};
+
+export const LendersPopulated = () => ({
+	components: { LendersAndTeams },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(lendersLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<lenders-and-teams :loan-id="${lendersLoan.id}" display-type="lenders" />`,
+});
+
+export const TeamsPopulated = () => ({
+	components: { LendersAndTeams },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(teamsLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<lenders-and-teams :loan-id="${teamsLoan.id}" display-type="teams" />`,
+});
+
+export const EmptyLenders = () => ({
+	components: { LendersAndTeams },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(emptyLendersLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<lenders-and-teams :loan-id="${emptyLendersLoan.id}" display-type="lenders" />`,
+});

--- a/.storybook/stories/BorrowerProfile/LoanDetails.stories.js
+++ b/.storybook/stories/BorrowerProfile/LoanDetails.stories.js
@@ -1,0 +1,118 @@
+import LoanDetails from '#src/components/BorrowerProfile/LoanDetails';
+
+export default {
+	title: 'Components/BorrowerProfile/LoanDetails',
+	component: LoanDetails,
+};
+
+export const PartnerLoan = () => ({
+	components: { LoanDetails },
+	template: `
+		<loan-details
+			partner-name="VisionFund Cambodia"
+			:loan-lender-repayment-term="14"
+			:loan-term-lender-repayment-term="0"
+			repayment-interval="monthly"
+			:flexible-fundraising-enabled="true"
+			:charges-fees-interest="true"
+			currency="KHR"
+			loss-liability-currency-exchange="shared"
+			disbursal-date="2025-06-15T00:00:00Z"
+			status="fundraising"
+		/>
+	`,
+});
+
+export const DirectLoan = () => ({
+	components: { LoanDetails },
+	template: `
+		<loan-details
+			partner-name=""
+			:loan-lender-repayment-term="0"
+			:loan-term-lender-repayment-term="12"
+			repayment-interval="monthly"
+			:flexible-fundraising-enabled="false"
+			:charges-fees-interest="false"
+			currency="USD"
+			loss-liability-currency-exchange="none"
+			disbursal-date="2025-08-01T00:00:00Z"
+			status="fundraising"
+		/>
+	`,
+});
+
+export const WithExpiredDate = () => ({
+	components: { LoanDetails },
+	template: `
+		<loan-details
+			partner-name="Turame Community Finance"
+			:loan-lender-repayment-term="8"
+			:loan-term-lender-repayment-term="0"
+			repayment-interval="monthly"
+			:flexible-fundraising-enabled="false"
+			:charges-fees-interest="true"
+			currency="BIF"
+			loss-liability-currency-exchange="partner"
+			disbursal-date=""
+			status="expired"
+			expired-date="2025-09-30T00:00:00Z"
+		/>
+	`,
+});
+
+export const WithDefaultedDate = () => ({
+	components: { LoanDetails },
+	template: `
+		<loan-details
+			partner-name="Fundacion Paraguaya"
+			:loan-lender-repayment-term="20"
+			:loan-term-lender-repayment-term="0"
+			repayment-interval="monthly"
+			:flexible-fundraising-enabled="false"
+			:charges-fees-interest="true"
+			currency="PYG"
+			loss-liability-currency-exchange="lender"
+			disbursal-date="2024-01-15T00:00:00Z"
+			status="defaulted"
+			defaulted-date="2025-07-01T00:00:00Z"
+		/>
+	`,
+});
+
+export const WithEndedDate = () => ({
+	components: { LoanDetails },
+	template: `
+		<loan-details
+			partner-name="BRAC"
+			:loan-lender-repayment-term="12"
+			:loan-term-lender-repayment-term="0"
+			repayment-interval="monthly"
+			:flexible-fundraising-enabled="false"
+			:charges-fees-interest="true"
+			currency="BDT"
+			loss-liability-currency-exchange="partner"
+			disbursal-date="2024-03-01T00:00:00Z"
+			status="ended"
+			ended-date="2025-03-01T00:00:00Z"
+		/>
+	`,
+});
+
+export const WithRefundedDate = () => ({
+	components: { LoanDetails },
+	template: `
+		<loan-details
+			partner-name="Grameen America"
+			:loan-lender-repayment-term="6"
+			:loan-term-lender-repayment-term="0"
+			repayment-interval="at_end"
+			:flexible-fundraising-enabled="false"
+			:charges-fees-interest="false"
+			currency="USD"
+			loss-liability-currency-exchange="none"
+			disbursal-date="2025-01-10T00:00:00Z"
+			status="refunded"
+			refunded-date="2025-04-15T00:00:00Z"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/LoanProgress.stories.js
+++ b/.storybook/stories/BorrowerProfile/LoanProgress.stories.js
@@ -1,0 +1,198 @@
+import LoanProgress from '#src/components/BorrowerProfile/LoanProgress';
+
+/**
+ * LoanProgress renders in both FullBorrowerProfile and MinimalBorrowerProfile.
+ *
+ * Public statuses:  fundraising, funded (virtual), expired, refunded
+ * Privileged-only:  raised, payingBack, ended, defaulted, inactive,
+ *                   inactiveExpired, reviewed, deleted, issue
+ */
+
+export default {
+	title: 'Components/BorrowerProfile/LoanProgress',
+	component: LoanProgress,
+};
+
+export const Fundraising = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="fundraising"
+			:progress-percent="0.75"
+			money-left="250.00"
+			time-left="5 days"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const FundedRaised = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="funded"
+			:progress-percent="1"
+			money-left="0.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+FundedRaised.storyName = 'Funded / Raised';
+
+export const Expired = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="expired"
+			:progress-percent="0.65"
+			money-left="350.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Inactive = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="inactive"
+			:progress-percent="0"
+			money-left="600.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const PrivateFundraisingPeriod = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="pfp"
+			:progress-percent="0.5"
+			money-left="500.00"
+			time-left="12 days"
+			:loading="false"
+			:loan-id="123"
+			:number-of-lenders="350"
+			:pfp-min-lenders="700"
+		/>
+	`,
+});
+
+export const PayingBack = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="payingBack"
+			:progress-percent="0.60"
+			money-left="400.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Ended = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="ended"
+			:progress-percent="1"
+			money-left="0.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Defaulted = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="defaulted"
+			:progress-percent="0.45"
+			money-left="550.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Refunded = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="refunded"
+			:progress-percent="1"
+			money-left="0.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const InactiveExpired = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="inactiveExpired"
+			:progress-percent="0"
+			money-left="500.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Reviewed = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="reviewed"
+			:progress-percent="0"
+			money-left="1000.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Deleted = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="deleted"
+			:progress-percent="0"
+			money-left="1000.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Issue = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="issue"
+			:progress-percent="0.20"
+			money-left="800.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+
+export const Loading = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			:loading="true"
+			:loan-id="123"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/LoanStory.stories.js
+++ b/.storybook/stories/BorrowerProfile/LoanStory.stories.js
@@ -1,0 +1,45 @@
+import LoanStory from '#src/components/BorrowerProfile/LoanStory';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import {
+	createQueryResult,
+	fundraisingPartnerLoan,
+	groupLoan,
+	repeatBorrowerLoan,
+	createMockLoan,
+} from './mockLoanFixtures';
+
+function loanStoryStory(loan) {
+	return () => ({
+		components: { LoanStory },
+		mixins: [
+			apolloStoryMixin({ queryResult: createQueryResult(loan) }),
+			cookieStoreStoryMixin(),
+			kvAuth0StoryMixin,
+		],
+		setup() {
+			return { loan };
+		},
+		template: '<loan-story :loan="loan" />',
+	});
+}
+
+export default {
+	title: 'Components/BorrowerProfile/LoanStory',
+	component: LoanStory,
+};
+
+export const SingleBorrower = loanStoryStory(fundraisingPartnerLoan);
+
+export const GroupLoan = loanStoryStory(groupLoan);
+GroupLoan.storyName = 'Group Loan (Multiple Borrowers)';
+
+export const RepeatBorrower = loanStoryStory(repeatBorrowerLoan);
+RepeatBorrower.storyName = 'Repeat Borrower (Previous Loan Link)';
+
+export const NoPreviousLoan = loanStoryStory(
+	createMockLoan({ previousLoanId: null }),
+);
+NoPreviousLoan.storyName = 'No Previous Loan';

--- a/.storybook/stories/BorrowerProfile/MoreAboutLoan.stories.js
+++ b/.storybook/stories/BorrowerProfile/MoreAboutLoan.stories.js
@@ -70,7 +70,7 @@ export const PartnerLoan = () => ({
 export const Loading = () => ({
 	components: { MoreAboutLoan },
 	mixins: [
-		apolloStoryMixin({ queryResult: new Promise(() => {}) }),
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan), loading: true }),
 		cookieStoreStoryMixin(),
 		kvAuth0StoryMixin,
 	],

--- a/.storybook/stories/BorrowerProfile/MoreAboutLoan.stories.js
+++ b/.storybook/stories/BorrowerProfile/MoreAboutLoan.stories.js
@@ -1,0 +1,78 @@
+import MoreAboutLoan from '#src/components/BorrowerProfile/MoreAboutLoan';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import {
+	fundraisingDirectLoan,
+	fundraisingPartnerLoan,
+	createQueryResult,
+} from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/MoreAboutLoan',
+	component: MoreAboutLoan,
+};
+
+const directLoan = {
+	...fundraisingDirectLoan,
+	__typename: 'LoanDirect',
+	businessName: 'Maria\'s Bakery',
+	businessDescription: 'A family-owned bakery specializing in artisan breads, pastries, and seasonal treats. '
+		+ 'Maria has been baking since she was a child, learning recipes from her grandmother.',
+	purpose: 'To buy a commercial oven and expand production so the bakery can serve more local customers '
+		+ 'and supply nearby cafes.',
+	yearsInBusiness: 5,
+	socialLinks: {
+		etsy: null,
+		facebook: 'https://facebook.com/marias-bakery',
+		instagram: 'https://instagram.com/marias-bakery',
+		linkedin: null,
+		twitter: null,
+		website: 'https://marias-bakery.example.com',
+		yelp: null,
+	},
+};
+
+const partnerLoan = {
+	...fundraisingPartnerLoan,
+	__typename: 'LoanPartner',
+	partnerName: 'Bai Tushum Bank',
+	partner: {
+		id: 100,
+		loanAlertText: '',
+	},
+	dualStatementNote: '',
+	moreInfoAboutLoan: 'This loan helps rural farmers in Kyrgyzstan invest in livestock and grow their dairy '
+		+ 'operations, providing food and income for their families.',
+};
+
+export const DirectLoan = () => ({
+	components: { MoreAboutLoan },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(directLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<more-about-loan :loan-id="${directLoan.id}" />`,
+});
+
+export const PartnerLoan = () => ({
+	components: { MoreAboutLoan },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(partnerLoan) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<more-about-loan :loan-id="${partnerLoan.id}" />`,
+});
+
+export const Loading = () => ({
+	components: { MoreAboutLoan },
+	mixins: [
+		apolloStoryMixin({ queryResult: new Promise(() => {}) }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	template: `<more-about-loan :loan-id="${fundraisingPartnerLoan.id}" />`,
+});

--- a/.storybook/stories/BorrowerProfile/RepaymentSchedule.stories.js
+++ b/.storybook/stories/BorrowerProfile/RepaymentSchedule.stories.js
@@ -1,0 +1,22 @@
+import RepaymentSchedule from '#src/components/BorrowerProfile/RepaymentSchedule';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/RepaymentSchedule',
+	component: RepaymentSchedule,
+};
+
+export const Default = () => ({
+	components: { RepaymentSchedule },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+	],
+	template: `
+		<repayment-schedule
+			:loan-id="${fundraisingPartnerLoan.id}"
+			status="payingBack"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/ShareButton.stories.js
+++ b/.storybook/stories/BorrowerProfile/ShareButton.stories.js
@@ -1,0 +1,32 @@
+import ShareButton from '#src/components/BorrowerProfile/ShareButton';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import { fundraisingPartnerLoan, createQueryResult, loggedInUser } from './mockLoanFixtures';
+
+export default {
+	title: 'Components/BorrowerProfile/ShareButton',
+	component: ShareButton,
+};
+
+export const Default = () => ({
+	components: { ShareButton },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan, loggedInUser) }),
+		cookieStoreStoryMixin(),
+	],
+	setup() {
+		return {
+			loan: fundraisingPartnerLoan,
+			lender: loggedInUser.userAccount,
+		};
+	},
+	template: `
+		<share-button
+			:loan="loan"
+			:lender="lender"
+			variant="caution"
+			campaign="social_share_bp"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/SummaryCard.stories.js
+++ b/.storybook/stories/BorrowerProfile/SummaryCard.stories.js
@@ -1,0 +1,67 @@
+import SummaryCard from '#src/components/BorrowerProfile/SummaryCard';
+
+import apolloStoryMixin from '../../mixins/apollo-story-mixin';
+import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
+import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
+import {
+	createQueryResult,
+	loggedInUser,
+	fundraisingPartnerLoan,
+	fullyFundedLoan,
+	payingBackLoan,
+	endedLoan,
+	pfpLoan,
+} from './mockLoanFixtures';
+
+function summaryCardStory(loan, myUser = null) {
+	const queryResult = createQueryResult(loan, myUser);
+	return () => ({
+		components: { SummaryCard },
+		mixins: [
+			apolloStoryMixin({ queryResult }),
+			cookieStoreStoryMixin(),
+			kvAuth0StoryMixin,
+		],
+		setup() {
+			return { loan };
+		},
+		template: `
+			<summary-card
+				:loan="loan"
+			/>
+		`,
+	});
+}
+
+export default {
+	title: 'Components/BorrowerProfile/SummaryCard',
+	component: SummaryCard,
+};
+
+export const Fundraising = summaryCardStory(fundraisingPartnerLoan, loggedInUser);
+
+export const FullyFunded = summaryCardStory(fullyFundedLoan);
+
+export const PayingBack = summaryCardStory(payingBackLoan, loggedInUser);
+
+export const Ended = summaryCardStory(endedLoan, loggedInUser);
+
+export const PFP = summaryCardStory(pfpLoan, loggedInUser);
+PFP.storyName = 'Private Fundraising Period';
+
+export const Loading = () => ({
+	components: { SummaryCard },
+	mixins: [
+		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan), loading: true }),
+		cookieStoreStoryMixin(),
+		kvAuth0StoryMixin,
+	],
+	setup() {
+		return { loan: fundraisingPartnerLoan };
+	},
+	template: `
+		<summary-card
+			:loan="loan"
+		/>
+	`,
+});

--- a/.storybook/stories/BorrowerProfile/SummaryCard.stories.js
+++ b/.storybook/stories/BorrowerProfile/SummaryCard.stories.js
@@ -22,14 +22,9 @@ function summaryCardStory(loan, myUser = null) {
 			cookieStoreStoryMixin(),
 			kvAuth0StoryMixin,
 		],
-		setup() {
-			return { loan };
-		},
-		template: `
-			<summary-card
-				:loan="loan"
-			/>
-		`,
+		// SummaryCard takes no props; it derives loanId from the route and
+		// fetches the loan via Apollo (mocked by apolloStoryMixin above).
+		template: '<summary-card />',
 	});
 }
 
@@ -56,12 +51,5 @@ export const Loading = () => ({
 		cookieStoreStoryMixin(),
 		kvAuth0StoryMixin,
 	],
-	setup() {
-		return { loan: fundraisingPartnerLoan };
-	},
-	template: `
-		<summary-card
-			:loan="loan"
-		/>
-	`,
+	template: '<summary-card />',
 });

--- a/.storybook/stories/BorrowerProfile/TrusteeDetails.stories.js
+++ b/.storybook/stories/BorrowerProfile/TrusteeDetails.stories.js
@@ -1,0 +1,46 @@
+import TrusteeDetails from '#src/components/BorrowerProfile/TrusteeDetails';
+
+export default {
+	title: 'Components/BorrowerProfile/TrusteeDetails',
+	component: TrusteeDetails,
+};
+
+const baseTrustee = {
+	borrowerName: 'Maria',
+	trusteeName: 'Community Hope Trust',
+	endorsement: 'We have worked alongside Maria for several years through our local '
+		+ 'entrepreneurship program. She is hardworking and reliable, and we are proud to '
+		+ 'vouch for her on Kiva.',
+	numLoansEndorsedPublic: 342,
+	totalLoansValue: '1875000.00',
+	numDefaultedLoans: 7,
+	repaymentRate: 98,
+	trusteeId: 12345,
+};
+
+export const WithEndorsement = () => ({
+	components: { TrusteeDetails },
+	data: () => ({ ...baseTrustee }),
+	template: '<trustee-details v-bind="$data" />',
+});
+WithEndorsement.storyName = 'Trustee (with endorsement)';
+
+export const WithoutEndorsementText = () => ({
+	components: { TrusteeDetails },
+	data: () => ({ ...baseTrustee, endorsement: '' }),
+	template: '<trustee-details v-bind="$data" />',
+});
+
+export const NoTrusteeEndorsement = () => ({
+	components: { TrusteeDetails },
+	data: () => ({
+		...baseTrustee,
+		trusteeName: 'No Trustee Endorsement',
+		endorsement: '',
+		numLoansEndorsedPublic: 0,
+		totalLoansValue: '0.00',
+		numDefaultedLoans: 0,
+		repaymentRate: 0,
+	}),
+	template: '<trustee-details v-bind="$data" />',
+});

--- a/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
+++ b/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
@@ -1,0 +1,508 @@
+/**
+ * Shared mock loan fixtures for BorrowerProfile stories.
+ *
+ * - createMockLoan(overrides) returns a full loan object with fields
+ *   for ALL child component queries (SummaryCard, LendCta, LoanStory,
+ *   CommentsAndWhySpecial, DetailsTabs, MoreAboutLoan, BorrowerCountry,
+ *   LendersAndTeams, JournalUpdates).
+ * - createQueryResult(loan, userOverrides) wraps a loan in the full
+ *   query result shape expected by apolloStoryMixin.
+ * - Named fixtures call createMockLoan with status-specific overrides.
+ */
+
+// ---------------------------------------------------------------------------
+// User context helpers
+// ---------------------------------------------------------------------------
+
+export const anonymousUser = {};
+
+export const loggedInUser = {
+	id: 'user-1',
+	userAccount: {
+		id: 123, balance: '50.00', inviterName: '', public: true
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Base factory
+// ---------------------------------------------------------------------------
+
+const mockComments = [
+	{
+		id: 101,
+		authorName: 'Sarah',
+		authorImageUrl: 'https://www.kiva.org/img/s100/4d844ac2c0b77a8a522741b908ea5c32.jpg',
+		authorRole: 'Lender',
+		authorLendingAction: {
+			teams: ['Kiva Lending Team'],
+			lender: { id: 201, teams: { values: [{ id: 1, name: 'Kiva Lending Team', teamPublicId: 'kiva' }] } },
+		},
+		body: 'Best wishes for your business! I hope this loan helps you achieve your goals.',
+	},
+	{
+		id: 102,
+		authorName: 'Aisha',
+		authorImageUrl: 'https://www.kiva.org/img/s100/9673d0722a7675b9b8d11f90849d9b44.jpg',
+		authorRole: 'Borrower',
+		authorLendingAction: null,
+		body: 'Thank you so much for your support! I will use this loan wisely.',
+	},
+];
+
+const mockLenders = [
+	{
+		id: 201, name: 'Sarah', publicId: 'sarah123', image: { hash: 'abc123' }, lenderPage: { whereabouts: 'Portland, OR' }
+	},
+	{
+		id: 202, name: 'Mike', publicId: 'mike456', image: { hash: 'def456' }, lenderPage: { whereabouts: 'Austin, TX' }
+	},
+	{
+		id: 203, name: 'Emma', publicId: 'emma789', image: { hash: 'ghi789' }, lenderPage: { whereabouts: 'London, UK' }
+	},
+];
+
+const mockTeams = [
+	{
+		id: 1, name: 'Kiva Lending Team', teamPublicId: 'kiva', image: { hash: 'team1' }, lenderCount: 500, lenderCountForLoan: 3
+	},
+	{
+		id: 2, name: 'Women Empowerment', teamPublicId: 'women', image: { hash: 'team2' }, lenderCount: 200, lenderCountForLoan: 1
+	},
+];
+
+const mockUpdates = [
+	{
+		id: 301,
+		body: 'Business is going well! I have bought two new heifers and milk production has increased.',
+		subject: 'Update from Aisha',
+		date: '2024-09-15T00:00:00Z',
+		image: { url: 'https://www.kiva.org/img/w480h360/9673d0722a7675b9b8d11f90849d9b44.webp' },
+	},
+];
+
+/**
+ * Create a mock loan with fields for all child component queries.
+ * @param {object} overrides - Properties to spread on top of the defaults.
+ * @returns {object} A full loan object.
+ */
+export function createMockLoan(overrides = {}) {
+	const expirationDate = new Date();
+	expirationDate.setDate(expirationDate.getDate() + 30);
+
+	return {
+		id: 1975833,
+		__typename: 'LoanPartner',
+		borrowerCount: 1,
+		name: 'Aisha',
+		businessName: '',
+		gender: 'female',
+		geocode: {
+			city: 'Kochkor district, Naryn region',
+			state: 'Naryn Region',
+			latitude: 41.5,
+			longitude: 75.8,
+			country: {
+				id: 1,
+				name: 'Kyrgyzstan',
+				isoCode: 'KG',
+				region: 'Asia',
+				numLoansFundraising: 342,
+				ppp: '3870',
+				geocode: { latitude: 41.2, longitude: 74.8 },
+				__typename: 'Country',
+			},
+			__typename: 'Geocode',
+		},
+		image: {
+			id: 3838911,
+			default: 'https://www.kiva.org/img/w480h360/9673d0722a7675b9b8d11f90849d9b44.webp',
+			retina: 'https://www.kiva.org/img/w960h720/9673d0722a7675b9b8d11f90849d9b44.webp',
+			url: 'https://www.kiva.org/img/w150h138/9673d0722a7675b9b8d11f90849d9b44.webp',
+			hash: '9673d0722a7675b9b8d11f90849d9b44',
+			__typename: 'Image',
+		},
+		plannedExpirationDate: expirationDate.toISOString(),
+		anonymizationLevel: 'none',
+		loanAmount: '600.00',
+		status: 'fundraising',
+		use: 'to purchase heifers to increase headcount of cattle and sales of organic milk.',
+		fullLoanUse: 'A loan of $600 helps to purchase heifers to increase headcount of cattle and sales of organic milk.',
+		fundraisingPercent: 0.875,
+		fundraisingTimeLeft: '30 days',
+		fundraisingTimeLeftMilliseconds: 2592000000,
+		loanFundraisingInfo: {
+			id: 1975833,
+			fundedAmount: '525.00',
+			reservedAmount: '0.00',
+			isExpiringSoon: false,
+			__typename: 'LoanFundraisingInfo',
+		},
+		inPfp: false,
+		pfpMinLenders: 0,
+		sector: { id: 1, name: 'Agriculture', __typename: 'Sector' },
+		activity: { id: 61, name: 'Dairy', __typename: 'Activity' },
+		paidAmount: '0.00',
+		expiredDate: '',
+		refundedDate: '',
+		defaultedDate: '',
+		endedDate: '',
+		disbursalDate: '2024-06-15T00:00:00Z',
+		distributionModel: 'partner',
+		partnerName: 'Bai Tushum Bank',
+		partner: {
+			id: 100,
+			name: 'Bai Tushum Bank',
+			countries: [{ id: 1, name: 'Kyrgyzstan', __typename: 'Country' }],
+			arrearsRate: 0.02,
+			avgBorrowerCost: 15.5,
+			avgBorrowerCostType: 'interest',
+			chargesFeesInterest: true,
+			defaultRate: 0.01,
+			loanAlertText: '',
+			riskRating: 3.5,
+			totalAmountRaised: '5000000.00',
+			startDate: '2018-06-01',
+			loansPosted: 1200,
+			avgLoanSizePercentPerCapitaIncome: 45.5,
+			__typename: 'Partner',
+		},
+		// User properties
+		userProperties: {
+			lentTo: false,
+			isPrivileged: false,
+			isAdmin: false,
+			subscribed: false,
+			favorited: false,
+			promoEligible: false,
+			__typename: 'LoanUserProperties',
+		},
+		// LendCta fields
+		minNoteSize: '25.00',
+		matchingText: '',
+		matchRatio: 0,
+		unreservedAmount: '75.00',
+		// LoanStory fields
+		description: 'Aisha is a 35-year-old woman living in Kyrgyzstan. She has been raising cattle for 10 years and wants to expand her dairy farm.',
+		descriptionInOriginalLanguage: '',
+		originalLanguage: null,
+		borrowers: [{
+			id: 1, firstName: 'Aisha', gender: 'female', isPrimary: true
+		}],
+		reviewer: null,
+		previousLoanId: null,
+		video: null,
+		// Comments
+		comments: {
+			totalCount: 2,
+			values: mockComments,
+			__typename: 'CommentCollection',
+		},
+		// Lenders and teams
+		lenders: {
+			totalCount: 34,
+			values: mockLenders,
+			__typename: 'LenderCollection',
+		},
+		teams: {
+			totalCount: 2,
+			values: mockTeams,
+			__typename: 'TeamCollection',
+		},
+		// Journal updates
+		updates: {
+			totalCount: 1,
+			values: mockUpdates,
+			__typename: 'UpdateCollection',
+		},
+		// DetailsTabs fields
+		lenderRepaymentTerm: 26,
+		repaymentInterval: 'monthly',
+		terms: {
+			currency: 'KGS',
+			currencyFullName: 'Kyrgyzstani Som',
+			flexibleFundraisingEnabled: false,
+			lenderRepaymentTerm: 26,
+			lossLiabilityCurrencyExchange: 'shared',
+			__typename: 'LoanTerm',
+		},
+		trustee: null,
+		endorsement: null,
+		// MoreAboutLoan fields
+		whySpecial: 'It supports organic farming and includes a lower interest rate.',
+		dualStatementNote: '',
+		moreInfoAboutLoan: 'This loan helps rural farmers in Kyrgyzstan.',
+		tags: ['user_favorite'],
+		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Query result wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Wraps a loan in the full query result shape that apolloStoryMixin expects.
+ * Includes shop, my, general, and community data that child components query.
+ *
+ * @param {object} loan - A loan from createMockLoan()
+ * @param {object} [myUser] - Override for `my` (user context). Pass loggedInUser or null.
+ * @returns {object} queryResult for apolloStoryMixin
+ */
+export function createQueryResult(loan, myUser = null) {
+	return {
+		data: {
+			lend: { loan },
+			shop: {
+				id: 'shop',
+				basket: {
+					id: 'basket',
+					hasFreeCredits: false,
+					items: { values: [] },
+				},
+				nonTrivialItemCount: 0,
+			},
+			my: myUser || { id: null },
+			general: { uiExperimentSetting: null },
+			community: { lender: null },
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Named loan fixtures
+// ---------------------------------------------------------------------------
+
+/** Fundraising partner loan (default). */
+export const fundraisingPartnerLoan = createMockLoan();
+
+/** Fundraising direct loan (US-based). */
+export const fundraisingDirectLoan = createMockLoan({
+	id: 2000001,
+	__typename: 'LoanDirect',
+	distributionModel: 'direct',
+	partnerName: '',
+	partner: null,
+	name: 'Maria',
+	businessName: 'Maria\'s Bakery',
+	businessDescription: 'A family-owned bakery specializing in artisan breads.',
+	purpose: 'To buy a commercial oven and expand production.',
+	yearsInBusiness: 5,
+	socialLinks: {},
+	geocode: {
+		city: 'Portland',
+		state: 'Oregon',
+		latitude: 45.5,
+		longitude: -122.7,
+		country: {
+			id: 2,
+			name: 'United States',
+			isoCode: 'US',
+			region: 'North America',
+			geocode: { latitude: 37.1, longitude: -95.7 },
+			__typename: 'Country',
+		},
+		__typename: 'Geocode',
+	},
+	use: 'to expand her bakery business and buy new equipment.',
+	fullLoanUse: 'A loan of $5,000 helps to expand her bakery business and buy new equipment.',
+	loanAmount: '5000.00',
+	loanFundraisingInfo: {
+		id: 2000001, fundedAmount: '3750.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '1250.00',
+	fundraisingPercent: 0.75,
+});
+
+/** Private fundraising period loan. */
+export const pfpLoan = createMockLoan({
+	id: 2000002,
+	inPfp: true,
+	pfpMinLenders: 700,
+	lenders: { totalCount: 150, values: mockLenders, __typename: 'LenderCollection' },
+});
+
+/** Fully funded loan (virtual status for public users). */
+export const fullyFundedLoan = createMockLoan({
+	id: 2000003,
+	status: 'funded',
+	fundraisingPercent: 1,
+	loanFundraisingInfo: {
+		id: 2000003, fundedAmount: '600.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Raised loan (privileged-only real status). */
+export const raisedLoan = createMockLoan({
+	id: 2000004,
+	status: 'raised',
+	fundraisingPercent: 1,
+	loanFundraisingInfo: {
+		id: 2000004, fundedAmount: '600.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Paying back loan (privileged-only; public sees "funded"). */
+export const payingBackLoan = createMockLoan({
+	id: 2000005,
+	status: 'payingBack',
+	fundraisingPercent: 1,
+	paidAmount: '275.00',
+	loanFundraisingInfo: {
+		id: 2000005, fundedAmount: '600.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Ended loan (privileged-only; public sees "funded"). */
+export const endedLoan = createMockLoan({
+	id: 2000006,
+	status: 'ended',
+	fundraisingPercent: 1,
+	paidAmount: '600.00',
+	endedDate: '2025-01-15T12:00:00Z',
+	loanFundraisingInfo: {
+		id: 2000006, fundedAmount: '600.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Defaulted loan (privileged-only; public sees "funded"). */
+export const defaultedLoan = createMockLoan({
+	id: 2000007,
+	status: 'defaulted',
+	fundraisingPercent: 1,
+	paidAmount: '150.00',
+	defaultedDate: '2025-02-20T12:00:00Z',
+	loanFundraisingInfo: {
+		id: 2000007, fundedAmount: '600.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Expired loan. Shown as-is to all users. */
+export const expiredLoan = createMockLoan({
+	id: 2000008,
+	status: 'expired',
+	fundraisingPercent: 0.5,
+	expiredDate: '2025-03-01T12:00:00Z',
+	disbursalDate: '',
+	loanFundraisingInfo: {
+		id: 2000008, fundedAmount: '300.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Refunded loan. Shown as-is to all users. */
+export const refundedLoan = createMockLoan({
+	id: 2000009,
+	status: 'refunded',
+	fundraisingPercent: 1,
+	refundedDate: '2025-02-10T12:00:00Z',
+	loanFundraisingInfo: {
+		id: 2000009, fundedAmount: '600.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Inactive loan (privileged-only). */
+export const inactiveLoan = createMockLoan({
+	id: 2000010,
+	status: 'inactive',
+	fundraisingPercent: 0,
+	loanFundraisingInfo: {
+		id: 2000010, fundedAmount: '0.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Inactive expired loan (privileged-only). */
+export const inactiveExpiredLoan = createMockLoan({
+	id: 2000011,
+	status: 'inactiveExpired',
+	fundraisingPercent: 0,
+	expiredDate: '2024-12-01T12:00:00Z',
+	loanFundraisingInfo: {
+		id: 2000011, fundedAmount: '0.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Reviewed loan (privileged-only). */
+export const reviewedLoan = createMockLoan({
+	id: 2000012,
+	status: 'reviewed',
+	fundraisingPercent: 0,
+	loanFundraisingInfo: {
+		id: 2000012, fundedAmount: '0.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Deleted loan (privileged-only). */
+export const deletedLoan = createMockLoan({
+	id: 2000013,
+	status: 'deleted',
+	fundraisingPercent: 0,
+	loanFundraisingInfo: {
+		id: 2000013, fundedAmount: '0.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Issue loan (privileged-only). */
+export const issueLoan = createMockLoan({
+	id: 2000014,
+	status: 'issue',
+	fundraisingPercent: 0,
+	loanFundraisingInfo: {
+		id: 2000014, fundedAmount: '0.00', reservedAmount: '0.00', isExpiringSoon: false, __typename: 'LoanFundraisingInfo'
+	},
+	unreservedAmount: '0.00',
+});
+
+/** Group loan (multiple borrowers). */
+export const groupLoan = createMockLoan({
+	id: 2000015,
+	name: 'Aisha\'s Group',
+	borrowerCount: 3,
+	borrowers: [
+		{
+			id: 1, firstName: 'Aisha', gender: 'female', isPrimary: true
+		},
+		{
+			id: 2, firstName: 'Fatima', gender: 'female', isPrimary: false
+		},
+		{
+			id: 3, firstName: 'Nadia', gender: 'female', isPrimary: false
+		},
+	],
+});
+
+/** Repeat borrower loan (has previous loan). */
+export const repeatBorrowerLoan = createMockLoan({
+	id: 2000016,
+	previousLoanId: 1900000,
+});
+
+/** Direct loan with trustee. */
+export const directLoanWithTrustee = createMockLoan({
+	id: 2000017,
+	__typename: 'LoanDirect',
+	distributionModel: 'direct',
+	partnerName: '',
+	partner: null,
+	name: 'James',
+	trustee: {
+		id: 50,
+		organizationName: 'Accion',
+		stats: {
+			numDefaultedLoans: 0,
+			numLoansEndorsedPublic: 120,
+			repaymentRate: 0.98,
+			totalLoansValue: 2000000,
+		},
+	},
+	endorsement: 'Accion endorses this loan for responsible lending.',
+});

--- a/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
+++ b/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
@@ -85,10 +85,11 @@ const mockUpdates = [
  * @param {object} overrides - Properties to spread on top of the defaults.
  * @returns {object} A full loan object.
  */
-export function createMockLoan(overrides = {}) {
-	const expirationDate = new Date();
-	expirationDate.setDate(expirationDate.getDate() + 30);
+// Fixed expiration date keeps story fixtures deterministic for visual
+// regression (avoids `new Date()`, which made snapshots drift day to day).
+const PLANNED_EXPIRATION_DATE = '2026-12-31T00:00:00.000Z';
 
+export function createMockLoan(overrides = {}) {
 	return {
 		id: 1975833,
 		__typename: 'LoanPartner',
@@ -121,7 +122,7 @@ export function createMockLoan(overrides = {}) {
 			hash: '9673d0722a7675b9b8d11f90849d9b44',
 			__typename: 'Image',
 		},
-		plannedExpirationDate: expirationDate.toISOString(),
+		plannedExpirationDate: PLANNED_EXPIRATION_DATE,
 		anonymizationLevel: 'none',
 		loanAmount: '600.00',
 		status: 'fundraising',

--- a/.storybook/stories/SupportedByLenders.stories.js
+++ b/.storybook/stories/SupportedByLenders.stories.js
@@ -24,3 +24,32 @@ const story = (args) => {
 export const Default = story({
 	participants: activities.lend.loan.lendingActions,
 });
+
+export const Empty = story({
+	participants: {
+		values: [],
+		__typename: 'LendingActionCollection',
+	},
+});
+
+export const CurrentUserHighlighted = story({
+	participants: {
+		values: [
+			{
+				latestSharePurchaseDate: '2023-11-15T08:00:00Z',
+				lender: {
+					name: 'You',
+					image: {
+						url: 'https://www.development.kiva.org/img/s100/4d844ac2c0b77a8a522741b908ea5c32.jpg',
+					},
+					publicId: 'current-user',
+				},
+				shareAmount: '50.00',
+				isCurrentUser: true,
+				__typename: 'LendingAction',
+			},
+			...activities.lend.loan.lendingActions.values,
+		],
+		__typename: 'LendingActionCollection',
+	},
+});


### PR DESCRIPTION
Adding stories for Borrower Profile components before the migration work lands.

Copilot summary:
This pull request adds comprehensive Storybook stories for all major components of the Borrower Profile feature, ensuring each component can be visually tested in isolation with realistic data scenarios. It also improves Storybook's Vue router handling to prevent navigation issues within the Storybook iframe and enhances the Apollo mock mixin for better compatibility with stories that use variable changes.

The most important changes are:

**Storybook stories for Borrower Profile components:**

* Added new Storybook stories for the following components, each with realistic mock data and multiple scenarios: `BorrowerCountry`, `BorrowerSideSheetContent`, `BorrowerSideSheetWrapper`, `CommentsAndWhySpecial`, `CountryInfo`, `DescriptionListItem`, `DetailsTabs`, `FieldPartnerDetails`, `JournalUpdates`, `LendCta`, `LendersAndTeams`, and `LoanDetails`. These stories cover various states and edge cases for each component. [[1]](diffhunk://#diff-c4bca229a5272ea47865785dfa0338515ea5ba6f13481448cadb50d6dc2a2fa1R1-R59) [[2]](diffhunk://#diff-0522c64c56d6c1524dcb249f4aafbfeb9d1b9aee8a2dc67bfa5cbc4db812b75aR1-R30) [[3]](diffhunk://#diff-2ff8049d8e8973d423d9e9a0ef510c74092f2541e0eef62b9257dd616cbc60ecR1-R51) [[4]](diffhunk://#diff-1301a0e78d9115a97c8fb5166897a31a0a986dc8b2df4120c1ca8be097aad9a5R1-R53) [[5]](diffhunk://#diff-2a0607c3c920e704ee72abfb71c3e61c7e45cfaa4a6fa8ec175fd68813b6f7c0R1-R37) [[6]](diffhunk://#diff-b2b534583dfe0d9bbe0f944da7a711924dcda170d97c0683a605d3d19f6e3290R1-R50) [[7]](diffhunk://#diff-af1d163a6207923d9f2e135b6c52be7e045a56b7512f6e7cbb5050385e3c9dbfR1-R42) [[8]](diffhunk://#diff-d3ad7c44241624372a49bbf98af89d19f90ef2eafb913eb9bd5219128da0be65R1-R56) [[9]](diffhunk://#diff-31012f5791bbc96c8db8dec7046e42dc48ba07f84b6e1fae3ab9ba118c9ac7c1R1-R40) [[10]](diffhunk://#diff-5070f95ce50a9c6124e57cdd26d8a8986831b7190b2da3205b1c1f3ea3302b52R1-R46) [[11]](diffhunk://#diff-1e23ae588df8cd75b361412f2bc211301cfdf3f22104391c0006b2a77439a3c7R1-R109) [[12]](diffhunk://#diff-54741a93df123589aa59055c53f913357169dfe95e203924fe28c131a53736e5R1-R118)

**Improvements to Storybook router setup:**

* Changed the Vue router in Storybook from `createWebHistory` to `createMemoryHistory` and added a catch-all route to prevent navigation from breaking Storybook's iframe when components use `$router.push()` or similar methods. [[1]](diffhunk://#diff-98b614e1838b171ee71c04450a8f1a562753193fb7d4f53a4de8b9b5a7e980eeL4-R4) [[2]](diffhunk://#diff-98b614e1838b171ee71c04450a8f1a562753193fb7d4f53a4de8b9b5a7e980eeL27-R35)

**Enhancements to Apollo mock mixin:**

* Added a stub implementation of `setVariables()` to the Apollo Storybook mixin to improve compatibility with components that interact with Apollo queries using variables.