### PR TITLE
fix: simultaneous matching on borrower profile fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^8.18.2",
+				"@kiva/kv-components": "^8.19.1",
 				"@kiva/kv-shop": "^3.7.89",
 				"@kiva/kv-tokens": "^4.2.0",
 				"@mdi/js": "^7.4.47",
@@ -3763,9 +3763,9 @@
 			"peer": true
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "8.18.2",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.18.2.tgz",
-			"integrity": "sha512-9SZGxBZPDeU8Zt6aQ3jHuARRSo+BG7eEaGixJkSwJf+LM8nLD7T1BFJLrhnXmlSOUTOuXNNKjWwONpBJzR6HrA==",
+			"version": "8.19.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.19.1.tgz",
+			"integrity": "sha512-wi/A+qvaEcjaATsQ12mwVfc1DSCjm1joBAdFgwNWh+pgcDHIr5uWG9Nbvr1KarDRatz/KXMPEUyR9awMXpTDDQ==",
 			"bundleDependencies": [
 				"aria-hidden",
 				"embla-carousel",
@@ -32962,9 +32962,9 @@
 			"peer": true
 		},
 		"@kiva/kv-components": {
-			"version": "8.18.2",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.18.2.tgz",
-			"integrity": "sha512-9SZGxBZPDeU8Zt6aQ3jHuARRSo+BG7eEaGixJkSwJf+LM8nLD7T1BFJLrhnXmlSOUTOuXNNKjWwONpBJzR6HrA==",
+			"version": "8.19.1",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.19.1.tgz",
+			"integrity": "sha512-wi/A+qvaEcjaATsQ12mwVfc1DSCjm1joBAdFgwNWh+pgcDHIr5uWG9Nbvr1KarDRatz/KXMPEUyR9awMXpTDDQ==",
 			"requires": {
 				"aria-hidden": "*",
 				"embla-carousel": "*",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
-		"@kiva/kv-components": "^8.18.2",
+		"@kiva/kv-components": "^8.19.1",
 		"@kiva/kv-shop": "^3.7.89",
 		"@kiva/kv-tokens": "^4.2.0",
 		"@mdi/js": "^7.4.47",

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -356,7 +356,7 @@
 						key="simultaneous-matching"
 						class="tw-col-span-12"
 						:simultaneous-matching="simultaneousMatching"
-						:lend-amount="Number(selectedOption)"
+						:lend-amount="selectedLendAmount"
 					/>
 				</kv-grid>
 			</transition>
@@ -572,7 +572,10 @@ export default {
 			this.matchingText = loan?.matchingText ?? '';
 			this.matchRatio = loan?.matchRatio ?? 0;
 			this.name = loan?.name ?? '';
-			this.matchingTextVisibility = this.status === 'fundraising' && this.matchingText && !this.isMatchAtRisk;
+			this.matchingTextVisibility = this.status === 'fundraising'
+				&& this.matchingText
+				&& !this.isMatchAtRisk
+				&& !this.enableMultiMatching;
 			this.inPfp = loan?.inPfp ?? false;
 			this.simultaneousMatching = loan?.simultaneousMatching ?? [];
 			this.userBalance = result?.data?.my?.userAccount?.balance;
@@ -669,8 +672,11 @@ export default {
 				if (this.status === 'fundraising' && this.numLenders > 0) {
 					possibleStats.push('lenderCount');
 				}
-				// Add matching text
-				if (this.status === 'fundraising' && this.matchingText.length && !this.isMatchAtRisk) {
+				// Add matching text (hidden when multi matching is enabled so the slot is skipped entirely)
+				if (this.status === 'fundraising'
+					&& this.matchingText.length
+					&& !this.isMatchAtRisk
+					&& !this.enableMultiMatching) {
 					possibleStats.push('matchingText');
 				}
 				// Cycle through the possible stats in the order they were added.
@@ -892,6 +898,11 @@ export default {
 		},
 		isLendAmountButton() {
 			return (this.lendButtonVisibility || this.state === 'lent-to') && (isLessThan25(this.unreservedAmount)); // eslint-disable-line max-len
+		},
+		// Large dropdown amounts are formatted with a thousands separator (e.g. "1,000"),
+		// so strip non-numeric characters before coercing to a Number to avoid NaN.
+		selectedLendAmount() {
+			return Number(String(this.selectedOption).replace(/[^0-9.]/g, ''));
 		},
 	},
 	mounted() {

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -894,7 +894,7 @@ export default {
 			return isLessThan25(this.unreservedAmount) || isBetween25And500(this.unreservedAmount);
 		},
 		showSparkles() {
-			return this.isCompleteLoanActive && Number(this.unreservedAmount).toFixed() === Number(this.selectedOption).toFixed(); // eslint-disable-line max-len
+			return this.isCompleteLoanActive && Number(this.unreservedAmount).toFixed() === this.selectedLendAmount.toFixed(); // eslint-disable-line max-len
 		},
 		isLendAmountButton() {
 			return (this.lendButtonVisibility || this.state === 'lent-to') && (isLessThan25(this.unreservedAmount)); // eslint-disable-line max-len

--- a/src/components/BorrowerProfile/SimultaneousMatchingInfo.vue
+++ b/src/components/BorrowerProfile/SimultaneousMatchingInfo.vue
@@ -12,13 +12,14 @@
 			/>
 		</div>
 		<p class="md:tw-text-left lg:tw-text-center">
-			${{ lendAmount }} becomes ${{ matchedAmount }} with partner matching
+			${{ formattedLendAmount }} becomes ${{ formattedMatchedAmount }} with partner matching
 			by {{ formattedNames }} while funds last.
 		</p>
 	</div>
 </template>
 
 <script>
+import numeral from 'numeral';
 import { KvUserAvatar } from '@kiva/kv-components';
 
 export default {
@@ -39,10 +40,16 @@ export default {
 	computed: {
 		matchedAmount() {
 			const matcherTotal = this.simultaneousMatching.reduce(
-				(sum, matcher) => sum + this.lendAmount * ((matcher.ratio ?? 0) + 1),
+				(sum, matcher) => sum + this.lendAmount * (matcher.ratio ?? 0),
 				0,
 			);
 			return Math.round(this.lendAmount + matcherTotal);
+		},
+		formattedLendAmount() {
+			return numeral(this.lendAmount).format('0,0');
+		},
+		formattedMatchedAmount() {
+			return numeral(this.matchedAmount).format('0,0');
 		},
 		formattedNames() {
 			const names = this.simultaneousMatching.map(m => m.displayName || 'a Kiva supporter');

--- a/test/unit/specs/components/BorrowerProfile/SimultaneousMatchingInfo.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/SimultaneousMatchingInfo.spec.js
@@ -24,39 +24,39 @@ function renderComponent(props) {
 describe('SimultaneousMatchingInfo', () => {
 	describe('matched amount calculation', () => {
 		it('calculates correctly for multiple matchers from real loan data', () => {
-			// $25 (you) + $25*(3+1) Capital One + $25*(1+1) Tripadvisor = $25 + $100 + $50 = $175
+			// $25 (you) + $25*3 Capital One + $25*1 Tripadvisor = $25 + $75 + $25 = $125
 			const { getByText } = renderComponent({ simultaneousMatching: loanMatchers, lendAmount: 25 });
-			getByText(/\$25 becomes \$175/);
+			getByText(/\$25 becomes \$125/);
 		});
 
-		it('calculates correctly for a single 4x matcher', () => {
-			// $25 (you) + $25*(3+1) Capital One = $25 + $100 = $125
+		it('calculates correctly for a single 3x matcher', () => {
+			// $25 (you) + $25*3 Capital One = $25 + $75 = $100
 			const { getByText } = renderComponent({
 				simultaneousMatching: [loanMatchers[0]],
 				lendAmount: 25,
 			});
-			getByText(/\$25 becomes \$125/);
+			getByText(/\$25 becomes \$100/);
 		});
 
-		it('calculates correctly for a single 2x matcher', () => {
-			// $25 (you) + $25*(1+1) Tripadvisor = $25 + $50 = $75
+		it('calculates correctly for a single 1x matcher', () => {
+			// $25 (you) + $25*1 Tripadvisor = $25 + $25 = $50
 			const { getByText } = renderComponent({
 				simultaneousMatching: [loanMatchers[1]],
 				lendAmount: 25,
 			});
-			getByText(/\$25 becomes \$75/);
+			getByText(/\$25 becomes \$50/);
 		});
 
 		it('respects the lendAmount prop', () => {
-			// $100 (you) + $100*4 Capital One + $100*2 Tripadvisor = $100 + $400 + $200 = $700
+			// $100 (you) + $100*3 Capital One + $100*1 Tripadvisor = $100 + $300 + $100 = $500
 			const { getByText } = renderComponent({ simultaneousMatching: loanMatchers, lendAmount: 100 });
-			getByText(/\$100 becomes \$700/);
+			getByText(/\$100 becomes \$500/);
 		});
 
 		it('defaults to $25 lend amount', () => {
-			// $25 (you) + $25*(3+1) Capital One = $125
+			// $25 (you) + $25*3 Capital One = $100
 			const { getByText } = renderComponent({ simultaneousMatching: [loanMatchers[0]] });
-			getByText(/\$25 becomes \$125/);
+			getByText(/\$25 becomes \$100/);
 		});
 	});
 

--- a/test/unit/specs/components/BorrowerProfile/SimultaneousMatchingInfo.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/SimultaneousMatchingInfo.spec.js
@@ -58,6 +58,12 @@ describe('SimultaneousMatchingInfo', () => {
 			const { getByText } = renderComponent({ simultaneousMatching: [loanMatchers[0]] });
 			getByText(/\$25 becomes \$100/);
 		});
+
+		it('formats large amounts with thousands separators', () => {
+			// $1,000 (you) + $1,000*3 Capital One + $1,000*1 Tripadvisor = $1,000 + $3,000 + $1,000 = $5,000
+			const { getByText } = renderComponent({ simultaneousMatching: loanMatchers, lendAmount: 1000 });
+			getByText(/\$1,000 becomes \$5,000/);
+		});
 	});
 
 	describe('partner name formatting', () => {


### PR DESCRIPTION
## Summary

### 1. Fixed NaN for large lend amounts
**Problem:** Large dropdown amounts are formatted with a thousands separator (e.g. `"1,000"`), so `Number(selectedOption)` produced `NaN` in `SimultaneousMatchingInfo`.

- `LendCta.vue` — added a `selectedLendAmount` computed that strips non-numeric chars before coercing to a Number, and bound the component to it instead of `Number(selectedOption)`.
- `SimultaneousMatchingInfo.vue` — formatted displayed amounts with commas (`formattedLendAmount` / `formattedMatchedAmount` via `numeral`) so large values render as `$1,000`.

### 2. Hide the matched-text slot when multi matching is enabled
- `LendCta.vue` — excluded `'matchingText'` from the slot-machine rotation (`cycleSlotMachine`) when `enableMultiMatching` is true, so the animation cadence stays gap-free.
- Also gated `matchingTextVisibility` with `!enableMultiMatching` to prevent an empty pill in the `numLenders === 0` edge case (this also suppresses the old `matching_highlight` experiment UI under multi matching).

### 3. Bumped @kiva/kv-components
- `8.18.2` → **8.19.1** in `package.json` and `package-lock.json`.

### 4. Fixed `matchedAmount` math
**Problem:** Each matcher was counted as `lendAmount × (ratio + 1)`, double-counting the original lend amount.

- `SimultaneousMatchingInfo.vue` — corrected to `lendAmount × ratio` per matcher. Example: $25 + 3 matchers @ ratio 1 = **$100**.
- `SimultaneousMatchingInfo.spec.js` — updated the 5 calculation tests (which had encoded the buggy values) and renamed two cases to match actual ratios. All 14 tests pass.

**Files touched:** `LendCta.vue`, `SimultaneousMatchingInfo.vue`, `SimultaneousMatchingInfo.spec.js`, `package.json`, `package-lock.json`.
