### PR TITLE
fix(BorrowerProfile): show delinquent status on the borrower profile AD-359

### DIFF
--- a/.storybook/stories/BorrowerProfile/LoanProgress.stories.js
+++ b/.storybook/stories/BorrowerProfile/LoanProgress.stories.js
@@ -96,6 +96,21 @@ export const PayingBack = () => ({
 	`,
 });
 
+export const PayingBackDelinquent = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="payingBack"
+			:is-delinquent="true"
+			:progress-percent="0.60"
+			money-left="400.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+PayingBackDelinquent.storyName = 'Paying Back / Delinquent';
+
 export const Ended = () => ({
 	components: { LoanProgress },
 	template: `

--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -116,7 +116,7 @@
 				</div>
 				<div v-else class="tw-flex tw-flex-auto">
 					<span class="tw-text-h3 tw-block tw-m-0">
-						Paying back
+						{{ isDelinquent ? 'Paying back delinquent' : 'Paying back' }}
 					</span>
 					<div class="tw-flex-auto tw-text-right">
 						<p class="tw-text-h3 tw-m-0" data-testid="bp-summary-amount-to-go">
@@ -191,6 +191,10 @@ export default {
 		loanStatus: {
 			type: String,
 			default: 'fundraising',
+		},
+		isDelinquent: {
+			type: Boolean,
+			default: false,
 		},
 		numberOfLenders: {
 			type: Number,

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -83,6 +83,7 @@
 						:progress-percent="effectiveProgressPercent"
 						:time-left="timeLeft"
 						:loan-status="inPfp ? 'pfp' : status"
+						:is-delinquent="delinquent"
 						:number-of-lenders="numLenders"
 						:pfp-min-lenders="pfpMinLenders"
 						:loading="isLoading"
@@ -161,6 +162,7 @@ export const summaryCardFragment = gql`fragment summaryCardFields on LoanBasic {
 	}
 	name
 	status
+	delinquent
 	use
 	anonymizationLevel
 	borrowerCount
@@ -205,43 +207,11 @@ const mountQuery = gql`
 		lend {
 			loan(id: $loanId) {
 				id
-				status
-				activity {
-					id
-					name
-				}
-				distributionModel
-				fundraisingPercent @client
-				fundraisingTimeLeft @client
-				fundraisingTimeLeftMilliseconds @client
-				geocode {
-					city
-					state
-					country {
-						id
-						name
-					}
-				}
-				loanAmount
-				paidAmount
-				loanFundraisingInfo {
-					id
-					fundedAmount
-					reservedAmount
-				}
-				plannedExpirationDate
-				unreservedAmount @client
-				inPfp
-				pfpMinLenders
-				lenders {
-					totalCount
-				}
-				comments {
-					totalCount
-				}
+				...summaryCardFields
 			}
 		}
 	}
+	${summaryCardFragment}
 `;
 
 export default {
@@ -309,6 +279,9 @@ export default {
 		},
 		status() {
 			return this.loan?.status ?? '';
+		},
+		delinquent() {
+			return this.loan?.delinquent ?? false;
 		},
 		use() {
 			return this.loan?.fullLoanUse ?? '';


### PR DESCRIPTION
The page was missing the actual "delinquent" message that appears on the classic borrower profile. This adds that and refactors the SummaryCard mount query to actually use the fields fragment, avoiding duplication.

### Before
<img width="459" height="89" alt="Screenshot 2026-07-13 at 10 43 57 AM" src="https://github.com/user-attachments/assets/a665f6e8-27c7-436c-8c7d-b75f4055447e" />

### After
<img width="454" height="81" alt="Screenshot 2026-07-13 at 10 44 07 AM" src="https://github.com/user-attachments/assets/0cf357a6-7b42-4515-a85a-0de0961db435" />