### PR TITLE
feat: implement several fe features for loans-beta

### DIFF
--- a/src/components/Portfolio/LoanFilterBar.vue
+++ b/src/components/Portfolio/LoanFilterBar.vue
@@ -73,7 +73,8 @@
 				</div>
 			</div>
 		</div>
-		<div class="tw-flex tw-items-center tw-mt-2">
+		<div class="tw-flex tw-items-center tw-gap-3 tw-mt-2">
+			<span class="tw-text-secondary" data-testid="loans-count">{{ loanCountLabel }}</span>
 			<button
 				v-if="hasActiveFilters"
 				type="button"
@@ -223,6 +224,11 @@ function emitDraftKeywordSearchIfChanged() {
 function getLegacyExportStatus(status) {
 	return status === FUNDRAISING ? LEGACY_FUNDRAISING_STATUS : status;
 }
+
+const loanCountLabel = computed(() => {
+	const count = props.totalLoans || 0;
+	return `${count.toLocaleString('en-US')} ${count === 1 ? 'loan' : 'loans'}`;
+});
 
 const hasActiveFilters = computed(() => (
 	selectedStatus.value !== ALL_FILTERS_VALUE

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -45,8 +45,12 @@
 							</td>
 						</tr>
 						<tr v-else-if="!loans.length">
-							<td class="tw-text-center tw-text-secondary tw-px-2" colspan="7">
-								No loans found
+							<td
+								class="tw-text-center tw-text-secondary tw-px-2 tw-pt-4"
+								colspan="7"
+								data-testid="no-loans-message"
+							>
+								You haven't made any loans that match this search.
 							</td>
 						</tr>
 						<tr
@@ -57,11 +61,20 @@
 						>
 							<td class="tw-px-2 tw-py-2">
 								<div class="tw-flex tw-items-start">
-									<img
-										:src="loan.image.url"
-										alt="Loan image"
-										class="loan-image tw-mr-2 tw-shrink-0"
-									>
+									<div class="tw-mr-2 tw-shrink-0 tw-text-center">
+										<img
+											:src="loan.image.url"
+											alt="Loan image"
+											class="loan-image"
+										>
+										<div
+											v-if="loan.userProperties?.wasMatched"
+											class="tw-text-small tw-text-secondary tw-mt-1"
+											data-testid="matched-badge"
+										>
+											Matched
+										</div>
+									</div>
 									<div>
 										<div class="tw-font-semibold">
 											<a
@@ -134,7 +147,9 @@
 										{{ $filters.numeral(
 											loan.userProperties.loanBalance.amountPurchasedByPromo,
 											'$0,0'
-										) }} free credit
+										) }} {{
+											loan.userProperties.loanBalance.promoTypeLabel || 'promotional credit'
+										}}
 									</div>
 								</div>
 							</td>

--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -42,7 +42,41 @@
 				:class="{ 'tw-bg-white': row.showInWhite, 'tw-bg-gray-50': row.showInGray }"
 			>
 				<td class="tw-p-1" :class="{ 'tw-pl-6': row.isTabbed }">
-					{{ row.label }}
+					<span class="tw-inline-flex tw-items-center tw-gap-1">
+						{{ row.label }}
+						<template v-if="row.salesforceId">
+							<button
+								:id="tooltipTriggerId(row.key)"
+								type="button"
+								class="tw-inline-flex tw-text-secondary"
+								:aria-label="`More information about ${row.label}`"
+								:data-testid="`stat-tooltip-trigger-${row.key}`"
+							>
+								<kv-material-icon
+									class="tw-w-2 tw-h-2"
+									:icon="mdiInformationOutline"
+								/>
+							</button>
+							<!-- Hover/focus help-text tooltip. Lazy-fetches the solution the first
+								time it opens (tool-tip-visible) so initial page load issues none of
+								these requests. -->
+							<kv-tooltip
+								:controller="tooltipTriggerId(row.key)"
+								:data-testid="`stat-tooltip-${row.key}`"
+								@tool-tip-visible="isVisible => onTooltipVisible(row, isVisible)"
+							>
+								<template v-if="solutions[row.key]" #title>
+									{{ solutions[row.key].name }}
+								</template>
+								<!-- eslint-disable-next-line vue/no-v-html -->
+								<div v-if="solutions[row.key]" v-html="solutions[row.key].note"></div>
+								<kv-loading-placeholder
+									v-else
+									style="width: 160px; height: 14px;"
+								/>
+							</kv-tooltip>
+						</template>
+					</span>
 				</td>
 				<td class="tw-text-right tw-p-1">
 					{{ formatValue(stats[row.key], row.type) }}
@@ -84,44 +118,73 @@
 </template>
 
 <script>
+import { mdiInformationOutline } from '@mdi/js';
 import lendingStatsQuery from '#src/graphql/query/myPortfolioLoansLendingStats.graphql';
-import { KvLoadingPlaceholder } from '@kiva/kv-components';
+import salesforceQuery from '#src/graphql/query/salesforceQuery.graphql';
+import logFormatter from '#src/util/logFormatter';
+import { KvLoadingPlaceholder, KvMaterialIcon, KvTooltip } from '@kiva/kv-components';
 
 export default {
 	name: 'LoanStatsTable',
 	components: {
-		KvLoadingPlaceholder
+		KvLoadingPlaceholder,
+		KvMaterialIcon,
+		KvTooltip
 	},
 	inject: ['apollo', 'cookieStore'],
 	emits: ['updated-as-of'],
 	data() {
 		return {
+			mdiInformationOutline,
 			stats: {},
 			avgStats: {},
 			loading: true,
+			// Per-row Salesforce-solution cache. Keyed by row.key; populated the
+			// first time a row's tooltip opens so we never issue the 13 requests on page load
+			// and never refetch a row already resolved within this component's lifecycle.
+			solutions: {},
+			// Guards against duplicate in-flight requests if a tooltip re-fires `show` before
+			// its fetch resolves. Plain (non-reactive) guard — nothing in the template reads it.
+			pendingSolutions: {},
 			// isTabbed / showInWhite / showInGray mirror the legacy setupCompareStat() flags
 			// in LoansView.php: tabbed rows indent under their parent metric, and the explicit
 			// white/gray banding groups related rows (replacing the flat migrated grid).
+			// salesforceId mirrors the legacy setupCompareStat($salesforce_id) wiring in
+			// LoansView.php; each row's help-text tooltip lazy-fetches general.salesforceSolution
+			// for this id.
 			statsRows: [
-				{ label: 'Amount lent', key: 'amount_lent', type: 'currency' },
+				{
+					label: 'Amount lent',
+					key: 'amount_lent',
+					type: 'currency',
+					salesforceId: '50150000000S8sy',
+				},
 				{
 					label: 'Amount repaid',
 					key: 'amount_repaid',
 					type: 'currency',
 					showInGray: true,
+					salesforceId: '50150000000S8tD',
 				},
-				{ label: 'Amount lost', key: 'amount_lost', type: 'currency' },
+				{
+					label: 'Amount lost',
+					key: 'amount_lost',
+					type: 'currency',
+					salesforceId: '50150000000S8tN',
+				},
 				{
 					label: 'Amount refunded',
 					key: 'amount_refunded',
 					type: 'currency',
 					showInGray: true,
+					salesforceId: '50150000000cdpF',
 				},
 				{
 					label: 'Delinquency rate',
 					key: 'arrears_rate',
 					type: 'percentage',
 					showInWhite: true,
+					salesforceId: '50150000000StY3',
 				},
 				{
 					label: 'Amount in arrears',
@@ -129,6 +192,7 @@ export default {
 					type: 'currency',
 					isTabbed: true,
 					showInWhite: true,
+					salesforceId: '50150000000SQIK',
 				},
 				{
 					label: 'Outstanding loans',
@@ -136,12 +200,14 @@ export default {
 					type: 'currency',
 					isTabbed: true,
 					showInWhite: true,
+					salesforceId: '50150000000SQIP',
 				},
 				{
 					label: 'Default rate',
 					key: 'default_rate',
 					type: 'percentage',
 					showInGray: true,
+					salesforceId: '50150000000T58V',
 				},
 				{
 					label: 'Amount defaulted',
@@ -149,6 +215,7 @@ export default {
 					type: 'currency',
 					isTabbed: true,
 					showInGray: true,
+					salesforceId: '50150000000S8pa',
 				},
 				{
 					label: 'Amount ended',
@@ -156,8 +223,12 @@ export default {
 					type: 'currency',
 					isTabbed: true,
 					showInGray: true,
+					salesforceId: '50150000000S8p1',
 				},
 				{
+					// No salesforceId: the mapped Currency-loss-rate solution (50150000000S8gY)
+					// has no help-text content, so we suppress its tooltip trigger entirely
+					// rather than show an info icon that opens an empty tooltip.
 					label: 'Currency loss rate',
 					key: 'currency_loss_rate',
 					type: 'currencyLossRate',
@@ -169,6 +240,7 @@ export default {
 					type: 'currencyLossAmount',
 					isTabbed: true,
 					showInWhite: true,
+					salesforceId: '50150000000S8q9',
 				},
 				{
 					label: 'Currency loss reimbursement',
@@ -176,6 +248,7 @@ export default {
 					type: 'currency',
 					isTabbed: true,
 					showInWhite: true,
+					salesforceId: '5011T000001GRUP',
 				}
 			],
 			loanCounts: {
@@ -203,6 +276,63 @@ export default {
 		};
 	},
 	methods: {
+		// Stable DOM id for a row's tooltip trigger; KvTooltip anchors to it via `controller`.
+		tooltipTriggerId(key) {
+			return `loan-stat-tooltip-${key}`;
+		},
+		// KvTooltip opened or closed (hover/focus). Lazy-fetch the solution the first time it
+		// becomes visible so initial page load issues none of these requests.
+		onTooltipVisible(row, isVisible) {
+			if (isVisible) {
+				this.fetchSolution(row);
+			}
+		},
+		// Strip exactly the tags/attrs the legacy SalesforceRelatedHelpTextTrait removed
+		// before the note is rendered with v-html: the span/font/blockquote/img/iframe/script
+		// element tags (inner text is kept, matching legacy) and any inline style="" attribute.
+		// A deterministic mirror of the legacy preg_replace — works identically under SSR, in
+		// tests, and in the browser (unlike a DOM-dependent sanitizer), so script/iframe markup
+		// can never reach the DOM as live elements.
+		sanitizeNote(html) {
+			if (!html) {
+				return '';
+			}
+			return String(html)
+				.replace(/<\/?(?:span|font|blockquote|img|iframe|script)\b[^>]*>/gi, '')
+				.replace(/\s*style=("[^"]*"|'[^']*')/gi, '');
+		},
+		// Lazy-fetch a row's Salesforce solution the first time its popover opens. Skips the
+		// request when the row has no mapped id, when it is already cached, or when a fetch is
+		// already in flight — so initial page load issues zero of these requests and each row
+		// resolves at most once.
+		fetchSolution(row) {
+			if (!row.salesforceId) {
+				return;
+			}
+			if (this.solutions[row.key] || this.pendingSolutions[row.key]) {
+				return;
+			}
+			this.pendingSolutions[row.key] = true;
+			this.apollo.query({
+				query: salesforceQuery,
+				variables: { id: row.salesforceId },
+			}).then(({ data }) => {
+				const solution = data?.general?.salesforceSolution;
+				if (solution) {
+					this.solutions = {
+						...this.solutions,
+						[row.key]: {
+							name: solution.name ?? '',
+							note: this.sanitizeNote(solution.note),
+						},
+					};
+				}
+			}).catch(error => {
+				logFormatter(`Error fetching salesforce solution for ${row.key}: ${error}`, 'error');
+			}).finally(() => {
+				delete this.pendingSolutions[row.key];
+			});
+		},
 		formatValue(value, type) {
 			// Currency-loss rate/amount mirror the legacy page: they read "Not available"
 			// when the backend has no value, instead of falling back to zero.

--- a/src/graphql/query/portfolio/myLoans.graphql
+++ b/src/graphql/query/portfolio/myLoans.graphql
@@ -70,9 +70,11 @@ query myLoans(
 				}
 				userProperties {
 					canChangeTeamAssignment
+					wasMatched
 					loanBalance {
 						amountPurchasedByLender
 						amountPurchasedByPromo
+						promoTypeLabel
 						amountRepaidToLender
 						amountReturnedTotal
 						latestSharePurchaseTime

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -104,7 +104,8 @@ export default {
 			loading: true,
 			// null until the first unfiltered fetch resolves; false only when the lender has
 			// never lent (lifetime loan count is 0), which swaps the page for the first-loan CTA.
-			// Set only from unfiltered requests so a filtered no-results page stays "No loans found".
+			// Set only from unfiltered requests so a filtered no-results page keeps the
+			// no-match empty state ("You haven't made any loans that match this search.").
 			hasEverLent: null,
 			loanState: {
 				offset: 0,

--- a/test/unit/specs/components/Portfolio/LoanFilterBar.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanFilterBar.spec.js
@@ -204,6 +204,36 @@ describe('LoanFilterBar', () => {
 		expect(page.queryByTestId('clear-filters')).not.toBeNull();
 	});
 
+	it('renders a comma-formatted, pluralized loans count', () => {
+		const page = renderLoanFilterBar({ props: { totalLoans: 1234 } });
+
+		expect(page.getByTestId('loans-count').textContent.trim()).toBe('1,234 loans');
+	});
+
+	it('renders the singular loans count for exactly one loan', () => {
+		const page = renderLoanFilterBar({ props: { totalLoans: 1 } });
+
+		expect(page.getByTestId('loans-count').textContent.trim()).toBe('1 loan');
+	});
+
+	it('renders "0 loans" when there are no results', () => {
+		const page = renderLoanFilterBar({ props: { totalLoans: 0 } });
+
+		expect(page.getByTestId('loans-count').textContent.trim()).toBe('0 loans');
+	});
+
+	it('places the loans count next to the clear-filters control when filters are active', () => {
+		const page = renderLoanFilterBar({
+			props: { totalLoans: 12, filters: { status: 'payingBack' } },
+		});
+
+		const count = page.getByTestId('loans-count');
+		const clear = page.getByTestId('clear-filters');
+		// Same flex row, count immediately before clear-filters (spacing comes from the row's gap).
+		expect(count.parentElement).toBe(clear.parentElement);
+		expect(count.nextElementSibling).toBe(clear);
+	});
+
 	it('resets all filters and the keyword search when clear-filters is clicked', async () => {
 		const page = renderLoanFilterBar({
 			props: {

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -23,11 +23,13 @@ const makeLoan = (overrides = {}) => ({
 		loanBalance: {
 			amountPurchasedByLender: '25',
 			amountPurchasedByPromo: null,
+			promoTypeLabel: null,
 			amountRepaidToLender: '5',
 			amountReturnedTotal: '5',
 			latestSharePurchaseTime: '2026-03-15T12:00:00Z',
 		},
 		userAttributedTeam: null,
+		wasMatched: false,
 	},
 	partnerName: 'Partner 44',
 	partnerId: 44,
@@ -58,6 +60,24 @@ const renderLoanList = ({
 			},
 		},
 	},
+});
+
+describe('LoanList — no-results empty state', () => {
+	it('renders the live legacy no-match copy when a filter/search returns no loans', () => {
+		const page = renderLoanList({ loans: [], loading: false });
+
+		expect(page.getByTestId('no-loans-message').textContent.trim())
+			.toBe("You haven't made any loans that match this search.");
+		// Legacy parity: this is the filtered no-match state, not the tombstoned
+		// DataTables "No loans found" / "No loans returned" strings.
+		expect(page.queryByText('No loans found')).toBeNull();
+	});
+
+	it('does not render the no-results copy while loans are still loading', () => {
+		const page = renderLoanList({ loans: [], loading: true });
+
+		expect(page.queryByTestId('no-loans-message')).toBeNull();
+	});
 });
 
 describe('LoanList — column order', () => {
@@ -180,13 +200,14 @@ describe('LoanList — "You loaned" cell', () => {
 		expect(page.queryByText('Invalid Date')).toBeNull();
 	});
 
-	it('renders free credit when amountPurchasedByPromo is positive', () => {
+	it('renders the typed promo label when promoTypeLabel is present', () => {
 		const page = renderLoanList({
 			loans: [makeLoan({
 				userProperties: {
 					loanBalance: {
 						amountPurchasedByLender: '25',
 						amountPurchasedByPromo: '10',
+						promoTypeLabel: 'free credit',
 						amountRepaidToLender: '5',
 						amountReturnedTotal: '5',
 						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
@@ -198,9 +219,48 @@ describe('LoanList — "You loaned" cell', () => {
 		expect(page.getByText('$10 free credit')).toBeTruthy();
 	});
 
-	it('omits free credit line when amountPurchasedByPromo is null or zero', () => {
+	it('renders the "free trial" promo label when promoTypeLabel is "free trial"', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: '10',
+						promoTypeLabel: 'free trial',
+						amountRepaidToLender: '5',
+						amountRepaidToPromo: null,
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+				},
+			})],
+		});
+
+		expect(page.getByText('$10 free trial')).toBeTruthy();
+	});
+
+	it('falls back to "promotional credit" when promoTypeLabel is null', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: '10',
+						promoTypeLabel: null,
+						amountRepaidToLender: '5',
+						amountRepaidToPromo: null,
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+				},
+			})],
+		});
+
+		expect(page.getByText('$10 promotional credit')).toBeTruthy();
+	});
+
+	it('omits the promo line when amountPurchasedByPromo is null or zero', () => {
 		const page = renderLoanList({ loans: [makeLoan()] });
 
+		expect(page.queryByText(/promotional credit/)).toBeNull();
 		expect(page.queryByText(/free credit/)).toBeNull();
 	});
 });
@@ -482,6 +542,56 @@ describe('LoanList — row banding', () => {
 		expect(rows[1].classList.contains('tw-bg-gray-50')).toBe(true);
 		expect(rows[2].classList.contains('tw-bg-gray-50')).toBe(false);
 		expect(rows[3].classList.contains('tw-bg-gray-50')).toBe(true);
+	});
+});
+
+describe('LoanList — matched badge', () => {
+	it('renders the "Matched" badge when the lender\'s purchase was matched (wasMatched true)', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					wasMatched: true,
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: null,
+						promoTypeLabel: null,
+						amountRepaidToLender: '5',
+						amountReturnedTotal: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					userAttributedTeam: null,
+				},
+			})],
+		});
+
+		expect(page.getByTestId('matched-badge').textContent.trim()).toBe('Matched');
+	});
+
+	it('does not render the "Matched" badge when wasMatched is false', () => {
+		const page = renderLoanList({ loans: [makeLoan()] });
+
+		expect(page.queryByTestId('matched-badge')).toBeNull();
+	});
+
+	it('does not render the "Matched" badge when wasMatched is null (no logged-in user)', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					wasMatched: null,
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: null,
+						promoTypeLabel: null,
+						amountRepaidToLender: '5',
+						amountReturnedTotal: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					userAttributedTeam: null,
+				},
+			})],
+		});
+
+		expect(page.queryByTestId('matched-badge')).toBeNull();
 	});
 });
 

--- a/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
@@ -422,4 +422,153 @@ describe('LoanStatsTable', () => {
 			});
 		});
 	});
+
+	describe('Salesforce help-text tooltips (MP-2858)', () => {
+		const flushPromises = () => new Promise(resolve => { setTimeout(resolve); });
+
+		const solutionResponse = (name, note) => ({
+			data: { general: { salesforceSolution: { name, note } } },
+		});
+
+		// Mirror the suite's direct-handler style: drive fetchSolution against a bare context
+		// carrying its own apollo + cache state and the component's real sanitizeNote.
+		const makeCtx = (overrides = {}) => ({
+			solutions: {},
+			pendingSolutions: {},
+			sanitizeNote: LoanStatsTable.methods.sanitizeNote,
+			...overrides,
+		});
+		const callFetch = (ctx, row) => LoanStatsTable.methods.fetchSolution.call(ctx, row);
+
+		// Context for the visibility path: onTooltipVisible calls this.fetchSolution when the
+		// tooltip opens, so bind the real methods together against shared state.
+		const makeVisibleCtx = (overrides = {}) => {
+			const ctx = makeCtx(overrides);
+			ctx.fetchSolution = row => LoanStatsTable.methods.fetchSolution.call(ctx, row);
+			return ctx;
+		};
+		const callVisible = (ctx, row, isVisible) => LoanStatsTable.methods
+			.onTooltipVisible.call(ctx, row, isVisible);
+
+		const amountLentRow = { key: 'amount_lent', salesforceId: '50150000000S8sy' };
+
+		it('renders a help-text info-icon trigger for every row mapped to a Salesforce solution', async () => {
+			const { getVm, container } = renderTable();
+			const vm = getVm();
+			vm.$options.apollo.result.call(vm, { data: fullData() });
+			await nextTick();
+
+			vm.statsRows.forEach(row => {
+				const trigger = container.querySelector(`[data-testid="stat-tooltip-trigger-${row.key}"]`);
+				if (row.salesforceId) {
+					expect(trigger, `trigger for ${row.key}`).not.toBeNull();
+				} else {
+					expect(trigger, `no trigger for ${row.key}`).toBeNull();
+				}
+			});
+			// 12 of the 13 comparison rows are mapped; Currency loss rate has no help-text
+			// content, so it intentionally renders no info icon.
+			const mapped = vm.statsRows.filter(row => row.salesforceId);
+			expect(mapped).toHaveLength(12);
+			expect(container.querySelectorAll('[data-testid^="stat-tooltip-trigger-"]')).toHaveLength(12);
+			expect(container.querySelector('[data-testid="stat-tooltip-trigger-currency_loss_rate"]')).toBeNull();
+		});
+
+		it('lazy-fetches the solution when the tooltip becomes visible', async () => {
+			const query = vi.fn().mockResolvedValue(solutionResponse('Amount lent', '<p>note</p>'));
+			const ctx = makeVisibleCtx({ apollo: { query } });
+
+			callVisible(ctx, amountLentRow, true);
+			await flushPromises();
+
+			expect(query).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not fetch while the tooltip is not visible', () => {
+			const query = vi.fn();
+			const ctx = makeVisibleCtx({ apollo: { query } });
+
+			callVisible(ctx, amountLentRow, false);
+
+			expect(query).not.toHaveBeenCalled();
+		});
+
+		it('lazy-fetches and caches the solution the first time a tooltip opens', async () => {
+			const query = vi.fn().mockResolvedValue(solutionResponse('Amount lent', '<p>How much you lent.</p>'));
+			const ctx = makeCtx({ apollo: { query } });
+
+			callFetch(ctx, amountLentRow);
+			await flushPromises();
+
+			expect(query).toHaveBeenCalledTimes(1);
+			expect(query.mock.calls[0][0]).toEqual(expect.objectContaining({
+				variables: { id: '50150000000S8sy' },
+			}));
+			expect(ctx.solutions.amount_lent).toEqual({
+				name: 'Amount lent',
+				note: '<p>How much you lent.</p>',
+			});
+		});
+
+		it('does not refetch a solution already cached for a row', async () => {
+			const query = vi.fn().mockResolvedValue(solutionResponse('Amount lent', '<p>note</p>'));
+			const ctx = makeCtx({ apollo: { query } });
+
+			callFetch(ctx, amountLentRow);
+			await flushPromises();
+			callFetch(ctx, amountLentRow);
+			await flushPromises();
+
+			expect(query).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not issue a second request while the first is still in flight', async () => {
+			let resolveQuery;
+			const query = vi.fn().mockReturnValue(new Promise(resolve => { resolveQuery = resolve; }));
+			const ctx = makeCtx({ apollo: { query } });
+
+			callFetch(ctx, amountLentRow);
+			callFetch(ctx, amountLentRow);
+
+			expect(query).toHaveBeenCalledTimes(1);
+
+			resolveQuery(solutionResponse('Amount lent', '<p>note</p>'));
+			await flushPromises();
+		});
+
+		it('skips rows that have no mapped Salesforce id', () => {
+			const query = vi.fn();
+			const ctx = makeCtx({ apollo: { query } });
+
+			callFetch(ctx, { key: 'unmapped', salesforceId: undefined });
+
+			expect(query).not.toHaveBeenCalled();
+		});
+
+		it('strips the legacy-forbidden tags and inline styles from the note before caching', async () => {
+			const dirtyNote = '<p style="color:red">Keep this'
+				+ '<span>drop span</span>'
+				+ '<font>drop font</font>'
+				+ '<blockquote>drop quote</blockquote>'
+				+ '<img src="x">'
+				+ '<iframe src="evil"></iframe>'
+				+ '<script>alert(1)</script>'
+				+ '</p>';
+			const query = vi.fn().mockResolvedValue(solutionResponse('Amount lent', dirtyNote));
+			const ctx = makeCtx({ apollo: { query } });
+
+			callFetch(ctx, amountLentRow);
+			await flushPromises();
+
+			const { note } = ctx.solutions.amount_lent;
+			expect(note).toContain('Keep this');
+			expect(note).not.toContain('<span');
+			expect(note).not.toContain('<font');
+			expect(note).not.toContain('<blockquote');
+			expect(note).not.toContain('<img');
+			expect(note).not.toContain('<iframe');
+			expect(note).not.toContain('<script');
+			expect(note).not.toContain('style=');
+		});
+	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2853
https://kiva.atlassian.net/browse/MP-2849
https://kiva.atlassian.net/browse/MP-2858
https://kiva.atlassian.net/browse/MP-2934
https://kiva.atlassian.net/browse/MP-2935

FE code to complete these loans-beta page tickets:
- Add total loans text to loans table
- Added info icons w/ SF-sourced data to stats table
- Ensured no loans found message matches legacy
- Added "matched" text to loans table
- Added accurate promo type to loans table

In order:
<img width="228" height="248" alt="image" src="https://github.com/user-attachments/assets/a632b220-c204-49c6-81a5-1b92927eaf22" />
<br />
<img width="373" height="376" alt="image" src="https://github.com/user-attachments/assets/c83d6246-2bf5-4681-8e14-04eb2f225aa9" />
<br />
<img width="463" height="185" alt="image" src="https://github.com/user-attachments/assets/b7fca1a7-7e67-4939-8927-fc61343ec4e7" />
<br />
<img width="457" height="371" alt="image" src="https://github.com/user-attachments/assets/5443a0f4-d2ae-4b35-a769-d344911ec6d8" />
<br />
<img width="231" height="201" alt="image" src="https://github.com/user-attachments/assets/b5e044af-1662-4ae6-bc31-1a11760e3a39" />