### PR TITLE
fix: cit 4468 UI simultaneous matching avatar

### DIFF
--- a/.storybook/stories/ContributingPartners.stories.js
+++ b/.storybook/stories/ContributingPartners.stories.js
@@ -45,3 +45,13 @@ export const WithLogo = story([
 	},
 	tripadvisor,
 ]);
+export const WithAvatar = story([
+	{
+		managedAccountId: 1,
+		displayName: 'Visa',
+		ratio: 1,
+		avatar: { id: 20, url: 'https://via.placeholder.com/96/2e7d32/ffffff?text=A' },
+		logo: { id: 10, url: 'https://via.placeholder.com/96/0070d2/ffffff?text=V' },
+	},
+	tripadvisor,
+]);

--- a/.storybook/stories/SimultaneousMatchingInfo.stories.js
+++ b/.storybook/stories/SimultaneousMatchingInfo.stories.js
@@ -65,6 +65,21 @@ WithLogo.args = {
 	lendAmount: 25,
 };
 
+export const WithAvatar = story.bind({});
+WithAvatar.args = {
+	simultaneousMatching: [
+		{
+			managedAccountId: 1,
+			displayName: 'Visa',
+			ratio: 1,
+			avatar: { id: 20, url: 'https://via.placeholder.com/40/2e7d32/ffffff?text=A' },
+			logo: { id: 10, url: 'https://via.placeholder.com/40/0070d2/ffffff?text=L' },
+		},
+		tripadvisor,
+	],
+	lendAmount: 25,
+};
+
 export const LargeLendAmount = story.bind({});
 LargeLendAmount.args = {
 	simultaneousMatching: [capitalOne, tripadvisor],

--- a/src/components/BorrowerProfile/ContributingPartners.vue
+++ b/src/components/BorrowerProfile/ContributingPartners.vue
@@ -19,7 +19,7 @@
 				<kv-user-avatar
 					class="tw-w-full tw-h-full"
 					:lender-name="matcher.displayName || 'Anonymous'"
-					:lender-image-url="matcher.logo && matcher.logo.url ? matcher.logo.url : ''"
+					:lender-image-url="matcher.avatar?.url || matcher.logo?.url || ''"
 				/>
 			</component>
 			<div>

--- a/src/components/BorrowerProfile/ContributingPartners.vue
+++ b/src/components/BorrowerProfile/ContributingPartners.vue
@@ -71,6 +71,10 @@ export default {
 							displayName
 							ratio
 							partnerContentfulPage
+							avatar {
+								id
+								url
+							}
 							logo {
 								id
 								url

--- a/src/components/BorrowerProfile/LendCta.vue
+++ b/src/components/BorrowerProfile/LendCta.vue
@@ -509,6 +509,10 @@ export default {
 							managedAccountId
 							displayName
 							ratio
+							avatar {
+								id
+								url
+							}
 							logo {
 								id
 								url

--- a/src/components/BorrowerProfile/SimultaneousMatchingInfo.vue
+++ b/src/components/BorrowerProfile/SimultaneousMatchingInfo.vue
@@ -8,7 +8,7 @@
 				is-small
 				:class="{ '-tw-ml-2': index > 0 }"
 				:lender-name="matcher.displayName || 'Anonymous'"
-				:lender-image-url="matcher.logo && matcher.logo.url ? matcher.logo.url : ''"
+				:lender-image-url="matcher.avatar?.url || matcher.logo?.url || ''"
 			/>
 		</div>
 		<p class="md:tw-text-left lg:tw-text-center">

--- a/test/unit/specs/components/BorrowerProfile/SimultaneousMatchingInfo.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/SimultaneousMatchingInfo.spec.js
@@ -146,6 +146,36 @@ describe('SimultaneousMatchingInfo', () => {
 			});
 			getByText('C');
 		});
+
+		it('renders the avatar image when avatar url is provided', () => {
+			const withAvatar = [
+				{
+					managedAccountId: 1,
+					displayName: 'Visa',
+					ratio: 1,
+					avatar: { id: 20, url: 'https://example.com/visa-avatar.png' },
+					logo: { id: 10, url: 'https://example.com/visa-logo.png' },
+				},
+			];
+			const { getByAltText } = renderComponent({ simultaneousMatching: withAvatar, lendAmount: 25 });
+			const img = getByAltText('Image of lender', { hidden: true });
+			expect(img.src).toBe('https://example.com/visa-avatar.png');
+		});
+
+		it('falls back to the logo image when avatar is null', () => {
+			const logoOnly = [
+				{
+					managedAccountId: 1,
+					displayName: 'Visa',
+					ratio: 1,
+					avatar: null,
+					logo: { id: 10, url: 'https://example.com/visa-logo.png' },
+				},
+			];
+			const { getByAltText } = renderComponent({ simultaneousMatching: logoOnly, lendAmount: 25 });
+			const img = getByAltText('Image of lender', { hidden: true });
+			expect(img.src).toBe('https://example.com/visa-logo.png');
+		});
 	});
 
 	it('is hidden on mobile via tw-hidden class on the wrapper', () => {


### PR DESCRIPTION
Moves primary image for simultaneous matching entries to use the avatar field and fallback to the logo field if that is missing. The logo fallback is likely not needed but is a temporary cover as we work on getting partner level logos uploaded.