### PR TITLE
feat: mp-2870-fix-mobile-bg-image

### DIFF
--- a/src/components/MyKiva/FeaturedGoalCard.vue
+++ b/src/components/MyKiva/FeaturedGoalCard.vue
@@ -412,6 +412,8 @@ watch(
 @screen md {
 	.featured-goal-card--no-goal {
 		background-image: url('/src/assets/images/my-kiva/featured-goal-card/no-goal-state.png');
+		background-position: calc(100% + 160px) bottom;
+		background-size: auto 100%;
 	}
 
 	.featured-goal-card--active-goal {

--- a/src/pages/Portfolio/ImpactDashboard/GoalEntrypoint.vue
+++ b/src/pages/Portfolio/ImpactDashboard/GoalEntrypoint.vue
@@ -123,7 +123,7 @@ onMounted(() => {
 	width: min(100%, 14rem);
 }
 
-@screen md {
+@screen lg {
 	.goal-entrypoint {
 		background-image: url('/src/assets/images/my-kiva/featured-goal-card/no-goal-state.png');
 		background-position: calc(100% + 160px) bottom;
@@ -132,12 +132,6 @@ onMounted(() => {
 
 	.goal-entrypoint__content {
 		max-width: 28rem;
-	}
-}
-
-@screen lg {
-	.goal-entrypoint {
-		background-size: auto 100%;
 	}
 }
 </style>

--- a/src/pages/Portfolio/ImpactDashboard/GoalEntrypoint.vue
+++ b/src/pages/Portfolio/ImpactDashboard/GoalEntrypoint.vue
@@ -94,10 +94,10 @@ onMounted(() => {
 
 <style lang="postcss" scoped>
 .goal-entrypoint {
-	background-image: url('/src/assets/images/my-kiva/featured-goal-card/no-goal-state.png');
-	background-position: calc(100% + clamp(100px, calc(420px - 50vw), 260px)) center;
+	background-image: url('/src/assets/images/my-kiva/featured-goal-card/mobile-no-goal-state.png');
+	background-position: bottom;
 	background-repeat: no-repeat;
-	background-size: auto 100%;
+	background-size: cover;
 	box-shadow: inset 0 0 0 4px #fff;
 	min-height: 112px;
 	overflow: hidden;
@@ -123,13 +123,21 @@ onMounted(() => {
 	width: min(100%, 14rem);
 }
 
-@screen lg {
+@screen md {
 	.goal-entrypoint {
-		background-position: right center;
+		background-image: url('/src/assets/images/my-kiva/featured-goal-card/no-goal-state.png');
+		background-position: calc(100% + 160px) bottom;
+		background-size: auto 100%;
 	}
 
 	.goal-entrypoint__content {
 		max-width: 28rem;
+	}
+}
+
+@screen lg {
+	.goal-entrypoint {
+		background-size: auto 100%;
 	}
 }
 </style>


### PR DESCRIPTION
fixing the mobile layout for the portfolio 

Updated the portfolio goal entrypoint background behavior across breakpoints:

desktop 
<img width="838" height="183" alt="image" src="https://github.com/user-attachments/assets/1087b3f7-f703-429e-8399-61920f6d4f34" />

Ipad pro 
<img width="354" height="94" alt="image" src="https://github.com/user-attachments/assets/6d5f69a7-5373-42b3-aa25-73631244f7b5" />

Iphone SE

<img width="403" height="550" alt="image" src="https://github.com/user-attachments/assets/967a7a59-e799-4a60-9824-ea277a4be3e5" />

Iphone 12 pro
<img width="398" height="467" alt="image" src="https://github.com/user-attachments/assets/f5a04408-c883-4460-80de-c4a431c4cbd6" />


Iphone 14 pro max

<img width="398" height="467" alt="image" src="https://github.com/user-attachments/assets/c6a9095b-7667-4d53-87ea-14af5ea4d925" />
