### PR TITLE
feat(MP-3036): add AI loan pills to the goal recommended-loan card

### DIFF
--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -357,14 +357,16 @@ const categories = getCategories(props.categoriesLoanCount, props.totalLoans);
 const selectedCategory = ref(categories[0]);
 
 // This container doesn't have the same multi-step flow as the modal,
-// so we can always show the recommended loan section when enabled
-const showPage = true;
+// so we can always show the recommended loan section when enabled.
+// A reactive ref (not a bare boolean) so the composable can watch it.
+const showPage = ref(true);
 const loadedSetData = ref(false);
 const {
 	showRecommendLoanAfterGoalView,
 	hasRecommendedLoans,
 	isLoadingRecommendedLoan,
 	recommendLoanHeaderDetails,
+	recommendedLoan,
 	recommendLoanCardProps,
 	recommendLoanIsInBasket,
 	enterRecommendedLoanStepAfterGoalSave,
@@ -386,16 +388,17 @@ const {
 	entrypoint: GOAL_RECOMMENDED_LOAN_ENTRYPOINT_GOALS_PAGE,
 	additionalExcludedLoanIds: toRef(props, 'excludedLoanIds'),
 	appConfig: $appConfig,
+	apollo,
 });
 
 const addToBasket = () => {
-	const { loan, loanId } = recommendLoanCardProps.value;
+	const { loanId } = recommendLoanCardProps.value;
 	if (!loanId) return;
 	const lendAmount = recommendLoanForGoalRef.value?.getSelectedAmount();
 	trackAddToBasketClick(loanId, lendAmount);
-	// Delegate to parent (GoalSetting.vue) which uses borrower-profile-exp-mixin.
-	// Pass the recommended loan so the parent can skip borrowerProfileSideSheetQuery.
-	emit('add-to-basket', { loanId, lendAmount, loan });
+	// Delegate to the parent, which owns the add-to-basket flow. Pass the raw recommended
+	// loan (not the card's blanked copy) so the parent can skip re-fetching it.
+	emit('add-to-basket', { loanId, lendAmount, loan: recommendedLoan.value });
 };
 
 const handleCheckoutClick = () => {

--- a/src/components/MyKiva/GoalSettingModal.vue
+++ b/src/components/MyKiva/GoalSettingModal.vue
@@ -304,6 +304,7 @@ const {
 	hasRecommendedLoans,
 	isLoadingRecommendedLoan,
 	recommendLoanHeaderDetails,
+	recommendedLoan,
 	recommendLoanCardProps,
 	recommendLoanIsInBasket,
 	resetRecommendedLoanState,
@@ -380,12 +381,13 @@ const recommendLoanForGoalContentRef = ref(null);
 
 const addToBasket = () => {
 	const lendAmount = recommendLoanForGoalContentRef.value?.getSelectedAmount();
-	const { loan, loanId } = recommendLoanCardProps.value;
+	const { loanId } = recommendLoanCardProps.value;
 	trackAddToBasketClick(loanId, lendAmount);
 	emit('add-to-basket', {
 		loanId,
 		lendAmount,
-		loan,
+		// Raw recommended loan, not the card's blanked copy.
+		loan: recommendedLoan.value,
 		onError: onAddToBasketError,
 	});
 };

--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -363,6 +363,7 @@ const {
 	hasRecommendedLoans,
 	isLoadingRecommendedLoan,
 	recommendLoanHeaderDetails,
+	recommendedLoan,
 	recommendLoanCardProps,
 	recommendLoanIsInBasket,
 	enterRecommendedLoanStepAfterGoalSave,
@@ -544,7 +545,12 @@ const setGoal = async preferences => {
 
 const handleAddToBasket = payload => {
 	trackAddToBasketClick();
-	handleAddRecommendedLoanToBasket({ ...payload, onError: onAddToBasketError });
+	// Prefer the raw recommended loan over the card's blanked copy in the forwarded payload.
+	handleAddRecommendedLoanToBasket({
+		...payload,
+		loan: recommendedLoan.value ?? payload.loan,
+		onError: onAddToBasketError,
+	});
 };
 
 const closeGoalModal = () => {

--- a/src/composables/useGoalSettingRecommendedLoan.js
+++ b/src/composables/useGoalSettingRecommendedLoan.js
@@ -5,6 +5,7 @@ import {
 } from 'vue';
 import { useRouter } from 'vue-router';
 import useTipMessage from '#src/composables/useTipMessage';
+import { fetchAiLoanPills } from '#src/util/aiLoanPillsUtils';
 
 export const GOAL_RECOMMENDED_LOAN_ENTRYPOINT_PORTFOLIO = 'portfolio';
 export const GOAL_RECOMMENDED_LOAN_ENTRYPOINT_POST_CHECKOUT = 'post-checkout';
@@ -17,10 +18,11 @@ const ENTRYPOINT_TRACK_CATEGORY = {
 };
 
 /**
- * Recommended-loan step state shared by {@link GoalSettingModal.vue} and
- * {@link GoalSettingContainer.vue}.
+ * Recommended-loan step state shared by the goal-setting hosts (the goal modal, the
+ * goals page, and the post-checkout thanks page).
  *
- * The host component owns refs and passes them in; this composable does not call `defineProps`.
+ * The host component owns the reactive inputs and passes them in; this composable does
+ * not declare its own props.
  *
  * @param {object} options
  * @param {Function} options.emit — Host emit function (`defineEmits`), e.g. `set-goal`.
@@ -30,21 +32,23 @@ const ENTRYPOINT_TRACK_CATEGORY = {
  *   `LoanReservation` entries’ **`id`** (the loan id) are sent to `getRecommendedLoans` as
  *   exclusions (`loanIds.none`) and drive the “recommended loan already in basket” check via
  *   **`__typename`**. The array is also forwarded on the loan card props.
- * @param {object} options.selectedGoalNumber — Vue ref from the modal; `.value` is goal target (loan count).
- * @param {object} options.selectedCategory — Vue ref from the modal; `.value` has `name`, `badgeId`.
- * @param {object} options.show — Vue ref from the modal; `.value` is whether the lightbox is open.
- * @param {object} options.goalProgress — Vue ref from `useGoalData`; `.value` is loans toward goal this year.
- * @param {Function} options.getRecommendedLoans — From `useGoalData`; returns a promise of loans for a category id.
- * @param {Function} options.getCtaHref — From `useGoalData`; builds lend URL + optional header query.
- * @param {object} options.userGoal — Vue ref from `useGoalData`; `.value` is saved goal or null (`target`, `category`).
+ * @param {object} options.selectedGoalNumber — Vue ref; `.value` is the goal target (loan count).
+ * @param {object} options.selectedCategory — Vue ref; `.value` has `name`, `badgeId`.
+ * @param {object} options.show — Vue ref (must be reactive, not a bare boolean); `.value` is
+ *   whether the recommended-loan view is active — a modal's lightbox-open flag, or a constant
+ *   `true` in hosts that always show the view.
+ * @param {object} options.goalProgress — Vue ref; `.value` is loans completed toward the goal this year.
+ * @param {Function} options.getRecommendedLoans — Returns a promise of recommended loans for a category id.
+ * @param {Function} options.getCtaHref — Builds the lend URL with an optional header query.
+ * @param {object} options.userGoal — Vue ref; `.value` is the saved goal or null (`target`, `category`).
  * @param {object} [options.additionalExcludedLoanIds] — Optional Vue ref; `.value` is an array of
  *   loan ids to also exclude from the recommended-loan fetch (e.g. loans the user just made).
- * @param {Function} options.kvTrackEvent — Analytics helper from GoalSettingModal (`$kvTrackEvent`).
+ * @param {Function} options.kvTrackEvent — Analytics tracking function.
  * @param {string} [options.entrypoint] — Where the composable is mounted. Use one of the exported
  *   `GOAL_RECOMMENDED_LOAN_ENTRYPOINT_*` constants; selects the analytics category for
  *   recommended-loan events. Omit to disable recommended-loan tracking.
- * @param {object} [options.appConfig] — From GoalSettingModal (`$appConfig`), e.g. `photoPath`.
- * @param {object} options.apollo — Apollo client instance for tip message mutations.
+ * @param {object} [options.appConfig] — App config values, e.g. `photoPath`.
+ * @param {object} options.apollo — Apollo client instance for tip message mutations and AI loan pill fetches.
  */
 export default function useGoalSettingRecommendedLoan({
 	emit,
@@ -70,7 +74,16 @@ export default function useGoalSettingRecommendedLoan({
 	const recommendedLoans = ref([]);
 	const recommendedLoanIndex = ref(0);
 	const recommendedLoan = ref(null);
-	const isLoadingRecommendedLoan = ref(false);
+	const isLoadingRecommendedLoanData = ref(false);
+	const isLoadingRecommendedLoanPills = ref(false);
+	const recommendedLoanPills = ref([]);
+
+	// Keep the host's loading skeleton up until BOTH the loan and its AI pills have
+	// resolved, so the card appears once with its final callouts instead of rendering
+	// the loan's own tags and then popping them out when the pills arrive.
+	const isLoadingRecommendedLoan = computed(() => (
+		isLoadingRecommendedLoanData.value || isLoadingRecommendedLoanPills.value
+	));
 
 	const showRecommendLoanAfterGoalView = computed(() => (
 		goalRecommendedLoanEnable.value && showPostGoalLoanRecommendation.value
@@ -97,6 +110,25 @@ export default function useGoalSettingRecommendedLoan({
 		return segments;
 	});
 
+	// The loan object handed to the card. When AI pills are present, blank the loan's
+	// own callout sources (activity/sector/tags/themes) so the loan card renders only
+	// the pills instead of appending them after its default callouts. Derived on its own
+	// so the (cloned) loan reference stays stable across basket/route changes and the card
+	// doesn't needlessly re-process it.
+	const recommendedLoanForCard = computed(() => {
+		const loan = recommendedLoan.value;
+		if (!loan?.id || !recommendedLoanPills.value.length) {
+			return loan;
+		}
+		return {
+			...loan,
+			activity: {},
+			sector: {},
+			tags: [],
+			themes: [],
+		};
+	});
+
 	const recommendLoanCardProps = computed(() => {
 		const loan = recommendedLoan.value;
 		const photoPath = appConfig?.photoPath ?? '';
@@ -113,10 +145,12 @@ export default function useGoalSettingRecommendedLoan({
 		if (!loan?.id) {
 			return base;
 		}
+		const pills = recommendedLoanPills.value;
 		return {
 			...base,
-			loan,
+			loan: recommendedLoanForCard.value,
 			loanId: loan.id,
+			...(pills.length ? { customCallouts: pills } : {}),
 		};
 	});
 
@@ -150,15 +184,17 @@ export default function useGoalSettingRecommendedLoan({
 		trackRecommendedLoanEvent('click', isPostCheckout ? 'complete-order' : 'go-to-checkout');
 	};
 
-	// Clears the recommended-loan data + in-flight flag. Does NOT touch
-	// `showPostGoalLoanRecommendation` so that watch handlers can call it
+	// Clears the recommended-loan data (loan + pills) and both in-flight flags. Does NOT
+	// touch `showPostGoalLoanRecommendation` so that watch handlers can call it
 	// without re-triggering themselves (resetting the step flag from inside
 	// the view watch would cause a recursive flip).
 	const clearRecommendedLoanData = () => {
 		recommendedLoans.value = [];
 		recommendedLoanIndex.value = 0;
 		recommendedLoan.value = null;
-		isLoadingRecommendedLoan.value = false;
+		recommendedLoanPills.value = [];
+		isLoadingRecommendedLoanData.value = false;
+		isLoadingRecommendedLoanPills.value = false;
 	};
 
 	const resetRecommendedLoanState = () => {
@@ -170,7 +206,7 @@ export default function useGoalSettingRecommendedLoan({
 		if (goalRecommendedLoanEnable.value) {
 			// Mark in-flight synchronously so the host's loading state covers
 			// the upcoming fetch (avoids a brief "no loan yet" flicker).
-			isLoadingRecommendedLoan.value = true;
+			isLoadingRecommendedLoanData.value = true;
 			showPostGoalLoanRecommendation.value = true;
 			trackRecommendedLoanEvent('view', 'confirm-goal-set-recommended-loan');
 		}
@@ -224,17 +260,39 @@ export default function useGoalSettingRecommendedLoan({
 				return;
 			}
 			clearRecommendedLoanData();
-			isLoadingRecommendedLoan.value = true;
+			isLoadingRecommendedLoanData.value = true;
 			try {
 				recommendedLoans.value = await getRecommendedLoans(categoryId, filteredLoanIds.value);
 				recommendedLoan.value = recommendedLoans.value[0] ?? null;
 			} catch {
 				$showTipMsg('There was a problem loading a loan.', 'error');
 			} finally {
-				isLoadingRecommendedLoan.value = false;
+				isLoadingRecommendedLoanData.value = false;
 			}
 		},
 	);
+
+	// Fetch AI loan pills for whichever loan is currently recommended, refetching when
+	// the recommended loan advances. The pills-loading flag folds into the host skeleton
+	// (see `isLoadingRecommendedLoan`) so the card waits for pills and appears once with
+	// its final callouts. Leaves pills empty (card falls back to its own callouts) when
+	// the query returns nothing or errors.
+	watch(() => recommendedLoan.value?.id, async loanId => {
+		recommendedLoanPills.value = [];
+		if (!loanId) {
+			isLoadingRecommendedLoanPills.value = false;
+			return;
+		}
+		isLoadingRecommendedLoanPills.value = true;
+		const result = await fetchAiLoanPills(apollo, [loanId]);
+		// Ignore a late response if the recommended loan advanced while awaiting; the
+		// newer invocation owns the loading flag from here.
+		if (recommendedLoan.value?.id !== loanId) {
+			return;
+		}
+		recommendedLoanPills.value = result?.[0]?.pills ?? [];
+		isLoadingRecommendedLoanPills.value = false;
+	});
 
 	const onAddToBasketError = () => {
 		recommendedLoan.value = null;
@@ -249,6 +307,10 @@ export default function useGoalSettingRecommendedLoan({
 		hasRecommendedLoans,
 		isLoadingRecommendedLoan,
 		recommendLoanHeaderDetails,
+		// Raw recommended loan for domain actions (add-to-basket); its callout fields are never blanked.
+		recommendedLoan,
+		// Loan-card props. `loan` here is callout-blanked for display when pills exist —
+		// use `recommendedLoan` for domain actions instead.
 		recommendLoanCardProps,
 		recommendLoanIsInBasket,
 		resetRecommendedLoanState,

--- a/src/composables/useGoalSettingRecommendedLoan.js
+++ b/src/composables/useGoalSettingRecommendedLoan.js
@@ -309,8 +309,7 @@ export default function useGoalSettingRecommendedLoan({
 		recommendLoanHeaderDetails,
 		// Raw recommended loan for domain actions (add-to-basket); its callout fields are never blanked.
 		recommendedLoan,
-		// Loan-card props. `loan` here is callout-blanked for display when pills exist —
-		// use `recommendedLoan` for domain actions instead.
+		// Loan-card props; its `loan` is the display-blanked counterpart of `recommendedLoan`.
 		recommendLoanCardProps,
 		recommendLoanIsInBasket,
 		resetRecommendedLoanState,

--- a/test/unit/specs/components/GoalSetting/GoalSettingContainer.spec.js
+++ b/test/unit/specs/components/GoalSetting/GoalSettingContainer.spec.js
@@ -1,0 +1,150 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import { ref, isRef } from 'vue';
+import GoalSettingContainer from '#src/components/GoalSetting/GoalSettingContainer';
+
+// Spy on the recommended-loan composable so we can assert how the container wires it.
+const { recommendedLoanSpy } = vi.hoisted(() => ({
+	recommendedLoanSpy: vi.fn(),
+}));
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('#src/composables/useGoalData', () => ({
+	GOAL_STATUS: { COMPLETED: 'completed' },
+	GOALS_CURRENT_YEAR: 2026,
+	default: () => ({
+		userGoal: ref(null),
+		loadGoalData: vi.fn().mockResolvedValue(),
+		storeGoalPreferences: vi.fn(),
+		loading: ref(false),
+		getCategories: vi.fn(() => [
+			{
+				id: 1, badgeId: 'women-equality', name: 'Women', eventProp: 'women',
+			},
+		]),
+		getCtaHref: vi.fn(() => '/lend'),
+		goalProgress: ref(0),
+		getLoanStatsByYear: vi.fn(),
+		userPreferences: ref(null),
+		removeGoalFromPreferences: vi.fn(),
+		updateCurrentGoal: vi.fn(),
+		userGoalAchieved: ref(false),
+		getRecommendedLoans: vi.fn(),
+	}),
+}));
+
+vi.mock('#src/composables/useGoalSettingRecommendedLoan', () => ({
+	GOAL_RECOMMENDED_LOAN_ENTRYPOINT_GOALS_PAGE: 'event-tracking',
+	default: recommendedLoanSpy,
+}));
+
+vi.mock('@kiva/kv-components', () => ({
+	KvButton: { name: 'KvButton', template: '<button type="button"><slot /></button>' },
+	KvLightbox: { name: 'KvLightbox', template: '<div><slot /></div>' },
+	KvLoadingPlaceholder: { name: 'KvLoadingPlaceholder', template: '<div />' },
+	KvMaterialIcon: { name: 'KvMaterialIcon', template: '<span />' },
+	KvUtilityMenu: { name: 'KvUtilityMenu', template: '<div><slot /></div>' },
+}));
+
+// Stub that exposes getSelectedAmount, as the real component does, so the
+// container's template ref can call it.
+const RecommendLoanForGoalContainerStub = {
+	name: 'RecommendLoanForGoalContainer',
+	methods: {
+		getSelectedAmount: () => 25,
+	},
+	template: '<div />',
+};
+
+function mountContainer(provide = {}) {
+	return mount(GoalSettingContainer, {
+		global: {
+			provide: {
+				$kvTrackEvent: vi.fn(),
+				$appConfig: {},
+				apollo: {},
+				...provide,
+			},
+			stubs: {
+				GoalSelector: true,
+				RecommendLoanForGoalContainer: RecommendLoanForGoalContainerStub,
+			},
+		},
+	});
+}
+
+describe('GoalSettingContainer', () => {
+	beforeEach(() => {
+		recommendedLoanSpy.mockReset();
+		// Render the recommended-loan branch (which this composable feeds) so the
+		// container's lazily-loaded category forms never mount during the smoke test.
+		recommendedLoanSpy.mockReturnValue({
+			showRecommendLoanAfterGoalView: ref(true),
+			hasRecommendedLoans: ref(true),
+			isLoadingRecommendedLoan: ref(false),
+			recommendLoanHeaderDetails: ref([]),
+			recommendedLoan: ref(null),
+			recommendLoanCardProps: ref({}),
+			recommendLoanIsInBasket: ref(false),
+			enterRecommendedLoanStepAfterGoalSave: vi.fn(),
+			handleExploreMoreLoans: vi.fn(),
+			trackAddToBasketClick: vi.fn(),
+			trackCheckoutClick: vi.fn(),
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// Regression guard: the container injects apollo but previously forgot to forward it,
+	// so pill fetches (and tip messages) inside the composable ran with an undefined client.
+	it('forwards the injected apollo client into useGoalSettingRecommendedLoan', () => {
+		const apollo = { query: vi.fn(), mutate: vi.fn() };
+		mountContainer({ apollo });
+		expect(recommendedLoanSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ apollo }),
+		);
+	});
+
+	// The composable watches `show`; passing a bare boolean triggers a Vue
+	// "Invalid watch source" warning, so it must be handed a reactive ref.
+	it('passes a reactive show ref into useGoalSettingRecommendedLoan', () => {
+		mountContainer();
+		const options = recommendedLoanSpy.mock.calls[0][0];
+		expect(isRef(options.show)).toBe(true);
+		expect(options.show.value).toBe(true);
+	});
+
+	// The add-to-basket emit must carry the RAW recommended loan, not the card's
+	// blanked copy (whose themes/tags are zeroed for the pill display) — the parent's
+	// add-to-basket flow reads themes off it.
+	it('emits the raw recommended loan (not the blanked card loan) on add-to-basket', async () => {
+		const rawLoan = { id: 55, themes: ['Growing businesses'] };
+		recommendedLoanSpy.mockReturnValue({
+			showRecommendLoanAfterGoalView: ref(true),
+			hasRecommendedLoans: ref(true),
+			isLoadingRecommendedLoan: ref(false),
+			recommendLoanHeaderDetails: ref([]),
+			recommendedLoan: ref(rawLoan),
+			recommendLoanCardProps: ref({ loanId: 55, loan: { id: 55, themes: [] } }),
+			recommendLoanIsInBasket: ref(false),
+			enterRecommendedLoanStepAfterGoalSave: vi.fn(),
+			handleExploreMoreLoans: vi.fn(),
+			trackAddToBasketClick: vi.fn(),
+			trackCheckoutClick: vi.fn(),
+		});
+
+		const wrapper = mountContainer();
+		await wrapper.findComponent({ name: 'RecommendLoanForGoalContainer' }).vm.$emit('primary-cta-click');
+
+		const emitted = wrapper.emitted('add-to-basket');
+		expect(emitted).toHaveLength(1);
+		// The raw loan keeps its themes; the blanked card loan would have `themes: []`.
+		expect(emitted[0][0].loan).toEqual(rawLoan);
+		expect(emitted[0][0].loan.themes).toEqual(['Growing businesses']);
+	});
+});

--- a/test/unit/specs/components/MyKiva/GoalSettingModal.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalSettingModal.spec.js
@@ -42,6 +42,7 @@ vi.mock('#src/composables/useGoalSettingRecommendedLoan', () => ({
 		hasRecommendedLoans: ref(false),
 		isLoadingRecommendedLoan: ref(false),
 		recommendLoanHeaderDetails: ref(''),
+		recommendedLoan: ref(null),
 		recommendLoanCardProps: ref({}),
 		recommendLoanIsInBasket: ref(false),
 		resetRecommendedLoanState: vi.fn(),

--- a/test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js
+++ b/test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js
@@ -647,6 +647,7 @@ describe('useGoalSettingRecommendedLoan', () => {
 			await flushPromises();
 		};
 
+		// The pills fetch stays gated behind the recommended-loan feature flag.
 		it('does not fetch pills when the recommended-loan feature is disabled', async () => {
 			// Default mount has goalRecommendedLoanEnable: false.
 			composable.enterRecommendedLoanStepAfterGoalSave();
@@ -663,6 +664,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(fetchAiLoanPills).toHaveBeenCalledWith(mockApollo, [55]);
 		});
 
+		// Pills replace the loan's own callouts: the card would otherwise append them, so the
+		// loan's callout sources are blanked to leave only the pills.
 		it('passes pills as customCallouts and blanks the loan-derived callout fields', async () => {
 			await mountEnabledWithLoan(
 				{
@@ -686,6 +689,7 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(card.loanId).toBe(55);
 		});
 
+		// No pills → the card keeps its own loan-derived callouts (the fallback path).
 		it('leaves loan callouts intact and sets no customCallouts when no pills are returned', async () => {
 			await mountEnabledWithLoan(
 				{
@@ -702,6 +706,7 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(card.loan.tags).toEqual(['#Eco-friendly']);
 		});
 
+		// A failed pills query degrades gracefully to the loan's own callouts.
 		it('falls back to loan callouts when the pills query errors (resolves undefined)', async () => {
 			// fetchAiLoanPills swallows errors and resolves undefined.
 			await mountEnabledWithLoan(
@@ -713,6 +718,7 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(card.loan.tags).toEqual(['#Eco-friendly']);
 		});
 
+		// Advancing to a different recommended loan refetches pills for the new id.
 		it('refetches pills when the recommended loan changes', async () => {
 			await mountEnabledWithLoan({ id: 55, name: 'First' }, [{ loanId: 55, pills: ['P1'] }]);
 			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['P1']);
@@ -726,6 +732,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['P2']);
 		});
 
+		// Advancing to a pill-less loan clears the previous pills and un-blanks the callouts,
+		// so stale pill state can't leak onto the next loan.
 		it('clears pills and restores loan callouts when the next loan has none', async () => {
 			await mountEnabledWithLoan(
 				{ id: 55, name: 'First', tags: ['#Eco-friendly'] },
@@ -746,6 +754,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(card.loanId).toBe(66);
 		});
 
+		// Out-of-order responses: a slow fetch for a loan we've moved past must not clobber
+		// the current loan's pills.
 		it('ignores a stale pills response for a loan that is no longer recommended', async () => {
 			let resolveStale;
 			const stalePills = new Promise(resolve => { resolveStale = resolve; });
@@ -772,6 +782,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(composable.isLoadingRecommendedLoan.value).toBe(false);
 		});
 
+		// The skeleton stays up through the pills fetch so the card appears once, instead of
+		// showing the loan's tags and then popping to the AI pills.
 		it('stays in the loading state until the pills query resolves', async () => {
 			let resolvePills;
 			const pendingPills = new Promise(resolve => { resolvePills = resolve; });
@@ -793,6 +805,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['AI pick']);
 		});
 
+		// Add-to-basket needs the real loan (themes/tags), not the display-blanked card copy —
+		// the parent's add-to-basket flow reads those fields.
 		it('exposes the raw recommended loan (not the blanked card loan) for domain actions', async () => {
 			await mountEnabledWithLoan(
 				{
@@ -816,6 +830,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			});
 		});
 
+		// Empty pills result still clears loading (the skeleton must not hang) and leaves the
+		// card on its own callouts.
 		it('clears the loading state when the pills query resolves with none', async () => {
 			await mountEnabledWithLoan(
 				{ id: 55, name: 'Pillable', tags: ['#Eco-friendly'] },
@@ -825,6 +841,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 			expect(composable.recommendLoanCardProps.value.customCallouts).toBeUndefined();
 		});
 
+		// A basket/route change recomputes the card props but must reuse the same blanked-loan
+		// object, so the card is not needlessly re-rendered.
 		it('keeps the card-facing loan reference stable across basket changes', async () => {
 			await mountEnabledWithLoan(
 				{ id: 55, name: 'Pillable', tags: ['#Eco-friendly'] },

--- a/test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js
+++ b/test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js
@@ -8,11 +8,16 @@ import useGoalSettingRecommendedLoan, {
 	GOAL_RECOMMENDED_LOAN_ENTRYPOINT_POST_CHECKOUT,
 	GOAL_RECOMMENDED_LOAN_ENTRYPOINT_GOALS_PAGE,
 } from '#src/composables/useGoalSettingRecommendedLoan';
+import { fetchAiLoanPills } from '#src/util/aiLoanPillsUtils';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({
 		currentRoute: { value: { path: '/mykiva', name: 'my-kiva' } },
 	}),
+}));
+
+vi.mock('#src/util/aiLoanPillsUtils', () => ({
+	fetchAiLoanPills: vi.fn(),
 }));
 
 describe('useGoalSettingRecommendedLoan', () => {
@@ -79,6 +84,8 @@ describe('useGoalSettingRecommendedLoan', () => {
 
 	beforeEach(() => {
 		mockKvTrackEvent = vi.fn();
+		fetchAiLoanPills.mockReset();
+		fetchAiLoanPills.mockResolvedValue([]);
 		mountComposable();
 	});
 
@@ -628,6 +635,212 @@ describe('useGoalSettingRecommendedLoan', () => {
 				composable.trackCheckoutClick();
 				expect(mockKvTrackEvent).not.toHaveBeenCalled();
 			});
+		});
+	});
+
+	describe('AI loan pills', () => {
+		const mountEnabledWithLoan = async (loan, pills) => {
+			fetchAiLoanPills.mockResolvedValue(pills);
+			mountComposable({ goalRecommendedLoanEnable: true });
+			composable.enterRecommendedLoanStepAfterGoalSave();
+			getRecommendedLoans.mockResolvedValue([loan]);
+			await flushPromises();
+		};
+
+		it('does not fetch pills when the recommended-loan feature is disabled', async () => {
+			// Default mount has goalRecommendedLoanEnable: false.
+			composable.enterRecommendedLoanStepAfterGoalSave();
+			getRecommendedLoans.mockResolvedValue([{ id: 55, name: 'First' }]);
+			await flushPromises();
+			expect(fetchAiLoanPills).not.toHaveBeenCalled();
+		});
+
+		it('fetches pills for the recommended loan id', async () => {
+			await mountEnabledWithLoan(
+				{ id: 55, name: 'Pillable' },
+				[{ loanId: 55, pills: ['AI pick'] }],
+			);
+			expect(fetchAiLoanPills).toHaveBeenCalledWith(mockApollo, [55]);
+		});
+
+		it('passes pills as customCallouts and blanks the loan-derived callout fields', async () => {
+			await mountEnabledWithLoan(
+				{
+					id: 55,
+					name: 'Pillable',
+					activity: { id: 1, name: 'Farming' },
+					sector: { id: 2, name: 'Agriculture' },
+					tags: ['#Eco-friendly'],
+					themes: ['Growing businesses'],
+				},
+				[{ loanId: 55, pills: ['Repaid on time', 'Woman-owned'] }],
+			);
+			const card = composable.recommendLoanCardProps.value;
+			expect(card.customCallouts).toEqual(['Repaid on time', 'Woman-owned']);
+			expect(card.loan.activity).toEqual({});
+			expect(card.loan.sector).toEqual({});
+			expect(card.loan.tags).toEqual([]);
+			expect(card.loan.themes).toEqual([]);
+			// Non-callout fields are preserved so the card still renders normally.
+			expect(card.loan.name).toBe('Pillable');
+			expect(card.loanId).toBe(55);
+		});
+
+		it('leaves loan callouts intact and sets no customCallouts when no pills are returned', async () => {
+			await mountEnabledWithLoan(
+				{
+					id: 55,
+					name: 'Pillable',
+					activity: { id: 1, name: 'Farming' },
+					tags: ['#Eco-friendly'],
+				},
+				[],
+			);
+			const card = composable.recommendLoanCardProps.value;
+			expect(card.customCallouts).toBeUndefined();
+			expect(card.loan.activity).toEqual({ id: 1, name: 'Farming' });
+			expect(card.loan.tags).toEqual(['#Eco-friendly']);
+		});
+
+		it('falls back to loan callouts when the pills query errors (resolves undefined)', async () => {
+			// fetchAiLoanPills swallows errors and resolves undefined.
+			await mountEnabledWithLoan(
+				{ id: 55, name: 'Pillable', tags: ['#Eco-friendly'] },
+				undefined,
+			);
+			const card = composable.recommendLoanCardProps.value;
+			expect(card.customCallouts).toBeUndefined();
+			expect(card.loan.tags).toEqual(['#Eco-friendly']);
+		});
+
+		it('refetches pills when the recommended loan changes', async () => {
+			await mountEnabledWithLoan({ id: 55, name: 'First' }, [{ loanId: 55, pills: ['P1'] }]);
+			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['P1']);
+
+			fetchAiLoanPills.mockResolvedValue([{ loanId: 66, pills: ['P2'] }]);
+			getRecommendedLoans.mockResolvedValue([{ id: 66, name: 'Second' }]);
+			selectedCategory.value = { id: '2', name: 'Climate', badgeId: 'climate-badge' };
+			await flushPromises();
+
+			expect(fetchAiLoanPills).toHaveBeenLastCalledWith(mockApollo, [66]);
+			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['P2']);
+		});
+
+		it('clears pills and restores loan callouts when the next loan has none', async () => {
+			await mountEnabledWithLoan(
+				{ id: 55, name: 'First', tags: ['#Eco-friendly'] },
+				[{ loanId: 55, pills: ['P1'] }],
+			);
+			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['P1']);
+
+			// Advance to a loan the backend returns no pills for.
+			fetchAiLoanPills.mockResolvedValue([]);
+			getRecommendedLoans.mockResolvedValue([{ id: 66, name: 'Second', tags: ['#Refugees'] }]);
+			selectedCategory.value = { id: '2', name: 'Climate', badgeId: 'climate-badge' };
+			await flushPromises();
+
+			const card = composable.recommendLoanCardProps.value;
+			expect(card.customCallouts).toBeUndefined();
+			// Loan callouts are restored (not left blanked from the previous loan).
+			expect(card.loan.tags).toEqual(['#Refugees']);
+			expect(card.loanId).toBe(66);
+		});
+
+		it('ignores a stale pills response for a loan that is no longer recommended', async () => {
+			let resolveStale;
+			const stalePills = new Promise(resolve => { resolveStale = resolve; });
+			fetchAiLoanPills.mockReturnValueOnce(stalePills);
+
+			mountComposable({ goalRecommendedLoanEnable: true });
+			composable.enterRecommendedLoanStepAfterGoalSave();
+			getRecommendedLoans.mockResolvedValue([{ id: 55, name: 'First' }]);
+			await flushPromises();
+
+			// Advance to a new loan whose pills resolve immediately.
+			fetchAiLoanPills.mockResolvedValue([{ loanId: 66, pills: ['fresh'] }]);
+			getRecommendedLoans.mockResolvedValue([{ id: 66, name: 'Second' }]);
+			selectedCategory.value = { id: '2', name: 'Climate', badgeId: 'climate-badge' };
+			await flushPromises();
+			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['fresh']);
+
+			// The slow response for loan 55 arrives late and must not overwrite loan 66's pills.
+			resolveStale([{ loanId: 55, pills: ['stale'] }]);
+			await flushPromises();
+			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['fresh']);
+			expect(composable.recommendLoanCardProps.value.loanId).toBe(66);
+			// The ignored stale response must not leave the skeleton stuck loading.
+			expect(composable.isLoadingRecommendedLoan.value).toBe(false);
+		});
+
+		it('stays in the loading state until the pills query resolves', async () => {
+			let resolvePills;
+			const pendingPills = new Promise(resolve => { resolvePills = resolve; });
+			fetchAiLoanPills.mockReturnValue(pendingPills);
+
+			mountComposable({ goalRecommendedLoanEnable: true });
+			composable.enterRecommendedLoanStepAfterGoalSave();
+			getRecommendedLoans.mockResolvedValue([{ id: 55, name: 'First' }]);
+			await flushPromises();
+
+			// Loan resolved but pills still in flight: keep the skeleton up so the
+			// callouts do not pop from the loan's own tags to the AI pills.
+			expect(composable.isLoadingRecommendedLoan.value).toBe(true);
+
+			resolvePills([{ loanId: 55, pills: ['AI pick'] }]);
+			await flushPromises();
+
+			expect(composable.isLoadingRecommendedLoan.value).toBe(false);
+			expect(composable.recommendLoanCardProps.value.customCallouts).toEqual(['AI pick']);
+		});
+
+		it('exposes the raw recommended loan (not the blanked card loan) for domain actions', async () => {
+			await mountEnabledWithLoan(
+				{
+					id: 55,
+					name: 'Pillable',
+					activity: { id: 1, name: 'Farming' },
+					sector: { id: 2, name: 'Agriculture' },
+					tags: ['#Eco-friendly'],
+					themes: ['Growing businesses'],
+				},
+				[{ loanId: 55, pills: ['AI pick'] }],
+			);
+			// The card-facing loan is blanked for display...
+			expect(composable.recommendLoanCardProps.value.loan.themes).toEqual([]);
+			// ...but the exposed recommended loan keeps its real fields for add-to-basket.
+			expect(composable.recommendedLoan.value).toMatchObject({
+				activity: { id: 1, name: 'Farming' },
+				sector: { id: 2, name: 'Agriculture' },
+				tags: ['#Eco-friendly'],
+				themes: ['Growing businesses'],
+			});
+		});
+
+		it('clears the loading state when the pills query resolves with none', async () => {
+			await mountEnabledWithLoan(
+				{ id: 55, name: 'Pillable', tags: ['#Eco-friendly'] },
+				[],
+			);
+			expect(composable.isLoadingRecommendedLoan.value).toBe(false);
+			expect(composable.recommendLoanCardProps.value.customCallouts).toBeUndefined();
+		});
+
+		it('keeps the card-facing loan reference stable across basket changes', async () => {
+			await mountEnabledWithLoan(
+				{ id: 55, name: 'Pillable', tags: ['#Eco-friendly'] },
+				[{ loanId: 55, pills: ['AI pick'] }],
+			);
+			const loanBefore = composable.recommendLoanCardProps.value.loan;
+
+			props.basketItems = [{ __typename: 'LoanReservation', id: 1 }];
+			await flushPromises();
+
+			const cardAfter = composable.recommendLoanCardProps.value;
+			// The props object recomputed (new basketItems)...
+			expect(cardAfter.basketItems).toEqual([{ __typename: 'LoanReservation', id: 1 }]);
+			// ...but the blanked loan is unchanged, so its reference must stay stable
+			// to avoid re-rendering the card.
+			expect(cardAfter.loan).toBe(loanBefore);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds an AI loan **pill** to the recommended-loan card shown across all three goal-setting surfaces — the goal-setting page, the checkout thank-you page, and the My Kiva goal modal. These surfaces share the `useGoalSettingRecommendedLoan` composable, so a single change covers every entry point. This extends the AI Loan Pill Emphasis rollout to the goal-setting recommendation surface.

## Related links

- **Ticket:** [MP-3036](https://kiva.atlassian.net/browse/MP-3036) — Implement AI pills in RecommendLoanForGoal loan card
- **Epic:** [MP-2048](https://kiva.atlassian.net/browse/MP-2048) — AI Loan Pill Emphasis
- **Prior art:** [MP-2994](https://kiva.atlassian.net/browse/MP-2994) (borrower profile), [MP-2964](https://kiva.atlassian.net/browse/MP-2964) (My Kiva / Checkout / borrower profile rollout)

## What changed

### Composable — `useGoalSettingRecommendedLoan`
- Fetches AI pills for the current recommended loan via `fetchAiLoanPills(apollo, [loanId])` in a watch on `recommendedLoan.id`; a stale-response guard ignores late responses after the loan advances.
- Passes pills to the card as `customCallouts`. When pills exist, blanks the loan's own callout sources (`activity` / `sector` / `tags` / `themes`) via a dedicated `recommendedLoanForCard` computed so the card renders **only** the pills; falls back to the loan's own callouts when there are none or the query errors.
- Folds pills-loading into `isLoadingRecommendedLoan` (now a computed of a loan-data flag + a pills flag) so the card waits behind the existing skeleton and appears once — no callout "pop".
- Keeps the card-facing loan a separate computed so its reference stays stable across basket/route changes and the card isn't needlessly re-processed.
- Exposes the **raw** `recommendedLoan` (never blanked) for domain actions; add-to-basket emits this instead of the display-blanked card loan, so downstream flows that read loan fields (e.g. `themes` on the added-to-basket confirmation) keep their values.

### Hosts
- **`GoalSettingContainer`** — forwards the injected `apollo` into the composable (was omitted → fetch-time `TypeError`) and passes `showPage` as a reactive `ref` (was a bare boolean → *"Invalid watch source"* warning). Emits the raw recommended loan on add-to-basket.
- **`GoalSettingModal`** / **`ThanksPageSingleVersion`** — emit the raw recommended loan on add-to-basket.

No experiment flag is needed (the gate was removed upstream).

## Acceptance criteria

- ✅ The card shows an AI pill when the backend returns pills for the recommended loan.
- ✅ When no pills are returned (or the query errors), the card renders its existing callouts with no console errors.
- ✅ The card renders cleanly — it waits behind the existing loading skeleton and appears once. This deliberately supersedes the ticket's original *"fetch independently so pills don't block render"* to avoid a visible callout pop; the pills query still never hard-blocks (it resolves on error and falls back).

## Related tests

**`test/unit/specs/composables/useGoalSettingRecommendedLoan.spec.js`**
- pills → `customCallouts` + blanked callout fields
- no pills / query error → existing callouts, no `customCallouts`
- refetches pills when the recommended loan changes
- ignores a stale pills response after the loan advances
- stays in the loading state until pills resolve (skeleton wait)
- clears loading + restores callouts on the pills → no-pills transition
- keeps the card-facing loan reference stable across basket changes
- exposes the raw (unblanked) recommended loan for domain actions
- does not fetch pills when the feature is disabled

**`test/unit/specs/components/GoalSetting/GoalSettingContainer.spec.js`** (new)
- forwards the injected `apollo` into the composable
- passes a reactive `show` ref (no *"Invalid watch source"* warning)
- emits the raw (unblanked) loan on add-to-basket

**`test/unit/specs/components/MyKiva/GoalSettingModal.spec.js`**
- updated composable mock to expose `recommendedLoan`

**Result:** 100/100 across the four affected specs; broader suite 829/829; ESLint clean.

## Testing notes

- `npm run unit` — all green.
- `npm run lint` — clean on the changed files.

[MP-3036]: https://kiva.atlassian.net/browse/MP-3036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2048]: https://kiva.atlassian.net/browse/MP-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2994]: https://kiva.atlassian.net/browse/MP-2994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2964]: https://kiva.atlassian.net/browse/MP-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ