### PR TITLE
feat: remaining changes for functionality parity between loans and loans-beta

### DIFF
--- a/src/components/Portfolio/LoanFilterBar.vue
+++ b/src/components/Portfolio/LoanFilterBar.vue
@@ -9,8 +9,26 @@
 				@keyup.enter.prevent="emitDraftKeywordSearchIfChanged"
 				@blur="emitDraftKeywordSearchIfChanged"
 			/>
+			<!-- On small screens the status/location/partner filters collapse behind a Filters/Hide filters toggle;
+				they are always shown from the lg breakpoint up. -->
+			<button
+				type="button"
+				class="lg:tw-hidden tw-self-start tw-text-action tw-text-small tw-underline tw-mt-2"
+				:aria-expanded="filtersExpanded ? 'true' : 'false'"
+				aria-controls="loan-filters"
+				data-testid="filters-toggle"
+				@click="filtersExpanded = !filtersExpanded"
+			>
+				{{ filtersExpanded ? 'Hide filters' : 'Filters' }}
+			</button>
 			<div class="tw-flex tw-flex-row tw-flex-wrap tw-items-center tw-gap-2 tw-mt-2">
-				<div class="tw-flex tw-items-center tw-gap-2">
+				<div
+					id="loan-filters"
+					:class="[
+						filtersExpanded ? 'tw-flex' : 'tw-hidden',
+						'lg:tw-flex tw-items-center tw-gap-2'
+					]"
+				>
 					<span class="tw-text-secondary">Status:</span>
 					<kv-select
 						id="loan-status-select"
@@ -26,7 +44,12 @@
 						</option>
 					</kv-select>
 				</div>
-				<div class="tw-flex tw-flex-row tw-items-center tw-gap-2">
+				<div
+					:class="[
+						filtersExpanded ? 'tw-flex' : 'tw-hidden',
+						'lg:tw-flex tw-flex-row tw-items-center tw-gap-2'
+					]"
+				>
 					<span class="tw-text-secondary">Filter by:</span>
 					<kv-select
 						id="loan-country-select"
@@ -34,7 +57,7 @@
 						@update:model-value="emitFiltersChanged()"
 					>
 						<option value="all">
-							All countries
+							Location
 						</option>
 						<option
 							v-for="country in countries"
@@ -50,7 +73,7 @@
 						@update:model-value="emitFiltersChanged()"
 					>
 						<option value="all">
-							All partners
+							Partner
 						</option>
 						<option
 							v-for="partner in partners"
@@ -74,7 +97,7 @@
 			</div>
 		</div>
 		<div class="tw-flex tw-items-center tw-gap-3 tw-mt-2">
-			<span class="tw-text-secondary" data-testid="loans-count">{{ loanCountLabel }}</span>
+			<span class="tw-text-subhead" data-testid="loans-count">{{ loanCountLabel }}</span>
 			<button
 				v-if="hasActiveFilters"
 				type="button"
@@ -114,9 +137,12 @@ const ENDED_WITH_LOSS = 'ended_with_loss';
 const LEGACY_FUNDRAISING_STATUS = 'fundRaising';
 
 const statusOptions = [
-	{ value: ALL_FILTERS_VALUE, label: 'All statuses' },
+	{ value: ALL_FILTERS_VALUE, label: 'All loans' },
 	{ value: FUNDRAISING, label: 'Fundraising' },
-	{ value: RAISED, label: 'Raised' },
+	// Legacy parity: the `raised` status is labelled "Funded" everywhere on the legacy
+	// page (getHumanizedStatusFromString) and in the new stats grid, so the filter
+	// dropdown matches rather than showing "Raised".
+	{ value: RAISED, label: 'Funded' },
 	{ value: PAYING_BACK, label: 'Paying back' },
 	{ value: DELINQUENT, label: 'Delinquent' },
 	{ value: ENDED, label: 'Repaid' },
@@ -168,6 +194,8 @@ const searchText = ref(props.keywordSearch || '');
 const selectedStatus = ref(getSelectedStatus(props.filters));
 const selectedCountry = ref(getFirstFilterValue(props.filters.country));
 const selectedPartner = ref(getFirstFilterValue(props.filters.partner));
+// Small-screen filter accordion: collapsed by default; the lg breakpoint shows the filters regardless of this flag.
+const filtersExpanded = ref(false);
 
 function buildActiveFilters() {
 	const filters = {};

--- a/src/components/Portfolio/LoanFilterBar.vue
+++ b/src/components/Portfolio/LoanFilterBar.vue
@@ -17,6 +17,7 @@
 				:aria-expanded="filtersExpanded ? 'true' : 'false'"
 				aria-controls="loan-filters"
 				data-testid="filters-toggle"
+				v-kv-track-event="['portfolio', 'click', 'toggle-loan-filters']"
 				@click="filtersExpanded = !filtersExpanded"
 			>
 				{{ filtersExpanded ? 'Hide filters' : 'Filters' }}

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -44,6 +44,15 @@
 								</div>
 							</td>
 						</tr>
+						<tr v-else-if="hasError">
+							<td
+								class="tw-text-center tw-text-danger tw-px-2 tw-pt-4"
+								colspan="7"
+								data-testid="loans-error-message"
+							>
+								We couldn't load your loans right now. Please refresh the page and try again.
+							</td>
+						</tr>
 						<tr v-else-if="!loans.length">
 							<td
 								class="tw-text-center tw-text-secondary tw-px-2 tw-pt-4"
@@ -65,21 +74,21 @@
 										<img
 											:src="loan.image.url"
 											alt="Loan image"
-											class="loan-image"
+											class="loan-image data-hj-suppress"
 										>
 										<div
 											v-if="loan.userProperties?.wasMatched"
 											class="tw-text-small tw-text-secondary tw-mt-1"
 											data-testid="matched-badge"
 										>
-											Matched
+											{{ matchedLabel(loan) }}
 										</div>
 									</div>
 									<div>
 										<div class="tw-font-semibold">
 											<a
 												:href="`/lend/${loan.id}`"
-												class="tw-text-action"
+												class="tw-text-action data-hj-suppress"
 												v-kv-track-event="[
 													'portfolio', 'click', 'View borrower details', loan.name, loan.id]"
 											>
@@ -106,6 +115,7 @@
 											<a
 												:href="getTrusteeUrl(loan.trusteeId)"
 												target="_blank"
+												class="data-hj-suppress"
 											>
 												{{ loan.trusteeName }}
 											</a>
@@ -114,9 +124,46 @@
 											<a
 												:href="getPartnerUrl(loan.partnerId)"
 												target="_blank"
+												class="data-hj-suppress"
 											>
 												{{ loan.partnerName }}
 											</a>
+										</div>
+										<!-- The logged-in lender's own dedication on this loan. A named recipient shows
+											a heart + link to the dedication page with the "repayments donated to
+											Kiva" footer; a to-Kiva dedication shows the thank-you line with no
+											link. Viewer-relative — the field is null when this lender has no
+											dedication on the loan. -->
+										<div
+											v-if="getDedication(loan)"
+											class="tw-mt-1"
+											data-testid="loan-dedication"
+										>
+											<a
+												v-if="getDedication(loan).recipientName"
+												:href="getDedication(loan).dedicationUrl"
+												class="tw-flex tw-items-center tw-text-action tw-text-small
+													data-hj-suppress"
+											>
+												<kv-material-icon
+													class="tw-w-2 tw-h-2 tw-mr-1 tw-shrink-0"
+													:icon="mdiHeart"
+												/>
+												Dedicated to {{ getDedication(loan).recipientName }}
+											</a>
+											<div
+												v-else-if="getDedication(loan).toKiva"
+												class="tw-text-secondary tw-text-small"
+											>
+												You opted to donate repayments from this loan to Kiva (Thanks!)
+											</div>
+											<div
+												v-if="getDedication(loan).recipientName"
+												class="tw-text-secondary tw-text-small"
+												data-testid="loan-dedication-footer"
+											>
+												Repayments for dedications are donated to Kiva
+											</div>
 										</div>
 									</div>
 								</div>
@@ -131,7 +178,7 @@
 									<div class="tw-mb-1">
 										{{ $filters.numeral(
 											loan.userProperties.loanBalance.amountPurchasedByLender,
-											'$0,0'
+											'$0,0.00'
 										) }}
 									</div>
 									<div
@@ -146,7 +193,7 @@
 									>
 										{{ $filters.numeral(
 											loan.userProperties.loanBalance.amountPurchasedByPromo,
-											'$0,0'
+											'$0,0[.]00'
 										) }} {{
 											loan.userProperties.loanBalance.promoTypeLabel || 'promotional credit'
 										}}
@@ -155,7 +202,7 @@
 							</td>
 							<td class="tw-text-right tw-px-2">
 								<div v-if="isRaisedOrFundraising(loan.status)">
-									{{ $filters.numeral(loan.loanFundraisingInfo?.fundedAmount, '$0,0') }} raised
+									{{ $filters.numeral(loan.loanFundraisingInfo?.fundedAmount, '$0,0.00') }} raised
 								</div>
 								<template v-else>
 									<paid-amount-modal
@@ -184,13 +231,13 @@
 							</td>
 							<td class="tw-text-right tw-px-2">
 								<div>
-									{{ loan.lenderRepaymentTerm || '-' }} months
+									{{ loan.lenderRepaymentTerm || '-' }} mos
 								</div>
 							</td>
 							<td class="tw-text-right tw-px-2">
 								<div>
 									<div>
-										{{ $filters.numeral(loan.terms.loanAmount, '$0,0') }}
+										{{ $filters.numeral(loan.terms.loanAmount, '$0,0.00') }}
 									</div>
 									<div
 										v-if="hasArrears(loan.arrearsAmount)"
@@ -213,7 +260,7 @@
 										v-if="canReassignTeam(loan)"
 										:key="`reassign-team-${loan.id}-${reassignNonce[loan.id] || 0}`"
 										:id="`reassign-team-${loan.id}`"
-										class="tw-w-full"
+										class="tw-w-full data-hj-suppress"
 										:model-value="currentTeamId(loan)"
 										:disabled="reassigningLoanIds.includes(loan.id)"
 										:aria-label="`Reassign team for ${loan.name}`"
@@ -227,15 +274,22 @@
 											{{ option.name }}
 										</option>
 									</kv-select>
-									<template v-else-if="loan.userProperties?.userAttributedTeam">
+									<!-- A read-only attributed team links to its team page. Renders an unlinked span
+										when no teamPublicId is resolvable. -->
+									<component
+										:is="teamUrl(loan.userProperties.userAttributedTeam) ? 'a' : 'span'"
+										v-else-if="loan.userProperties?.userAttributedTeam"
+										:href="teamUrl(loan.userProperties.userAttributedTeam)"
+										class="tw-flex tw-items-center data-hj-suppress"
+									>
 										<img
 											v-if="loan.userProperties.userAttributedTeam.image?.url"
 											:src="loan.userProperties.userAttributedTeam.image.url"
 											:alt="`${loan.userProperties.userAttributedTeam.name} team image`"
-											class="tw-w-5 tw-h-5"
+											class="tw-w-5 tw-h-5 tw-mr-1"
 										>
-										<span>{{ loan.userProperties.userAttributedTeam.name }}</span>
-									</template>
+										<span>{{ truncateTeamName(loan.userProperties.userAttributedTeam.name) }}</span>
+									</component>
 								</div>
 							</td>
 						</tr>
@@ -248,7 +302,10 @@
 </template>
 
 <script>
-import { KvFlag, KvLoadingPlaceholder, KvSelect } from '@kiva/kv-components';
+import { mdiHeart } from '@mdi/js';
+import {
+	KvFlag, KvLoadingPlaceholder, KvMaterialIcon, KvSelect
+} from '@kiva/kv-components';
 import {
 	EXPIRED,
 	FUNDRAISING,
@@ -272,6 +329,10 @@ export default {
 			type: Boolean,
 			default: true
 		},
+		hasError: {
+			type: Boolean,
+			default: false
+		},
 		lendingTeams: {
 			type: Array,
 			default: () => []
@@ -289,12 +350,16 @@ export default {
 	components: {
 		KvFlag,
 		KvLoadingPlaceholder,
+		KvMaterialIcon,
 		KvSelect,
 		PaidAmountModal
 	},
 	methods: {
 		formatDate(date) {
 			if (!date) return '';
+			// Intentionally formats in the lender's browser timezone (no `timeZone` option). The
+			// field is a full ISO-8601 instant and rows render client-side, so the displayed day
+			// is the lender's local day.
 			return new Date(date).toLocaleDateString('en-US', {
 				month: 'short',
 				day: 'numeric',
@@ -303,6 +368,18 @@ export default {
 		},
 		getStatusLabel(loan) {
 			return loan.statusLabel || loan.status;
+		},
+		matchedLabel(loan) {
+			// The matched badge shows "Nx matched" when the loan's match ratio is known, otherwise a bare "Matched".
+			// The badge itself stays gated on the viewer-relative wasMatched flag; matchRatio
+			// is the loan-level multiplier the lender's matched share was purchased at.
+			const ratio = loan.matchRatio;
+			return ratio ? `${ratio}x matched` : 'Matched';
+		},
+		getDedication(loan) {
+			// Viewer-relative dedication for this loan (LoanUserProperties.dedication);
+			// null when the logged-in lender has no dedication on it, or no logged-in user.
+			return loan.userProperties?.dedication || null;
 		},
 		hasArrears(amount) {
 			// Only a positive amount is "in arrears"; zero/absent renders no line.
@@ -343,8 +420,19 @@ export default {
 			const verb = REFUNDED_OR_EXPIRED_STATUSES.has(loan.status) ? 'repaid/refunded' : 'repaid';
 			return `${verb} to ${recipient}`;
 		},
+		teamUrl(team) {
+			// Legacy parity: the read-only attributed team links to its team page,
+			// keyed off the human-readable teamPublicId (legacy `viewTeamSummary`).
+			// Null when no slug is resolvable, so the cell falls back to plain text.
+			return team?.teamPublicId ? `/team/${team.teamPublicId}` : null;
+		},
+		truncateTeamName(name) {
+			// The read-only attributed team name is truncated to 20 characters with a trailing ellipsis.
+			if (!name) return '';
+			return name.length > 20 ? `${name.slice(0, 20)}...` : name;
+		},
 		canReassignTeam(loan) {
-			// Legacy parity: the dropdown only appears when the loan is eligible AND the
+			// The dropdown only appears when the loan is eligible AND the
 			// user actually belongs to at least one team to reassign to. With no teams there
 			// is nothing to pick (and no "None" detach), so the cell stays read-only.
 			return Boolean(loan.userProperties?.canChangeTeamAssignment) && this.lendingTeams.length > 0;
@@ -391,6 +479,7 @@ export default {
 	},
 	data() {
 		return {
+			mdiHeart,
 			placeholders: [
 				{ span: 4 },
 				{ span: 1 },

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -372,11 +372,11 @@ export default {
 			return loan.statusLabel || loan.status;
 		},
 		matchedLabel(loan) {
-			// The matched badge shows "Nx matched" when the loan's match ratio is known, otherwise a bare "Matched".
-			// The badge itself stays gated on the viewer-relative wasMatched flag; matchRatio
-			// is the loan-level multiplier the lender's matched share was purchased at.
+			// Show "Nx matched" only when the ratio is greater than 1; a 1:1 match
+			// (ratio 1, or absent) shows a bare "Matched". The badge itself stays gated
+			// on the viewer-relative wasMatched flag.
 			const ratio = loan.matchRatio;
-			return ratio ? `${ratio}x matched` : 'Matched';
+			return ratio > 1 ? `${ratio}x matched` : 'Matched';
 		},
 		getDedication(loan) {
 			// Viewer-relative dedication for this loan (LoanUserProperties.dedication);

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -144,6 +144,8 @@
 												:href="getDedication(loan).dedicationUrl"
 												class="tw-flex tw-items-center tw-text-action tw-text-small
 													data-hj-suppress"
+												v-kv-track-event="[
+													'portfolio', 'click', 'View loan dedication', loan.id]"
 											>
 												<kv-material-icon
 													class="tw-w-2 tw-h-2 tw-mr-1 tw-shrink-0"

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -233,7 +233,7 @@
 							</td>
 							<td class="tw-text-right tw-px-2">
 								<div>
-									{{ loan.lenderRepaymentTerm || '-' }} mos
+									{{ loan.lenderRepaymentTerm || '-' }} months
 								</div>
 							</td>
 							<td class="tw-text-right tw-px-2">

--- a/src/components/Portfolio/PaidAmountModal.vue
+++ b/src/components/Portfolio/PaidAmountModal.vue
@@ -17,7 +17,7 @@
 					This loan has no repayments
 				</p>
 				<div v-else class="tw-grid tw-grid-cols-2">
-					<div v-for="(payment, index) in paymentHistory" :key="index" class="tw-contents">
+					<div v-for="(payment, index) in sortedHistory" :key="index" class="tw-contents">
 						<span>{{ formatDate(payment.createTime) }}:</span>
 						<span>
 							{{ formatAmount(payment.amount) }}
@@ -50,20 +50,38 @@ const showModal = ref(false);
 
 const formattedAmount = computed(() => numeral(props.amount).format('0,0.00'));
 
+function isCurrencyLoss(type) {
+	return typeof type === 'string' && type.endsWith('_currency_loss');
+}
+
+const sortedHistory = computed(() => {
+	// Show oldest-first, and when a currency-loss row shares the exact same timestamp as its
+	// repayment, sort the loss row *after* the repayment (legacy added +0.5 to the loss row's
+	// sort key). The backend already returns oldest-first, so this only re-breaks same-timestamp
+	// ties; Array.sort is stable, preserving order otherwise.
+	return [...props.paymentHistory].sort((a, b) => {
+		const timeA = new Date(a.createTime).getTime();
+		const timeB = new Date(b.createTime).getTime();
+		if (timeA !== timeB) {
+			return timeA - timeB;
+		}
+		return (isCurrencyLoss(a.type) ? 1 : 0) - (isCurrencyLoss(b.type) ? 1 : 0);
+	});
+});
+
 function formatAmount(value) {
 	return numeral(value).format('$0,0.00');
 }
 
 function formatDate(iso) {
 	if (!iso) return '';
+	// Intentionally formats in the lender's browser timezone (no `timeZone` option). The field
+	// is a full ISO-8601 instant and the modal renders client-side, so the displayed day is the
+	// lender's local day.
 	return new Date(iso).toLocaleDateString('en-US', {
 		month: 'short',
 		day: 'numeric',
 		year: 'numeric'
 	});
-}
-
-function isCurrencyLoss(type) {
-	return typeof type === 'string' && type.endsWith('_currency_loss');
 }
 </script>

--- a/src/graphql/query/portfolio/myLoans.graphql
+++ b/src/graphql/query/portfolio/myLoans.graphql
@@ -43,6 +43,7 @@ query myLoans(
 				name
 				status
 				statusLabel
+				matchRatio
 				image {
 					id
 					url
@@ -71,6 +72,11 @@ query myLoans(
 				userProperties {
 					canChangeTeamAssignment
 					wasMatched
+					dedication {
+						recipientName
+						toKiva
+						dedicationUrl
+					}
 					loanBalance {
 						amountPurchasedByLender
 						amountPurchasedByPromo
@@ -87,6 +93,7 @@ query myLoans(
 					userAttributedTeam {
 						id
 						name
+						teamPublicId
 						image {
 							id
 							url

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -37,6 +37,7 @@
 						<loan-list
 							:loans="loans"
 							:loading="loading"
+							:has-error="loadError"
 							:lending-teams="lendingTeams"
 							:reassigning-loan-ids="reassigningLoanIds"
 							:reassign-nonce="reassignNonce"
@@ -102,6 +103,9 @@ export default {
 			reassignNonce: {},
 			totalLoans: 0,
 			loading: true,
+			// Set when a loans fetch rejects so the list can show a distinct error state
+			// instead of the "no loans match this search" empty copy.
+			loadError: false,
 			// null until the first unfiltered fetch resolves; false only when the lender has
 			// never lent (lifetime loan count is 0), which swaps the page for the first-loan CTA.
 			// Set only from unfiltered requests so a filtered no-results page keeps the
@@ -167,6 +171,7 @@ export default {
 			const requestSequence = this.loanRequestSequence + 1;
 			this.loanRequestSequence = requestSequence;
 			this.loading = true;
+			this.loadError = false;
 			if (clearLoans) {
 				this.loans = [];
 			}
@@ -207,6 +212,7 @@ export default {
 				if (requestSequence !== this.loanRequestSequence) {
 					return;
 				}
+				this.loadError = true;
 				logFormatter(`Error fetching loans: ${error}`, 'error');
 			}).finally(() => {
 				if (requestSequence === this.loanRequestSequence) {

--- a/test/unit/specs/components/Portfolio/LoanFilterBar.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanFilterBar.spec.js
@@ -222,6 +222,38 @@ describe('LoanFilterBar', () => {
 		expect(page.getByTestId('loans-count').textContent.trim()).toBe('0 loans');
 	});
 
+	it('labels the raised status "Funded" (legacy parity), not "Raised"', () => {
+		const page = renderLoanFilterBar();
+
+		const labels = Array.from(getSelect(page.container, 'loan-status-select').querySelectorAll('option'))
+			.map(option => option.textContent.trim());
+		// Legacy + the stats grid both call this bucket "Funded"; the dropdown must match.
+		expect(labels).toContain('Funded');
+		expect(labels).not.toContain('Raised');
+	});
+
+	it('uses the legacy default filter option labels', () => {
+		const page = renderLoanFilterBar();
+
+		const firstOption = id => getSelect(page.container, id).querySelector('option').textContent.trim();
+		expect(firstOption('loan-status-select')).toBe('All loans');
+		expect(firstOption('loan-country-select')).toBe('Location');
+		expect(firstOption('loan-partner-select')).toBe('Partner');
+	});
+
+	it('toggles the small-screen filter accordion via the Filters button', async () => {
+		const page = renderLoanFilterBar();
+
+		const toggle = page.getByTestId('filters-toggle');
+		expect(toggle.textContent.trim()).toBe('Filters');
+		expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+		await fireEvent.click(toggle);
+
+		expect(toggle.textContent.trim()).toBe('Hide filters');
+		expect(toggle.getAttribute('aria-expanded')).toBe('true');
+	});
+
 	it('places the loans count next to the clear-filters control when filters are active', () => {
 		const page = renderLoanFilterBar({
 			props: { totalLoans: 12, filters: { status: 'payingBack' } },

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -822,18 +822,17 @@ describe('LoanList — matched badge', () => {
 });
 
 describe('LoanList — "Length" cell', () => {
-	it('renders the legacy "mos" abbreviation, not "months"', () => {
+	it('renders the "months" suffix on the repayment term', () => {
 		const page = renderLoanList({ loans: [makeLoan({ lenderRepaymentTerm: 8 })] });
 
-		// Legacy parity (07-my-loans-table-row.mustache:97): "{term} mos", not "months".
-		expect(page.getByText('8 mos')).toBeTruthy();
-		expect(page.queryByText('8 months')).toBeNull();
+		expect(page.getByText('8 months')).toBeTruthy();
+		expect(page.queryByText('8 mos')).toBeNull();
 	});
 
-	it('renders a dash with "mos" when the repayment term is missing', () => {
+	it('renders a dash with "months" when the repayment term is missing', () => {
 		const page = renderLoanList({ loans: [makeLoan({ lenderRepaymentTerm: null })] });
 
-		expect(page.getByText('- mos')).toBeTruthy();
+		expect(page.getByText('- months')).toBeTruthy();
 	});
 });
 

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -774,6 +774,25 @@ describe('LoanList — matched badge', () => {
 		expect(page.getByTestId('matched-badge').textContent.trim()).toBe('2x matched');
 	});
 
+	it('renders a bare "Matched" when the match ratio is exactly 1 (legacy parity — no "1x matched")', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				matchRatio: 1,
+				userProperties: {
+					wasMatched: true,
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountRepaidToLender: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					userAttributedTeam: null,
+				},
+			})],
+		});
+
+		expect(page.getByTestId('matched-badge').textContent.trim()).toBe('Matched');
+	});
+
 	it('falls back to a bare "Matched" when wasMatched is true but the ratio is absent', () => {
 		const page = renderLoanList({
 			loans: [makeLoan({

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -37,10 +37,10 @@ const makeLoan = (overrides = {}) => ({
 });
 
 const renderLoanList = ({
-	loans, loading = false, lendingTeams = [], reassigningLoanIds = [], reassignNonce = {},
+	loans, loading = false, hasError = false, lendingTeams = [], reassigningLoanIds = [], reassignNonce = {},
 } = {}) => render(LoanList, {
 	props: {
-		loans, loading, lendingTeams, reassigningLoanIds, reassignNonce,
+		loans, loading, hasError, lendingTeams, reassigningLoanIds, reassignNonce,
 	},
 	global: {
 		provide: {
@@ -53,6 +53,7 @@ const renderLoanList = ({
 		stubs: {
 			KvFlag: { template: '<span class="kv-flag" />' },
 			KvLoadingPlaceholder: { template: '<div class="kv-loading-placeholder" />' },
+			KvMaterialIcon: { props: ['icon'], template: '<span class="kv-material-icon" />' },
 			PaidAmountModal: {
 				props: ['amount'],
 				// eslint-disable-next-line no-template-curly-in-string
@@ -77,6 +78,88 @@ describe('LoanList — no-results empty state', () => {
 		const page = renderLoanList({ loans: [], loading: true });
 
 		expect(page.queryByTestId('no-loans-message')).toBeNull();
+	});
+});
+
+describe('LoanList — error state', () => {
+	it('shows a distinct error message (not the no-match copy) when hasError is set', () => {
+		const page = renderLoanList({ loans: [], loading: false, hasError: true });
+
+		expect(page.getByTestId('loans-error-message').textContent.trim())
+			.toBe("We couldn't load your loans right now. Please refresh the page and try again.");
+		// A backend failure must NOT masquerade as the filtered "no loans match" empty state.
+		expect(page.queryByTestId('no-loans-message')).toBeNull();
+	});
+
+	it('does not render the error message while loans are still loading', () => {
+		const page = renderLoanList({ loans: [], loading: true, hasError: true });
+
+		expect(page.queryByTestId('loans-error-message')).toBeNull();
+	});
+});
+
+describe('LoanList — Hotjar PII suppression (legacy parity)', () => {
+	// Legacy tagged every borrower-identifying surface with the data-hj-suppress hook so
+	// names, loan IDs, and dedication recipients are masked in Hotjar recordings.
+	const piiLoan = () => makeLoan({
+		partnerName: 'Partner 44',
+		partnerId: 44,
+		userProperties: {
+			loanBalance: {
+				amountPurchasedByLender: '25',
+				amountPurchasedByPromo: null,
+				promoTypeLabel: null,
+				amountRepaidToLender: '5',
+				amountReturnedTotal: '5',
+				latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+			},
+			wasMatched: false,
+			canChangeTeamAssignment: false,
+			dedication: { recipientName: 'Grandma Rosa', dedicationUrl: '/dedicate/1', toKiva: false },
+			userAttributedTeam: {
+				id: 7, name: 'Team Kiva', teamPublicId: 'team-kiva', image: { url: '/t.jpg' },
+			},
+		},
+	});
+
+	it('suppresses the borrower image, name/ID link, partner link, dedication link, and read-only team link', () => {
+		const page = renderLoanList({ loans: [piiLoan()] });
+
+		expect(page.container.querySelector('img.loan-image').classList.contains('data-hj-suppress')).toBe(true);
+		expect(
+			page.container.querySelector('a[href="/lend/1208499"]').classList.contains('data-hj-suppress')
+		).toBe(true);
+		expect(page.getByText('Partner 44').closest('a').classList.contains('data-hj-suppress')).toBe(true);
+		expect(
+			page.container.querySelector('[data-testid="loan-dedication"] a').classList.contains('data-hj-suppress')
+		).toBe(true);
+		expect(page.getByText('Team Kiva').closest('a').classList.contains('data-hj-suppress')).toBe(true);
+	});
+
+	it('suppresses the team reassignment select for eligible loans', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: null,
+						promoTypeLabel: null,
+						amountRepaidToLender: '5',
+						amountReturnedTotal: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					wasMatched: false,
+					canChangeTeamAssignment: true,
+					userAttributedTeam: null,
+				},
+			})],
+			lendingTeams: [{ id: 7, name: 'Team Kiva' }],
+		});
+
+		const select = page.container.querySelector('#reassign-team-1208499');
+		expect(select).not.toBeNull();
+		// The suppress hook may sit on the select or a KvSelect wrapper; either masks the subtree.
+		expect(select.closest('.data-hj-suppress')).not.toBeNull();
 	});
 });
 
@@ -178,7 +261,8 @@ describe('LoanList — "You loaned" cell', () => {
 	it('renders the formatted latest share purchase date under the amount', () => {
 		const page = renderLoanList({ loans: [makeLoan()] });
 
-		expect(page.getByText('$25')).toBeTruthy();
+		// Legacy parity (MP-2936): lender share uses $0,0.00 — always two decimals.
+		expect(page.getByText('$25.00')).toBeTruthy();
 		expect(page.getByText('Mar 15, 2026')).toBeTruthy();
 	});
 
@@ -195,7 +279,7 @@ describe('LoanList — "You loaned" cell', () => {
 			})],
 		});
 
-		expect(page.getByText('$25')).toBeTruthy();
+		expect(page.getByText('$25.00')).toBeTruthy();
 		expect(page.queryByText('Mar 15, 2026')).toBeNull();
 		expect(page.queryByText('Invalid Date')).toBeNull();
 	});
@@ -265,6 +349,83 @@ describe('LoanList — "You loaned" cell', () => {
 	});
 });
 
+describe('LoanList — cents formatting (MP-2936)', () => {
+	// Legacy parity: fractional amounts must keep their cents instead of rounding to
+	// whole dollars ($10.50 -> $11). Legacy uses an always-two-decimal $0,0.00 for the
+	// lender / raised / loan-amount figures and a cents-when-present $0,0[.]00 for promo.
+	it('renders the lender share with cents, not rounded to whole dollars', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '10.50',
+						amountRepaidToLender: '5',
+						latestSharePurchaseTime: null,
+					},
+				},
+			})],
+		});
+
+		expect(page.getByText('$10.50')).toBeTruthy();
+		expect(page.queryByText('$11')).toBeNull();
+	});
+
+	it('renders the promo amount with cents when present', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: '10.50',
+						promoTypeLabel: 'free trial',
+						latestSharePurchaseTime: null,
+					},
+				},
+			})],
+		});
+
+		expect(page.getByText('$10.50 free trial')).toBeTruthy();
+	});
+
+	it('renders a whole-dollar promo amount without trailing .00 (legacy [.]00 behavior)', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountPurchasedByPromo: '10',
+						promoTypeLabel: 'free trial',
+						latestSharePurchaseTime: null,
+					},
+				},
+			})],
+		});
+
+		// Promo is the one field whose cents are conditional: $10, not $10.00.
+		expect(page.getByText('$10 free trial')).toBeTruthy();
+	});
+
+	it('renders the loan amount with cents, not rounded', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({ terms: { loanAmount: '525.50', expectedPayments: [] } })],
+		});
+
+		expect(page.getByText('$525.50')).toBeTruthy();
+		expect(page.queryByText('$526')).toBeNull();
+	});
+
+	it('renders the "raised" amount with cents, not rounded', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				status: 'fundraising',
+				loanFundraisingInfo: { id: 1, fundedAmount: '300.25' },
+			})],
+		});
+
+		expect(page.getByText('$300.25 raised')).toBeTruthy();
+	});
+});
+
 describe('LoanList — "Paid back or raised" cell', () => {
 	it('renders "raised" amount for fundraising loans', () => {
 		const page = renderLoanList({
@@ -274,7 +435,7 @@ describe('LoanList — "Paid back or raised" cell', () => {
 			})],
 		});
 
-		expect(page.getByText('$300 raised')).toBeTruthy();
+		expect(page.getByText('$300.00 raised')).toBeTruthy();
 	});
 
 	it('renders "raised" amount for raised loans', () => {
@@ -285,7 +446,7 @@ describe('LoanList — "Paid back or raised" cell', () => {
 			})],
 		});
 
-		expect(page.getByText('$525 raised')).toBeTruthy();
+		expect(page.getByText('$525.00 raised')).toBeTruthy();
 	});
 
 	it('renders the lender-repaid amount as the clickable trigger with "repaid to you" copy below', () => {
@@ -510,7 +671,7 @@ describe('LoanList — arrears rendering', () => {
 			})],
 		});
 
-		expect(page.getByText('$50,000')).toBeTruthy();
+		expect(page.getByText('$50,000.00')).toBeTruthy();
 		expect(page.getByText('(-$1,234.56 in arrears)')).toBeTruthy();
 		expect(page.getByText('(-$61.73 in arrears)')).toBeTruthy();
 	});
@@ -593,10 +754,72 @@ describe('LoanList — matched badge', () => {
 
 		expect(page.queryByTestId('matched-badge')).toBeNull();
 	});
+
+	it('renders "Nx matched" when the matched loan carries a match ratio (legacy parity)', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				matchRatio: 2,
+				userProperties: {
+					wasMatched: true,
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountRepaidToLender: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					userAttributedTeam: null,
+				},
+			})],
+		});
+
+		expect(page.getByTestId('matched-badge').textContent.trim()).toBe('2x matched');
+	});
+
+	it('falls back to a bare "Matched" when wasMatched is true but the ratio is absent', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				matchRatio: null,
+				userProperties: {
+					wasMatched: true,
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountRepaidToLender: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					userAttributedTeam: null,
+				},
+			})],
+		});
+
+		expect(page.getByTestId('matched-badge').textContent.trim()).toBe('Matched');
+	});
+
+	it('does not render the badge from a match ratio alone when wasMatched is false', () => {
+		// The viewer-relative wasMatched flag is the gate; a loan-level ratio on an
+		// unmatched-for-this-lender share must not surface a badge.
+		const page = renderLoanList({ loans: [makeLoan({ matchRatio: 3 })] });
+
+		expect(page.queryByTestId('matched-badge')).toBeNull();
+	});
+});
+
+describe('LoanList — "Length" cell', () => {
+	it('renders the legacy "mos" abbreviation, not "months"', () => {
+		const page = renderLoanList({ loans: [makeLoan({ lenderRepaymentTerm: 8 })] });
+
+		// Legacy parity (07-my-loans-table-row.mustache:97): "{term} mos", not "months".
+		expect(page.getByText('8 mos')).toBeTruthy();
+		expect(page.queryByText('8 months')).toBeNull();
+	});
+
+	it('renders a dash with "mos" when the repayment term is missing', () => {
+		const page = renderLoanList({ loans: [makeLoan({ lenderRepaymentTerm: null })] });
+
+		expect(page.getByText('- mos')).toBeTruthy();
+	});
 });
 
 describe('LoanList — team cell', () => {
-	it('renders the user-attributed team name and image when present', () => {
+	it('renders the user-attributed team name and image, linked to the team page, when present', () => {
 		const page = renderLoanList({
 			loans: [makeLoan({
 				userProperties: {
@@ -608,6 +831,7 @@ describe('LoanList — team cell', () => {
 					userAttributedTeam: {
 						id: 42,
 						name: 'Cat Lovers',
+						teamPublicId: 'cat_lovers',
 						image: { id: 5, url: '/img/team-cat.jpg' },
 					},
 				},
@@ -616,6 +840,56 @@ describe('LoanList — team cell', () => {
 
 		expect(page.getByText('Cat Lovers')).toBeTruthy();
 		expect(page.getByAltText('Cat Lovers team image')).toBeTruthy();
+		// Legacy parity: the read-only team wraps name + image in an anchor to its team page.
+		const link = page.container.querySelector('.team-cell a');
+		expect(link).not.toBeNull();
+		expect(link.getAttribute('href')).toBe('/team/cat_lovers');
+	});
+
+	it('truncates a read-only attributed team name longer than 20 characters (legacy parity)', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountRepaidToLender: '5',
+						latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+					},
+					userAttributedTeam: {
+						id: 42,
+						name: 'A Really Long Team Name That Exceeds Twenty',
+						teamPublicId: 'long_team',
+					},
+				},
+			})],
+		});
+
+		// Legacy LoanRowView truncates to 20 chars + "..." ("A Really Long Team N").
+		expect(page.getByText('A Really Long Team N...')).toBeTruthy();
+		expect(page.queryByText('A Really Long Team Name That Exceeds Twenty')).toBeNull();
+	});
+
+	it('renders the read-only team unlinked when no teamPublicId is resolvable', () => {
+		const page = renderLoanList({
+			loans: [makeLoan({
+				userProperties: {
+					loanBalance: {
+						amountPurchasedByLender: '25',
+						amountRepaidToLender: '5',
+						latestSharePurchaseTime: null,
+					},
+					userAttributedTeam: {
+						id: 7,
+						name: 'No Slug Team',
+						teamPublicId: null,
+						image: null,
+					},
+				},
+			})],
+		});
+
+		expect(page.getByText('No Slug Team')).toBeTruthy();
+		expect(page.container.querySelector('.team-cell a')).toBeNull();
 	});
 
 	it('renders an empty cell when there is no user-attributed team', () => {
@@ -802,5 +1076,91 @@ describe('LoanList — team reassignment', () => {
 		});
 
 		expect(teamSelect(page.container).value).toBe('1');
+	});
+});
+
+describe('LoanList — dedication indicator (MP-2847)', () => {
+	// Override userProperties wholesale (loanBalance must stay for the "You loaned" cell)
+	// so each test fully controls the viewer-relative dedication shape.
+	const dedicatedLoan = dedication => makeLoan({
+		userProperties: {
+			loanBalance: {
+				amountPurchasedByLender: '25',
+				amountRepaidToLender: '5',
+				amountReturnedTotal: '5',
+				latestSharePurchaseTime: '2026-03-15T12:00:00Z',
+			},
+			userAttributedTeam: null,
+			dedication,
+		},
+	});
+
+	it('renders no dedication block when the lender has no dedication on the loan', () => {
+		// makeLoan's default userProperties omits `dedication` entirely (field resolves null
+		// for a loan this lender never dedicated, or when there is no logged-in user).
+		const page = renderLoanList({ loans: [makeLoan()] });
+
+		expect(page.queryByTestId('loan-dedication')).toBeNull();
+	});
+
+	it('renders no dedication block when dedication is null', () => {
+		const page = renderLoanList({ loans: [dedicatedLoan(null)] });
+
+		expect(page.queryByTestId('loan-dedication')).toBeNull();
+	});
+
+	it('renders a heart + "Dedicated to {name}" linking to the dedication page for a named recipient', () => {
+		const page = renderLoanList({
+			loans: [dedicatedLoan({
+				recipientName: 'Jane Doe',
+				toKiva: false,
+				dedicationUrl: '/dedication/1208499',
+			})],
+		});
+
+		const block = page.getByTestId('loan-dedication');
+		// Legacy copy: "Dedicated to {name}" with no colon.
+		expect(block.textContent).toContain('Dedicated to Jane Doe');
+		expect(block.textContent).not.toContain('Dedicated to:');
+
+		// The whole indicator is the link to /dedication/{loanId} (legacy parity).
+		const link = block.querySelector('a');
+		expect(link.getAttribute('href')).toBe('/dedication/1208499');
+		expect(link.querySelector('.kv-material-icon')).not.toBeNull();
+
+		// Named dedications carry the legacy footer about repayments going to Kiva.
+		expect(page.getByTestId('loan-dedication-footer').textContent.trim())
+			.toBe('Repayments for dedications are donated to Kiva');
+	});
+
+	it('renders the legacy "multiple recipients" label when the loan was dedicated to more than one person', () => {
+		const page = renderLoanList({
+			loans: [dedicatedLoan({
+				recipientName: 'multiple recipients',
+				toKiva: false,
+				dedicationUrl: '/dedication/1208499',
+			})],
+		});
+
+		expect(page.getByTestId('loan-dedication').textContent).toContain('Dedicated to multiple recipients');
+	});
+
+	it('renders the to-Kiva thank-you copy with no link and no footer for a Kiva dedication', () => {
+		const page = renderLoanList({
+			loans: [dedicatedLoan({
+				recipientName: null,
+				toKiva: true,
+				dedicationUrl: null,
+			})],
+		});
+
+		const block = page.getByTestId('loan-dedication');
+		expect(block.textContent).toContain('You opted to donate repayments from this loan to Kiva (Thanks!)');
+		// Legacy parity: to-Kiva dedications render without a link, without the footer note,
+		// and without the heart icon (the heart is reserved for named recipients).
+		expect(block.querySelector('a')).toBeNull();
+		expect(block.querySelector('.kv-material-icon')).toBeNull();
+		expect(page.queryByTestId('loan-dedication-footer')).toBeNull();
+		expect(page.queryByText('Dedicated to', { exact: false })).toBeNull();
 	});
 });

--- a/test/unit/specs/components/Portfolio/PaidAmountModal.spec.js
+++ b/test/unit/specs/components/Portfolio/PaidAmountModal.spec.js
@@ -1,0 +1,69 @@
+import { render, fireEvent } from '@testing-library/vue';
+import PaidAmountModal from '#src/components/Portfolio/PaidAmountModal';
+
+const renderModal = ({ amount = '10', paymentHistory = [] } = {}) => render(PaidAmountModal, {
+	props: { amount, paymentHistory },
+	global: {
+		stubs: {
+			// Render the lightbox slot only when visible, mirroring the real component.
+			KvLightbox: {
+				props: ['visible', 'title'],
+				template: '<div v-if="visible" class="kv-lightbox"><slot /></div>',
+			},
+		},
+	},
+});
+
+// The clickable trigger is the only span with the tw-text-link class.
+const openHistory = async page => {
+	await fireEvent.click(page.container.querySelector('.tw-text-link'));
+};
+
+const labelRows = page => Array.from(page.container.querySelectorAll('.tw-grid .tw-contents'))
+	.map(row => row.querySelectorAll('span')[1].textContent.replace(/\s+/g, ' ').trim());
+
+describe('PaidAmountModal', () => {
+	it('shows the empty-state copy when there is no repayment history', async () => {
+		const page = renderModal({ paymentHistory: [] });
+
+		await openHistory(page);
+
+		expect(page.getByText('This loan has no repayments')).toBeTruthy();
+	});
+
+	it('orders a same-timestamp currency-loss row after its repayment (legacy +0.5 nudge)', async () => {
+		const page = renderModal({
+			paymentHistory: [
+				// Currency-loss row arrives before its same-timestamp repayment in the source order.
+				{ createTime: '2026-01-01T00:00:00Z', amount: '5', type: 'loan_repayment_currency_loss' },
+				{ createTime: '2026-01-01T00:00:00Z', amount: '20', type: 'loan_repayment' },
+				{ createTime: '2025-06-01T00:00:00Z', amount: '10', type: 'loan_repayment' },
+			],
+		});
+
+		await openHistory(page);
+
+		// Oldest first; the same-second loss row is nudged after its repayment.
+		expect(labelRows(page)).toEqual([
+			'$10.00 repaid',
+			'$20.00 repaid',
+			'$5.00 currency loss',
+		]);
+	});
+
+	it('keeps distinct timestamps in chronological order regardless of type', async () => {
+		const page = renderModal({
+			paymentHistory: [
+				{ createTime: '2026-03-01T00:00:00Z', amount: '8', type: 'loan_repayment' },
+				{ createTime: '2026-02-01T00:00:00Z', amount: '3', type: 'direct_loan_repayment_currency_loss' },
+			],
+		});
+
+		await openHistory(page);
+
+		expect(labelRows(page)).toEqual([
+			'$3.00 currency loss',
+			'$8.00 repaid',
+		]);
+	});
+});

--- a/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
@@ -94,13 +94,14 @@ const renderLoansPage = ({ apollo = null, router = null } = {}) => {
 						`,
 					},
 					LoanList: {
-						props: ['loans', 'loading', 'lendingTeams', 'reassigningLoanIds', 'reassignNonce'],
+						props: ['loans', 'loading', 'hasError', 'lendingTeams', 'reassigningLoanIds', 'reassignNonce'],
 						emits: ['reassign-team'],
 						template: `
 							<div data-testid="loan-list">
 								loading:{{ loading }} loans:{{ loans.map(loan => loan.id).join(",") }}
 								teams:{{ (lendingTeams || []).map(team => team.name).join(",") }}
 								attributed:{{ loans.map(l => l.userProperties?.userAttributedTeam?.name).join(",") }}
+								error:{{ hasError }}
 								<button
 									type="button"
 									data-testid="reassign"
@@ -201,6 +202,17 @@ describe('LoansPage', () => {
 
 		await waitFor(() => expect(page.getByTestId('loan-list')).toBeTruthy());
 		expect(page.queryByTestId('first-loan-cta')).toBeNull();
+	});
+
+	it('flags the list with an error (and shows no first-loan CTA) when the loans query rejects', async () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const query = vi.fn().mockRejectedValue(new Error('boom'));
+		const page = renderLoansPage({ apollo: { query } });
+
+		await waitFor(() => expect(page.getByTestId('loan-list').textContent).toContain('error:true'));
+		// The never-lent signal stays unknown on error, so we never flip to the first-loan CTA.
+		expect(page.queryByTestId('first-loan-cta')).toBeNull();
+		consoleError.mockRestore();
 	});
 
 	it('keeps the no-results page (not the CTA) when filters match zero loans for a lender who has lent', async () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2847
https://kiva.atlassian.net/browse/MP-2936
https://kiva.atlassian.net/browse/MP-2815
https://kiva.atlassian.net/browse/MP-2939

Remaining UI work on loans-beta for parity with legacy page. Some UX cleanup coming, but I wanted to get parity in first, style next.

Some screenshot examples:

<img width="284" height="202" alt="image" src="https://github.com/user-attachments/assets/964841a2-066c-4348-98c0-8840c751e122" />

<img width="518" height="239" alt="image" src="https://github.com/user-attachments/assets/8b8040cf-7231-4d01-b9f7-1832d8054f8e" />

<img width="510" height="257" alt="image" src="https://github.com/user-attachments/assets/9bb744a0-1012-484e-ad53-c60104e96e59" />

<img width="498" height="456" alt="image" src="https://github.com/user-attachments/assets/312a4d61-998e-4827-9822-c47655d4e45c" />

