### PR TITLE
fix: loans beta styling update to match other new portfolio pages

### DIFF
--- a/src/components/Portfolio/LoanFilterBar.vue
+++ b/src/components/Portfolio/LoanFilterBar.vue
@@ -49,6 +49,7 @@
 					<span class="tw-text-secondary tw-whitespace-nowrap">Filter by:</span>
 					<kv-select
 						id="loan-country-select"
+						class="loan-filter-select tw-min-w-0"
 						v-model="selectedCountry"
 						@update:model-value="emitFiltersChanged()"
 					>
@@ -65,6 +66,7 @@
 					</kv-select>
 					<kv-select
 						id="loan-partner-select"
+						class="loan-filter-select tw-min-w-0"
 						v-model="selectedPartner"
 						@update:model-value="emitFiltersChanged()"
 					>
@@ -334,3 +336,20 @@ const handleExportClick = async () => {
 	}
 };
 </script>
+
+<style lang="postcss" scoped>
+/* From the lg breakpoint up the filters lay out in a row; give the location and partner
+   selects an equal flex-basis there so they render at the same width (below lg they stack
+   full-width, so no basis is applied — it would otherwise size their height in the column). */
+@media (width >= 1024px) {
+	.loan-filter-select {
+		flex-basis: 12rem;
+	}
+}
+
+/* Make each inner native select fill its (equal-basis) container so both dropdowns match
+   width; without this the longer partner names stretch the partner select wider. */
+.loan-filter-select :deep(select) {
+	@apply tw-w-full tw-min-w-0;
+}
+</style>

--- a/src/components/Portfolio/LoanFilterBar.vue
+++ b/src/components/Portfolio/LoanFilterBar.vue
@@ -30,9 +30,10 @@
 				]"
 			>
 				<div class="tw-flex tw-items-center tw-gap-2">
-					<span class="tw-text-secondary tw-whitespace-nowrap">Status:</span>
+					<span class="tw-whitespace-nowrap">Status:</span>
 					<kv-select
 						id="loan-status-select"
+						class="loan-status-select"
 						v-model="selectedStatus"
 						@update:model-value="emitFiltersChanged()"
 					>
@@ -46,7 +47,7 @@
 					</kv-select>
 				</div>
 				<div class="tw-flex tw-flex-col lg:tw-flex-row lg:tw-items-center tw-gap-2">
-					<span class="tw-text-secondary tw-whitespace-nowrap">Filter by:</span>
+					<span class="tw-whitespace-nowrap">Filter by:</span>
 					<kv-select
 						id="loan-country-select"
 						class="loan-filter-select tw-min-w-0"
@@ -341,7 +342,7 @@ const handleExportClick = async () => {
 /* From the lg breakpoint up the filters lay out in a row; give the location and partner
    selects an equal flex-basis there so they render at the same width (below lg they stack
    full-width, so no basis is applied — it would otherwise size their height in the column). */
-@media (width >= 1024px) {
+@screen lg {
 	.loan-filter-select {
 		flex-basis: 12rem;
 	}
@@ -351,5 +352,25 @@ const handleExportClick = async () => {
    width; without this the longer partner names stretch the partner select wider. */
 .loan-filter-select :deep(select) {
 	@apply tw-w-full tw-min-w-0;
+}
+
+/* Below lg the filters stack, so let the Status select grow to fill the row width (and its
+   inner native select fill that container); from lg up it returns to its natural size. */
+.loan-status-select {
+	@apply tw-flex-1;
+}
+
+.loan-status-select :deep(select) {
+	@apply tw-w-full tw-min-w-0;
+}
+
+@screen lg {
+	.loan-status-select {
+		@apply tw-flex-initial;
+	}
+
+	.loan-status-select :deep(select) {
+		@apply tw-w-auto;
+	}
 }
 </style>

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -1,29 +1,29 @@
 <template>
 	<div class="tw-mt-2">
 		<div class="tw-relative">
-			<div class="tw-overflow-x-auto tw-min-w-full">
+			<div ref="scrollContainer" class="tw-overflow-x-auto tw-min-w-full" @scroll="updateScrollGradients">
 				<table class="tw-w-full tw-border-collapse tw-text-small lg:tw-text-base">
 					<thead>
-						<tr class="tw-bg-brand">
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+						<tr class="tw-bg-gray-200">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								Loan details
 							</th>
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								Status
 							</th>
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								You loaned
 							</th>
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								Paid back or raised
 							</th>
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								Length
 							</th>
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								Amount
 							</th>
-							<th class="tw-text-left tw-font-bold tw-text-white tw-px-2 tw-py-1">
+							<th class="tw-text-left tw-font-bold tw-px-2 tw-py-1">
 								Team
 							</th>
 						</tr>
@@ -78,7 +78,7 @@
 							v-for="(loan, index) in loans"
 							:key="loan.id"
 							class="tw-border-b tw-border-tertiary"
-							:class="{ 'tw-bg-secondary': index % 2 === 1 }"
+							:class="{ 'tw-bg-gray-50': index % 2 === 1 }"
 						>
 							<td class="loan-details-cell tw-break-words tw-px-2 tw-py-2">
 								<div class="tw-flex tw-items-start">
@@ -311,8 +311,8 @@
 					</tbody>
 				</table>
 			</div>
-			<div class="scroll-gradient scroll-gradient--left lg:tw-hidden"></div>
-			<div class="scroll-gradient scroll-gradient--right lg:tw-hidden"></div>
+			<div v-show="canScrollLeft" class="scroll-gradient scroll-gradient--left"></div>
+			<div v-show="canScrollRight" class="scroll-gradient scroll-gradient--right"></div>
 		</div>
 	</div>
 </template>
@@ -371,6 +371,20 @@ export default {
 		PaidAmountModal
 	},
 	methods: {
+		// Toggle the left/right scroll-gradient overlays from the table's scroll position:
+		// each shows only when the table can still scroll that direction. Recomputed on
+		// scroll, on resize, and after the row set changes (see mounted/watch).
+		updateScrollGradients() {
+			const el = this.$refs.scrollContainer;
+			if (!el) {
+				this.canScrollLeft = false;
+				this.canScrollRight = false;
+				return;
+			}
+			// 1px tolerance so sub-pixel rounding at the extremes doesn't leave a gradient on.
+			this.canScrollLeft = el.scrollLeft > 1;
+			this.canScrollRight = el.scrollLeft < (el.scrollWidth - el.clientWidth - 1);
+		},
 		formatDate(date) {
 			if (!date) return '';
 			// Intentionally formats in the lender's browser timezone (no `timeZone` option). The
@@ -499,8 +513,35 @@ export default {
 			// Number of skeleton rows shown while loading. Each row mirrors a real row's
 			// height (image + stacked detail lines) so the table reserves representative
 			// space and the swap to loaded content doesn't jump.
-			skeletonRowCount: 5
+			skeletonRowCount: 5,
+			canScrollLeft: false,
+			canScrollRight: false
 		};
+	},
+	watch: {
+		loans() {
+			this.$nextTick(this.updateScrollGradients);
+		},
+		loading() {
+			this.$nextTick(this.updateScrollGradients);
+		}
+	},
+	mounted() {
+		this.$nextTick(this.updateScrollGradients);
+		// Available width changes on viewport resize and the row set changes on load/pagination;
+		// neither fires a scroll event, so recompute on both.
+		window.addEventListener('resize', this.updateScrollGradients);
+		if (typeof ResizeObserver !== 'undefined' && this.$refs.scrollContainer) {
+			this.scrollResizeObserver = new ResizeObserver(() => this.updateScrollGradients());
+			this.scrollResizeObserver.observe(this.$refs.scrollContainer);
+		}
+	},
+	beforeUnmount() {
+		window.removeEventListener('resize', this.updateScrollGradients);
+		if (this.scrollResizeObserver) {
+			this.scrollResizeObserver.disconnect();
+			this.scrollResizeObserver = null;
+		}
 	}
 };
 </script>
@@ -525,7 +566,8 @@ export default {
 }
 
 .loan-details-cell {
-	max-width: 18rem;
+	min-width: 20rem;
+	max-width: 24rem;
 }
 
 .loan-image {

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -77,8 +77,8 @@
 						<tr
 							v-for="(loan, index) in loans"
 							:key="loan.id"
-							class="tw-border-b tw-border-tertiary"
-							:class="{ 'tw-bg-gray-50': index % 2 === 1 }"
+							class="tw-border-b tw-border-tertiary tw-bg-primary"
+							:class="{ '!tw-bg-gray-50': index % 2 === 1 }"
 						>
 							<td class="loan-details-cell tw-break-words tw-px-2 tw-py-2">
 								<div class="tw-flex tw-items-start">

--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -1,12 +1,12 @@
 <template>
 	<table class="tw-w-full tw-text-small lg:tw-text-base">
 		<thead>
-			<tr class="tw-bg-brand">
+			<tr class="tw-bg-gray-200">
 				<th class="tw-px-1 lg:tw-px-2 tw-py-1"></th>
-				<th class="tw-text-right tw-font-bold tw-text-white tw-px-1 lg:tw-px-2 tw-py-1">
+				<th class="tw-text-right tw-font-bold tw-px-1 lg:tw-px-2 tw-py-1">
 					My stats
 				</th>
-				<th class="tw-text-right tw-font-bold tw-text-white tw-px-1 lg:tw-px-2 tw-py-1">
+				<th class="tw-text-right tw-font-bold tw-px-1 lg:tw-px-2 tw-py-1">
 					Avg Kiva lender
 				</th>
 			</tr>
@@ -95,7 +95,7 @@
 	<hr class="tw-border-tertiary tw-my-4">
 
 	<div
-		class="tw-grid tw-grid-cols-1 md:tw-grid-cols-3 tw-gap-x-6 tw-gap-y-1"
+		class="tw-grid loan-count-grid tw-gap-x-6 tw-gap-y-1"
 		role="table"
 		aria-label="Loan count statistics"
 	>
@@ -446,3 +446,19 @@ export default {
 	}
 };
 </script>
+
+<style scoped>
+/* Loan-count summary: a single column on mobile, then three uneven columns from the md
+   breakpoint up. The narrow middle column holds the short labels (Funded/Repaid/Refunded)
+   while the wider side columns carry the longer labels; the first column is trimmed slightly
+   to tighten the gap between its labels and counts. */
+.loan-count-grid {
+	grid-template-columns: minmax(0, 1fr);
+}
+
+@media (width >= 768px) {
+	.loan-count-grid {
+		grid-template-columns: 1.15fr 0.4fr 1.3fr;
+	}
+}
+</style>

--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -36,7 +36,8 @@
 			<tr
 				v-for="row in statsRows"
 				:key="row.key"
-				:class="{ 'tw-bg-primary': row.showInWhite, 'tw-bg-secondary': row.showInGray }"
+				class="tw-bg-primary"
+				:class="{ '!tw-bg-gray-50': row.showInGray }"
 			>
 				<td class="tw-px-1 lg:tw-px-2 tw-py-1" :class="{ 'tw-pl-3 lg:tw-pl-6': row.isTabbed }">
 					<span class="tw-inline-flex tw-items-center tw-gap-0.5">
@@ -447,7 +448,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style lang="postcss" scoped>
 /* Loan-count summary: a single column on mobile, then three uneven columns from the md
    breakpoint up. The narrow middle column holds the short labels (Funded/Repaid/Refunded)
    while the wider side columns carry the longer labels; the first column is trimmed slightly
@@ -456,7 +457,7 @@ export default {
 	grid-template-columns: minmax(0, 1fr);
 }
 
-@media (width >= 768px) {
+@screen md {
 	.loan-count-grid {
 		grid-template-columns: 1.15fr 0.4fr 1.3fr;
 	}

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -7,14 +7,30 @@
 			<kv-grid class="tw-grid-cols-12 tw--mx-2.5 md:tw-mx-0">
 				<the-portfolio-tertiary-menu class="tw-pt-2 tw-col-span-3 tw-hidden md:tw-block" />
 				<div class="tw-col-span-12 md:tw-col-span-9 tw-pt-1.5 md:tw-pt-3">
-					<div class="tw-rounded-none md:tw-rounded tw-py-3 tw-px-2 md:tw-px-3 tw-bg-primary">
-						<h1 class="tw-text-display tw-mb-2">
-							My loans
-						</h1>
-						<loans-first-loan-cta v-if="showFirstLoanCta" />
-						<div v-else class="tw-mb-2">
+					<div class="tw-rounded-none md:tw-rounded-t tw-py-3 md:tw-pb-0 tw-px-2 md:tw-px-3 md:tw-bg-primary">
+						<div class="md:tw-flex md:tw-items-baseline md:tw-justify-between">
+							<h1 class="tw-text-display">
+								My loans
+							</h1>
 							<div
-								class="tw-flex tw-justify-end tw-text-tertiary tw-text-small tw-mb-1 tw-min-h-2.5"
+								v-if="!showFirstLoanCta"
+								class="tw-hidden md:tw-flex tw-justify-end tw-text-tertiary tw-text-small tw-min-h-2.5"
+							>
+								<span v-if="lastUpdated">*Updated as of {{ lastUpdated }}</span>
+								<kv-loading-placeholder
+									v-else-if="!statsLoaded"
+									class="tw-self-center"
+									style="width: 11rem; height: 0.875rem;"
+								/>
+							</div>
+						</div>
+					</div>
+					<div class="tw-rounded-none md:tw-rounded-b tw-py-3 lg:tw-pt-1 tw-px-2 md:tw-px-3 tw-bg-primary">
+						<loans-first-loan-cta v-if="showFirstLoanCta" />
+						<template v-else>
+							<div
+								class="md:tw-hidden tw-flex tw-justify-end tw-text-tertiary tw-text-small tw-min-h-2.5
+									tw-mb-0.5"
 							>
 								<span v-if="lastUpdated">*Updated as of {{ lastUpdated }}</span>
 								<kv-loading-placeholder
@@ -24,11 +40,11 @@
 								/>
 							</div>
 							<loan-stats-table @updated-as-of="handleUpdatedAsOf" />
-						</div>
+						</template>
 					</div>
 					<div
 						v-if="!showFirstLoanCta"
-						class="tw-rounded-none md:tw-rounded tw-py-3 tw-px-2 md:tw-px-3 md:tw-mt-3 tw-bg-primary"
+						class="tw-rounded-none md:tw-rounded tw-py-3 tw-px-2 md:tw-px-3 md:tw-mt-3 md:tw-bg-primary"
 					>
 						<loan-filter-bar
 							:countries="filterOptions.countries"

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -1,67 +1,66 @@
 <template>
-	<www-page>
+	<www-page main-class="tw-bg-secondary tw-pb-3">
 		<template #secondary>
 			<the-my-kiva-secondary-menu />
 		</template>
 		<kv-page-container>
-			<kv-grid class="tw-grid-cols-12">
+			<kv-grid class="tw-grid-cols-12 tw--mx-2.5 md:tw-mx-0">
 				<the-portfolio-tertiary-menu class="tw-pt-2 tw-col-span-3 tw-hidden md:tw-block" />
-				<div
-					class="tw-col-span-12 md:tw-col-span-9 tw-pt-4
-					md:tw-pt-6 lg:tw-pt-8"
-				>
-					<h1 class="tw-text-display tw-mb-2">
-						My loans
-					</h1>
-					<loans-first-loan-cta v-if="showFirstLoanCta" />
-					<div v-else class="tw-mb-2">
-						<div
-							class="tw-flex tw-justify-end tw-text-tertiary tw-text-small tw-mb-1 tw-min-h-2.5"
-						>
-							<span v-if="lastUpdated">*Updated as of {{ lastUpdated }}</span>
-							<kv-loading-placeholder
-								v-else-if="!statsLoaded"
-								class="tw-self-center"
-								style="width: 11rem; height: 0.875rem;"
+				<div class="tw-col-span-12 md:tw-col-span-9 tw-pt-1.5 md:tw-pt-3">
+					<div class="tw-rounded-none md:tw-rounded tw-py-3 tw-px-2 md:tw-px-3 tw-bg-primary">
+						<h1 class="tw-text-display tw-mb-2">
+							My loans
+						</h1>
+						<loans-first-loan-cta v-if="showFirstLoanCta" />
+						<div v-else class="tw-mb-2">
+							<div
+								class="tw-flex tw-justify-end tw-text-tertiary tw-text-small tw-mb-1 tw-min-h-2.5"
+							>
+								<span v-if="lastUpdated">*Updated as of {{ lastUpdated }}</span>
+								<kv-loading-placeholder
+									v-else-if="!statsLoaded"
+									class="tw-self-center"
+									style="width: 11rem; height: 0.875rem;"
+								/>
+							</div>
+							<loan-stats-table @updated-as-of="handleUpdatedAsOf" />
+						</div>
+					</div>
+					<div
+						v-if="!showFirstLoanCta"
+						class="tw-rounded-none md:tw-rounded tw-py-3 tw-px-2 md:tw-px-3 md:tw-mt-3 tw-bg-primary"
+					>
+						<loan-filter-bar
+							:countries="filterOptions.countries"
+							:filters="loanState.filters"
+							:keyword-search="loanState.keywordSearch"
+							:partners="filterOptions.partners"
+							:total-loans="totalLoans"
+							@filters-changed="handleFiltersChanged"
+						/>
+						<div ref="loanTableTop">
+							<loan-list
+								:loans="loans"
+								:loading="loading"
+								:has-error="loadError"
+								:lending-teams="lendingTeams"
+								:reassigning-loan-ids="reassigningLoanIds"
+								:reassign-nonce="reassignNonce"
+								@reassign-team="handleReassignTeam"
 							/>
 						</div>
-						<loan-stats-table @updated-as-of="handleUpdatedAsOf" />
-					</div>
-				</div>
-				<div
-					v-if="!showFirstLoanCta"
-					class="tw-col-span-12"
-				>
-					<loan-filter-bar
-						:countries="filterOptions.countries"
-						:filters="loanState.filters"
-						:keyword-search="loanState.keywordSearch"
-						:partners="filterOptions.partners"
-						:total-loans="totalLoans"
-						@filters-changed="handleFiltersChanged"
-					/>
-					<div ref="loanTableTop">
-						<loan-list
-							:loans="loans"
-							:loading="loading"
-							:has-error="loadError"
-							:lending-teams="lendingTeams"
-							:reassigning-loan-ids="reassigningLoanIds"
-							:reassign-nonce="reassignNonce"
-							@reassign-team="handleReassignTeam"
+						<kv-pagination
+							v-if="showPagination"
+							class="tw-mt-3"
+							:class="{ 'tw-pointer-events-none tw-opacity-low': loading }"
+							:limit="loanState.limit"
+							:offset="loanState.offset"
+							:aria-disabled="loading ? 'true' : undefined"
+							:scroll-to-top="false"
+							:total="totalLoans"
+							@page-changed="handlePageChange"
 						/>
 					</div>
-					<kv-pagination
-						v-if="showPagination"
-						class="tw-mt-3"
-						:class="{ 'tw-pointer-events-none tw-opacity-low': loading }"
-						:limit="loanState.limit"
-						:offset="loanState.offset"
-						:aria-disabled="loading ? 'true' : undefined"
-						:scroll-to-top="false"
-						:total="totalLoans"
-						@page-changed="handlePageChange"
-					/>
 				</div>
 			</kv-grid>
 		</kv-page-container>

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -725,10 +725,10 @@ describe('LoanList — row banding', () => {
 		const rows = [...page.container.querySelectorAll('tbody tr')];
 
 		expect(rows).toHaveLength(4);
-		expect(rows[0].classList.contains('tw-bg-gray-50')).toBe(false);
-		expect(rows[1].classList.contains('tw-bg-gray-50')).toBe(true);
-		expect(rows[2].classList.contains('tw-bg-gray-50')).toBe(false);
-		expect(rows[3].classList.contains('tw-bg-gray-50')).toBe(true);
+		expect(rows[0].classList.contains('!tw-bg-gray-50')).toBe(false);
+		expect(rows[1].classList.contains('!tw-bg-gray-50')).toBe(true);
+		expect(rows[2].classList.contains('!tw-bg-gray-50')).toBe(false);
+		expect(rows[3].classList.contains('!tw-bg-gray-50')).toBe(true);
 	});
 });
 

--- a/test/unit/specs/components/Portfolio/LoanList.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanList.spec.js
@@ -725,10 +725,10 @@ describe('LoanList — row banding', () => {
 		const rows = [...page.container.querySelectorAll('tbody tr')];
 
 		expect(rows).toHaveLength(4);
-		expect(rows[0].classList.contains('tw-bg-secondary')).toBe(false);
-		expect(rows[1].classList.contains('tw-bg-secondary')).toBe(true);
-		expect(rows[2].classList.contains('tw-bg-secondary')).toBe(false);
-		expect(rows[3].classList.contains('tw-bg-secondary')).toBe(true);
+		expect(rows[0].classList.contains('tw-bg-gray-50')).toBe(false);
+		expect(rows[1].classList.contains('tw-bg-gray-50')).toBe(true);
+		expect(rows[2].classList.contains('tw-bg-gray-50')).toBe(false);
+		expect(rows[3].classList.contains('tw-bg-gray-50')).toBe(true);
 	});
 });
 

--- a/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
+++ b/test/unit/specs/components/Portfolio/LoanStatsTable.spec.js
@@ -373,22 +373,22 @@ describe('LoanStatsTable', () => {
 	describe('legacy row banding and indent', () => {
 		// Based on the legacy setupCompareStat($label, ..., $is_tabbed, $show_in_white,
 		// $show_in_gray) flags in LoansView.php (MP-2859), plus product-requested gray banding
-		// on the Amount repaid / Amount refunded rows. `bg` is the expected explicit row
-		// background (null = default); `tabbed` indents the label under its parent metric.
+		// on the Amount repaid / Amount refunded rows. `gray` marks the rows that carry the
+		// gray banding override; `tabbed` indents the label under its parent metric.
 		const expected = {
-			'Amount lent': { tabbed: false, bg: null },
-			'Amount repaid': { tabbed: false, bg: 'tw-bg-secondary' },
-			'Amount lost': { tabbed: false, bg: null },
-			'Amount refunded': { tabbed: false, bg: 'tw-bg-secondary' },
-			'Delinquency rate': { tabbed: false, bg: 'tw-bg-primary' },
-			'Amount in arrears': { tabbed: true, bg: 'tw-bg-primary' },
-			'Outstanding loans': { tabbed: true, bg: 'tw-bg-primary' },
-			'Default rate': { tabbed: false, bg: 'tw-bg-secondary' },
-			'Amount defaulted': { tabbed: true, bg: 'tw-bg-secondary' },
-			'Amount ended': { tabbed: true, bg: 'tw-bg-secondary' },
-			'Currency loss rate': { tabbed: false, bg: 'tw-bg-primary' },
-			'Amount of currency loss': { tabbed: true, bg: 'tw-bg-primary' },
-			'Currency loss reimbursement': { tabbed: true, bg: 'tw-bg-primary' },
+			'Amount lent': { tabbed: false, gray: false },
+			'Amount repaid': { tabbed: false, gray: true },
+			'Amount lost': { tabbed: false, gray: false },
+			'Amount refunded': { tabbed: false, gray: true },
+			'Delinquency rate': { tabbed: false, gray: false },
+			'Amount in arrears': { tabbed: true, gray: false },
+			'Outstanding loans': { tabbed: true, gray: false },
+			'Default rate': { tabbed: false, gray: true },
+			'Amount defaulted': { tabbed: true, gray: true },
+			'Amount ended': { tabbed: true, gray: true },
+			'Currency loss rate': { tabbed: false, gray: false },
+			'Amount of currency loss': { tabbed: true, gray: false },
+			'Currency loss reimbursement': { tabbed: true, gray: false },
 		};
 
 		const renderRows = async () => {
@@ -404,13 +404,15 @@ describe('LoanStatsTable', () => {
 
 		it('applies the legacy white/gray banding per row', async () => {
 			const container = await renderRows();
-			Object.entries(expected).forEach(([label, { bg }]) => {
+			Object.entries(expected).forEach(([label, { gray }]) => {
 				const tr = trByLabel(container, label);
 				expect(tr, `row "${label}" should render`).toBeTruthy();
-				expect(tr.classList.contains('tw-bg-primary'), `${label} white banding`)
-					.toBe(bg === 'tw-bg-primary');
-				expect(tr.classList.contains('tw-bg-secondary'), `${label} gray banding`)
-					.toBe(bg === 'tw-bg-secondary');
+				// Every row carries an explicit white base so the banding holds on the
+				// transparent (mobile) card background; gray rows override it.
+				expect(tr.classList.contains('tw-bg-primary'), `${label} white base`)
+					.toBe(true);
+				expect(tr.classList.contains('!tw-bg-gray-50'), `${label} gray banding`)
+					.toBe(gray);
 			});
 		});
 

--- a/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/Loans/LoansPage.spec.js
@@ -403,22 +403,24 @@ describe('LoansPage', () => {
 	it('hides the "Updated as of" line until the stats table emits a timestamp', async () => {
 		const page = renderLoansPage();
 
-		expect(page.queryByText(/Updated as of/)).toBeNull();
+		// Rendered twice (a desktop copy on the heading line, a mobile copy in the stats box),
+		// both gated on the same timestamp — so assert on the count rather than a single node.
+		expect(page.queryAllByText(/Updated as of/)).toHaveLength(0);
 
 		await fireEvent.click(page.getByTestId('emit-updated-as-of'));
 
-		await waitFor(() => expect(page.queryByText(/Updated as of/)).not.toBeNull());
-		expect(page.queryByText(/Updated as of/).textContent).toContain('2026');
+		await waitFor(() => expect(page.queryAllByText(/Updated as of/).length).toBeGreaterThan(0));
+		expect(page.queryAllByText(/Updated as of/)[0].textContent).toContain('2026');
 	});
 
 	it('hides the "Updated as of" line when the stats table emits null', async () => {
 		const page = renderLoansPage();
 
 		await fireEvent.click(page.getByTestId('emit-updated-as-of'));
-		await waitFor(() => expect(page.queryByText(/Updated as of/)).not.toBeNull());
+		await waitFor(() => expect(page.queryAllByText(/Updated as of/).length).toBeGreaterThan(0));
 
 		await fireEvent.click(page.getByTestId('emit-null-updated-as-of'));
-		await waitFor(() => expect(page.queryByText(/Updated as of/)).toBeNull());
+		await waitFor(() => expect(page.queryAllByText(/Updated as of/)).toHaveLength(0));
 	});
 
 	it('passes the viewer lending teams to the loan list', async () => {


### PR DESCRIPTION
I decided for fun to take another look at the `loans-beta` styling to make it closely match the other newer portfolio pages, like `/portfolio` and `/portfolio/donations`.

<img width="988" height="1638" alt="image" src="https://github.com/user-attachments/assets/36998db5-00b6-4600-9b05-37811a17dbbb" />
<br />
<img width="390" height="666" alt="image" src="https://github.com/user-attachments/assets/9fc5a1fb-0492-407d-a729-59821d5b77a3" />
<br />
<img width="389" height="768" alt="image" src="https://github.com/user-attachments/assets/29aa5dbf-8ee3-4983-8c8c-5e9e4225c69d" />
