### PR TITLE
fix: update stats typography in borrower profile

### DIFF
--- a/src/components/BorrowerProfile/CountryInfo.vue
+++ b/src/components/BorrowerProfile/CountryInfo.vue
@@ -22,7 +22,7 @@
 			</h2>
 			<div class="tw-flex tw-mb-3">
 				<p class="tw-flex-auto" data-testid="bp-country-aai">
-					<span class="tw-block tw-text-headline" data-testid="bp-country-aai-value">
+					<span class="tw-block tw-text-headline-two" data-testid="bp-country-aai-value">
 						{{ avgAnnualIncomeFormatted }}
 					</span>
 					<span class="tw-block tw-text-upper tw-text-secondary">
@@ -30,7 +30,7 @@
 					</span>
 				</p>
 				<p class="tw-flex-auto" data-testid="bp-country-loans-fundraising">
-					<span class="tw-block tw-text-headline" data-testid="bp-country-loans-fundraising-value">
+					<span class="tw-block tw-text-headline-two" data-testid="bp-country-loans-fundraising-value">
 						{{ numLoansFundraising }}
 					</span>
 					<span class="tw-block tw-text-upper tw-text-secondary">


### PR DESCRIPTION
Forgot about this typography update to make numbers smaller than title

<img width="623" height="220" alt="image" src="https://github.com/user-attachments/assets/cfea3f1d-2962-4186-9cb1-ab4e8c6d2ed3" />
