### PR TITLE
fix: ensure uiv does not get overridden

### DIFF
--- a/server/vue-middleware.js
+++ b/server/vue-middleware.js
@@ -77,6 +77,14 @@ export default function createMiddleware({ config, vite }) {
 		// Get cookies from the request
 		const cookies = parseCookie(req.get('Cookie') || '');
 
+		// Fastly assigns the authoritative visitor id (uiv) at the edge and forwards it
+		// via the Fastly-KV-UIV header. Seed it so the app reads (and never re-mints) the
+		// edge value — re-minting would set a competing cookie that overwrites the edge
+		// value and re-randomizes experiment assignments on the next page load.
+		if (!cookies.uiv && req.headers['fastly-kv-uiv']) {
+			cookies.uiv = req.headers['fastly-kv-uiv'];
+		}
+
 		// Get device information from the user agent
 		const userAgent = req.get('User-Agent');
 		const device = userAgent ? Bowser.getParser(userAgent).parse().parsedResult : null;

--- a/src/util/visitorCookie.js
+++ b/src/util/visitorCookie.js
@@ -9,7 +9,9 @@ export default function setVisitorIdCookie(cookieStore) {
 		// Store visitor id as 'uiv' cookie
 		cookieStore.set('uiv', uuidv4(), {
 			expires,
-			sameSite: true,
+			// Lax (not Strict) so the visitor id is sent on top-level cross-site
+			// navigations (ads, email, search), keeping experiment assignments stable.
+			sameSite: 'lax',
 			secure: true,
 			path: '/',
 		});

--- a/test/unit/specs/util/visitorCookie.spec.js
+++ b/test/unit/specs/util/visitorCookie.spec.js
@@ -18,7 +18,7 @@ describe('setVisitorIdCookie', () => {
 			MOCK_UUID,
 			expect.objectContaining({
 				expires: expect.any(Date),
-				sameSite: true,
+				sameSite: 'lax',
 				secure: true,
 				path: '/',
 			})
@@ -94,7 +94,7 @@ describe('setVisitorIdCookie', () => {
 		expect(setCallArgs[2].secure).toBe(true);
 	});
 
-	it('should set cookie with sameSite flag', () => {
+	it('should set cookie with sameSite lax', () => {
 		const cookieStore = {
 			has: vi.fn().mockReturnValue(false),
 			set: vi.fn(),
@@ -103,7 +103,7 @@ describe('setVisitorIdCookie', () => {
 		setVisitorIdCookie(cookieStore);
 
 		const setCallArgs = cookieStore.set.mock.calls[0];
-		expect(setCallArgs[2].sameSite).toBe(true);
+		expect(setCallArgs[2].sameSite).toBe('lax');
 	});
 
 	it('should use uuid v4 for generating visitor id', () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2937

There appear to be situations where the app could create multiple `uiv` cookies per request. The effort here is to: a) ensure Fastly is source of truth, b) have a fallback for local development. The `Lax` change allows the browser to send the `uiv` cookie with external navigation to the site.