### PR TITLE
feat: mp-2913-build-impact-contentful-issue

### DIFF
--- a/src/pages/MyKiva/MyKivaNextStepsContent.vue
+++ b/src/pages/MyKiva/MyKivaNextStepsContent.vue
@@ -119,70 +119,72 @@
 		<div class="tw-flex tw-flex-col">
 			<div :style="{ order: showPostLendingNextStepsCards ? 1 : 2 }">
 				<div>
-					<h3 class="tw-text-title tw-text-primary tw-mt-2 tw-mb-2">
-						Build impact beyond your loan
-					</h3>
-					<section class="badges-section tw-grid tw-grid-cols-1 tw-gap-4">
-						<template v-if="latestLoan !== null && !isMobile">
-							<MyKivaEmailUpdatesTransition
-								v-if="showEmailInBuildSection"
-								:accepted="acceptedEmailMarketingUpdates"
+					<template v-if="showBuildImpactSection">
+						<h3 class="tw-text-title tw-text-primary tw-mt-2 tw-mb-2">
+							Build impact beyond your loan
+						</h3>
+						<section class="badges-section tw-grid tw-grid-cols-1 tw-gap-4">
+							<template v-if="latestLoan !== null && !isMobile">
+								<MyKivaEmailUpdatesTransition
+									v-if="showEmailInBuildSection"
+									:accepted="acceptedEmailMarketingUpdates"
+									:loans="loans"
+									:latest-loan="latestLoan"
+									@accept-email-updates="acceptedEmailMarketingUpdates = true"
+								/>
+								<MyKivaLatestLoanCard
+									v-if="showLatestLoanInBuildSection"
+									:loan="latestLoan"
+									@open-impact-insight-modal="showImpactInsightsModal = true"
+								/>
+							</template>
+							<template v-if="!isMobile">
+								<MyKivaSurveyCard
+									v-if="showSurveyInBuildSection"
+								/>
+								<MyKivaCard
+									v-for="slide in nonBadgesSlides"
+									:key="slide.badgeKey"
+									class="card-container tw-w-full tw-h-full"
+									:bg-image="getSlideBackgroundImg(slide, isNonBadgeSlide(slide), false)"
+									:is-bg-top-aligned="isNonBadgeSlide(slide)"
+									:has-gradient="!isNonBadgeSlide(slide)"
+									:title="getSlideTitle(slide)"
+									:subtitle="getSlideSubTitle(slide, isNonBadgeSlide(slide))"
+									:is-black-subtitle="isNonBadgeSlide(slide)"
+									:secondary-cta-text="getSlideSecondaryCtaText(slide)"
+									:primary-cta-text="getSlidePrimaryCtaText(slide)"
+									:primary-cta-variant="getSlidePrimaryCtaVariant(slide)"
+									:is-full-width-primary-cta="isNonBadgeSlide(slide)"
+									:is-title-font-sans="isSlideTitleFontSans(slide)"
+									:title-color="getSlideTitleColor(slide, isNonBadgeSlide(slide))"
+									@primary-cta-clicked="handlePrimaryCtaClick(slide)"
+									@secondary-cta-clicked="handleSecondaryCtaClick(slide)"
+								/>
+							</template>
+							<!-- Mobile carousel: post-lending cards + survey -->
+							<JourneyCardCarousel
+								v-else
+								:key="'beyond-loan-row'"
+								class="carousel tw--mt-6"
+								controls-top-right
+								hide-goal-card
+								in-lending-stats
+								user-in-homepage
+								:post-lending-next-steps-enable="true"
+								:show-post-lending-next-steps-cards="!showPostLendingNextStepsCards"
+								:hero-badge-data="null"
+								:hero-tiered-achievements="heroTieredAchievements"
+								:lender="lender"
 								:loans="loans"
+								:slides="heroSlides"
 								:latest-loan="latestLoan"
-								@accept-email-updates="acceptedEmailMarketingUpdates = true"
-							/>
-							<MyKivaLatestLoanCard
-								v-if="showLatestLoanInBuildSection"
-								:loan="latestLoan"
+								:user-info="userInfo"
+								:enable-slide-limit="false"
 								@open-impact-insight-modal="showImpactInsightsModal = true"
 							/>
-						</template>
-						<template v-if="!isMobile">
-							<MyKivaSurveyCard
-								v-if="showSurveyInBuildSection"
-							/>
-							<MyKivaCard
-								v-for="slide in nonBadgesSlides"
-								:key="slide.badgeKey"
-								class="card-container tw-w-full tw-h-full"
-								:bg-image="getSlideBackgroundImg(slide, isNonBadgeSlide(slide), false)"
-								:is-bg-top-aligned="isNonBadgeSlide(slide)"
-								:has-gradient="!isNonBadgeSlide(slide)"
-								:title="getSlideTitle(slide)"
-								:subtitle="getSlideSubTitle(slide, isNonBadgeSlide(slide))"
-								:is-black-subtitle="isNonBadgeSlide(slide)"
-								:secondary-cta-text="getSlideSecondaryCtaText(slide)"
-								:primary-cta-text="getSlidePrimaryCtaText(slide)"
-								:primary-cta-variant="getSlidePrimaryCtaVariant(slide)"
-								:is-full-width-primary-cta="isNonBadgeSlide(slide)"
-								:is-title-font-sans="isSlideTitleFontSans(slide)"
-								:title-color="getSlideTitleColor(slide, isNonBadgeSlide(slide))"
-								@primary-cta-clicked="handlePrimaryCtaClick(slide)"
-								@secondary-cta-clicked="handleSecondaryCtaClick(slide)"
-							/>
-						</template>
-						<!-- Mobile carousel: post-lending cards + survey -->
-						<JourneyCardCarousel
-							v-else
-							:key="'beyond-loan-row'"
-							class="carousel tw--mt-6"
-							controls-top-right
-							hide-goal-card
-							in-lending-stats
-							user-in-homepage
-							:post-lending-next-steps-enable="true"
-							:show-post-lending-next-steps-cards="!showPostLendingNextStepsCards"
-							:hero-badge-data="null"
-							:hero-tiered-achievements="heroTieredAchievements"
-							:lender="lender"
-							:loans="loans"
-							:slides="heroSlides"
-							:latest-loan="latestLoan"
-							:user-info="userInfo"
-							:enable-slide-limit="false"
-							@open-impact-insight-modal="showImpactInsightsModal = true"
-						/>
-					</section>
+						</section>
+					</template>
 
 					<!-- eslint-disable-next-line max-len -->
 					<template v-if="!userLentToAllRegions && (!showRegionExperienceInFirstRow || showLendingNextStepsCards)">
@@ -617,6 +619,22 @@ const showLatestLoanInBuildSection = computed(
 const showSurveyInBuildSection = computed(
 	() => showSurveyCard.value && !topRowPriorityCards.value.has(PRIORITY_CARD_SURVEY)
 );
+
+// Aggregates the same per-card conditions already used to render each card below, so the
+// "Build impact beyond your loan" header never renders with an empty grid underneath,
+// whether that's because no card is eligible or because Contentful returned no slides.
+const showBuildImpactSection = computed(() => {
+	if (nonBadgesSlides.value.length > 0) return true;
+
+	if (isMobile.value && !showPostLendingNextStepsCards.value) {
+		return shouldShowEmailMarketingCard.value || showLatestLoan.value || showSurveyCard.value;
+	}
+
+	const showLoanDependentCard = props.latestLoan !== null
+		&& (showEmailInBuildSection.value || showLatestLoanInBuildSection.value);
+
+	return showLoanDependentCard || showSurveyInBuildSection.value;
+});
 
 // Navigation
 const goToDashboard = position => {

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -240,6 +240,34 @@ export default {
 				return [];
 			}
 		},
+		readContentfulSlides() {
+			try {
+				const slidesResult = this.apollo.readQuery({
+					query: contentfulEntriesQuery,
+					variables: {
+						contentType: 'carousel',
+						contentKey: CONTENTFUL_CAROUSEL_KEY,
+					}
+				});
+				return slidesResult.contentful?.entries?.items?.[0]?.fields?.slides ?? [];
+			} catch (e) {
+				logReadQueryError(e, 'MyKivaPage readContentfulSlides');
+				return [];
+			}
+		},
+		readContentfulBadgeData() {
+			try {
+				const contentfulChallengeResult = this.apollo.readQuery({
+					query: contentfulEntriesQuery,
+					variables: { contentType: 'challenge', limit: 200 }
+				});
+				return (contentfulChallengeResult.contentful?.entries?.items ?? [])
+					.map(entry => getContentfulLevelData(entry));
+			} catch (e) {
+				logReadQueryError(e, 'MyKivaPage readContentfulBadgeData');
+				return [];
+			}
+		},
 		readShouldRenderFeaturedSlot() {
 			// The viewedGoalComplete[currentYear] flag is set only after a user has
 			// already seen and persisted the completed-goal celebration.
@@ -351,20 +379,8 @@ export default {
 			this.currentYearTieredAchievements = this.readTieredAchievementsFromCache(CURRENT_YEAR);
 			// Apply centralized fresh progress during creation to avoid initial stale render.
 			this.applyMyKivaFreshProgress();
-			const contentfulChallengeResult = this.apollo.readQuery({
-				query: contentfulEntriesQuery,
-				variables: { contentType: 'challenge', limit: 200 }
-			});
-			const slidesResult = this.apollo.readQuery({
-				query: contentfulEntriesQuery,
-				variables: {
-					contentType: 'carousel',
-					contentKey: CONTENTFUL_CAROUSEL_KEY,
-				}
-			});
-			this.heroSlides = slidesResult.contentful?.entries?.items?.[0]?.fields?.slides ?? [];
-			this.heroBadgeContentfulData = (contentfulChallengeResult.contentful?.entries?.items ?? [])
-				.map(entry => getContentfulLevelData(entry));
+			this.heroSlides = this.readContentfulSlides();
+			this.heroBadgeContentfulData = this.readContentfulBadgeData();
 		} catch (e) {
 			logReadQueryError(e, 'MyKivaPage created');
 		}

--- a/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
@@ -131,6 +131,29 @@ const createWrapper = ({
 	};
 };
 
+const buildNonBadgeSlide = achievementKey => ({
+	fields: {
+		richText: {
+			content: [
+				{
+					data: {
+						target: {
+							sys: { contentType: { sys: { id: 'uiSetting' } } },
+							fields: {
+								dataObject: {
+									achievementKey,
+									title: 'Invite friends',
+									contentText: 'Share Kiva with someone new.',
+								},
+							},
+						},
+					},
+				},
+			],
+		},
+	},
+});
+
 describe('MyKivaNextStepsContent', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -218,6 +241,62 @@ describe('MyKivaNextStepsContent', () => {
 			});
 			const carousels = wrapper.findAllComponents({ name: 'JourneyCardCarousel' });
 			expect(carousels[0].props('hideGoalCard')).toBe(false);
+		});
+	});
+
+	describe('build impact section', () => {
+		it('hides the section when there are no Contentful slides and no other eligible cards', () => {
+			const { wrapper } = createWrapper({
+				cookieValue: 'true',
+				props: { heroSlides: [], latestLoan: null },
+			});
+
+			expect(wrapper.text()).not.toContain('Build impact beyond your loan');
+		});
+
+		it('shows the section when a non-badge Contentful slide is available', () => {
+			const { wrapper } = createWrapper({
+				cookieValue: 'true',
+				props: { heroSlides: [buildNonBadgeSlide('invite-friends')] },
+			});
+
+			expect(wrapper.text()).toContain('Build impact beyond your loan');
+		});
+
+		it('hides the section when an email card is eligible but no latest loan is available', () => {
+			const { wrapper } = createWrapper({
+				props: {
+					heroSlides: [],
+					latestLoan: null,
+					loans: [{ id: 1 }],
+					userInfo: {
+						userPreferences: {
+							preferences: JSON.stringify({ savedForms: [{ formName: 'mykiva-input-form' }] }),
+						},
+						communicationSettings: { lenderNews: false, loanUpdates: false },
+					},
+				},
+			});
+
+			expect(wrapper.text()).not.toContain('Build impact beyond your loan');
+		});
+
+		it('shows the section when a non-anonymous latest loan makes the latest-loan card eligible', () => {
+			const { wrapper } = createWrapper({
+				props: {
+					heroSlides: [],
+					latestLoan: { id: 42, anonymizationLevel: null },
+					loans: [{ id: 42 }],
+					userInfo: {
+						userPreferences: {
+							preferences: JSON.stringify({ savedForms: [{ formName: 'mykiva-input-form' }] }),
+						},
+						communicationSettings: { lenderNews: true, loanUpdates: true },
+					},
+				},
+			});
+
+			expect(wrapper.text()).toContain('Build impact beyond your loan');
 		});
 	});
 });

--- a/test/unit/specs/pages/MyKiva/MyKivaPage.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaPage.spec.js
@@ -1,4 +1,9 @@
 import MyKivaPage from '#src/pages/MyKiva/MyKivaPage';
+import logReadQueryError from '#src/util/logReadQueryError';
+
+vi.mock('#src/util/logReadQueryError', () => ({
+	default: vi.fn(),
+}));
 
 describe('MyKivaPage', () => {
 	const getTimestampMinutesAgo = minutesAgo => {
@@ -6,6 +11,10 @@ describe('MyKivaPage', () => {
 		date.setTime(date.getTime() - (minutesAgo * 60 * 1000));
 		return date.toISOString();
 	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
 
 	describe('methods', () => {
 		it('applyMyKivaFreshProgress centralizes and applies fresh progress to hero achievements', () => {
@@ -179,6 +188,110 @@ describe('MyKivaPage', () => {
 				variables: { year: 2025, loanPurchasesLimit: 20 },
 			});
 		});
+
+		it('readContentfulSlides returns slides when Contentful has carousel content', () => {
+			const slides = [{ fields: { richText: {} } }];
+			const cachedResult = { contentful: { entries: { items: [{ fields: { slides } }] } } };
+			const context = {
+				apollo: {
+					readQuery: vi.fn().mockReturnValue(cachedResult),
+				},
+			};
+
+			const result = MyKivaPage.methods.readContentfulSlides.call(context);
+
+			expect(result).toEqual(slides);
+		});
+
+		it('readContentfulSlides returns empty array when Contentful has no carousel entries', () => {
+			const context = {
+				apollo: {
+					readQuery: vi.fn().mockReturnValue({ contentful: { entries: { items: [] } } }),
+				},
+			};
+
+			const result = MyKivaPage.methods.readContentfulSlides.call(context);
+
+			expect(result).toEqual([]);
+		});
+
+		it('readContentfulSlides returns empty array when the cache read throws', () => {
+			const error = new Error('cache miss');
+			const context = {
+				apollo: {
+					readQuery: vi.fn().mockImplementation(() => { throw error; }),
+				},
+			};
+
+			const result = MyKivaPage.methods.readContentfulSlides.call(context);
+
+			expect(result).toEqual([]);
+			expect(logReadQueryError).toHaveBeenCalledWith(error, 'MyKivaPage readContentfulSlides');
+		});
+
+		it('readContentfulBadgeData normalizes challenge entries when Contentful has content', () => {
+			const context = {
+				apollo: {
+					readQuery: vi.fn().mockReturnValue({
+						contentful: {
+							entries: {
+								items: [
+									{
+										fields: {
+											key: 'womens-equality-level-2',
+											levelName: '2',
+											challengeName: 'Women',
+											badgeImage: { fields: { file: { url: '/badge-2.svg' } } },
+										}
+									}
+								]
+							}
+						}
+					}),
+				},
+			};
+
+			const result = MyKivaPage.methods.readContentfulBadgeData.call(context);
+
+			expect(result).toEqual([
+				{
+					id: 'womens-equality',
+					level: 2,
+					levelName: '2',
+					challengeName: 'Women',
+					imageUrl: '/badge-2.svg',
+					shareFact: '',
+					shareFactFootnote: '',
+					shareFactUrl: '',
+				}
+			]);
+		});
+
+		it('readContentfulBadgeData returns empty array when Contentful has no challenge entries', () => {
+			const context = {
+				apollo: {
+					readQuery: vi.fn().mockReturnValue({ contentful: { entries: { items: [] } } }),
+				},
+			};
+
+			const result = MyKivaPage.methods.readContentfulBadgeData.call(context);
+
+			expect(result).toEqual([]);
+		});
+
+		it('readContentfulBadgeData returns empty array when the cache read throws', () => {
+			const error = new Error('network error');
+			const context = {
+				apollo: {
+					readQuery: vi.fn().mockImplementation(() => { throw error; }),
+				},
+			};
+
+			const result = MyKivaPage.methods.readContentfulBadgeData.call(context);
+
+			expect(result).toEqual([]);
+			expect(logReadQueryError).toHaveBeenCalledWith(error, 'MyKivaPage readContentfulBadgeData');
+		});
 	});
 
 	describe('computed', () => {
@@ -264,12 +377,11 @@ describe('MyKivaPage', () => {
 					.mockReturnValueOnce(heroTieredAchievements)
 					.mockReturnValueOnce(currentYearTieredAchievements),
 				applyMyKivaFreshProgress: vi.fn(),
+				readContentfulSlides: vi.fn().mockReturnValue([]),
+				readContentfulBadgeData: vi.fn().mockReturnValue([]),
 				heroTieredAchievements: [],
 				currentYearTieredAchievements: [],
 				apollo: {
-					readQuery: vi.fn()
-						.mockReturnValueOnce({ contentful: { entries: { items: [] } } })
-						.mockReturnValueOnce({ contentful: { entries: { items: [{ fields: { slides: [] } }] } } }),
 					readFragment: vi.fn().mockReturnValue(undefined),
 				},
 				cookieStore: {
@@ -290,35 +402,21 @@ describe('MyKivaPage', () => {
 				.toBeLessThan(context.applyMyKivaFreshProgress.mock.invocationCallOrder[0]);
 		});
 
-		it('normalizes challenge contentful entries in parent before passing to children', () => {
+		it('wires heroSlides and heroBadgeContentfulData from the isolated Contentful readers', () => {
+			const slides = [{ fields: { slides: [] } }];
+			const badgeData = [{ id: 'womens-equality' }];
 			const context = {
 				fetchMyKivaData: vi.fn(),
 				readTieredAchievementsFromCache: vi.fn()
 					.mockReturnValueOnce([])
 					.mockReturnValueOnce([]),
 				applyMyKivaFreshProgress: vi.fn(),
+				readContentfulSlides: vi.fn().mockReturnValue(slides),
+				readContentfulBadgeData: vi.fn().mockReturnValue(badgeData),
 				heroTieredAchievements: [],
 				currentYearTieredAchievements: [],
 				heroBadgeContentfulData: [],
 				apollo: {
-					readQuery: vi.fn()
-						.mockReturnValueOnce({
-							contentful: {
-								entries: {
-									items: [
-										{
-											fields: {
-												key: 'womens-equality-level-2',
-												levelName: '2',
-												challengeName: 'Women',
-												badgeImage: { fields: { file: { url: '/badge-2.svg' } } },
-											}
-										}
-									]
-								}
-							}
-						})
-						.mockReturnValueOnce({ contentful: { entries: { items: [{ fields: { slides: [] } }] } } }),
 					readFragment: vi.fn().mockReturnValue(undefined),
 				},
 				cookieStore: {
@@ -330,18 +428,8 @@ describe('MyKivaPage', () => {
 
 			MyKivaPage.created.call(context);
 
-			expect(context.heroBadgeContentfulData).toEqual([
-				{
-					id: 'womens-equality',
-					level: 2,
-					levelName: '2',
-					challengeName: 'Women',
-					imageUrl: '/badge-2.svg',
-					shareFact: '',
-					shareFactFootnote: '',
-					shareFactUrl: '',
-				}
-			]);
+			expect(context.heroSlides).toEqual(slides);
+			expect(context.heroBadgeContentfulData).toEqual(badgeData);
 		});
 	});
 });


### PR DESCRIPTION
##Issue

The MyKiva next steps page could show the Build impact beyond your loan section title even when there was no content to display. This could happen when Contentful returned no eligible content or when the cache read failed.

##Fix

Added a showBuildImpactSection check so the section only appears when there is at least one card or Contentful slide to show.

Also split the Contentful cache reads into separate helpers for slides and badge data. If a cache read fails, the error is logged and an empty array is returned so the page can continue loading.

##Tests

Added coverage for:

Hiding the section when there is no content
Showing the section when eligible content exists
Handling missing or failed Contentful cache reads gracefully
