### PR TITLE
fix: update matching ratio display and add info tooltip to loan matcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@godaddy/terminus": "^4.11.0",
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
-				"@kiva/kv-components": "^8.19.1",
+				"@kiva/kv-components": "^8.21.0",
 				"@kiva/kv-shop": "^3.7.89",
 				"@kiva/kv-tokens": "^4.2.0",
 				"@mdi/js": "^7.4.47",
@@ -3763,9 +3763,9 @@
 			"peer": true
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "8.19.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.19.1.tgz",
-			"integrity": "sha512-wi/A+qvaEcjaATsQ12mwVfc1DSCjm1joBAdFgwNWh+pgcDHIr5uWG9Nbvr1KarDRatz/KXMPEUyR9awMXpTDDQ==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.21.0.tgz",
+			"integrity": "sha512-shFLOS9yTM+wDEMWGhVP9TbqI6HPCtwEW81Uddz/Jwm7m+bAsvJjCnsDfLALcenSvecR3ZHox/k5F1w8hxsK7A==",
 			"bundleDependencies": [
 				"aria-hidden",
 				"embla-carousel",
@@ -32962,9 +32962,9 @@
 			"peer": true
 		},
 		"@kiva/kv-components": {
-			"version": "8.19.1",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.19.1.tgz",
-			"integrity": "sha512-wi/A+qvaEcjaATsQ12mwVfc1DSCjm1joBAdFgwNWh+pgcDHIr5uWG9Nbvr1KarDRatz/KXMPEUyR9awMXpTDDQ==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-8.21.0.tgz",
+			"integrity": "sha512-shFLOS9yTM+wDEMWGhVP9TbqI6HPCtwEW81Uddz/Jwm7m+bAsvJjCnsDfLALcenSvecR3ZHox/k5F1w8hxsK7A==",
 			"requires": {
 				"aria-hidden": "*",
 				"embla-carousel": "*",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@godaddy/terminus": "^4.11.0",
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
-		"@kiva/kv-components": "^8.19.1",
+		"@kiva/kv-components": "^8.21.0",
 		"@kiva/kv-shop": "^3.7.89",
 		"@kiva/kv-tokens": "^4.2.0",
 		"@mdi/js": "^7.4.47",

--- a/src/components/BorrowerProfile/ContributingPartners.vue
+++ b/src/components/BorrowerProfile/ContributingPartners.vue
@@ -24,7 +24,7 @@
 			</component>
 			<div>
 				<p class="tw-text-upper">
-					{{ matcher.ratio }}:1 MATCHING
+					{{ matcher.ratio ?? 0 }}:1 MATCHING
 				</p>
 				<p class="tw-mt-0.5">
 					{{ getDisplayName(matcher) }}

--- a/src/components/BorrowerProfile/ContributingPartners.vue
+++ b/src/components/BorrowerProfile/ContributingPartners.vue
@@ -24,7 +24,7 @@
 			</component>
 			<div>
 				<p class="tw-text-upper">
-					{{ matcher.ratio ?? 0 }}:1 MATCHING
+					{{ matcher.ratio }}:1 MATCHING
 				</p>
 				<p class="tw-mt-0.5">
 					{{ getDisplayName(matcher) }}

--- a/src/components/BorrowerProfile/ContributingPartners.vue
+++ b/src/components/BorrowerProfile/ContributingPartners.vue
@@ -24,7 +24,7 @@
 			</component>
 			<div>
 				<p class="tw-text-upper">
-					{{ (matcher.ratio ?? 0) + 1 }}X MATCHING
+					{{ matcher.ratio }}:1 MATCHING
 				</p>
 				<p class="tw-mt-0.5">
 					{{ getDisplayName(matcher) }}

--- a/src/components/Checkout/LoanMatcher.vue
+++ b/src/components/Checkout/LoanMatcher.vue
@@ -1,17 +1,42 @@
 <template>
-	<p class="tw-text-small tw-text-secondary matching-text">
+	<p class="tw-text-small tw-text-secondary">
 		<template v-if="enableMultiMatching && simultaneousMatching.length > 0">
 			{{ totalRatio }}x matching by contributing partners
 		</template>
 		<template v-else>
 			Matched by {{ matchingText }}
 		</template>
+		<button
+			:id="tooltipId"
+			type="button"
+			class="tw-inline-flex tw-text-secondary tw-align-middle tw--mt-0.5"
+			aria-label="More information about loan matching"
+		>
+			<kv-material-icon
+				class="tw-w-2 tw-h-2"
+				:icon="mdiInformationOutline"
+			/>
+		</button>
+		<kv-tooltip :controller="tooltipId">
+			Loans will be matched while funds last, up to the full loan amount.
+		</kv-tooltip>
 	</p>
 </template>
 
 <script>
+import { getCurrentInstance } from 'vue';
+import { KvTooltip, KvMaterialIcon } from '@kiva/kv-components';
+import { mdiInformationOutline } from '@mdi/js';
+
 export default {
 	name: 'LoanMatcher',
+	components: {
+		KvMaterialIcon,
+		KvTooltip,
+	},
+	data() {
+		return { mdiInformationOutline };
+	},
 	props: {
 		matchingText: {
 			type: String,
@@ -27,8 +52,13 @@ export default {
 		},
 	},
 	computed: {
+		tooltipId() {
+			return `loan-matcher-tooltip-${getCurrentInstance().uid}`;
+		},
 		totalRatio() {
-			return this.simultaneousMatching.reduce((sum, m) => sum + ((m.ratio ?? 0) + 1), 0);
+			// 1 base match + each org's ratio. e.g. 3 orgs each with ratio 1 => 1 + 1 + 1 + 1 = 4x
+			// or 1 org at ratio 2 + 2 orgs at ratio 1 => 1 + 2 + 1 + 1 = 5x
+			return this.simultaneousMatching.reduce((sum, m) => sum + m.ratio, 1);
 		},
 	},
 };

--- a/test/unit/specs/components/BorrowerProfile/ContributingPartners.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/ContributingPartners.spec.js
@@ -88,19 +88,19 @@ describe('ContributingPartners', () => {
 	describe('ratio display', () => {
 		it('displays the correct ratio for each partner', async () => {
 			const { findByText } = renderComponent({ simultaneousMatching: [capitalOne, tripadvisor] });
-			// Capital One ratio=3 → 4X MATCHING
-			await findByText('4X MATCHING');
-			// Tripadvisor ratio=1 → 2X MATCHING
-			await findByText('2X MATCHING');
+			// Capital One ratio=3 → 3:1 MATCHING
+			await findByText('3:1 MATCHING');
+			// Tripadvisor ratio=1 → 1:1 MATCHING
+			await findByText('1:1 MATCHING');
 		});
 
-		it('handles null ratio safely (displays 1X)', async () => {
+		it('handles null ratio safely (displays 0:1)', async () => {
 			const { findByText } = renderComponent({
 				simultaneousMatching: [{
 					managedAccountId: 1, displayName: 'Test Partner', ratio: null, logo: null
 				}],
 			});
-			await findByText('1X MATCHING');
+			await findByText('0:1 MATCHING');
 		});
 	});
 

--- a/test/unit/specs/components/BorrowerProfile/ContributingPartners.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/ContributingPartners.spec.js
@@ -94,14 +94,6 @@ describe('ContributingPartners', () => {
 			await findByText('1:1 MATCHING');
 		});
 
-		it('handles null ratio safely (displays 0:1)', async () => {
-			const { findByText } = renderComponent({
-				simultaneousMatching: [{
-					managedAccountId: 1, displayName: 'Test Partner', ratio: null, logo: null
-				}],
-			});
-			await findByText('0:1 MATCHING');
-		});
 	});
 
 	describe('partner name display', () => {

--- a/test/unit/specs/components/BorrowerProfile/ContributingPartners.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/ContributingPartners.spec.js
@@ -93,7 +93,6 @@ describe('ContributingPartners', () => {
 			// Tripadvisor ratio=1 → 1:1 MATCHING
 			await findByText('1:1 MATCHING');
 		});
-
 	});
 
 	describe('partner name display', () => {

--- a/test/unit/specs/components/Checkout/BasketItem.spec.js
+++ b/test/unit/specs/components/Checkout/BasketItem.spec.js
@@ -205,9 +205,9 @@ describe('BasketItem loan', () => {
 			};
 			const { getByTestId } = renderWithFlag(loan);
 			await flushPromises();
-			// Capital One 4x + Tripadvisor 2x = 6x total
+			// 1 base + Capital One ratio 3 + Tripadvisor ratio 1 = 5x
 			const matchingText = getByTestId('basket-loan-matching-text').textContent;
-			expect(matchingText).toContain('6x matching by contributing partners');
+			expect(matchingText).toContain('5x matching by contributing partners');
 		});
 
 		it('shows simultaneous matching text even when matchingText is also present', async () => {
@@ -222,7 +222,7 @@ describe('BasketItem loan', () => {
 			const { getByTestId } = renderWithFlag(loan);
 			await flushPromises();
 			const matchingText = getByTestId('basket-loan-matching-text').textContent;
-			expect(matchingText).toContain('6x matching by contributing partners');
+			expect(matchingText).toContain('5x matching by contributing partners');
 		});
 
 		it('falls back to matchingText when the multiMatching flag is off, even if matchers are present', async () => {


### PR DESCRIPTION
## Summary
- Updates Contributing Partners ratio display from `Nx MATCHING` to `ratio:1 MATCHING` to align with kv-ui-elements tooltip format change
- Fixes `totalRatio` calculation in `LoanMatcher` to use `1 base + sum of each org's ratio` (was incorrectly summing `ratio + 1` per org, e.g. 2 orgs with ratio 1 would show 4x instead of 3x)
- Adds an info tooltip to `LoanMatcher` with the text "Loans will be matched while funds last, up to the full loan amount."
- Bumps `@kiva/kv-components` from `8.19.1` to `8.21.0`
- Updates `BasketItem` unit tests to reflect corrected `totalRatio` calculation

<img width="549" height="174" alt="Screenshot 2026-07-08 at 11 43 44 AM" src="https://github.com/user-attachments/assets/0eb66943-22b7-4fe6-9ce4-08edd834b450" />
