### PR TITLE
feat: suppress achievement messages when goal is active

### DIFF
--- a/src/components/Checkout/BasketItem.vue
+++ b/src/components/Checkout/BasketItem.vue
@@ -202,7 +202,7 @@ export default {
 			type: Boolean,
 			default: false
 		},
-		hasGoal: {
+		suppressAchievementNudges: {
 			type: Boolean,
 			default: false
 		}
@@ -245,9 +245,8 @@ export default {
 			return this.loan.team ? this.loan.team.id : 0;
 		},
 		showPill() {
-			if (this.hasGoal) {
-				if (this.loanContributesToGoal) return true;
-				return false;
+			if (this.suppressAchievementNudges) {
+				return this.loanContributesToGoal;
 			}
 			return (this.contributesInAchievement || this.isFirstLoan)
 			|| this.pillMessage.length > 0;

--- a/src/components/Checkout/BasketItemsList.vue
+++ b/src/components/Checkout/BasketItemsList.vue
@@ -13,7 +13,7 @@
 					:is-first-loan="isFirstLoan(index)"
 					:loan-contributes-to-goal="loansContributingToGoal[index]"
 					:loading-goal-data="loadingGoalData"
-					:has-goal="userGoal !== null && userGoal?.status === 'in-progress'"
+					:suppress-achievement-nudges="suppressAchievementNudges"
 					@validateprecheckout="$emit('validateprecheckout')"
 					@refreshtotals="$emit('refreshtotals', $event)"
 					@updating-totals="$emit('updating-totals', $event)"
@@ -245,6 +245,7 @@ export default {
 			userGoal,
 			goalProgress,
 			getPostCheckoutProgressByLoans,
+			suppressAchievementNudges,
 		} = useGoalData({ apollo });
 
 		return {
@@ -253,6 +254,7 @@ export default {
 			goalProgress,
 			getPostCheckoutProgressByLoans,
 			getJourneysByLoan,
+			suppressAchievementNudges,
 		};
 	},
 	async mounted() {

--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -66,6 +66,7 @@ const {
 	loadGoalData,
 	getPostCheckoutProgressByLoans,
 	isProgressCompletingGoal,
+	suppressAchievementNudges,
 } = useGoalData({ apollo });
 
 const userData = ref({});
@@ -81,6 +82,12 @@ const milestonesProgress = ref({});
 const hasEverLoggedIn = ref(false);
 const basketTotal = ref(0);
 const loanGoalProgress = ref(0);
+// Tracks whether the just-added loan actually contributes to the goal's
+// category (e.g. a male loan does not contribute to a women-equality goal).
+// loanGoalProgress alone is the cumulative yearly total and stays > 0 across
+// non-contributing adds, so we need this flag to correctly identify a goal
+// add vs. an unrelated achievement add.
+const loanContributesToGoal = ref(false);
 
 const basketCount = computed(() => {
 	return addedLoan.value?.basketSize ?? 0;
@@ -93,6 +100,7 @@ const resetModal = () => {
 	oneLoanAwayFilteredUrl.value = '';
 	oneLoanAwayCategory.value = '';
 	modalVisible.value = false;
+	loanContributesToGoal.value = false;
 };
 
 const handleRedirect = payload => {
@@ -146,7 +154,7 @@ const isFirstLoan = computed(() => {
 });
 
 // eslint-disable-next-line max-len
-const isLoanGoal = computed(() => loanGoalProgress.value > 0 && userGoal.value?.status === 'in-progress' && loanGoalProgress.value <= userGoal.value?.target);
+const isLoanGoal = computed(() => loanContributesToGoal.value && loanGoalProgress.value > 0 && userGoal.value?.status === 'in-progress' && loanGoalProgress.value <= userGoal.value?.target);
 
 const isCompletingGoal = computed(() => isProgressCompletingGoal(loanGoalProgress.value));
 
@@ -179,12 +187,13 @@ const fetchPostCheckoutAchievements = async loanIds => {
 	// Use yearly progress with current year
 	const year = new Date().getFullYear();
 	// Increment counter per add-to-basket action
-	const { totalProgress } = await getPostCheckoutProgressByLoans({
+	const { totalProgress, hasContributingLoans } = await getPostCheckoutProgressByLoans({
 		loans: loanIds.map(id => ({ id })),
 		year,
 		increment: true,
 	});
 	loanGoalProgress.value = totalProgress;
+	loanContributesToGoal.value = hasContributingLoans;
 	const userTarget = userGoal.value?.target || 0;
 	const isOneLoanAwayFromGoal = userTarget - totalProgress === 1;
 	const goalAchieved = loanGoalProgress.value === userTarget;
@@ -204,7 +213,11 @@ const fetchPostCheckoutAchievements = async loanIds => {
 
 	// If added loan is not related to user goal, proceed with achievements logic.
 	// This condition will prevent any conflict between goal and achievement messages.
-	if (!isLoanGoal.value) {
+	// While the lender has an active goal experience (in-progress, or completed but
+	// the celebration hasn't been acknowledged yet) we also suppress achievement
+	// nudges entirely so they don't compete with the goal flow — they resume once
+	// the viewed-goal-complete flag is set or the lender has no goal at all.
+	if (!isLoanGoal.value && !suppressAchievementNudges.value) {
 		await apollo.query({
 			query: postCheckoutAchievementsQuery,
 			variables: { loanIds }

--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -82,11 +82,7 @@ const milestonesProgress = ref({});
 const hasEverLoggedIn = ref(false);
 const basketTotal = ref(0);
 const loanGoalProgress = ref(0);
-// Tracks whether the just-added loan actually contributes to the goal's
-// category (e.g. a male loan does not contribute to a women-equality goal).
-// loanGoalProgress alone is the cumulative yearly total and stays > 0 across
-// non-contributing adds, so we need this flag to correctly identify a goal
-// add vs. an unrelated achievement add.
+// Tracks whether the just-added loan actually contributes to the goal's category
 const loanContributesToGoal = ref(false);
 
 const basketCount = computed(() => {
@@ -213,10 +209,8 @@ const fetchPostCheckoutAchievements = async loanIds => {
 
 	// If added loan is not related to user goal, proceed with achievements logic.
 	// This condition will prevent any conflict between goal and achievement messages.
-	// While the lender has an active goal experience (in-progress, or completed but
-	// the celebration hasn't been acknowledged yet) we also suppress achievement
-	// nudges entirely so they don't compete with the goal flow — they resume once
-	// the viewed-goal-complete flag is set or the lender has no goal at all.
+	// While the lender has an active goal experience we also suppress achievement
+	// nudges entirely so they don't compete with the goal flow.
 	if (!isLoanGoal.value && !suppressAchievementNudges.value) {
 		await apollo.query({
 			query: postCheckoutAchievementsQuery,

--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -207,11 +207,7 @@ const fetchPostCheckoutAchievements = async loanIds => {
 		return;
 	}
 
-	// If added loan is not related to user goal, proceed with achievements logic.
-	// This condition will prevent any conflict between goal and achievement messages.
-	// While the lender has an active goal experience we also suppress achievement
-	// nudges entirely so they don't compete with the goal flow.
-	if (!isLoanGoal.value && !suppressAchievementNudges.value) {
+	if (!suppressAchievementNudges.value) {
 		await apollo.query({
 			query: postCheckoutAchievementsQuery,
 			variables: { loanIds }

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -975,8 +975,8 @@ export default {
 		// component fetches its own loan-search-suggestion dataset (mirrors loadMenu → loadMenuData).
 		// onSearchSubmit still performs navigation since the header emits the search payload.
 		loadSearchData() {
-			if (this.$refs.newExpHeader) {
-				this.$refs.newExpHeader.loadSearchSuggestions(this.apollo);
+			if (this.$refs?.newExpHeader) {
+				// this.$refs?.newExpHeader?.loadSearchSuggestions(this.apollo);
 			}
 		},
 		onSearchSubmit(payload) {

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -975,8 +975,8 @@ export default {
 		// component fetches its own loan-search-suggestion dataset (mirrors loadMenu → loadMenuData).
 		// onSearchSubmit still performs navigation since the header emits the search payload.
 		loadSearchData() {
-			if (this.$refs?.newExpHeader) {
-				// this.$refs?.newExpHeader?.loadSearchSuggestions(this.apollo);
+			if (this.$refs.newExpHeader) {
+				this.$refs.newExpHeader.loadSearchSuggestions(this.apollo);
 			}
 		},
 		onSearchSubmit(payload) {

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -728,16 +728,12 @@ export default function useGoalData({ apollo } = {}) {
 	}
 
 	/**
-	 * True while the lender has a goal whose completion celebration they
-	 * have not yet acknowledged. Drives the basket / ATB-modal achievement
+	 * Drives the basket / ATB-modal achievement
 	 * nudges so they stay out of the way during the goal experience and
 	 * resume only after the viewed-goal-complete flag is set (or the lender
 	 * has no goal at all).
 	 */
 	const suppressAchievementNudges = computed(() => {
-		// Matches the truthy + non-empty convention used by userHasGoal in
-		// BadgesSectionV2 — setGoalState writes an empty object for "no goal"
-		// rather than null, so a plain Boolean check would misfire.
 		const hasGoal = !!userGoal.value && Object.keys(userGoal.value).length > 0;
 		return hasGoal && !hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR);
 	});

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -728,15 +728,13 @@ export default function useGoalData({ apollo } = {}) {
 	}
 
 	/**
-	 * Drives the basket / ATB-modal achievement
-	 * nudges so they stay out of the way during the goal experience and
-	 * resume only after the viewed-goal-complete flag is set (or the lender
-	 * has no goal at all).
+	 * Drives the basket / ATB-modal achievement nudges so they stay out of the
+	 * way while a goal is in progress and resume as soon as the goal is
+	 * completed (or the lender has no goal at all).
 	 */
-	const suppressAchievementNudges = computed(() => {
-		const hasGoal = !!userGoal.value && Object.keys(userGoal.value).length > 0;
-		return hasGoal && !hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR);
-	});
+	const suppressAchievementNudges = computed(() => (
+		userGoal.value?.status === GOAL_STATUS.IN_PROGRESS
+	));
 
 	async function setViewedGoalCompletePreference(year = GOALS_CURRENT_YEAR) {
 		if (!year) return;

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -727,6 +727,21 @@ export default function useGoalData({ apollo } = {}) {
 		return Boolean(viewedGoalCompleteByYear.value?.[year]);
 	}
 
+	/**
+	 * True while the lender has a goal whose completion celebration they
+	 * have not yet acknowledged. Drives the basket / ATB-modal achievement
+	 * nudges so they stay out of the way during the goal experience and
+	 * resume only after the viewed-goal-complete flag is set (or the lender
+	 * has no goal at all).
+	 */
+	const suppressAchievementNudges = computed(() => {
+		// Matches the truthy + non-empty convention used by userHasGoal in
+		// BadgesSectionV2 — setGoalState writes an empty object for "no goal"
+		// rather than null, so a plain Boolean check would misfire.
+		const hasGoal = !!userGoal.value && Object.keys(userGoal.value).length > 0;
+		return hasGoal && !hasViewedCompletedGoalForYear(GOALS_CURRENT_YEAR);
+	});
+
 	async function setViewedGoalCompletePreference(year = GOALS_CURRENT_YEAR) {
 		if (!year) return;
 		const parsedPrefs = await loadPreferences('network-only');
@@ -1087,6 +1102,7 @@ export default function useGoalData({ apollo } = {}) {
 		userGoal,
 		userGoalAchieved,
 		userGoalAchievedNow,
+		suppressAchievementNudges,
 		userPreferences,
 		completedGoalsHistory,
 		// Goal Entry for 2026 Goals

--- a/test/unit/specs/components/Checkout/BasketItem.spec.js
+++ b/test/unit/specs/components/Checkout/BasketItem.spec.js
@@ -252,7 +252,7 @@ describe('BasketItem loan', () => {
 		expect(within(LoanPrice).getByRole('option', { name: '$3,685' }));
 	});
 
-	describe('achievement / goal pill suppression (MP-2875)', () => {
+	describe('achievement / goal pill suppression', () => {
 		const renderItem = (props = {}) => render(BasketItem, {
 			global: {
 				...globalOptions,

--- a/test/unit/specs/components/Checkout/BasketItem.spec.js
+++ b/test/unit/specs/components/Checkout/BasketItem.spec.js
@@ -251,4 +251,78 @@ describe('BasketItem loan', () => {
 		expect(within(LoanPrice).getByRole('option', { name: '$2,000' }));
 		expect(within(LoanPrice).getByRole('option', { name: '$3,685' }));
 	});
+
+	describe('achievement / goal pill suppression (MP-2875)', () => {
+		const renderItem = (props = {}) => render(BasketItem, {
+			global: {
+				...globalOptions,
+				plugins: [router],
+				stubs: {
+					LoanReservation: { ...emptyComponent },
+					KvCartPill: {
+						name: 'KvCartPill',
+						props: ['customMessage'],
+						template: '<div data-testid="cart-pill">{{ customMessage }}<slot name="icon" /></div>',
+					},
+				},
+			},
+			props: {
+				disableMatching: false,
+				disableRedirects: false,
+				loan: loanReservation,
+				teams: basketLoanTeams,
+				...props,
+			},
+		});
+
+		it('shows the achievement pill when nudges are not suppressed and loan contributes to an achievement', () => {
+			const { queryByTestId } = renderItem({
+				contributesInAchievement: true,
+				suppressAchievementNudges: false,
+				loadingGoalData: false,
+			});
+			expect(queryByTestId('cart-pill')).not.toBeNull();
+		});
+
+		it('hides the achievement pill when nudges are suppressed and the loan does not contribute to the goal', () => {
+			const { queryByTestId } = renderItem({
+				contributesInAchievement: true,
+				suppressAchievementNudges: true,
+				loanContributesToGoal: false,
+				loadingGoalData: false,
+			});
+			expect(queryByTestId('cart-pill')).toBeNull();
+		});
+
+		it('does not show the first-loan pill while nudges are suppressed', () => {
+			const { queryByTestId } = renderItem({
+				contributesInAchievement: false,
+				suppressAchievementNudges: true,
+				loanContributesToGoal: false,
+				isFirstLoan: true,
+				loadingGoalData: false,
+			});
+			expect(queryByTestId('cart-pill')).toBeNull();
+		});
+
+		it('still shows the goal-progress pill when nudges are suppressed and the loan contributes to the goal', () => {
+			const { queryByTestId, getByText } = renderItem({
+				contributesInAchievement: false,
+				suppressAchievementNudges: true,
+				loanContributesToGoal: true,
+				loadingGoalData: false,
+			});
+			expect(queryByTestId('cart-pill')).not.toBeNull();
+			expect(getByText('Supporting this loan reaches your annual goal!')).toBeTruthy();
+		});
+
+		it('hides the pill while goal data is still loading even when nudges are not suppressed', () => {
+			const { queryByTestId } = renderItem({
+				contributesInAchievement: true,
+				suppressAchievementNudges: false,
+				loadingGoalData: true,
+			});
+			expect(queryByTestId('cart-pill')).toBeNull();
+		});
+	});
 });

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -4803,16 +4803,6 @@ describe('useGoalData', () => {
 	});
 
 	describe('suppressAchievementNudges (MP-2875)', () => {
-		// Lock the clock so the year-keyed viewedGoalComplete check is deterministic.
-		beforeEach(() => {
-			vi.useFakeTimers();
-			vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
-		});
-
-		afterEach(() => {
-			vi.useRealTimers();
-		});
-
 		const loadPrefs = async prefs => {
 			mockApollo.query = vi.fn().mockResolvedValue({
 				data: {
@@ -4826,9 +4816,6 @@ describe('useGoalData', () => {
 				},
 			});
 			await composable.loadPreferences('network-only');
-			// loadPreferences only populates the prefs ref; userGoal is set by
-			// setGoalState (normally called by loadGoalData). Set it explicitly
-			// so the computed sees the right active goal.
 			composable.setGoalState(prefs);
 		};
 
@@ -4849,7 +4836,7 @@ describe('useGoalData', () => {
 			expect(composable.suppressAchievementNudges.value).toBe(true);
 		});
 
-		it('is true when the goal is completed but the celebration has not been viewed', async () => {
+		it('flips back to false as soon as the goal is completed', async () => {
 			await loadPrefs({
 				goals: [{
 					status: GOAL_STATUS.COMPLETED,
@@ -4857,19 +4844,6 @@ describe('useGoalData', () => {
 					category: 'womens-equality',
 					target: 5,
 				}],
-			});
-			expect(composable.suppressAchievementNudges.value).toBe(true);
-		});
-
-		it('flips back to false once viewedGoalComplete is set for the current year', async () => {
-			await loadPrefs({
-				goals: [{
-					status: GOAL_STATUS.COMPLETED,
-					dateStarted: '2026-02-10T12:00:00.000Z',
-					category: 'womens-equality',
-					target: 5,
-				}],
-				viewedGoalComplete: { 2026: true },
 			});
 			expect(composable.suppressAchievementNudges.value).toBe(false);
 		});

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -4801,4 +4801,77 @@ describe('useGoalData', () => {
 			expect(composable.completedGoalsHistory.value).toEqual([]);
 		});
 	});
+
+	describe('suppressAchievementNudges (MP-2875)', () => {
+		// Lock the clock so the year-keyed viewedGoalComplete check is deterministic.
+		beforeEach(() => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-06-15T12:00:00Z'));
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		const loadPrefs = async prefs => {
+			mockApollo.query = vi.fn().mockResolvedValue({
+				data: {
+					my: {
+						userPreferences: {
+							id: 'pref-suppress',
+							preferences: JSON.stringify(prefs),
+						},
+						loans: { totalCount: 0 },
+					},
+				},
+			});
+			await composable.loadPreferences('network-only');
+			// loadPreferences only populates the prefs ref; userGoal is set by
+			// setGoalState (normally called by loadGoalData). Set it explicitly
+			// so the computed sees the right active goal.
+			composable.setGoalState(prefs);
+		};
+
+		it('is false when the lender has no goal', async () => {
+			await loadPrefs({ goals: [] });
+			expect(composable.suppressAchievementNudges.value).toBe(false);
+		});
+
+		it('is true while the lender has an in-progress goal', async () => {
+			await loadPrefs({
+				goals: [{
+					status: GOAL_STATUS.IN_PROGRESS,
+					dateStarted: '2026-02-10T12:00:00.000Z',
+					category: 'womens-equality',
+					target: 5,
+				}],
+			});
+			expect(composable.suppressAchievementNudges.value).toBe(true);
+		});
+
+		it('is true when the goal is completed but the celebration has not been viewed', async () => {
+			await loadPrefs({
+				goals: [{
+					status: GOAL_STATUS.COMPLETED,
+					dateStarted: '2026-02-10T12:00:00.000Z',
+					category: 'womens-equality',
+					target: 5,
+				}],
+			});
+			expect(composable.suppressAchievementNudges.value).toBe(true);
+		});
+
+		it('flips back to false once viewedGoalComplete is set for the current year', async () => {
+			await loadPrefs({
+				goals: [{
+					status: GOAL_STATUS.COMPLETED,
+					dateStarted: '2026-02-10T12:00:00.000Z',
+					category: 'womens-equality',
+					target: 5,
+				}],
+				viewedGoalComplete: { 2026: true },
+			});
+			expect(composable.suppressAchievementNudges.value).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2875

- If no goal set, achievements are visible in ATB and checkout pill.
- When user has an active goal, all achievements messages from ATB and Checkout will be hidden until the experience is over. 

### How to test
- Set a goal, all atb messages should be related to the goal
- Do not set a goal or remove your active goal, atb messages related to achievements will appear