### PR TITLE
feat: [MP-2903] - revert remove rounded bottom border in goal page

### DIFF
--- a/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalHeader.vue
+++ b/src/components/LoanCards/RecommendLoanForGoal/RecommendLoanForGoalHeader.vue
@@ -1,7 +1,7 @@
 <template>
 	<div
-		class="tw-flex tw-flex-col tw-items-center tw-justify-center
-			tw-bg-gray-50 tw-p-3 tw-pb-2 tw-text-center tw-rounded-t"
+		class="recommended-goal-card-header tw-flex tw-flex-col tw-items-center tw-justify-center
+			tw-bg-gray-50 tw-p-3 tw-pb-2 tw-text-center tw-rounded"
 		role="status"
 	>
 		<div

--- a/src/components/Thanks/SingleVersion/GoalEntrypoint.vue
+++ b/src/components/Thanks/SingleVersion/GoalEntrypoint.vue
@@ -9,6 +9,7 @@
 				ref="recommendLoanForGoalRef"
 				header-title="Goal set!"
 				express-checkout-enabled
+				class="recommended-goal-card-wrapper"
 				:header-details="recommendLoanHeaderDetails"
 				:content-card-props="recommendLoanCardProps"
 				:is-adding="isAdding"
@@ -219,6 +220,12 @@ const handleAddToBasket = () => {
 
 	@screen md {
 		min-height: 583px;
+	}
+}
+
+.recommended-goal-card-wrapper :deep {
+	.recommended-goal-card-header {
+		@apply !tw-rounded-b-none;
 	}
 }
 </style>


### PR DESCRIPTION
# MP-2903 UPDATE

- set rounded bottom border in goal page
- remove rounded bottom border in TY page

## Evidences

### TY Page

<img width="944" height="462" alt="Captura de pantalla 2026-06-18 a la(s) 11 49 51" src="https://github.com/user-attachments/assets/6a51431f-1030-4f91-a1ca-b3e97c7cef3d" />

### Goal Page

<img width="773" height="454" alt="Captura de pantalla 2026-06-18 a la(s) 11 42 45" src="https://github.com/user-attachments/assets/053895f2-1f66-4634-90c6-b45fc244dca9" />

### MyKiva PAge

<img width="919" height="538" alt="Captura de pantalla 2026-06-18 a la(s) 11 42 13" src="https://github.com/user-attachments/assets/37336e93-f9cc-49ab-851c-88bf2753a08c" />
