### PR TITLE
fix: add no loans cta to loans-beta and cleaned up stats

### DIFF
--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -293,33 +293,25 @@ export default {
 			};
 			this.loading = false;
 
-			// The ended-with-currency-loss count is not exposed on userStats, so we derive it
-			// from the loans search the way the legacy getStatusCounts() does. The search's
-			// `ended_with_loss` status filter resolves to `defaulted OR (ended AND currency loss)`,
-			// so it also matches every defaulted loan; subtract the defaulted bucket (same search
-			// source) to recover just the ended-with-currency-loss loans. "Repaid" is then the
-			// remaining ended loans: ended total - ended-with-loss.
-			const endedTotal = data?.my?.endedLoans?.totalCount ?? 0;
-			const endedWithLossOrDefaulted = data?.my?.endedWithLossLoans?.totalCount ?? 0;
-			const searchedDefaulted = data?.my?.defaultedLoans?.totalCount ?? 0;
-			const endedWithLoss = Math.max(endedWithLossOrDefaulted - searchedDefaulted, 0);
-
-			// Update loan counts. Note this table mixes two sources: the ended-state rows
-			// (repaid, repaidWithCurrencyLoss, defaulted) are derived together from the loans
-			// search so they reconcile against one snapshot (ended total = repaid + with-loss,
-			// and defaulted shares that source), while the unrelated rows come from userStats
-			// num_* counts. A future backend loanStatusCounts field would let the whole table
-			// come from a single source (see legacy API::user()->getStatusCounts()).
+			// Every status count comes from the my.loans search (Sphinx). On the live path the
+			// status buckets are mutually exclusive — `ended` excludes currency-loss ends,
+			// `ended_with_loss` is ended-with-currency-loss only, and `defaulted` is separate —
+			// so each totalCount maps straight to its row with no subtraction. This matches the
+			// legacy getStatusCounts() split (Repaid = ended_without_loss, Repaid with currency
+			// loss = ended_with_loss, Ended in default = defaulted) and keeps large lenders off
+			// the slow user-stats count path. See MP-2817.
+			const count = bucket => bucket?.totalCount ?? 0;
+			const my = data?.my ?? {};
 			this.loanCounts = {
-				fundraising: userStats.num_fund_raising || 0,
-				funded: userStats.num_raised || 0,
-				payingBack: userStats.num_paying_back || 0,
-				payingBackDelinquent: userStats.number_delinquent || 0,
-				repaid: Math.max(endedTotal - endedWithLoss, 0),
-				repaidWithCurrencyLoss: endedWithLoss,
-				defaulted: searchedDefaulted,
-				refunded: userStats.num_refunded || 0,
-				expired: userStats.num_expired || 0
+				fundraising: count(my.fundRaisingLoans),
+				funded: count(my.raisedLoans),
+				payingBack: count(my.payingBackLoans),
+				payingBackDelinquent: count(my.delinquentLoans),
+				repaid: count(my.endedLoans),
+				repaidWithCurrencyLoss: count(my.endedWithLossLoans),
+				defaulted: count(my.defaultedLoans),
+				refunded: count(my.refundedLoans),
+				expired: count(my.expiredLoans)
 			};
 		}
 	}

--- a/src/components/Portfolio/LoansFirstLoanCta.vue
+++ b/src/components/Portfolio/LoansFirstLoanCta.vue
@@ -5,10 +5,22 @@
 		</h2>
 		<p class="tw-text-base">
 			Make your first loan today and change a life! Start by lending to a
-			<a href="/lend-by-category/women" class="tw-text-action tw-underline">woman</a>,
-			<a href="/lend-by-category/single-parents" class="tw-text-action tw-underline">single parent</a>,
+			<a
+				href="/lend-by-category/women"
+				class="tw-text-action tw-underline"
+				v-kv-track-event="['portfolio', 'click', 'first-loan-cta-women']"
+			>woman</a>,
+			<a
+				href="/lend-by-category/single-parents"
+				class="tw-text-action tw-underline"
+				v-kv-track-event="['portfolio', 'click', 'first-loan-cta-single-parents']"
+			>single parent</a>,
 			or
-			<a href="/lend-by-category" class="tw-text-action tw-underline">another category</a>.
+			<a
+				href="/lend-by-category"
+				class="tw-text-action tw-underline"
+				v-kv-track-event="['portfolio', 'click', 'first-loan-cta-another-category']"
+			>another category</a>.
 		</p>
 	</div>
 </template>

--- a/src/components/Portfolio/LoansFirstLoanCta.vue
+++ b/src/components/Portfolio/LoansFirstLoanCta.vue
@@ -1,0 +1,20 @@
+<template>
+	<div class="tw-py-6">
+		<h2 class="tw-text-subhead tw-mb-2">
+			You haven't made a loan yet.
+		</h2>
+		<p class="tw-text-base">
+			Make your first loan today and change a life! Start by lending to a
+			<a href="/lend-by-category/women" class="tw-text-action tw-underline">woman</a>,
+			<a href="/lend-by-category/single-parents" class="tw-text-action tw-underline">single parent</a>,
+			or
+			<a href="/lend-by-category" class="tw-text-action tw-underline">another category</a>.
+		</p>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'LoansFirstLoanCta',
+};
+</script>

--- a/src/graphql/query/myPortfolioLoansLendingStats.graphql
+++ b/src/graphql/query/myPortfolioLoansLendingStats.graphql
@@ -18,12 +18,23 @@ query myPortfolioLoansLendingStats {
 			currency_loss_rate
 			currency_loss
 			currency_loss_reimbursement
-			num_fund_raising
-			num_raised
-			num_paying_back
-			number_delinquent
-			num_refunded
-			num_expired
+		}
+		# Status counts come from the my.loans search (Sphinx) rather than userStats num_*
+		# counts: the search buckets are mutually exclusive (ended excludes currency-loss
+		# ends, ended_with_loss is ended-with-loss only, defaulted is separate), so each
+		# totalCount maps directly to a row, and large lenders avoid the slow user-stats
+		# count calculation.
+		fundRaisingLoans: loans(filters: { status: fundraising }, limit: 1) {
+			totalCount
+		}
+		raisedLoans: loans(filters: { status: raised }, limit: 1) {
+			totalCount
+		}
+		payingBackLoans: loans(filters: { status: payingBack }, limit: 1) {
+			totalCount
+		}
+		delinquentLoans: loans(filters: { status: delinquent }, limit: 1) {
+			totalCount
 		}
 		endedLoans: loans(filters: { status: ended }, limit: 1) {
 			totalCount
@@ -32,6 +43,12 @@ query myPortfolioLoansLendingStats {
 			totalCount
 		}
 		defaultedLoans: loans(filters: { status: defaulted }, limit: 1) {
+			totalCount
+		}
+		refundedLoans: loans(filters: { status: refunded }, limit: 1) {
+			totalCount
+		}
+		expiredLoans: loans(filters: { status: expired }, limit: 1) {
 			totalCount
 		}
 	}

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -13,7 +13,8 @@
 					<h1 class="tw-text-display tw-mb-2">
 						My loans
 					</h1>
-					<div class="tw-mb-2">
+					<loans-first-loan-cta v-if="showFirstLoanCta" />
+					<div v-else class="tw-mb-2">
 						<p v-if="lastUpdated" class="tw-text-right tw-text-tertiary tw-text-small">
 							*Updated as of {{ lastUpdated }}
 						</p>
@@ -21,6 +22,7 @@
 					</div>
 				</div>
 				<div
+					v-if="!showFirstLoanCta"
 					class="tw-col-span-12"
 				>
 					<loan-filter-bar
@@ -61,6 +63,7 @@ import logFormatter from '#src/util/logFormatter';
 import LoanStatsTable from '#src/components/Portfolio/LoanStatsTable';
 import LoanFilterBar from '#src/components/Portfolio/LoanFilterBar';
 import LoanList from '#src/components/Portfolio/LoanList';
+import LoansFirstLoanCta from '#src/components/Portfolio/LoansFirstLoanCta';
 import myLoansQuery from '#src/graphql/query/portfolio/myLoans.graphql';
 
 const PAGE_LIMIT = 20;
@@ -79,7 +82,8 @@ export default {
 		KvPagination,
 		LoanStatsTable,
 		LoanFilterBar,
-		LoanList
+		LoanList,
+		LoansFirstLoanCta
 	},
 	data() {
 		return {
@@ -87,6 +91,10 @@ export default {
 			loans: [],
 			totalLoans: 0,
 			loading: true,
+			// null until the first unfiltered fetch resolves; false only when the lender has
+			// never lent (lifetime loan count is 0), which swaps the page for the first-loan CTA.
+			// Set only from unfiltered requests so a filtered no-results page stays "No loans found".
+			hasEverLent: null,
 			loanState: {
 				offset: 0,
 				limit: PAGE_LIMIT,
@@ -118,6 +126,9 @@ export default {
 		showPagination() {
 			return this.totalLoans > this.loanState.limit;
 		},
+		showFirstLoanCta() {
+			return this.hasEverLent === false;
+		},
 	},
 	mounted() {
 		this.fetchLoans();
@@ -147,9 +158,13 @@ export default {
 			if (clearLoans) {
 				this.loans = [];
 			}
+			const variables = this.buildLoanQueryVariables();
+			// An unfiltered request returns the lender's lifetime loan count, so it's the only
+			// request allowed to set the never-lent signal (filtered no-results must not).
+			const isUnfilteredRequest = !variables.filters && !variables.keywordSearch;
 			return this.apollo.query({
 				query: myLoansQuery,
-				variables: this.buildLoanQueryVariables(),
+				variables,
 				fetchPolicy: 'network-only'
 			}).then(({ data }) => {
 				if (requestSequence !== this.loanRequestSequence) {
@@ -165,6 +180,9 @@ export default {
 				if (data?.my?.loans) {
 					this.loans = data.my.loans.values || [];
 					this.totalLoans = data.my.loans.totalCount;
+					if (isUnfilteredRequest) {
+						this.hasEverLent = (data.my.loans.totalCount || 0) > 0;
+					}
 				}
 			}).catch(error => {
 				if (requestSequence !== this.loanRequestSequence) {

--- a/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
@@ -21,22 +21,21 @@ const fullData = (overrides = {}) => ({
 			currency_loss_rate: 1.5,
 			currency_loss: -12.5,
 			currency_loss_reimbursement: 7.25,
-			num_fund_raising: 3,
-			num_raised: 4,
-			num_paying_back: 5,
-			number_delinquent: 1,
-			num_ended: 9,
-			num_defaulted: 2,
-			num_refunded: 1,
-			num_expired: 0,
 			...overrides.userStats,
 		},
-		// endedWithLossLoans is the `ended_with_loss` search bucket, which the backend
-		// resolves to `defaulted OR (ended AND currency loss)` — so it = defaulted (2) +
-		// ended-with-currency-loss (3). The component subtracts defaultedLoans to recover 3.
-		endedLoans: { totalCount: 9, ...overrides.endedLoans },
-		endedWithLossLoans: { totalCount: 5, ...overrides.endedWithLossLoans },
+		// Every status count comes from the my.loans search. On the live (Sphinx) path the
+		// status buckets are mutually exclusive: `ended` excludes currency-loss ends,
+		// `ended_with_loss` is ended-with-currency-loss only, and `defaulted` is separate —
+		// so each totalCount maps directly to its row with no subtraction.
+		fundRaisingLoans: { totalCount: 3, ...overrides.fundRaisingLoans },
+		raisedLoans: { totalCount: 4, ...overrides.raisedLoans },
+		payingBackLoans: { totalCount: 5, ...overrides.payingBackLoans },
+		delinquentLoans: { totalCount: 1, ...overrides.delinquentLoans },
+		endedLoans: { totalCount: 6, ...overrides.endedLoans },
+		endedWithLossLoans: { totalCount: 3, ...overrides.endedWithLossLoans },
 		defaultedLoans: { totalCount: 2, ...overrides.defaultedLoans },
+		refundedLoans: { totalCount: 1, ...overrides.refundedLoans },
+		expiredLoans: { totalCount: 0, ...overrides.expiredLoans },
 	},
 	general: {
 		kivaStats: {
@@ -180,19 +179,14 @@ describe('LoanStatsTable', () => {
 			expect(ctx.stats.currency_loss).toBe(-12.5);
 		});
 
-		it('maps loan status counts, subtracting defaulted from the ended-with-loss bucket', () => {
-			const { ctx } = runResult(fullData({
-				endedLoans: { totalCount: 9 },
-				endedWithLossLoans: { totalCount: 5 }, // defaulted (2) + ended-with-loss (3)
-				defaultedLoans: { totalCount: 2 },
-			}));
+		it('maps each loan status count directly from its my.loans search bucket', () => {
+			const { ctx } = runResult(fullData());
 
 			expect(ctx.loanCounts).toEqual({
 				fundraising: 3,
 				funded: 4,
 				payingBack: 5,
 				payingBackDelinquent: 1,
-				// Repaid = ended total (9) - ended-with-loss-only (5 - 2 = 3)
 				repaid: 6,
 				repaidWithCurrencyLoss: 3,
 				defaulted: 2,
@@ -201,50 +195,53 @@ describe('LoanStatsTable', () => {
 			});
 		});
 
-		it('does not count defaulted loans as repaid-with-currency-loss', () => {
-			// The `ended_with_loss` search bucket here is entirely defaulted loans
-			// (no real currency-loss ends), so the split must show zero with-loss.
+		it('keeps defaulted and repaid-with-currency-loss as separate buckets', () => {
+			// On the live search path `ended_with_loss` excludes defaulted loans, so the
+			// with-loss count is the bucket value directly and defaulted is independent —
+			// no subtraction, no overlap.
 			const { ctx } = runResult(fullData({
-				endedLoans: { totalCount: 10 },
-				endedWithLossLoans: { totalCount: 5 },
+				endedWithLossLoans: { totalCount: 7 },
 				defaultedLoans: { totalCount: 5 },
 			}));
 
-			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(0);
-			expect(ctx.loanCounts.repaid).toBe(10);
+			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(7);
+			expect(ctx.loanCounts.defaulted).toBe(5);
 		});
 
-		it('sources the defaulted count from the search, not userStats', () => {
+		it('sources the defaulted count from the defaulted search bucket', () => {
 			const { ctx } = runResult(fullData({
-				userStats: { num_defaulted: 99 },
 				defaultedLoans: { totalCount: 4 },
-				endedWithLossLoans: { totalCount: 4 },
 			}));
 
 			expect(ctx.loanCounts.defaulted).toBe(4);
 		});
 
-		it('derives the ended split from search buckets, not the currency loss amount', () => {
+		it('derives the ended split from search buckets, not the currency-loss amount', () => {
 			const { ctx } = runResult(fullData({
 				userStats: { currency_loss: -99999 },
-				endedLoans: { totalCount: 20 },
+				endedLoans: { totalCount: 15 },
 				endedWithLossLoans: { totalCount: 5 },
-				defaultedLoans: { totalCount: 0 },
 			}));
 
 			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(5);
 			expect(ctx.loanCounts.repaid).toBe(15);
 		});
 
-		it('never reports negative repaid or with-loss counts', () => {
+		it('renders zero for empty status buckets', () => {
+			const zero = { totalCount: 0 };
 			const { ctx } = runResult(fullData({
-				endedLoans: { totalCount: 0 },
-				endedWithLossLoans: { totalCount: 0 },
-				defaultedLoans: { totalCount: 0 },
+				fundRaisingLoans: zero,
+				raisedLoans: zero,
+				payingBackLoans: zero,
+				delinquentLoans: zero,
+				endedLoans: zero,
+				endedWithLossLoans: zero,
+				defaultedLoans: zero,
+				refundedLoans: zero,
+				expiredLoans: zero,
 			}));
 
-			expect(ctx.loanCounts.repaid).toBe(0);
-			expect(ctx.loanCounts.repaidWithCurrencyLoss).toBe(0);
+			Object.values(ctx.loanCounts).forEach(value => expect(value).toBe(0));
 		});
 
 		it('emits the avg-lender snapshot timestamp as updated-as-of', () => {

--- a/test/unit/specs/components/Portfolio/LoansFirstLoanCta.spec.js
+++ b/test/unit/specs/components/Portfolio/LoansFirstLoanCta.spec.js
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/vue';
+import LoansFirstLoanCta from '#src/components/Portfolio/LoansFirstLoanCta';
+
+describe('LoansFirstLoanCta', () => {
+	it('shows the first-loan onboarding headline', () => {
+		const { getByText } = render(LoansFirstLoanCta);
+		expect(getByText(/You haven't made a loan yet/i)).toBeTruthy();
+	});
+
+	it('links to the woman, single-parent, and all-categories lend pages', () => {
+		const { getByText } = render(LoansFirstLoanCta);
+
+		expect(getByText('woman').getAttribute('href')).toBe('/lend-by-category/women');
+		expect(getByText('single parent').getAttribute('href')).toBe('/lend-by-category/single-parents');
+		expect(getByText('another category').getAttribute('href')).toBe('/lend-by-category');
+	});
+});

--- a/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
@@ -98,6 +98,7 @@ const renderLoansPage = ({ apollo = null, router = null } = {}) => {
 							</div>
 						`,
 					},
+					LoansFirstLoanCta: { template: '<div data-testid="first-loan-cta" />' },
 					LoanFilterBar: {
 						props: ['filters', 'keywordSearch', 'countries', 'partners', 'totalLoans'],
 						emits: ['filters-changed'],
@@ -170,6 +171,37 @@ const renderLoansPage = ({ apollo = null, router = null } = {}) => {
 describe('LoansPage', () => {
 	beforeEach(() => {
 		scrollIntoView.mockClear();
+	});
+
+	it('shows the first-loan CTA and hides the stats/filter/list when the lender has never lent', async () => {
+		const query = vi.fn().mockResolvedValue({ data: loansResponse('101', 0) });
+		const page = renderLoansPage({ apollo: { query } });
+
+		await waitFor(() => expect(page.queryByTestId('first-loan-cta')).not.toBeNull());
+		expect(page.queryByTestId('loan-list')).toBeNull();
+		expect(page.queryByTestId('pagination')).toBeNull();
+		expect(page.queryByTestId('filter')).toBeNull();
+	});
+
+	it('shows the normal page and no first-loan CTA when the lender has loans', async () => {
+		const page = renderLoansPage();
+
+		await waitFor(() => expect(page.getByTestId('loan-list')).toBeTruthy());
+		expect(page.queryByTestId('first-loan-cta')).toBeNull();
+	});
+
+	it('keeps the no-results page (not the CTA) when filters match zero loans for a lender who has lent', async () => {
+		const query = vi.fn()
+			.mockResolvedValueOnce({ data: loansResponse('101', 45) })
+			.mockResolvedValueOnce({ data: loansResponse('101', 0) });
+		const page = renderLoansPage({ apollo: { query } });
+
+		await waitFor(() => expect(page.getByTestId('loan-list')).toBeTruthy());
+		await fireEvent.click(page.getByTestId('filter'));
+		await waitFor(() => expect(query).toHaveBeenCalledTimes(2));
+
+		expect(page.queryByTestId('first-loan-cta')).toBeNull();
+		expect(page.getByTestId('loan-list')).toBeTruthy();
 	});
 
 	it('queries my loans with first page paging variables', async () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2817
https://kiva.atlassian.net/browse/MP-2931

Added the "no loans CTA" that was missing from loans-beta page, matching legacy.

Cleaned up where data was sourced in stats table.

<img width="827" height="454" alt="image" src="https://github.com/user-attachments/assets/74f37c1e-2ec4-4f2d-b968-2fd523d2ac4f" />
