### PR TITLE
feat(live-loan): bundle img card style for ERL bundle emails

### DIFF
--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -234,6 +234,13 @@ export default function liveLoanRouter(cache) {
 		});
 	});
 
+	// User IMG Router (Bundle Legacy - no CTA)
+	router.use('/u/:id(\\d{0,})/bundle-img-legacy/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'bundle-legacy', cache, req, res, QUERY_TYPE.DEFAULT, MAX_BUNDLE_COUNT);
+		});
+	});
+
 	// User URL Router FLSS
 	router.use('/flss/u/:id(\\d{0,})/url/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToUrl', { resource: req.path }, async () => {
@@ -262,6 +269,13 @@ export default function liveLoanRouter(cache) {
 		});
 	});
 
+	// User IMG Router FLSS (Bundle Legacy - no CTA)
+	router.use('/flss/u/:id(\\d{0,})/bundle-img-legacy/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.flss.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'bundle-legacy', cache, req, res, QUERY_TYPE.FLSS, MAX_BUNDLE_COUNT);
+		});
+	});
+
 	// User URL Router Recommendations
 	router.use('/recommendations/u/:id(\\d{0,})/url/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToUrl', { resource: req.path }, async () => {
@@ -287,6 +301,13 @@ export default function liveLoanRouter(cache) {
 	router.use('/recommendations/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
 			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.RECOMMENDATIONS, MAX_BUNDLE_COUNT);
+		});
+	});
+
+	// User IMG Router Recommendations (Bundle Legacy - no CTA)
+	router.use('/recommendations/u/:id(\\d{0,})/bundle-img-legacy/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'bundle-legacy', cache, req, res, QUERY_TYPE.RECOMMENDATIONS, MAX_BUNDLE_COUNT);
 		});
 	});
 

--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -4,7 +4,7 @@ import { getFromCache, setToCache } from './util/memJsUtils.js';
 import drawLoanCard from './util/live-loan/live-loan-draw.js';
 import fetchLoansByType, { QUERY_TYPE } from './util/live-loan/live-loan-fetch.js';
 import { trace } from './util/mockTrace.js';
-import { resolveBundleSize, DEFAULT_BUNDLE_COUNT } from './util/live-loan/bundle-size.js';
+import { resolveBundleSize, DEFAULT_BUNDLE_COUNT, MAX_BUNDLE_COUNT } from './util/live-loan/bundle-size.js';
 
 async function fetchRecommendedLoans(type, id, cache, queryType = QUERY_TYPE.DEFAULT, count = DEFAULT_BUNDLE_COUNT) {
 	const queryTypeSuffix = queryType !== QUERY_TYPE.DEFAULT ? `-${queryType}` : '';
@@ -133,13 +133,13 @@ async function redirectToBundleUrl(type, cache, req, res, queryType = QUERY_TYPE
 	}
 }
 
-async function serveImg(type, style, cache, req, res, queryType = QUERY_TYPE.DEFAULT) {
+async function serveImg(type, style, cache, req, res, queryType = QUERY_TYPE.DEFAULT, count = DEFAULT_BUNDLE_COUNT) {
 	let loan;
 	let loanImg;
 	let hasBorrowerImage = true;
 
 	try {
-		loan = await trace('getLoanForRequest', async () => getLoanForRequest(type, cache, req, queryType));
+		loan = await trace('getLoanForRequest', async () => getLoanForRequest(type, cache, req, queryType, count));
 		const queryTypeSuffix = queryType !== QUERY_TYPE.DEFAULT ? `-${queryType}` : '';
 		const imgCachedName = `loan-card-img-${style}-${loan.id}${queryTypeSuffix}`;
 		const cachedLoanImg = await getFromCache(imgCachedName, cache);
@@ -230,7 +230,7 @@ export default function liveLoanRouter(cache) {
 	// User IMG Router (Bundle - no CTA)
 	router.use('/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.user.serveImg', { resource: req.path }, async () => {
-			await serveImg('user', 'bundle', cache, req, res);
+			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.DEFAULT, MAX_BUNDLE_COUNT);
 		});
 	});
 
@@ -258,7 +258,7 @@ export default function liveLoanRouter(cache) {
 	// User IMG Router FLSS (Bundle - no CTA)
 	router.use('/flss/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.serveImg', { resource: req.path }, async () => {
-			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.FLSS);
+			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.FLSS, MAX_BUNDLE_COUNT);
 		});
 	});
 
@@ -286,7 +286,7 @@ export default function liveLoanRouter(cache) {
 	// User IMG Router Recommendations (Bundle - no CTA)
 	router.use('/recommendations/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
-			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.RECOMMENDATIONS);
+			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.RECOMMENDATIONS, MAX_BUNDLE_COUNT);
 		});
 	});
 

--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -227,6 +227,13 @@ export default function liveLoanRouter(cache) {
 		});
 	});
 
+	// User IMG Router (Bundle - no CTA)
+	router.use('/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'bundle', cache, req, res);
+		});
+	});
+
 	// User URL Router FLSS
 	router.use('/flss/u/:id(\\d{0,})/url/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToUrl', { resource: req.path }, async () => {
@@ -248,6 +255,13 @@ export default function liveLoanRouter(cache) {
 		});
 	});
 
+	// User IMG Router FLSS (Bundle - no CTA)
+	router.use('/flss/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.flss.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.FLSS);
+		});
+	});
+
 	// User URL Router Recommendations
 	router.use('/recommendations/u/:id(\\d{0,})/url/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToUrl', { resource: req.path }, async () => {
@@ -266,6 +280,13 @@ export default function liveLoanRouter(cache) {
 	router.use('/recommendations/u/:id(\\d{0,})/img2/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
 			await serveImg('user', 'classic', cache, req, res, QUERY_TYPE.RECOMMENDATIONS);
+		});
+	});
+
+	// User IMG Router Recommendations (Bundle - no CTA)
+	router.use('/recommendations/u/:id(\\d{0,})/bundle-img/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'bundle', cache, req, res, QUERY_TYPE.RECOMMENDATIONS);
 		});
 	});
 

--- a/server/util/live-loan/bundle-size.js
+++ b/server/util/live-loan/bundle-size.js
@@ -1,10 +1,11 @@
 export const DEFAULT_BUNDLE_COUNT = 4;
+export const MAX_BUNDLE_COUNT = 6;
 
 const REDIRECT_PATH = '/lend/filter';
 const MAX_BALANCE = 150;
 const TIER_STEP = 25;
 const MIN_LOANS = 1;
-const MAX_LOANS = 6;
+const MAX_LOANS = MAX_BUNDLE_COUNT;
 
 /**
  * Resolves how many loans should be included in a live-loan email bundle, based on the

--- a/server/util/live-loan/bundle-size.js
+++ b/server/util/live-loan/bundle-size.js
@@ -5,7 +5,6 @@ const REDIRECT_PATH = '/lend/filter';
 const MAX_BALANCE = 150;
 const TIER_STEP = 25;
 const MIN_LOANS = 1;
-const MAX_LOANS = MAX_BUNDLE_COUNT;
 
 /**
  * Resolves how many loans should be included in a live-loan email bundle, based on the
@@ -35,6 +34,6 @@ export function resolveBundleSize(balanceInput) {
 		return { redirect: REDIRECT_PATH };
 	}
 	const raw = Math.ceil(balance / TIER_STEP);
-	const count = Math.min(Math.max(raw, MIN_LOANS), MAX_LOANS);
+	const count = Math.min(Math.max(raw, MIN_LOANS), MAX_BUNDLE_COUNT);
 	return { count };
 }

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -195,7 +195,7 @@ async function drawLegacy(loanData) {
 	}
 }
 
-async function drawClassic(loanData) {
+async function drawClassic(loanData, { skipButton = false } = {}) {
 	// Get canvas & context
 	const canvas = trace('classicCanvasPool.use', () => classicCanvasPool.use());
 	const ctx = trace('canvas.getContext', () => canvas.getContext('2d', { alpha: false }));
@@ -314,26 +314,28 @@ async function drawClassic(loanData) {
 		});
 
 		// Button
-		trace('button', () => {
-			const btnXPos = 252 * classicResizeFactor;
-			const btnYPos = 454 * classicResizeFactor;
-			const btnHeight = 48 * classicResizeFactor;
-			const btnWidth = 180 * classicResizeFactor;
-			const btnBorderRadius = 14 * classicResizeFactor;
-			const btnFontSize = 17 * classicResizeFactor;
-			const btnTxtXPos = btnXPos + (btnWidth / 2);
-			const btnTxtYPos = btnYPos + (btnHeight / 2) - (btnFontSize / 2);
-			// Button background
-			roundRect(ctx, btnXPos, btnYPos, btnWidth, btnHeight, btnBorderRadius);
-			ctx.fillStyle = kivaColors.action;
-			ctx.fill();
-			// Button Text
-			ctx.fillStyle = kivaColors.white;
-			ctx.font = `500 ${btnFontSize}px "Kiva Post Grot"`;
-			ctx.textAlign = 'center';
-			ctx.fillText('Lend now', btnTxtXPos, btnTxtYPos);
-			ctx.textAlign = 'left';
-		});
+		if (!skipButton) {
+			trace('button', () => {
+				const btnXPos = 252 * classicResizeFactor;
+				const btnYPos = 454 * classicResizeFactor;
+				const btnHeight = 48 * classicResizeFactor;
+				const btnWidth = 180 * classicResizeFactor;
+				const btnBorderRadius = 14 * classicResizeFactor;
+				const btnFontSize = 17 * classicResizeFactor;
+				const btnTxtXPos = btnXPos + (btnWidth / 2);
+				const btnTxtYPos = btnYPos + (btnHeight / 2) - (btnFontSize / 2);
+				// Button background
+				roundRect(ctx, btnXPos, btnYPos, btnWidth, btnHeight, btnBorderRadius);
+				ctx.fillStyle = kivaColors.action;
+				ctx.fill();
+				// Button Text
+				ctx.fillStyle = kivaColors.white;
+				ctx.font = `500 ${btnFontSize}px "Kiva Post Grot"`;
+				ctx.textAlign = 'center';
+				ctx.fillText('Lend now', btnTxtXPos, btnTxtYPos);
+				ctx.textAlign = 'left';
+			});
+		}
 
 		// Export to jpeg
 		const buffer = trace('export-jpeg', () => canvas.toBuffer('image/jpeg', { quality: 0.25 }));
@@ -353,6 +355,8 @@ async function drawClassic(loanData) {
 
 export default async function draw(loanData, style) {
 	switch (style) {
+		case 'bundle':
+			return drawClassic(loanData, { skipButton: true });
 		case 'classic':
 			return drawClassic(loanData);
 		case 'legacy':

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -59,7 +59,7 @@ const classicCanvasPool = deePool.create(function makeCanvas() {
 legacyCanvasPool.grow(2);
 classicCanvasPool.grow(2);
 
-async function drawLegacy(loanData) {
+async function drawLegacy(loanData, { skipButton = false } = {}) {
 	// Get canvas & context
 	const canvas = trace('legacyCanvasPool.use', () => legacyCanvasPool.use());
 	const ctx = trace('canvas.getContext', () => canvas.getContext('2d', { alpha: false }));
@@ -138,27 +138,29 @@ async function drawLegacy(loanData) {
 		});
 
 		// Button
-		trace('button', () => {
-			const btnXPos = (cardWidth - bodyWidth) / 2;
-			const btnYPos = 450 * resizeFactor;
-			const btnHeight = 50 * resizeFactor;
-			const btnBorderRadius = 14 * resizeFactor;
-			const btnFontSize = 19;
-			const btnFontRenderSize = btnFontSize * resizeFactor;
-			const btnTxtXPos = cardWidth / 2;
-			const btnTxtYPos = btnYPos + (btnHeight / 2) - (btnFontRenderSize / 2);
-			// ctx.shadowBlur = 0;
-			// ctx.shadowOffsetX = 0;
-			// ctx.shadowOffsetY = 2 * resizeFactor;
-			// ctx.shadowColor = kivaColors.darkBlue;
-			roundRect(ctx, btnXPos, btnYPos, bodyWidth, btnHeight, btnBorderRadius);
-			ctx.fillStyle = kivaColors.action;
-			ctx.fill();
-			ctx.shadowColor = 'transparent';
-			ctx.fillStyle = kivaColors.white;
-			ctx.font = `500 ${btnFontSize * resizeFactor}px "Kiva Post Grot"`;
-			ctx.fillText('Lend now', btnTxtXPos, btnTxtYPos);
-		});
+		if (!skipButton) {
+			trace('button', () => {
+				const btnXPos = (cardWidth - bodyWidth) / 2;
+				const btnYPos = 450 * resizeFactor;
+				const btnHeight = 50 * resizeFactor;
+				const btnBorderRadius = 14 * resizeFactor;
+				const btnFontSize = 19;
+				const btnFontRenderSize = btnFontSize * resizeFactor;
+				const btnTxtXPos = cardWidth / 2;
+				const btnTxtYPos = btnYPos + (btnHeight / 2) - (btnFontRenderSize / 2);
+				// ctx.shadowBlur = 0;
+				// ctx.shadowOffsetX = 0;
+				// ctx.shadowOffsetY = 2 * resizeFactor;
+				// ctx.shadowColor = kivaColors.darkBlue;
+				roundRect(ctx, btnXPos, btnYPos, bodyWidth, btnHeight, btnBorderRadius);
+				ctx.fillStyle = kivaColors.action;
+				ctx.fill();
+				ctx.shadowColor = 'transparent';
+				ctx.fillStyle = kivaColors.white;
+				ctx.font = `500 ${btnFontSize * resizeFactor}px "Kiva Post Grot"`;
+				ctx.fillText('Lend now', btnTxtXPos, btnTxtYPos);
+			});
+		}
 
 		// Borrower Image
 		const hasBorrowerImage = await trace('borrower-image', async () => {
@@ -359,6 +361,8 @@ export default async function draw(loanData, style) {
 			return drawClassic(loanData, { skipButton: true });
 		case 'classic':
 			return drawClassic(loanData);
+		case 'bundle-legacy':
+			return drawLegacy(loanData, { skipButton: true });
 		case 'legacy':
 		default:
 			return drawLegacy(loanData);

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -23,6 +23,8 @@ polyfillPath2D(global);
 const resizeFactor = 3;
 const cardWidth = 300 * resizeFactor;
 const cardHeight = 525 * resizeFactor;
+// Bundle Legacy is the legacy card with the CTA removed; shrink height to ~20px below the fundraising row
+const bundleLegacyCardHeight = 450 * resizeFactor;
 
 // Kiva Classic styling constants
 const classicResizeFactor = 3;
@@ -51,17 +53,25 @@ trace('registerFonts', () => {
 const legacyCanvasPool = deePool.create(function makeCanvas() {
 	return trace('createLegacyCanvas', () => createCanvas(cardWidth, cardHeight));
 });
+// eslint-disable-next-line prefer-arrow-callback
+const bundleLegacyCanvasPool = deePool.create(function makeCanvas() {
+	return trace('createBundleLegacyCanvas', () => createCanvas(cardWidth, bundleLegacyCardHeight));
+});
 
 // eslint-disable-next-line prefer-arrow-callback
 const classicCanvasPool = deePool.create(function makeCanvas() {
 	return trace('createClassicCanvas', () => createCanvas(classicCardWidth, classicCardHeight));
 });
 legacyCanvasPool.grow(2);
+bundleLegacyCanvasPool.grow(2);
 classicCanvasPool.grow(2);
 
 async function drawLegacy(loanData, { skipButton = false } = {}) {
+	const pool = skipButton ? bundleLegacyCanvasPool : legacyCanvasPool;
+	const poolTraceName = skipButton ? 'bundleLegacyCanvasPool' : 'legacyCanvasPool';
+	const effectiveCardHeight = skipButton ? bundleLegacyCardHeight : cardHeight;
 	// Get canvas & context
-	const canvas = trace('legacyCanvasPool.use', () => legacyCanvasPool.use());
+	const canvas = trace(`${poolTraceName}.use`, () => pool.use());
 	const ctx = trace('canvas.getContext', () => canvas.getContext('2d', { alpha: false }));
 	const borderThickness = 2 * resizeFactor;
 	const bodyWidth = cardWidth * 0.85;
@@ -82,7 +92,7 @@ async function drawLegacy(loanData, { skipButton = false } = {}) {
 			ctx.textAlign = 'center';
 			ctx.textBaseline = 'top';
 			ctx.fillStyle = '#fff';
-			ctx.fillRect(0, 0, cardWidth, cardHeight);
+			ctx.fillRect(0, 0, cardWidth, effectiveCardHeight);
 		});
 
 		// Borrower name
@@ -177,7 +187,7 @@ async function drawLegacy(loanData, { skipButton = false } = {}) {
 				borderThickness / 2,
 				borderThickness / 2,
 				cardWidth - borderThickness,
-				cardHeight - borderThickness
+				effectiveCardHeight - borderThickness
 			);
 		});
 
@@ -185,13 +195,13 @@ async function drawLegacy(loanData, { skipButton = false } = {}) {
 		const buffer = trace('export-jpeg', () => canvas.toBuffer('image/jpeg', { quality: 0.5 }));
 
 		// Recycle canvas for use in other requests
-		trace('legacyCanvasPool.recycle', () => legacyCanvasPool.recycle(canvas));
+		trace(`${poolTraceName}.recycle`, () => pool.recycle(canvas));
 
 		return { buffer, hasBorrowerImage };
 	} catch (e) {
 		// Recycle canvas for use in other requests
 		if (canvas) {
-			trace('legacyCanvasPool.recycle', () => legacyCanvasPool.recycle(canvas));
+			trace(`${poolTraceName}.recycle`, () => pool.recycle(canvas));
 		}
 		throw e;
 	}

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -430,22 +430,6 @@ describe('live-loan-router bundle-url routes', () => {
 			);
 		});
 
-		it('serves distinct loans at offsets 5 and 6 when 6 loans are returned', async () => {
-			const sixLoans = [
-				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 },
-			];
-			liveLoanFetch.default.mockResolvedValue(sixLoans);
-
-			const app = createApp(cache);
-			const result5 = await makeRequest(app, '/live-loan/u/42/bundle-img/5');
-			const result6 = await makeRequest(app, '/live-loan/u/42/bundle-img/6');
-
-			expect(result5.statusCode).toBe(200);
-			expect(result6.statusCode).toBe(200);
-			expect(drawLoanCard).toHaveBeenCalledWith({ id: 5 }, 'bundle');
-			expect(drawLoanCard).toHaveBeenCalledWith({ id: 6 }, 'bundle');
-		});
-
 		it('legacy /u/:id/img2/:offset route still fetches the 4-loan default', async () => {
 			liveLoanFetch.default.mockResolvedValue([
 				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 },

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -370,4 +370,57 @@ describe('live-loan-router bundle-url routes', () => {
 			expect(liveLoanFetch.default).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('serveImg - bundle-img routes', () => {
+		let drawLoanCard;
+
+		beforeEach(async () => {
+			const drawModule = await import('#server/util/live-loan/live-loan-draw');
+			drawLoanCard = drawModule.default;
+			drawLoanCard.mockResolvedValue({ buffer: Buffer.from('jpeg-bytes'), hasBorrowerImage: true });
+		});
+
+		it('serves jpeg for /u/:id/bundle-img/:offset with bundle style', async () => {
+			liveLoanFetch.default.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-img/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 1 }, 'bundle');
+		});
+
+		it('FLSS bundle-img route passes FLSS query type and bundle style', async () => {
+			liveLoanFetch.default.mockResolvedValue([{ id: 11 }, { id: 22 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/flss/u/42/bundle-img/2');
+
+			expect(result.statusCode).toBe(200);
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 22 }, 'bundle');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.FLSS,
+				4,
+			);
+		});
+
+		it('recommendations bundle-img route passes recommendations query type and bundle style', async () => {
+			liveLoanFetch.default.mockResolvedValue([{ id: 33 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/recommendations/u/42/bundle-img/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 33 }, 'bundle');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.RECOMMENDATIONS,
+				4,
+			);
+		});
+	});
 });

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -3,6 +3,7 @@ import express from 'express';
 import liveLoanRouter from '#server/live-loan-router';
 import * as liveLoanFetch from '#server/util/live-loan/live-loan-fetch';
 import * as memJsUtils from '#server/util/memJsUtils';
+import drawLoanCard from '#server/util/live-loan/live-loan-draw';
 
 // Mock out modules to prevent real network/cache calls
 vi.mock('#server/util/live-loan/live-loan-fetch');
@@ -372,11 +373,7 @@ describe('live-loan-router bundle-url routes', () => {
 	});
 
 	describe('serveImg - bundle-img routes', () => {
-		let drawLoanCard;
-
-		beforeEach(async () => {
-			const drawModule = await import('#server/util/live-loan/live-loan-draw');
-			drawLoanCard = drawModule.default;
+		beforeEach(() => {
 			drawLoanCard.mockResolvedValue({ buffer: Buffer.from('jpeg-bytes'), hasBorrowerImage: true });
 		});
 
@@ -389,6 +386,12 @@ describe('live-loan-router bundle-url routes', () => {
 			expect(result.statusCode).toBe(200);
 			expect(result.headers['content-type']).toBe('image/jpeg');
 			expect(drawLoanCard).toHaveBeenCalledWith({ id: 1 }, 'bundle');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.DEFAULT,
+				4,
+			);
 		});
 
 		it('FLSS bundle-img route passes FLSS query type and bundle style', async () => {

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -378,7 +378,9 @@ describe('live-loan-router bundle-url routes', () => {
 		});
 
 		it('serves jpeg for /u/:id/bundle-img/:offset with bundle style', async () => {
-			liveLoanFetch.default.mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]);
+			liveLoanFetch.default.mockResolvedValue([
+				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 },
+			]);
 
 			const app = createApp(cache);
 			const result = await makeRequest(app, '/live-loan/u/42/bundle-img/1');
@@ -390,7 +392,7 @@ describe('live-loan-router bundle-url routes', () => {
 				'user',
 				'42',
 				liveLoanFetch.QUERY_TYPE.DEFAULT,
-				4,
+				6,
 			);
 		});
 
@@ -407,7 +409,7 @@ describe('live-loan-router bundle-url routes', () => {
 				'user',
 				'42',
 				liveLoanFetch.QUERY_TYPE.FLSS,
-				4,
+				6,
 			);
 		});
 
@@ -424,6 +426,39 @@ describe('live-loan-router bundle-url routes', () => {
 				'user',
 				'42',
 				liveLoanFetch.QUERY_TYPE.RECOMMENDATIONS,
+				6,
+			);
+		});
+
+		it('serves distinct loans at offsets 5 and 6 when 6 loans are returned', async () => {
+			const sixLoans = [
+				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 },
+			];
+			liveLoanFetch.default.mockResolvedValue(sixLoans);
+
+			const app = createApp(cache);
+			const result5 = await makeRequest(app, '/live-loan/u/42/bundle-img/5');
+			const result6 = await makeRequest(app, '/live-loan/u/42/bundle-img/6');
+
+			expect(result5.statusCode).toBe(200);
+			expect(result6.statusCode).toBe(200);
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 5 }, 'bundle');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 6 }, 'bundle');
+		});
+
+		it('legacy /u/:id/img2/:offset route still fetches the 4-loan default', async () => {
+			liveLoanFetch.default.mockResolvedValue([
+				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 },
+			]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/img2/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.DEFAULT,
 				4,
 			);
 		});

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -398,6 +398,7 @@ describe('live-loan-router bundle-url routes', () => {
 			const result = await makeRequest(app, '/live-loan/flss/u/42/bundle-img/2');
 
 			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
 			expect(drawLoanCard).toHaveBeenCalledWith({ id: 22 }, 'bundle');
 			expect(liveLoanFetch.default).toHaveBeenCalledWith(
 				'user',
@@ -414,6 +415,7 @@ describe('live-loan-router bundle-url routes', () => {
 			const result = await makeRequest(app, '/live-loan/recommendations/u/42/bundle-img/1');
 
 			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
 			expect(drawLoanCard).toHaveBeenCalledWith({ id: 33 }, 'bundle');
 			expect(liveLoanFetch.default).toHaveBeenCalledWith(
 				'user',

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -447,4 +447,63 @@ describe('live-loan-router bundle-url routes', () => {
 			);
 		});
 	});
+
+	describe('serveImg - bundle-img-legacy routes', () => {
+		beforeEach(() => {
+			drawLoanCard.mockResolvedValue({ buffer: Buffer.from('jpeg-bytes'), hasBorrowerImage: true });
+		});
+
+		it('serves jpeg for /u/:id/bundle-img-legacy/:offset with bundle-legacy style', async () => {
+			liveLoanFetch.default.mockResolvedValue([
+				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 },
+			]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-img-legacy/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 1 }, 'bundle-legacy');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.DEFAULT,
+				6,
+			);
+		});
+
+		it('FLSS bundle-img-legacy route passes FLSS query type and bundle-legacy style', async () => {
+			liveLoanFetch.default.mockResolvedValue([{ id: 11 }, { id: 22 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/flss/u/42/bundle-img-legacy/2');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 22 }, 'bundle-legacy');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.FLSS,
+				6,
+			);
+		});
+
+		it('recommendations bundle-img-legacy route passes recommendations query type and bundle-legacy style', async () => { // eslint-disable-line max-len
+			liveLoanFetch.default.mockResolvedValue([{ id: 33 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/recommendations/u/42/bundle-img-legacy/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 33 }, 'bundle-legacy');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.RECOMMENDATIONS,
+				6,
+			);
+		});
+	});
 });

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -489,7 +489,7 @@ describe('live-loan-router bundle-url routes', () => {
 			);
 		});
 
-		it('recommendations bundle-img-legacy route passes recommendations query type and bundle-legacy style', async () => { // eslint-disable-line max-len
+		it('recommendations bundle-img-legacy route uses recs query type and bundle-legacy style', async () => {
 			liveLoanFetch.default.mockResolvedValue([{ id: 33 }]);
 
 			const app = createApp(cache);


### PR DESCRIPTION
## Summary

Adds two new live-loan card image styles — `bundle` (classic without CTA) and `bundle-legacy` (legacy without CTA) — along with six new Express routes that serve them, for the new ERL bundle email design. The `bundle` card is byte-identical to its classic parent minus the "Lend now" CTA; the `bundle-legacy` card matches the legacy parent minus the CTA, and its canvas is shrunk vertically (525 → 450 in 1x units) to drop the dead space left by the removed button. The email's wrapping `<a>` tag provides the click target. Routes also fetch up to 6 loans (vs. the legacy 4-loan default) so high-balance recipients in MP-2713's tier ladder see distinct cards at every bundle position.

**Out of scope (other tickets):**
- Email template wiring + subject/body copy — [MP-2901](https://kiva.atlassian.net/browse/MP-2901)
- Bundle-URL / add-all-to-basket CTA — already shipped under [MP-2660](https://kiva.atlassian.net/browse/MP-2660)
- Balance-based bundle size — already shipped under [MP-2713](https://kiva.atlassian.net/browse/MP-2713)

## Related links

- Ticket: [MP-2714 — Updates to live loan image](https://kiva.atlassian.net/browse/MP-2714)
- Epic: [MP-2659 — Live loan bundles in emails](https://kiva.atlassian.net/browse/MP-2659)
- Design: [Figma — ERL Loan Bundle email](https://www.figma.com/design/rLBhG6XIPcYWYoeOJnMf1M/-ERL-LB--ERL-Loan-Bundle-email?node-id=3201-637)

## What changed

| File | Change |
| --- | --- |
| `server/util/live-loan/live-loan-draw.js` | `drawClassic` and `drawLegacy` each accept `{ skipButton = false }`. `draw()` switch handles `'bundle'` and `'bundle-legacy'`. Default args preserve byte-identical existing output. For `bundle-legacy`, a new `bundleLegacyCanvasPool` sized 300×450 (1x) is used so the card is shorter — eliminates the ~95px dead space below the fundraising row that the removed button used to occupy. Classic-bundle keeps the original 300×510 height since classic's bottom padding was already tight. |
| `server/util/live-loan/bundle-size.js` | Exports `MAX_BUNDLE_COUNT = 6`. Private `MAX_LOANS` now references it; `resolveBundleSize` behavior unchanged. |
| `server/live-loan-router.js` | `serveImg` gains a `count` param (defaults to `DEFAULT_BUNDLE_COUNT`, preserving legacy `img`/`img2` behavior). Six new routes — three each for the two new styles — across user/FLSS/recommendations query types; each passes `MAX_BUNDLE_COUNT`. |
| `test/unit/specs/server/live-loan-router.spec.js` | +7 tests: 3 for `bundle-img`, 3 for `bundle-img-legacy`, 1 legacy `img2` regression guard. |

### New routes

| Route | Style | Query type |
| --- | --- | --- |
| `/live-loan/u/:id/bundle-img/:offset` | `bundle` (classic, no CTA) | DEFAULT |
| `/live-loan/flss/u/:id/bundle-img/:offset` | `bundle` | FLSS |
| `/live-loan/recommendations/u/:id/bundle-img/:offset` | `bundle` | RECOMMENDATIONS |
| `/live-loan/u/:id/bundle-img-legacy/:offset` | `bundle-legacy` (legacy, no CTA, shorter card) | DEFAULT |
| `/live-loan/flss/u/:id/bundle-img-legacy/:offset` | `bundle-legacy` | FLSS |
| `/live-loan/recommendations/u/:id/bundle-img-legacy/:offset` | `bundle-legacy` | RECOMMENDATIONS |

## Tests

**7 new test cases** in `test/unit/specs/server/live-loan-router.spec.js`:

**`describe: serveImg - bundle-img routes`** — 3 cases (one per query type), each asserting 200 + `image/jpeg` + `drawLoanCard` called with `'bundle'` + `liveLoanFetch.default` called with the right `QUERY_TYPE` and `count=6`.

**`describe: serveImg - bundle-img-legacy routes`** — 3 cases (one per query type), each asserting the same four facets with style `'bundle-legacy'`.

**Legacy regression guard** (in the bundle-img block) — `legacy /u/:id/img2/:offset route still fetches the 4-loan default` — ensures the new `count` plumbing on `serveImg` did not disturb existing `img`/`img2` callers.

**Totals:** 30/30 in `live-loan-router.spec.js` (23 pre-existing + 7 new), 40/40 in `bundle-size.spec.js`. Whole suite: **3853 passing / 6 skipped** across 253 test files. Run locally:

## Test plan

- [ ] **Classic bundle (no CTA)** local visual diff: hit `/live-loan/u/<uid>/img2/1` vs `/live-loan/u/<uid>/bundle-img/1` — should be pixel-identical except for the empty button area.
- [ ] **Legacy bundle (no CTA, shorter)** local visual diff: hit `/live-loan/u/<uid>/img/1` vs `/live-loan/u/<uid>/bundle-img-legacy/1` — should be the same card with the button cropped off and the card shortened so there's only normal bottom padding below the fundraising bar (no big gap).
- [ ] Confirm `/bundle-img/5` and `/bundle-img/6` (and likewise `/bundle-img-legacy/5`, `/6`) return distinct loans (not duplicates of loan #4).
- [ ] Confirm FLSS and recommendations variants resolve for both bundle styles.
- [ ] No regression on existing routes: `/img/1` and `/img2/1` render unchanged for the same user.

## Image examples
<img width="937" height="1076" alt="Screenshot 2026-06-16 at 4 38 46 p m" src="https://github.com/user-attachments/assets/ca2a9346-532b-4d81-a09c-1c5a7017597e" />

<img width="647" height="941" alt="Screenshot 2026-06-16 at 4 54 19 p m" src="https://github.com/user-attachments/assets/d8565baa-cae2-477f-8762-4662355d142e" />



[MP-2901]: https://kiva.atlassian.net/browse/MP-2901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2660]: https://kiva.atlassian.net/browse/MP-2660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2713]: https://kiva.atlassian.net/browse/MP-2713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ