### PR TITLE
fix(MP-2279): send false instead of unknown for missing Hotjar identify attributes

### DIFF
--- a/src/util/hotJarUtils.js
+++ b/src/util/hotJarUtils.js
@@ -9,16 +9,16 @@ export function setHotJarUserAttributes(userData) {
 
 	if (window.hj) {
 		window.hj('identify', userData?.userId, {
-			'Has ever logged in': userData?.hasEverLoggedIn,
-			'Has lent before': userData?.hasLentBefore,
-			'Has deposit before': userData?.hasDepositBefore,
+			'Has ever logged in': userData?.hasEverLoggedIn ?? false,
+			'Has lent before': userData?.hasLentBefore ?? false,
+			'Has deposit before': userData?.hasDepositBefore ?? false,
 		});
 
 		if (userData?.isFirstLoan !== undefined) {
 			window.hj('identify', userData?.userId, {
-				'First loan': userData?.isFirstLoan,
-				'Has direct loan': userData?.hasDirectLoan,
-				'Has core loan': userData?.hasCoreLoan,
+				'First loan': userData?.isFirstLoan ?? false,
+				'Has direct loan': userData?.hasDirectLoan ?? false,
+				'Has core loan': userData?.hasCoreLoan ?? false,
 			});
 		}
 	}

--- a/test/unit/specs/util/hotJarUtils.spec.js
+++ b/test/unit/specs/util/hotJarUtils.spec.js
@@ -146,6 +146,32 @@ describe('hotJarUtils.js', () => {
 				'Has core loan': false,
 			});
 		});
+
+		it('should coerce null attributes to false', () => {
+			const userData = {
+				userId: '55555',
+				hasEverLoggedIn: null,
+				hasLentBefore: null,
+				hasDepositBefore: null,
+				isFirstLoan: true,
+				hasDirectLoan: null,
+				hasCoreLoan: null,
+			};
+
+			setHotJarUserAttributes(userData);
+
+			expect(mockHj).toHaveBeenCalledTimes(2);
+			expect(mockHj).toHaveBeenNthCalledWith(1, 'identify', '55555', {
+				'Has ever logged in': false,
+				'Has lent before': false,
+				'Has deposit before': false,
+			});
+			expect(mockHj).toHaveBeenNthCalledWith(2, 'identify', '55555', {
+				'First loan': true,
+				'Has direct loan': false,
+				'Has core loan': false,
+			});
+		});
 	});
 
 	describe('fireHotJarEvent', () => {

--- a/test/unit/specs/util/hotJarUtils.spec.js
+++ b/test/unit/specs/util/hotJarUtils.spec.js
@@ -99,6 +99,53 @@ describe('hotJarUtils.js', () => {
 				'Has core loan': true,
 			});
 		});
+
+		it('should coerce undefined hasEverLoggedIn to false', () => {
+			const userData = {
+				userId: '22222',
+				hasLentBefore: true,
+				hasDepositBefore: true,
+			};
+
+			setHotJarUserAttributes(userData);
+
+			expect(mockHj).toHaveBeenCalledWith('identify', '22222', {
+				'Has ever logged in': false,
+				'Has lent before': true,
+				'Has deposit before': true,
+			});
+		});
+
+		it('should coerce all user attributes to false when undefined', () => {
+			const userData = { userId: '33333' };
+
+			setHotJarUserAttributes(userData);
+
+			expect(mockHj).toHaveBeenCalledWith('identify', '33333', {
+				'Has ever logged in': false,
+				'Has lent before': false,
+				'Has deposit before': false,
+			});
+		});
+
+		it('should coerce loan attributes to false when undefined', () => {
+			const userData = {
+				userId: '44444',
+				hasEverLoggedIn: true,
+				hasLentBefore: true,
+				hasDepositBefore: true,
+				isFirstLoan: true,
+			};
+
+			setHotJarUserAttributes(userData);
+
+			expect(mockHj).toHaveBeenCalledTimes(2);
+			expect(mockHj).toHaveBeenNthCalledWith(2, 'identify', '44444', {
+				'First loan': true,
+				'Has direct loan': false,
+				'Has core loan': false,
+			});
+		});
 	});
 
 	describe('fireHotJarEvent', () => {


### PR DESCRIPTION
## Summary
- Coerce nullish HotJar user attributes (`hasEverLoggedIn`, `hasLentBefore`,
  `hasDepositBefore`, `isFirstLoan`, `hasDirectLoan`, `hasCoreLoan`) to `false`
  with `?? false` so HotJar segmentation no longer classifies them as
  "unknown". [MP-2279]
- Preserves the existing `isFirstLoan !== undefined` guard so callers that
  don't know loan status (`TheHeader.vue`, `CampaignThanks.vue`) don't start
  pushing `false` loan attributes.
- Added unit tests covering `undefined` and `null` coercion on both
  `hj('identify', ...)` calls.

## Test plan
- [x] `npm run unit -- test/unit/specs/util/hotJarUtils.spec.js` — 14/14 pass
- [ ] Manual check in HotJar dashboard after deploy: users with missing
      attributes appear as `false` in segmentation instead of "unknown"

[MP-2279]: https://kiva.atlassian.net/browse/MP-2279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ