### PR TITLE
feat: show AI loan pill in borrower profile summary card (MP-2994)

### DIFF
--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -121,7 +121,10 @@
 					</span>
 				</summary-tag>
 
-				<summary-tag data-testid="bp-summary-activity-tag" v-if="activityName">
+				<summary-tag v-if="aiPill" data-testid="bp-summary-ai-pill">
+					{{ aiPill }}
+				</summary-tag>
+				<summary-tag v-else-if="activityName" data-testid="bp-summary-activity-tag">
 					{{ activityName }}
 				</summary-tag>
 			</template>
@@ -147,6 +150,7 @@ import {
 	KvIconButton, KvMaterialIcon, KvLoadingPlaceholder, KvTextLink,
 } from '@kiva/kv-components';
 import useBorrowerProfileDefinitions from '#src/composables/useBorrowerProfileDefinitions';
+import { fetchAiLoanPills } from '#src/util/aiLoanPillsUtils';
 import BorrowerImage from './BorrowerImage';
 import BorrowerName from './BorrowerName';
 import ContentLightbox from './ContentLightbox';
@@ -266,6 +270,7 @@ export default {
 			pfpMinLenders: 0,
 			numLenders: 0,
 			totalComments: 0,
+			aiPill: '',
 		};
 	},
 	computed: {
@@ -286,13 +291,20 @@ export default {
 	},
 	methods: {
 		async fetchSummaryCardData() {
+			this.aiPill = '';
 			this.$kvTrackEvent(
 				'Borrower profile',
 				'borrower profile status',
 				this.status
 			);
 
-			const { data } = await this.apollo.query({ query: mountQuery, variables: { loanId: this.loanId } });
+			// Fetch AI pills alongside the summary data so the loader stays up until both
+			// resolve, letting the pill (or activity fallback) render once instead of
+			// popping in after the summary.
+			const [{ data }] = await Promise.all([
+				this.apollo.query({ query: mountQuery, variables: { loanId: this.loanId } }),
+				this.fetchAiPills(),
+			]);
 			const loan = data?.lend?.loan;
 			this.inPfp = loan?.inPfp ?? false;
 			this.pfpMinLenders = loan?.pfpMinLenders ?? 0;
@@ -311,6 +323,10 @@ export default {
 			}
 			this.totalComments = loan?.comments?.totalCount ?? 0;
 			this.isLoading = false;
+		},
+		async fetchAiPills() {
+			const result = await fetchAiLoanPills(this.apollo, [this.loanId]);
+			this.aiPill = result?.[0]?.pills?.[0] ?? '';
 		},
 		async showDefinition({ cid, sfid }) {
 			const result = await this.definitions.resolveDefinition({ cid, sfid });

--- a/test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js
@@ -3,6 +3,8 @@ import { mount, flushPromises } from '@vue/test-utils';
 import SummaryCard from '#src/components/BorrowerProfile/SummaryCard';
 import { globalOptions } from '../../../specUtils';
 
+vi.mock('#src/util/logReadQueryError');
+
 // Builds a Contentful apollo response containing a borrower-profile-definitions group.
 function makeContentfulResponse(entries) {
 	return {
@@ -140,6 +142,7 @@ describe('SummaryCard', () => {
 		};
 		const query = vi.fn()
 			.mockResolvedValueOnce({}) // mountQuery from mounted()
+			.mockResolvedValueOnce({ data: { getLoanPills: { values: [] } } }) // aiLoanPills from mounted()
 			.mockResolvedValueOnce(makeContentfulResponse([])) // Contentful: no matching entry
 			.mockResolvedValueOnce({ // Salesforce fallback
 				data: { general: { salesforceSolution } },
@@ -161,5 +164,139 @@ describe('SummaryCard', () => {
 		expect(wrapper.findComponent({ name: 'KvLightbox' }).props('visible')).toBe(true);
 		expect(wrapper.findComponent({ name: 'KvLightbox' }).props('title')).toBe(salesforceSolution.name);
 		expect(wrapper.get('[data-testid="stub-lightbox"]').html()).toContain(salesforceSolution.note);
+	});
+});
+
+describe('SummaryCard AI pills', () => {
+	const loanResponse = {
+		data: {
+			lend: {
+				loan: {
+					id: 12345,
+					activity: { id: 1, name: 'Retail' },
+					distributionModel: 'fieldPartner',
+					fundraisingPercent: 0.5,
+					fundraisingTimeLeft: '5 days',
+					fundraisingTimeLeftMilliseconds: 1,
+					geocode: { city: 'Lima', state: '', country: { id: 1, name: 'Peru' } },
+					loanAmount: '600',
+					loanFundraisingInfo: { id: 1, fundedAmount: '300', reservedAmount: '0' },
+					plannedExpirationDate: '2026-12-01',
+					unreservedAmount: '300',
+					inPfp: false,
+					pfpMinLenders: 0,
+					lenders: { totalCount: 3 },
+					comments: { totalCount: 0 },
+				},
+			},
+		},
+	};
+
+	// Mounts SummaryCard with a controllable apollo.query mock; callers queue the
+	// mount-query response first, then the AI-pills response.
+	function mountWithQuery(query) {
+		return mount(SummaryCard, {
+			global: {
+				...globalOptions,
+				mocks: {
+					...globalOptions.mocks,
+					$route: { params: { id: '12345' } },
+				},
+				provide: {
+					...globalOptions.provide,
+					apollo: { ...globalOptions.provide.apollo, query },
+				},
+				stubs: {
+					KvLightbox: {
+						name: 'KvLightbox',
+						props: ['visible', 'title'],
+						template: '<div v-if="visible"><slot /></div>',
+					},
+				},
+			},
+		});
+	}
+
+	it('renders a single AI pill in place of the activity tag when pills are returned', async () => {
+		const query = vi.fn()
+			.mockResolvedValueOnce(loanResponse) // mountQuery
+			.mockResolvedValueOnce({
+				data: {
+					getLoanPills: {
+						values: [
+							{ loanId: 12345, pills: ['Woman-owned', 'First loan'] },
+						]
+					}
+				}
+			}); // aiLoanPills
+		const wrapper = mountWithQuery(query);
+		await flushPromises();
+
+		const pill = wrapper.find('[data-testid="bp-summary-ai-pill"]');
+		expect(pill.exists()).toBe(true);
+		expect(pill.text()).toBe('Woman-owned'); // only the first pill
+		expect(wrapper.findAll('[data-testid="bp-summary-ai-pill"]')).toHaveLength(1);
+		expect(wrapper.find('[data-testid="bp-summary-country-tag"]').exists()).toBe(true);
+		expect(wrapper.find('[data-testid="bp-summary-activity-tag"]').exists()).toBe(false);
+		expect(query).toHaveBeenNthCalledWith(2, expect.objectContaining({ variables: { loanIds: [12345] } }));
+	});
+
+	it('falls back to the activity tag when no pills are returned', async () => {
+		const query = vi.fn()
+			.mockResolvedValueOnce(loanResponse) // mountQuery
+			.mockResolvedValueOnce({ data: { getLoanPills: { values: [] } } }); // aiLoanPills
+		const wrapper = mountWithQuery(query);
+		await flushPromises();
+
+		expect(wrapper.find('[data-testid="bp-summary-ai-pill"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="bp-summary-activity-tag"]').text()).toBe('Retail');
+		expect(wrapper.find('[data-testid="bp-summary-country-tag"]').exists()).toBe(true);
+	});
+
+	it('falls back to the activity tag when the loan entry has an empty pills list', async () => {
+		const query = vi.fn()
+			.mockResolvedValueOnce(loanResponse) // mountQuery
+			.mockResolvedValueOnce({
+				data: { getLoanPills: { values: [{ loanId: 12345, pills: [] }] } },
+			}); // aiLoanPills: loan entry present, but no pills for it
+		const wrapper = mountWithQuery(query);
+		await flushPromises();
+
+		expect(wrapper.find('[data-testid="bp-summary-ai-pill"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="bp-summary-activity-tag"]').text()).toBe('Retail');
+	});
+
+	it('falls back to the activity tag when the pills query rejects', async () => {
+		const query = vi.fn()
+			.mockResolvedValueOnce(loanResponse) // mountQuery
+			.mockRejectedValueOnce(new Error('network error')); // aiLoanPills fails
+		const wrapper = mountWithQuery(query);
+		await flushPromises();
+
+		expect(wrapper.find('[data-testid="bp-summary-ai-pill"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="bp-summary-activity-tag"]').text()).toBe('Retail');
+	});
+
+	it('keeps the loader until the pills fetch resolves (no activity-then-pill pop)', async () => {
+		let resolvePills;
+		const pillsPromise = new Promise(resolve => { resolvePills = resolve; });
+		const query = vi.fn()
+			.mockResolvedValueOnce(loanResponse) // mountQuery
+			.mockReturnValueOnce(pillsPromise); // aiLoanPills still pending
+		const wrapper = mountWithQuery(query);
+		await flushPromises();
+
+		// The mount query has resolved but pills are still in flight, so the card is
+		// still loading: the tags must not render the activity tag (which would then
+		// pop to the pill once pills arrive).
+		expect(wrapper.find('[data-testid="bp-summary-activity-tag"]').exists()).toBe(false);
+		expect(wrapper.find('[data-testid="bp-summary-ai-pill"]').exists()).toBe(false);
+
+		resolvePills({
+			data: { getLoanPills: { values: [{ loanId: 12345, pills: ['Woman-owned'] }] } },
+		});
+		await flushPromises();
+
+		expect(wrapper.find('[data-testid="bp-summary-ai-pill"]').text()).toBe('Woman-owned');
 	});
 });


### PR DESCRIPTION
## Summary

Renders an AI loan "pill" on the borrower profile page (`/lend/:id`) for the
single loan shown, completing the AI Loan Pill Emphasis rollout that already
shipped on My Kiva, Checkout, and the borrower profile side sheet.

When the backend returns pills for the loan, the summary card's tag row shows
**one** AI pill in place of the activity tag. The country tag always stays.
When there are no pills (or the query errors), the row falls back to the
existing activity tag — matching the side sheet's fallback behavior.

## What changed

- **`src/components/BorrowerProfile/SummaryCard.vue`**
  - Fetches pills for the single loan via `fetchAiLoanPills(apollo, [loanId])`
    from `#src/util/aiLoanPillsUtils`, mirroring the side sheet reference.
  - New `aiPill` string; `fetchAiPills()` sets it to `result?.[0]?.pills?.[0] ?? ''`.
  - Pills are fetched **client-side, in parallel** with the summary mount query
    (`Promise.all`), so there is no added serial latency and SSR/CDN render is
    unaffected.
  - The card's loader is held until both the mount query and pills resolve, so
    the tag renders once instead of the activity tag popping to a pill.
  - Tag row: `country` (always) → AI pill if present, else activity tag.
- **`test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js`** — new
  `SummaryCard AI pills` suite (details below).

## Behavior

| Backend response | Tag row (slot 2) |
| --- | --- |
| Pills present | First AI pill |
| Entry present, empty `pills` | Activity tag (fallback) |
| Empty `values` | Activity tag (fallback) |
| Query error | Activity tag (fallback), no card stall |

## Related links

- Jira: [MP-2994 – Implement AI pills in borrower profile page](https://kiva.atlassian.net/browse/MP-2994)
- Epic: [MP-2048 – AI Loan Pill Emphasis](https://kiva.atlassian.net/browse/MP-2048)

## Related tests

`test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js` — run with `npm run unit -- SummaryCard` (8/8 passing):

- renders a single AI pill in place of the activity tag when pills are returned
  (asserts only the first of several pills renders, country tag stays, and the
  pills query fires with `{ loanIds: [12345] }`)
- falls back to the activity tag when no pills are returned
- falls back to the activity tag when the loan entry has an empty pills list
- falls back to the activity tag when the pills query rejects
- keeps the loader until the pills fetch resolves (no activity-then-pill pop)

## Notes / trade-off

Because the change reuses the single `isLoading` flag, the summary card's loader
now also waits on the pills fetch (not just the tag row). Pills run concurrently
with the existing mount query, so there's no added serial latency, and a pills
**error** is swallowed by the util and falls back to the activity tag without
stalling the card.