### PR TITLE
fix: use kv avatar component with integration fallback

### DIFF
--- a/src/components/Portfolio/KivaCardListItem.vue
+++ b/src/components/Portfolio/KivaCardListItem.vue
@@ -16,12 +16,11 @@
 								'portfolio', 'click', 'View Kiva Card redeemer', redeemer.lenderPublicId
 							]"
 						>
-							<img
-								v-if="redeemer.image?.url"
-								:src="redeemer.image.url"
-								:alt="`${redeemer.name} profile image`"
-								class="tw-rounded-full tw-object-cover tw-w-10 tw-h-10"
-							>
+							<KvUserAvatar
+								:lender-name="redeemer.name"
+								:lender-image-url="redeemer.image?.url || ''"
+								class="tw-w-10 tw-h-10"
+							/>
 						</a>
 						<a
 							:href="lenderUrl"
@@ -155,7 +154,7 @@
 </template>
 
 <script>
-import { KvGrid } from '@kiva/kv-components';
+import { KvGrid, KvUserAvatar } from '@kiva/kv-components';
 import {
 	ACTIVE, REDEEMED, EXPIRED, CANCELLED,
 } from '#src/api/fixtures/KivaCardStatusEnum';
@@ -165,6 +164,7 @@ export default {
 	name: 'KivaCardListItem',
 	components: {
 		KvGrid,
+		KvUserAvatar,
 	},
 	props: {
 		card: {

--- a/test/unit/specs/components/Portfolio/KivaCardListItem.spec.js
+++ b/test/unit/specs/components/Portfolio/KivaCardListItem.spec.js
@@ -33,6 +33,10 @@ const renderItem = card => render(KivaCardListItem, {
 		},
 		stubs: {
 			KvGrid: { template: '<div><slot /></div>' },
+			KvUserAvatar: {
+				props: ['lenderName', 'lenderImageUrl'],
+				template: '<div data-testid="avatar" :data-name="lenderName" :data-image="lenderImageUrl"></div>',
+			},
 		},
 	},
 });
@@ -65,6 +69,36 @@ describe('KivaCardListItem', () => {
 		const link = getByText('Casey');
 		expect(link.getAttribute('href')).toBe('/lender/casey8526');
 		expect(getByText('Redeemed on Date:')).toBeTruthy();
+	});
+
+	it('passes the redeemer photo to the avatar when present', () => {
+		const { getByTestId } = renderItem({
+			status: 'redeemed',
+			redeemTime: 1487000000,
+			redeemer: {
+				isPublic: true,
+				name: 'Casey',
+				lenderPublicId: 'casey8526',
+				image: { id: '1', url: 'https://example.com/a.jpg' },
+			},
+		});
+		expect(getByTestId('avatar').getAttribute('data-image')).toBe('https://example.com/a.jpg');
+	});
+
+	it('renders a fallback avatar for a public redeemer with no profile photo', () => {
+		const { getByTestId } = renderItem({
+			status: 'redeemed',
+			redeemTime: 1487000000,
+			redeemer: {
+				isPublic: true,
+				name: 'Jane',
+				lenderPublicId: 'jane1',
+				image: null,
+			},
+		});
+		const avatar = getByTestId('avatar');
+		expect(avatar.getAttribute('data-name')).toBe('Jane');
+		expect(avatar.getAttribute('data-image')).toBe('');
 	});
 
 	it('shows the private redeemer name without a profile link', () => {


### PR DESCRIPTION
Fixed issue identified with internal testing of `kiva-cards-beta`. We weren't using the avatar component, so there was no fallback for users sent a Kiva card who didn't have an profile photo.

Now with fallback avatar:

<img width="298" height="366" alt="Screenshot 2026-07-13 at 8 24 29 AM" src="https://github.com/user-attachments/assets/5fd959e8-73ba-4373-b5ee-f010fdc9b400" />
