### PR TITLE
chore(MP-2992): roll out mykiva_goal_tile experiment, remove assignment code

### DIFF
--- a/src/components/GoalSetting/GoalSettingContainer.vue
+++ b/src/components/GoalSetting/GoalSettingContainer.vue
@@ -358,7 +358,6 @@ const selectedCategory = ref(categories[0]);
 
 // This container doesn't have the same multi-step flow as the modal,
 // so we can always show the recommended loan section when enabled.
-// A reactive ref (not a bare boolean) so the composable can watch it.
 const showPage = ref(true);
 const loadedSetData = ref(false);
 const {

--- a/src/components/MyKiva/JourneyCardCarousel.vue
+++ b/src/components/MyKiva/JourneyCardCarousel.vue
@@ -21,7 +21,6 @@
 					:user-goal="userGoal"
 					:prev-year-loans="womenLoansLastYear"
 					:hide-goal-card="hideGoalCard"
-					:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 					@open-goal-modal="$emit('open-goal-modal', $event)"
 				/>
 				<MyKivaSurveyCard
@@ -221,10 +220,6 @@ const props = defineProps({
 	showSurveySlide: {
 		type: Boolean,
 		default: true
-	},
-	isGoalTileExperimentEnabled: {
-		type: Boolean,
-		default: false
 	},
 	showLendingNextStepsCards: {
 		type: Boolean,

--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -45,7 +45,6 @@
 				:user-info="userInfo"
 				:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
 				:show-lending-next-steps-cards="true"
-				:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 				@open-goal-modal="openGoalModal($event)"
 				@open-impact-insight-modal="showImpactInsightsModal = true"
 			/>
@@ -83,7 +82,6 @@
 			:latest-loan="latestLoan"
 			:user-info="userInfo"
 			:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
-			:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 			@open-goal-modal="openGoalModal($event)"
 			@open-impact-insight-modal="showImpactInsightsModal = true"
 		/>
@@ -174,10 +172,6 @@ export default {
 		userInfo: {
 			type: Object,
 			default: () => ({}),
-		},
-		isGoalTileExperimentEnabled: {
-			type: Boolean,
-			default: false
 		},
 		goalRecommendedLoanEnable: {
 			type: Boolean,

--- a/src/components/MyKiva/NextYearGoalCard.vue
+++ b/src/components/MyKiva/NextYearGoalCard.vue
@@ -81,10 +81,6 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	isGoalTileExperimentEnabled: {
-		type: Boolean,
-		default: false,
-	},
 });
 
 const emit = defineEmits(['open-goal-modal']);
@@ -112,10 +108,7 @@ const title = computed(() => (
 	goalCopy.titleGoalSignupWomensLastYear(props.prevYearLoans, { cssClass: 'tw-text-action' })
 ));
 const subtitle = computed(() => {
-	if (
-		props.isGoalTileExperimentEnabled
-		&& goalCopy.getGoalSignupCopyVariant() === GOAL_SIGNUP_COPY_NO_GOAL_YET
-	) {
+	if (goalCopy.getGoalSignupCopyVariant() === GOAL_SIGNUP_COPY_NO_GOAL_YET) {
 		return goalCopy.CARD_HABIT_PROMPT_EXPERIMENT;
 	}
 	return goalCopy.TITLE_HOW_MANY_LOANS_GENERIC;

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -32,7 +32,6 @@
 			:latest-loan="latestLoan"
 			:goal-refresh-key="goalRefreshKey"
 			:show-my-giving-funds-card="showMyGivingFundsCard"
-			:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 			:goal-recommended-loan-enable="goalRecommendedLoanEnable"
 			:goals-row-enabled="goalsRowEnabled"
 			:should-render-featured-slot="shouldRenderFeaturedSlot"
@@ -65,7 +64,6 @@ import useBadgeData, {
 import { inject, provide } from 'vue';
 
 const CURRENT_YEAR = new Date().getFullYear();
-const GOAL_TILE_EXPERIMENT_KEY = 'mykiva_goal_tile';
 const GOALS_ROW_EXP_KEY = 'mykiva_goals_row';
 
 /**
@@ -115,7 +113,6 @@ export default {
 			goalRefreshKey: 0,
 			showMyGivingFundsCard: false,
 			recentTransactionLoans: [],
-			isGoalTileExperimentEnabled: false,
 			goalRecommendedLoanEnable: false,
 			goalsRowEnabled: false,
 			shouldRenderFeaturedSlot: true,
@@ -196,10 +193,6 @@ export default {
 				client.query({
 					query: contentfulEntriesQuery,
 					variables: { contentType: 'challenge', limit: 200 }
-				}),
-				client.query({
-					query: experimentAssignmentQuery,
-					variables: { id: GOAL_TILE_EXPERIMENT_KEY },
 				}),
 				client.query({
 					query: experimentAssignmentQuery,
@@ -374,19 +367,6 @@ export default {
 		} catch (e) {
 			logReadQueryError(e, 'MyKivaPage created');
 		}
-
-		initializeExperiment(
-			this.cookieStore,
-			this.apollo,
-			this.$route,
-			GOAL_TILE_EXPERIMENT_KEY,
-			version => {
-				this.isGoalTileExperimentEnabled = Boolean(version === 'b') && !this.isNextStepsRoute.value;
-			},
-			this.$kvTrackEvent,
-			'EXP-MP-2565-Mar2026',
-			'portfolio'
-		);
 
 		initializeExperiment(
 			this.cookieStore,

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -38,7 +38,6 @@
 				:latest-loan="latestLoan"
 				:goal-refresh-key="goalRefreshKey"
 				:user-info="userInfo"
-				:is-goal-tile-experiment-enabled="isGoalTileExperimentEnabled"
 				:goal-recommended-loan-enable="goalRecommendedLoanEnable"
 				:goals-row-enabled="goalsRowEnabled"
 				:basket-items="basketItems"
@@ -312,10 +311,6 @@ export default {
 			default: 0
 		},
 		showMyGivingFundsCard: {
-			type: Boolean,
-			default: false
-		},
-		isGoalTileExperimentEnabled: {
 			type: Boolean,
 			default: false
 		},

--- a/test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js
+++ b/test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js
@@ -78,7 +78,7 @@ describe('NextYearGoalCard', () => {
 		expect(goalData.setHideGoalCardPreference).not.toHaveBeenCalled();
 	});
 
-	it('uses date-based title copy even when the goal tile experiment is enabled', () => {
+	it('uses date-based title copy', () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-03-15T12:00:00'));
 
@@ -86,7 +86,6 @@ describe('NextYearGoalCard', () => {
 			props: {
 				userGoal: null,
 				prevYearLoans: 2,
-				isGoalTileExperimentEnabled: true,
 			},
 		});
 
@@ -94,7 +93,7 @@ describe('NextYearGoalCard', () => {
 		expect(wrapper.text()).not.toContain("You haven't set your goal yet!");
 	});
 
-	it('uses the loan question subtitle before April even when the goal tile experiment is enabled', () => {
+	it('uses the loan question subtitle before April', () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-03-31T12:00:00'));
 
@@ -102,16 +101,15 @@ describe('NextYearGoalCard', () => {
 			props: {
 				userGoal: null,
 				prevYearLoans: 30,
-				isGoalTileExperimentEnabled: true,
 			},
 		});
 
 		expect(wrapper.text()).toContain('Last year, you helped 30 women shape their futures');
 		expect(wrapper.text()).toContain(goalCopy.TITLE_HOW_MANY_LOANS_GENERIC);
-		expect(wrapper.text()).not.toContain(goalCopy.CARD_HABIT_PROMPT_SINGLE_LINE);
+		expect(wrapper.text()).not.toContain('Make helping others a habit.');
 	});
 
-	it('uses the habit prompt subtitle starting April when the goal tile experiment is enabled', () => {
+	it('uses the habit prompt subtitle starting April', () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date('2026-04-01T12:00:00'));
 
@@ -119,7 +117,6 @@ describe('NextYearGoalCard', () => {
 			props: {
 				userGoal: null,
 				prevYearLoans: 30,
-				isGoalTileExperimentEnabled: true,
 			},
 		});
 


### PR DESCRIPTION
## Summary

Removes the `mykiva_goal_tile` A/B experiment and makes its variant the default (100% rollout). The experiment gated a single copy change — the `NextYearGoalCard` subtitle — so this deletes the experiment assignment/plumbing and hardcodes the variant at the leaf.

## Related links

- **Ticket:** [MP-2992](https://kiva.atlassian.net/browse/MP-2992) — Roll out mykiva_goal_tile experiment
- **Epic:** [MP-44](https://kiva.atlassian.net/browse/MP-44) — Core Lending KTLO

## What changed

- **`MyKivaPage.vue`** — removed the experiment assignment code: the `GOAL_TILE_EXPERIMENT_KEY` constant, its `experimentAssignmentQuery` **prefetch** (one fewer SSR round-trip), its `initializeExperiment(...)` call, the `isGoalTileExperimentEnabled` data flag, and the prop binding. The separate `mykiva_goals_row` experiment and the shared `initializeExperiment` / `experimentAssignmentQuery` imports are untouched.
- **Prop chain removed** — dropped `isGoalTileExperimentEnabled` from `MyKivaPageContent` → `LendingStats` (×2 pass-throughs) → `JourneyCardCarousel` → `NextYearGoalCard`.
- **`NextYearGoalCard.vue`** — the `subtitle` now returns the habit-prompt copy whenever the date-based `getGoalSignupCopyVariant() === NO_GOAL_YET` (April onward), otherwise the generic loan question. `getGoalSignupCopyVariant()` is a **separate, date-based** mechanism — unaffected by removing the A/B experiment.

## ⚠️ Behavior note (please confirm)

`NextYearGoalCard` renders on **two** surfaces:
- The main `/mykiva` tile (via `MyKivaPageContent`) — this is where the experiment ran; control users now get the variant copy. ✅ intended rollout.
- The **`/mykiva/next-steps`** card (via `MyKivaNextStepsContent → JourneyCardCarousel`) — this chain **never** carried the experiment prop, so it always showed the generic question. With the variant now unconditional, the habit-prompt copy **also appears here** (live from April onward).

Product confirmed the variant copy should show everywhere the card renders, so this is intended — flagging it so reviewers know the next-steps copy changes too.

## Related tests

**`test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js`**
- Dropped the now-removed `isGoalTileExperimentEnabled` prop from the 3 subtitle tests and renamed them (no experiment anymore).
- Retained date-boundary coverage: Mar 15 → last-year title; Mar 31 → generic subtitle; Apr 1 → habit-prompt subtitle.
- Tightened the before-April negative assertion to check the habit-prompt copy is actually absent (previously asserted a constant the component never renders).

No new tests added — a "prefetch no longer includes the goal_tile query" guard was considered and dropped as low-value (asserting a deletion stays deleted).

## Testing notes

- `npm run unit` — affected specs green (`NextYearGoalCard`, `JourneyCardCarousel`, `LendingStats`, `MyKivaPage`, `MyKivaPageContent`, `goalCopy`).
- `npm run lint` — clean on changed files.
- `grep` confirms zero remaining references to `mykiva_goal_tile` / `GOAL_TILE_EXPERIMENT_KEY` / `isGoalTileExperimentEnabled`.

[MP-2992]: https://kiva.atlassian.net/browse/MP-2992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-44]: https://kiva.atlassian.net/browse/MP-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ