### PR TITLE
feat: implement portfolio credit deposit migration

### DIFF
--- a/.storybook/stories/ThanksPageSingleVersion.stories.js
+++ b/.storybook/stories/ThanksPageSingleVersion.stories.js
@@ -655,9 +655,6 @@ const queryResultWithNoGoal = {
 	}
 };
 
-const customGoalAmountExperimentEnabledCookie = {
-	uiab: 'custom_goal_amount:b:12345:1:false',
-};
 const mockTieredLendingAchievementsOnlyLastYearProgress = mockTieredLendingAchievementsAllCategories
 	.map(achievement => ({
 		id: achievement.id,
@@ -717,7 +714,7 @@ export const GoalEntrypointCustomGoalAmountEnabled = story({
 
 	totalLoans: 0,
 	tieredAchievements: [],
-}, queryResultWithNoGoal, customGoalAmountExperimentEnabledCookie);
+}, queryResultWithNoGoal);
 
 // Story: No goal set, custom amount experiment enabled, only last year progress
 export const GoalEntrypointWithOnlyLastYearProgressCustomAmount = story({
@@ -733,7 +730,7 @@ export const GoalEntrypointWithOnlyLastYearProgressCustomAmount = story({
 
 	totalLoans: 20,
 	tieredAchievements: mockTieredLendingAchievementsOnlyLastYearProgress,
-}, queryResultWithNoGoal, customGoalAmountExperimentEnabledCookie);
+}, queryResultWithNoGoal);
 
 // Story: No goal set, custom amount experiment enabled, only current year progress
 export const GoalEntrypointWithOnlyCurrentYearProgressCustomAmount = story({
@@ -749,7 +746,7 @@ export const GoalEntrypointWithOnlyCurrentYearProgressCustomAmount = story({
 
 	totalLoans: 20,
 	tieredAchievements: mockTieredLendingAchievementsOnlyCurrentYearProgress,
-}, queryResultWithNoGoalAndThisAndLastYearProgress, customGoalAmountExperimentEnabledCookie);
+}, queryResultWithNoGoalAndThisAndLastYearProgress);
 
 // Story: No goal set, custom amount experiment enabled, current and last year progress available
 export const GoalEntrypointWithThisAndLastYearProgressCustomAmount = story({
@@ -765,7 +762,7 @@ export const GoalEntrypointWithThisAndLastYearProgressCustomAmount = story({
 
 	totalLoans: 20,
 	tieredAchievements: mockTieredLendingAchievementsThisAndLastYearProgress,
-}, queryResultWithNoGoalAndThisAndLastYearProgress, customGoalAmountExperimentEnabledCookie);
+}, queryResultWithNoGoalAndThisAndLastYearProgress);
 
 // Story: Guest user with goals experiment enabled - should NOT show goal modules
 export const GuestWithGoalsExperiment = story({

--- a/src/components/Deposit/DepositDropInPaymentWrapper.vue
+++ b/src/components/Deposit/DepositDropInPaymentWrapper.vue
@@ -1,0 +1,171 @@
+<template>
+	<div class="dropin-payment-holder tw-px-0 tw-mt-2">
+		<braintree-drop-in-interface
+			v-if="isClientReady"
+			ref="braintreeDropInInterface"
+			:amount="formattedAmount"
+			flow="checkout"
+			:payment-types="['paypal', 'card']"
+			@transactions-enabled="enableConfirmButton = $event"
+		/>
+
+		<div id="dropin-submit">
+			<kv-button
+				class="tw-w-full md:tw-w-auto tw-mt-2"
+				:state="buttonState"
+				data-testid="deposit-submit"
+				@click="submit"
+				v-kv-track-event="['portfolio', 'click', 'Deposit continue']"
+			>
+				<span class="tw-inline-flex tw-items-center tw-justify-center">
+					<kv-material-icon class="tw-w-3 tw-h-3 tw-mr-0.5" :icon="mdiLock" />
+					Add credit
+				</span>
+			</kv-button>
+		</div>
+
+		<p class="tw-text-small tw-text-secondary tw-mt-3">
+			Thanks to PayPal, Kiva receives free payment processing.
+		</p>
+	</div>
+</template>
+
+<script>
+import numeral from 'numeral';
+import { defineAsyncComponent } from 'vue';
+import { mdiLock } from '@mdi/js';
+import braintreeDropInError from '#src/plugins/braintree-dropin-error-mixin';
+import logFormatter from '#src/util/logFormatter';
+import depositWithBraintreeNonceMutation from '#src/graphql/mutation/deposit/depositWithBraintreeNonce.graphql';
+import { KvButton, KvMaterialIcon } from '@kiva/kv-components';
+
+export default {
+	name: 'DepositDropInPaymentWrapper',
+	components: {
+		KvButton,
+		KvMaterialIcon,
+		BraintreeDropInInterface: defineAsyncComponent(() => import(
+			'#src/components/Payment/BraintreeDropInInterface'
+		)),
+	},
+	mixins: [braintreeDropInError],
+	inject: ['apollo'],
+	emits: ['complete-transaction', 'processing'],
+	props: {
+		amount: {
+			type: [Number, String],
+			default: 0,
+		},
+		// Parent-side validation (amount within min/max). Keeps the confirm button disabled
+		// until the entered amount is valid, in addition to the drop-in being ready.
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			mdiLock,
+			isClientReady: false,
+			enableConfirmButton: false,
+			submitting: false,
+		};
+	},
+	watch: {
+		// Let the parent lock the amount input while a charge is in flight.
+		submitting(value) {
+			this.$emit('processing', value);
+		},
+	},
+	computed: {
+		formattedAmount() {
+			return numeral(this.amount).format('0.00');
+		},
+		buttonState() {
+			if (this.submitting) {
+				return 'loading';
+			}
+			if (this.disabled || !this.enableConfirmButton) {
+				return 'disabled';
+			}
+			return '';
+		},
+	},
+	methods: {
+		submit() {
+			if (this.disabled || !this.enableConfirmButton || this.submitting) {
+				return;
+			}
+			this.submitting = true;
+			// Snapshot the amount at submit time so the charge and the confirmation reflect the amount
+			// the user confirmed, even if the input changes while the request is in flight.
+			const { amount } = this;
+			this.$refs.braintreeDropInInterface.btDropinInstance.requestPaymentMethod()
+				.then(paymentMethod => {
+					const nonce = paymentMethod?.nonce;
+					const deviceData = paymentMethod?.deviceData;
+					const paymentType = paymentMethod?.type;
+					if (!nonce) {
+						this.submitting = false;
+						return;
+					}
+					this.recordDeposit(nonce, deviceData, paymentType, amount);
+				})
+				.catch(error => {
+					// requestPaymentMethod rejects when no valid payment method is selected.
+					this.submitting = false;
+					logFormatter(`Braintree requestPaymentMethod error: ${error}`, 'error');
+				});
+		},
+		recordDeposit(nonce, deviceData, paymentType, amount) {
+			this.apollo.mutate({
+				mutation: depositWithBraintreeNonceMutation,
+				variables: {
+					amount: numeral(amount).format('0.00'),
+					nonce,
+					deviceData,
+				},
+			}).then(response => {
+				const transactionId = response?.data?.my?.depositWithBraintreeNonce ?? null;
+				if (response.errors || !transactionId) {
+					this.handleFailure(response);
+					return;
+				}
+				this.handleSuccess(transactionId, paymentType, amount);
+			}).catch(error => {
+				this.handleFailure(error);
+			});
+		},
+		handleSuccess(transactionId, paymentType, amount) {
+			// Legacy parity: mirrors DepositView.js trackAddCredit — the value is the deposit in cents.
+			this.$kvTrackEvent(
+				'Lending',
+				'Add Credit',
+				'Add Credit Page',
+				null,
+				Math.round(numeral(amount).value() * 100),
+			);
+			// Braintree drop-in success event, mirroring the sibling payment wrappers.
+			this.$kvTrackEvent(
+				'portfolio',
+				`${paymentType} Braintree DropIn Deposit`,
+				'Success',
+				transactionId,
+				transactionId,
+			);
+			this.submitting = false;
+			this.$emit('complete-transaction', { transactionId, paymentType, amount });
+		},
+		handleFailure(response) {
+			this.submitting = false;
+			// Shows the standard payment-error tip + fires the error event (shared with checkout / auto-deposit).
+			this.processBraintreeDropInError('Deposit', response);
+			// Clear the failed payment selection so the lender can retry.
+			this.$refs.braintreeDropInInterface?.btDropinInstance?.clearSelectedPaymentMethod?.();
+		},
+	},
+	mounted() {
+		this.isClientReady = typeof window !== 'undefined';
+	},
+};
+</script>

--- a/src/components/Deposit/DepositDropInPaymentWrapper.vue
+++ b/src/components/Deposit/DepositDropInPaymentWrapper.vue
@@ -1,39 +1,65 @@
 <template>
 	<div class="dropin-payment-holder tw-px-0 tw-mt-2">
-		<braintree-drop-in-interface
-			v-if="isClientReady"
-			ref="braintreeDropInInterface"
-			:amount="formattedAmount"
-			flow="checkout"
-			:payment-types="['paypal', 'card']"
-			@transactions-enabled="enableConfirmButton = $event"
-		/>
-
-		<div id="dropin-submit">
+		<!-- Token fetch failed -->
+		<div v-if="tokenError" data-testid="deposit-payment-error">
+			<p>We couldn't load payment options. Please try again.</p>
 			<kv-button
-				class="tw-w-full md:tw-w-auto tw-mt-2"
-				:state="buttonState"
-				data-testid="deposit-submit"
-				@click="submit"
-				v-kv-track-event="['portfolio', 'click', 'Deposit continue']"
+				class="tw-mt-2"
+				@click="loadClientToken"
+				v-kv-track-event="['portfolio', 'click', 'Deposit retry payment load']"
 			>
-				<span class="tw-inline-flex tw-items-center tw-justify-center">
-					<kv-material-icon class="tw-w-3 tw-h-3 tw-mr-0.5" :icon="mdiLock" />
-					Add credit
-				</span>
+				Try again
 			</kv-button>
 		</div>
 
-		<p class="tw-text-small tw-text-secondary tw-mt-3">
-			Thanks to PayPal, Kiva receives free payment processing.
-		</p>
+		<!-- Once the client token resolves, KvPaymentSelect renders and owns its own
+			loading spinner while the Braintree drop-in initializes. -->
+		<template v-else-if="authToken">
+			<!-- Lock the payment selection while a charge is in flight so the user can't
+				swap the payment method mid-submit. -->
+			<div
+				data-testid="deposit-payment-wrap"
+				:class="{ 'tw-pointer-events-none tw-opacity-low': submitting }"
+				:inert="submitting || undefined"
+			>
+				<KvPaymentSelect
+					ref="paymentSelect"
+					:amount="formattedAmount"
+					:auth-token="authToken"
+					drop-in-name="deposit"
+					flow="vault"
+					:payment-types="paymentTypes"
+					@transactions-enabled="enableConfirmButton = $event"
+					@error="onPaymentError"
+				/>
+			</div>
+
+			<div id="dropin-submit">
+				<kv-button
+					class="tw-w-full md:tw-w-auto tw-mt-2"
+					:state="buttonState"
+					data-testid="deposit-submit"
+					@click="submit"
+					v-kv-track-event="['portfolio', 'click', 'Deposit continue']"
+				>
+					<span class="tw-inline-flex tw-items-center tw-justify-center">
+						<kv-material-icon class="tw-w-3 tw-h-3 tw-mr-0.5" :icon="mdiLock" />
+						Add credit
+					</span>
+				</kv-button>
+			</div>
+
+			<p class="tw-text-small tw-text-secondary tw-mt-3">
+				Thanks to PayPal, Kiva receives free payment processing.
+			</p>
+		</template>
 	</div>
 </template>
 
 <script>
 import numeral from 'numeral';
-import { defineAsyncComponent } from 'vue';
 import { mdiLock } from '@mdi/js';
+import { getClientToken, KvPaymentSelect } from '@kiva/kv-shop';
 import braintreeDropInError from '#src/plugins/braintree-dropin-error-mixin';
 import logFormatter from '#src/util/logFormatter';
 import depositWithBraintreeNonceMutation from '#src/graphql/mutation/deposit/depositWithBraintreeNonce.graphql';
@@ -44,9 +70,7 @@ export default {
 	components: {
 		KvButton,
 		KvMaterialIcon,
-		BraintreeDropInInterface: defineAsyncComponent(() => import(
-			'#src/components/Payment/BraintreeDropInInterface'
-		)),
+		KvPaymentSelect,
 	},
 	mixins: [braintreeDropInError],
 	inject: ['apollo'],
@@ -66,7 +90,10 @@ export default {
 	data() {
 		return {
 			mdiLock,
-			isClientReady: false,
+			// Preserve the original deposit payment options (PayPal + card) and order.
+			paymentTypes: ['paypal', 'card'],
+			authToken: '',
+			tokenError: false,
 			enableConfirmButton: false,
 			submitting: false,
 		};
@@ -92,7 +119,25 @@ export default {
 		},
 	},
 	methods: {
-		submit() {
+		async loadClientToken() {
+			this.tokenError = false;
+			try {
+				// Deposit is behind auth, so we always fetch a customer-scoped token
+				// (getClientToken queries with useCustomerId: true) to support vaulting.
+				this.authToken = await getClientToken(this.apollo) ?? '';
+				if (!this.authToken) {
+					this.tokenError = true;
+				}
+			} catch (error) {
+				this.tokenError = true;
+				logFormatter(`Deposit getClientToken error: ${error}`, 'error');
+			}
+		},
+		onPaymentError(message) {
+			const errorMsg = message || 'Something went wrong. Please refresh the page and try again.';
+			this.$showTipMsg(errorMsg, 'error');
+		},
+		async submit() {
 			if (this.disabled || !this.enableConfirmButton || this.submitting) {
 				return;
 			}
@@ -100,22 +145,20 @@ export default {
 			// Snapshot the amount at submit time so the charge and the confirmation reflect the amount
 			// the user confirmed, even if the input changes while the request is in flight.
 			const { amount } = this;
-			this.$refs.braintreeDropInInterface.btDropinInstance.requestPaymentMethod()
-				.then(paymentMethod => {
-					const nonce = paymentMethod?.nonce;
-					const deviceData = paymentMethod?.deviceData;
-					const paymentType = paymentMethod?.type;
-					if (!nonce) {
-						this.submitting = false;
-						return;
-					}
-					this.recordDeposit(nonce, deviceData, paymentType, amount);
-				})
-				.catch(error => {
-					// requestPaymentMethod rejects when no valid payment method is selected.
+			try {
+				const paymentMethod = await this.$refs.paymentSelect.requestPaymentMethod();
+				const nonce = paymentMethod?.nonce;
+				if (!nonce) {
+					// No requestable payment method (e.g. selection cleared). Let the user retry.
 					this.submitting = false;
-					logFormatter(`Braintree requestPaymentMethod error: ${error}`, 'error');
-				});
+					return;
+				}
+				this.recordDeposit(nonce, paymentMethod?.deviceData, paymentMethod?.type, amount);
+			} catch (error) {
+				// requestPaymentMethod rejects when no valid payment method is selected.
+				this.submitting = false;
+				logFormatter(`KvPaymentSelect requestPaymentMethod error: ${error}`, 'error');
+			}
 		},
 		recordDeposit(nonce, deviceData, paymentType, amount) {
 			this.apollo.mutate({
@@ -160,12 +203,23 @@ export default {
 			this.submitting = false;
 			// Shows the standard payment-error tip + fires the error event (shared with checkout / auto-deposit).
 			this.processBraintreeDropInError('Deposit', response);
-			// Clear the failed payment selection so the lender can retry.
-			this.$refs.braintreeDropInInterface?.btDropinInstance?.clearSelectedPaymentMethod?.();
 		},
 	},
 	mounted() {
-		this.isClientReady = typeof window !== 'undefined';
+		this.loadClientToken();
 	},
 };
 </script>
+
+<style lang="postcss" scoped>
+/*
+ * While the Braintree drop-in initializes it renders its own loader inside the
+ * container, and KvPaymentSelect additionally renders its own KvLoadingSpinner
+ * (a direct <svg> child of .kv-payment-select) — showing two spinners at once.
+ * Hide the redundant KvPaymentSelect spinner and let the drop-in's own loader
+ * be the single loading indicator.
+ */
+:deep(.kv-payment-select > svg) {
+	@apply tw-hidden;
+}
+</style>

--- a/src/graphql/mutation/deposit/depositWithBraintreeNonce.graphql
+++ b/src/graphql/mutation/deposit/depositWithBraintreeNonce.graphql
@@ -1,0 +1,5 @@
+mutation DepositWithBraintreeNonce($amount: Money!, $nonce: String!, $deviceData: String!) {
+    my {
+        depositWithBraintreeNonce(amount: $amount, nonce: $nonce, deviceData: $deviceData)
+    }
+}

--- a/src/graphql/query/deposit/depositReadModel.graphql
+++ b/src/graphql/query/deposit/depositReadModel.graphql
@@ -1,0 +1,13 @@
+query DepositReadModel {
+    my {
+        id
+        userAccount {
+            id
+            balance
+            deposit {
+                canDeposit
+                maxDepositAmount
+            }
+        }
+    }
+}

--- a/src/pages/Deposit/DepositPage.vue
+++ b/src/pages/Deposit/DepositPage.vue
@@ -1,0 +1,230 @@
+<template>
+	<PortfolioShell>
+		<div class="tw-rounded md:tw-bg-primary tw-p-2 tw-py-3 md:tw-p-3">
+			<h1 class="tw-mb-1">
+				Add credit
+			</h1>
+
+			<!-- Loading -->
+			<KvLoadingPlaceholder
+				v-if="loading"
+				style="height: 120px;"
+			/>
+
+			<!-- Error loading the read model -->
+			<div v-else-if="loadError" data-testid="deposit-load-error">
+				<p>An error occurred. Please try again.</p>
+				<KvButton
+					class="tw-mt-2"
+					@click="fetchDepositData"
+					v-kv-track-event="['portfolio', 'click', 'Deposit retry load']"
+				>
+					Try again
+				</KvButton>
+			</div>
+
+			<!-- Not an existing lender (canDeposit === false) -->
+			<div v-else-if="!canDeposit" data-testid="deposit-forbidden">
+				<p>
+					Add Credit is only available to existing lenders who have already made a loan.
+					Please make a loan and checkout in order to deposit to Kiva.
+				</p>
+				<KvButton
+					:to="LEND_ROUTE"
+					class="tw-mt-2"
+					v-kv-track-event="['portfolio', 'click', 'Deposit not eligible lend']"
+				>
+					Find a borrower to support
+				</KvButton>
+			</div>
+
+			<!-- Thanks (successful deposit) -->
+			<div v-else-if="depositComplete" data-testid="deposit-thanks">
+				<h2 class="tw-text-title tw-mb-1">
+					Thanks for adding to your Kiva account!
+				</h2>
+				<p>
+					We're currently processing your deposit and you should see
+					<router-link
+						to="/portfolio"
+						class="tw-no-underline"
+						v-kv-track-event="['portfolio', 'click', 'Deposit thanks to portfolio']"
+					>
+						your portfolio
+					</router-link>
+					balance update by
+					<strong class="tw-text-eco-green" data-testid="deposit-amount-paid">
+						{{ numeral(depositedAmount).format('$0,0.00') }}
+					</strong> momentarily.
+				</p>
+			</div>
+
+			<!-- Add-credit form -->
+			<template v-else>
+				<p>
+					Add funds to your Kiva balance, making it easier to lend when you find borrowers
+					you want to support.
+				</p>
+
+				<div class="tw-mt-3 tw-mb-2">
+					<p class="tw-text-small tw-text-tertiary tw-font-medium tw-text-upper">
+						Current Kiva balance
+					</p>
+					<p class="tw-text-headline tw-text-eco-green" data-testid="deposit-current-balance">
+						{{ numeral(currentBalance).format('$0,0.00') }}
+					</p>
+				</div>
+
+				<div class="tw-mb-2" @focusin="trackAmountFocus">
+					<label for="deposit-amount" class="tw-block tw-font-medium tw-mb-0.5">
+						Amount to deposit
+					</label>
+					<KvCurrencyInput
+						id="deposit-amount"
+						class="tw-w-full md:tw-w-1/2"
+						:model-value="amount"
+						:disabled="processing"
+						clear-zero-on-focus
+						@input="onAmountInput"
+					/>
+					<ul v-if="v$.amount.$error" class="tw-text-danger tw-text-small tw-mt-0.5">
+						<li v-for="error in v$.amount.$errors" :key="error.$uid">
+							{{ error.$message }}
+						</li>
+					</ul>
+				</div>
+
+				<p class="tw-mb-2">
+					<router-link
+						:to="AUTO_DEPOSIT_ROUTE"
+						class="tw-no-underline"
+						v-kv-track-event="['portfolio', 'click', 'Deposit make monthly deposit']"
+					>
+						Make a monthly deposit
+					</router-link>
+				</p>
+
+				<DepositDropInPaymentWrapper
+					:amount="amount"
+					:disabled="v$.$invalid"
+					@processing="processing = $event"
+					@complete-transaction="onDepositComplete"
+				/>
+			</template>
+		</div>
+	</PortfolioShell>
+</template>
+
+<script>
+import numeral from 'numeral';
+import { useVuelidate } from '@vuelidate/core';
+import {
+	required, minValue, maxValue, helpers,
+} from '@vuelidate/validators';
+import { KvButton, KvLoadingPlaceholder } from '@kiva/kv-components';
+import PortfolioShell from '#src/components/WwwFrame/PortfolioShell';
+import KvCurrencyInput from '#src/components/Kv/KvCurrencyInput';
+import DepositDropInPaymentWrapper from '#src/components/Deposit/DepositDropInPaymentWrapper';
+import logFormatter from '#src/util/logFormatter';
+import depositReadModelQuery from '#src/graphql/query/deposit/depositReadModel.graphql';
+import {
+	DEPOSIT_MIN_AMOUNT,
+	DEPOSIT_MAX_AMOUNT,
+	AUTO_DEPOSIT_ROUTE,
+	LEND_ROUTE,
+} from '#src/util/deposit/depositConstants';
+
+export default {
+	name: 'DepositPage',
+	components: {
+		PortfolioShell,
+		KvButton,
+		KvLoadingPlaceholder,
+		KvCurrencyInput,
+		DepositDropInPaymentWrapper,
+	},
+	inject: ['apollo'],
+	setup() {
+		return { v$: useVuelidate() };
+	},
+	data() {
+		return {
+			numeral,
+			AUTO_DEPOSIT_ROUTE,
+			LEND_ROUTE,
+			loading: true,
+			loadError: false,
+			canDeposit: false,
+			currentBalance: 0,
+			maxDepositAmount: DEPOSIT_MAX_AMOUNT,
+			amount: 0,
+			processing: false,
+			depositComplete: false,
+			depositedAmount: 0,
+			amountFocusTracked: false,
+		};
+	},
+	validations() {
+		return {
+			amount: {
+				required: helpers.withMessage('Please enter a valid amount in USD.', required),
+				minValue: helpers.withMessage(
+					'Please enter a valid amount in USD.',
+					minValue(DEPOSIT_MIN_AMOUNT),
+				),
+				maxValue: helpers.withMessage(
+					'Deposits must be a valid amount in USD and are limited to '
+						+ `${numeral(this.maxDepositAmount).format('$0,0')}. `
+						+ "If you'd like to add more, please do so in separate deposits.",
+					maxValue(this.maxDepositAmount),
+				),
+			},
+		};
+	},
+	methods: {
+		async fetchDepositData() {
+			this.loading = true;
+			this.loadError = false;
+			try {
+				const response = await this.apollo.query({
+					query: depositReadModelQuery,
+					fetchPolicy: 'network-only',
+				});
+				const userAccount = response?.data?.my?.userAccount;
+				const deposit = userAccount?.deposit;
+				if (!deposit) {
+					this.loadError = true;
+					return;
+				}
+				this.canDeposit = deposit.canDeposit;
+				this.currentBalance = userAccount.balance ?? 0;
+				this.maxDepositAmount = deposit.maxDepositAmount ?? DEPOSIT_MAX_AMOUNT;
+			} catch (error) {
+				this.loadError = true;
+				logFormatter(`Error fetching deposit data: ${error}`, 'error');
+			} finally {
+				this.loading = false;
+			}
+		},
+		onAmountInput(value) {
+			this.amount = value;
+			this.v$.amount.$touch();
+		},
+		trackAmountFocus() {
+			if (this.amountFocusTracked) {
+				return;
+			}
+			this.amountFocusTracked = true;
+			this.$kvTrackEvent('portfolio', 'click', 'Deposit amount field');
+		},
+		onDepositComplete({ amount }) {
+			// Use the amount the wrapper actually charged (snapshotted at submit), not the live input.
+			this.depositedAmount = amount;
+			this.depositComplete = true;
+		},
+	},
+	mounted() {
+		this.fetchDepositData();
+	},
+};
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,4 +1,5 @@
 import { WITHDRAW_ROUTE, WITHDRAW_PROCESS } from '#src/util/withdraw/withdrawConstants';
+import { DEPOSIT_ROUTE } from '#src/util/deposit/depositConstants';
 
 export default [
 	{
@@ -405,6 +406,14 @@ export default [
 		props: route => ({
 			token: route.query.token,
 		}),
+	},
+	{
+		path: DEPOSIT_ROUTE.BASE,
+		component: () => import('#src/pages/Deposit/DepositPage'),
+		meta: {
+			authenticationRequired: true,
+			excludeFromStaticSitemap: true,
+		},
 	},
 	{
 		path: '/portfolio/kiva-cards-beta',

--- a/src/util/deposit/depositConstants.js
+++ b/src/util/deposit/depositConstants.js
@@ -1,0 +1,19 @@
+// Route path for the deposit-beta (Add credit) page. Imported by the router and the
+// page so the navigation target resolves to a single source of truth.
+export const DEPOSIT_ROUTE = {
+	BASE: '/portfolio/credit/deposit-beta',
+};
+
+// Where "Make a monthly deposit" links (the recurring auto-deposit flow), matching
+// the legacy add-credit template's monthly-deposit link.
+export const AUTO_DEPOSIT_ROUTE = '/auto-deposit';
+
+// Where non-eligible (non-lender) users are pointed to make their first loan.
+export const LEND_ROUTE = '/lend/filter';
+
+// Client-side floor mirrors the legacy add-credit form's data-min-amount.
+export const DEPOSIT_MIN_AMOUNT = 0.01;
+
+// Fallback ceiling if the read model is unavailable; the server is authoritative
+// (config www.basket.maxCreditDeposit, default 10000).
+export const DEPOSIT_MAX_AMOUNT = 10000;

--- a/test/unit/specs/components/Deposit/DepositDropInPaymentWrapper.spec.js
+++ b/test/unit/specs/components/Deposit/DepositDropInPaymentWrapper.spec.js
@@ -1,50 +1,66 @@
 import { render, fireEvent, waitFor } from '@testing-library/vue';
-import DepositDropInPaymentWrapper from '#src/components/Deposit/DepositDropInPaymentWrapper';
 
 vi.mock('@sentry/vue', () => ({ captureException: vi.fn(), withScope: vi.fn() }));
 
-// Stubs the Braintree Drop-in: emits transactions-enabled on mount and exposes the
-// btDropinInstance the wrapper calls.
-const dropInStub = requestPaymentMethod => ({
-	name: 'BraintreeDropInInterface',
-	emits: ['transactions-enabled'],
-	data() {
-		return {
-			btDropinInstance: {
-				requestPaymentMethod,
-				clearSelectedPaymentMethod: vi.fn(),
+// Shared handles the KvPaymentSelect stub delegates to, so each test can control
+// the client-token fetch, the drop-in readiness, and the payment-method request.
+const shopMocks = vi.hoisted(() => ({
+	getClientToken: vi.fn(),
+	requestPaymentMethod: vi.fn(),
+	transactionsEnabled: true,
+}));
+
+// Mock @kiva/kv-shop so we neither hit the real getClientToken query nor pull in
+// the heavy KvPaymentSelect dependency graph. The stub mirrors the real component's
+// contract: it emits transactions-enabled on mount and exposes requestPaymentMethod.
+vi.mock('@kiva/kv-shop', () => ({
+	getClientToken: shopMocks.getClientToken,
+	KvPaymentSelect: {
+		name: 'KvPaymentSelect',
+		props: ['amount', 'authToken', 'dropInName', 'flow', 'paymentTypes'],
+		emits: ['transactions-enabled', 'error'],
+		methods: {
+			requestPaymentMethod() {
+				return shopMocks.requestPaymentMethod();
 			},
-		};
+		},
+		mounted() {
+			this.$emit('transactions-enabled', shopMocks.transactionsEnabled);
+		},
+		template: '<div data-testid="kv-payment-select" />',
 	},
-	mounted() {
-		this.$emit('transactions-enabled', true);
-	},
-	template: '<div data-testid="braintree-dropin" />',
-});
+}));
+
+// eslint-disable-next-line import/first
+import DepositDropInPaymentWrapper from '#src/components/Deposit/DepositDropInPaymentWrapper';
 
 const renderWrapper = ({
 	amount = 50,
 	disabled = false,
 	mutateResult = { data: { my: { depositWithBraintreeNonce: 123 } } },
-	requestPaymentMethod = vi.fn().mockResolvedValue({ nonce: 'fake-nonce', deviceData: 'dd', type: 'PayPalAccount' }),
+	mutate = null,
+	paymentMethod = { nonce: 'fake-nonce', deviceData: 'dd', type: 'PayPalAccount' },
+	clientToken = 'fake-token',
 } = {}) => {
-	const mutate = vi.fn().mockResolvedValue(mutateResult);
+	shopMocks.getClientToken.mockResolvedValue(clientToken);
+	shopMocks.requestPaymentMethod.mockResolvedValue(paymentMethod);
+
+	const mutateFn = mutate ?? vi.fn().mockResolvedValue(mutateResult);
 	const kvTrackEvent = vi.fn();
 	const showTipMsg = vi.fn();
 
 	return {
-		mutate,
+		mutate: mutateFn,
 		kvTrackEvent,
 		showTipMsg,
-		requestPaymentMethod,
+		requestPaymentMethod: shopMocks.requestPaymentMethod,
 		...render(DepositDropInPaymentWrapper, {
 			props: { amount, disabled },
 			global: {
-				provide: { apollo: { mutate } },
+				provide: { apollo: { mutate: mutateFn } },
 				mocks: { $kvTrackEvent: kvTrackEvent, $showTipMsg: showTipMsg },
 				directives: { 'kv-track-event': {} },
 				stubs: {
-					BraintreeDropInInterface: dropInStub(requestPaymentMethod),
 					KvButton: {
 						props: ['state'],
 						template: '<button :disabled="state === \'disabled\' || state === \'loading\'"'
@@ -58,11 +74,18 @@ const renderWrapper = ({
 };
 
 describe('DepositDropInPaymentWrapper', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		shopMocks.transactionsEnabled = true;
+	});
+
 	it('charges, emits complete-transaction, and fires legacy + braintree analytics on success', async () => {
 		const {
 			getByTestId, emitted, mutate, kvTrackEvent,
 		} = renderWrapper({ amount: 50 });
 
+		// The submit button only appears once the client token resolves and the
+		// drop-in reports it is ready.
 		await waitFor(() => expect(getByTestId('deposit-submit').disabled).toBe(false));
 		await fireEvent.click(getByTestId('deposit-submit'));
 
@@ -114,10 +137,42 @@ describe('DepositDropInPaymentWrapper', () => {
 	it('does not submit when disabled', async () => {
 		const { getByTestId, mutate, requestPaymentMethod } = renderWrapper({ disabled: true });
 
+		// Wait for the drop-in to render, then confirm the button stays disabled.
+		await waitFor(() => expect(getByTestId('deposit-submit')).toBeTruthy());
 		expect(getByTestId('deposit-submit').disabled).toBe(true);
 		await fireEvent.click(getByTestId('deposit-submit'));
 
 		expect(requestPaymentMethod).not.toHaveBeenCalled();
 		expect(mutate).not.toHaveBeenCalled();
+	});
+
+	it('locks the payment selection while a charge is in flight', async () => {
+		// Keep the mutation pending so we can observe the in-flight (submitting) state.
+		let resolveMutate;
+		const mutate = vi.fn(() => new Promise(resolve => { resolveMutate = resolve; }));
+		const { getByTestId } = renderWrapper({ mutate });
+
+		await waitFor(() => expect(getByTestId('deposit-submit').disabled).toBe(false));
+		await fireEvent.click(getByTestId('deposit-submit'));
+
+		// While the charge is pending the payment selection is inert and dimmed.
+		const wrap = getByTestId('deposit-payment-wrap');
+		await waitFor(() => expect(wrap.hasAttribute('inert')).toBe(true));
+		expect(wrap.classList.contains('tw-pointer-events-none')).toBe(true);
+		// tw-opacity-low is the kv-tokens opacity utility (0.3); tw-opacity-50 is not generated.
+		expect(wrap.classList.contains('tw-opacity-low')).toBe(true);
+
+		// Once it settles the selection is interactive again.
+		resolveMutate({ data: { my: { depositWithBraintreeNonce: 123 } } });
+		await waitFor(() => expect(wrap.hasAttribute('inert')).toBe(false));
+		expect(wrap.classList.contains('tw-pointer-events-none')).toBe(false);
+		expect(wrap.classList.contains('tw-opacity-low')).toBe(false);
+	});
+
+	it('shows a retry state when the client token cannot be fetched', async () => {
+		const { getByTestId, queryByTestId } = renderWrapper({ clientToken: '' });
+
+		await waitFor(() => expect(getByTestId('deposit-payment-error')).toBeTruthy());
+		expect(queryByTestId('deposit-submit')).toBeNull();
 	});
 });

--- a/test/unit/specs/components/Deposit/DepositDropInPaymentWrapper.spec.js
+++ b/test/unit/specs/components/Deposit/DepositDropInPaymentWrapper.spec.js
@@ -1,0 +1,123 @@
+import { render, fireEvent, waitFor } from '@testing-library/vue';
+import DepositDropInPaymentWrapper from '#src/components/Deposit/DepositDropInPaymentWrapper';
+
+vi.mock('@sentry/vue', () => ({ captureException: vi.fn(), withScope: vi.fn() }));
+
+// Stubs the Braintree Drop-in: emits transactions-enabled on mount and exposes the
+// btDropinInstance the wrapper calls.
+const dropInStub = requestPaymentMethod => ({
+	name: 'BraintreeDropInInterface',
+	emits: ['transactions-enabled'],
+	data() {
+		return {
+			btDropinInstance: {
+				requestPaymentMethod,
+				clearSelectedPaymentMethod: vi.fn(),
+			},
+		};
+	},
+	mounted() {
+		this.$emit('transactions-enabled', true);
+	},
+	template: '<div data-testid="braintree-dropin" />',
+});
+
+const renderWrapper = ({
+	amount = 50,
+	disabled = false,
+	mutateResult = { data: { my: { depositWithBraintreeNonce: 123 } } },
+	requestPaymentMethod = vi.fn().mockResolvedValue({ nonce: 'fake-nonce', deviceData: 'dd', type: 'PayPalAccount' }),
+} = {}) => {
+	const mutate = vi.fn().mockResolvedValue(mutateResult);
+	const kvTrackEvent = vi.fn();
+	const showTipMsg = vi.fn();
+
+	return {
+		mutate,
+		kvTrackEvent,
+		showTipMsg,
+		requestPaymentMethod,
+		...render(DepositDropInPaymentWrapper, {
+			props: { amount, disabled },
+			global: {
+				provide: { apollo: { mutate } },
+				mocks: { $kvTrackEvent: kvTrackEvent, $showTipMsg: showTipMsg },
+				directives: { 'kv-track-event': {} },
+				stubs: {
+					BraintreeDropInInterface: dropInStub(requestPaymentMethod),
+					KvButton: {
+						props: ['state'],
+						template: '<button :disabled="state === \'disabled\' || state === \'loading\'"'
+							+ ' @click="$emit(\'click\')"><slot /></button>',
+					},
+					KvMaterialIcon: { props: ['icon'], template: '<i />' },
+				},
+			},
+		}),
+	};
+};
+
+describe('DepositDropInPaymentWrapper', () => {
+	it('charges, emits complete-transaction, and fires legacy + braintree analytics on success', async () => {
+		const {
+			getByTestId, emitted, mutate, kvTrackEvent,
+		} = renderWrapper({ amount: 50 });
+
+		await waitFor(() => expect(getByTestId('deposit-submit').disabled).toBe(false));
+		await fireEvent.click(getByTestId('deposit-submit'));
+
+		await waitFor(() => {
+			expect(emitted()['complete-transaction']).toBeTruthy();
+		});
+		// The confirmation carries the amount that was charged (snapshotted at submit).
+		expect(emitted()['complete-transaction'][0][0]).toEqual(
+			expect.objectContaining({ transactionId: 123, amount: 50 }),
+		);
+		// It signals processing on (submit) then off (settled) so the parent can lock the input.
+		expect(emitted().processing).toEqual([[true], [false]]);
+		expect(mutate).toHaveBeenCalledWith(expect.objectContaining({
+			variables: expect.objectContaining({ amount: '50.00', nonce: 'fake-nonce', deviceData: 'dd' }),
+		}));
+		// Legacy parity event: category/action/label + value in cents (50 * 100).
+		expect(kvTrackEvent).toHaveBeenCalledWith('Lending', 'Add Credit', 'Add Credit Page', null, 5000);
+		// Braintree drop-in success event.
+		expect(kvTrackEvent).toHaveBeenCalledWith(
+			'portfolio',
+			'PayPalAccount Braintree DropIn Deposit',
+			'Success',
+			123,
+			123,
+		);
+	});
+
+	it('surfaces the payment error and does not complete when the mutation fails', async () => {
+		const {
+			getByTestId, emitted, showTipMsg, kvTrackEvent,
+		} = renderWrapper({
+			mutateResult: { errors: [{ message: 'Card declined.' }] },
+		});
+
+		await waitFor(() => expect(getByTestId('deposit-submit').disabled).toBe(false));
+		await fireEvent.click(getByTestId('deposit-submit'));
+
+		await waitFor(() => {
+			expect(showTipMsg).toHaveBeenCalled();
+		});
+		expect(kvTrackEvent).toHaveBeenCalledWith(
+			'Deposit',
+			'DropIn Payment Error',
+			expect.stringContaining('Card declined.'),
+		);
+		expect(emitted()['complete-transaction']).toBeFalsy();
+	});
+
+	it('does not submit when disabled', async () => {
+		const { getByTestId, mutate, requestPaymentMethod } = renderWrapper({ disabled: true });
+
+		expect(getByTestId('deposit-submit').disabled).toBe(true);
+		await fireEvent.click(getByTestId('deposit-submit'));
+
+		expect(requestPaymentMethod).not.toHaveBeenCalled();
+		expect(mutate).not.toHaveBeenCalled();
+	});
+});

--- a/test/unit/specs/pages/Deposit/DepositPage.spec.js
+++ b/test/unit/specs/pages/Deposit/DepositPage.spec.js
@@ -1,0 +1,164 @@
+import { render, fireEvent, waitFor } from '@testing-library/vue';
+import DepositPage from '#src/pages/Deposit/DepositPage';
+
+const readModelResponse = ({
+	canDeposit = true,
+	maxDepositAmount = 10000,
+	balance = 150,
+} = {}) => ({
+	my: {
+		id: 'my-id',
+		userAccount: {
+			id: 3,
+			balance,
+			deposit: {
+				canDeposit,
+				maxDepositAmount,
+			},
+		},
+	},
+});
+
+const stubInput = {
+	props: ['modelValue'],
+	emits: ['input', 'update:modelValue'],
+	template: `<input
+		:value="modelValue"
+		@input="$emit('input', $event.target.value); $emit('update:modelValue', $event.target.value)"
+	/>`,
+};
+
+// Stubs the drop-in wrapper: exposes the amount/disabled props and lets a test drive the
+// complete-transaction event the page listens for.
+const wrapperStub = {
+	name: 'DepositDropInPaymentWrapper',
+	props: ['amount', 'disabled'],
+	emits: ['complete-transaction', 'processing'],
+	template: `<div>
+		<button
+			data-testid="deposit-submit"
+			:disabled="disabled"
+			@click="$emit('complete-transaction', { transactionId: 123, paymentType: 'PayPalAccount', amount })"
+		>Add credit</button>
+		<button data-testid="stub-start-processing" @click="$emit('processing', true)">processing</button>
+	</div>`,
+};
+
+const renderPage = ({ response = readModelResponse(), rejects = false } = {}) => {
+	const query = rejects
+		? vi.fn().mockRejectedValue(new Error('boom'))
+		: vi.fn().mockResolvedValue({ data: response });
+	const kvTrackEvent = vi.fn();
+
+	return {
+		query,
+		kvTrackEvent,
+		...render(DepositPage, {
+			global: {
+				provide: { apollo: { query }, cookieStore: {} },
+				mocks: { $router: { push: vi.fn() }, $kvTrackEvent: kvTrackEvent },
+				directives: { 'kv-track-event': {} },
+				stubs: {
+					RouterLink: { props: ['to'], template: '<a><slot /></a>' },
+					PortfolioShell: { template: '<div><slot /></div>' },
+					DepositDropInPaymentWrapper: wrapperStub,
+					KvButton: {
+						props: ['to', 'state'],
+						template: '<button :disabled="state === \'disabled\' || state === \'loading\'">'
+							+ '<slot /></button>',
+					},
+					KvLoadingPlaceholder: { template: '<div data-testid="loading" />' },
+					KvCurrencyInput: stubInput,
+				},
+			},
+		}),
+	};
+};
+
+describe('DepositPage', () => {
+	it('renders the current balance and form for an eligible lender', async () => {
+		const { getByTestId } = renderPage();
+		await waitFor(() => {
+			expect(getByTestId('deposit-current-balance').textContent).toContain('$150.00');
+		});
+		expect(getByTestId('deposit-submit')).toBeTruthy();
+	});
+
+	it('shows the not-eligible state when canDeposit is false', async () => {
+		const { getByTestId, queryByTestId } = renderPage({
+			response: readModelResponse({ canDeposit: false }),
+		});
+		await waitFor(() => {
+			expect(getByTestId('deposit-forbidden')).toBeTruthy();
+		});
+		expect(queryByTestId('deposit-submit')).toBeNull();
+	});
+
+	it('shows an error state when the read model fails to load', async () => {
+		const { getByTestId } = renderPage({ rejects: true });
+		await waitFor(() => {
+			expect(getByTestId('deposit-load-error')).toBeTruthy();
+		});
+	});
+
+	it('keeps the confirm button disabled until a valid amount is entered', async () => {
+		const { getByLabelText, getByTestId } = renderPage();
+		await waitFor(() => getByTestId('deposit-submit'));
+
+		// Disabled on first load (amount 0 fails the minimum).
+		expect(getByTestId('deposit-submit').disabled).toBe(true);
+
+		await fireEvent.update(getByLabelText('Amount to deposit'), '50');
+
+		await waitFor(() => {
+			expect(getByTestId('deposit-submit').disabled).toBe(false);
+		});
+	});
+
+	it('keeps the confirm button disabled when the amount exceeds the max', async () => {
+		const { getByLabelText, getByTestId } = renderPage();
+		await waitFor(() => getByTestId('deposit-submit'));
+
+		await fireEvent.update(getByLabelText('Amount to deposit'), '20000');
+
+		await waitFor(() => {
+			expect(getByTestId('deposit-submit').disabled).toBe(true);
+		});
+	});
+
+	it('shows the thanks state with the deposited amount on completion', async () => {
+		const { getByLabelText, getByTestId } = renderPage();
+		await waitFor(() => getByTestId('deposit-submit'));
+
+		await fireEvent.update(getByLabelText('Amount to deposit'), '50');
+		await waitFor(() => expect(getByTestId('deposit-submit').disabled).toBe(false));
+		await fireEvent.click(getByTestId('deposit-submit'));
+
+		await waitFor(() => {
+			expect(getByTestId('deposit-thanks')).toBeTruthy();
+		});
+		expect(getByTestId('deposit-amount-paid').textContent).toContain('$50.00');
+	});
+
+	it('tracks the amount field on first focus', async () => {
+		const { getByLabelText, getByTestId, kvTrackEvent } = renderPage();
+		await waitFor(() => getByTestId('deposit-submit'));
+
+		await fireEvent.focusIn(getByLabelText('Amount to deposit'));
+
+		expect(kvTrackEvent).toHaveBeenCalledWith('portfolio', 'click', 'Deposit amount field');
+	});
+
+	it('disables the amount input while a deposit is processing', async () => {
+		const { getByLabelText, getByTestId } = renderPage();
+		await waitFor(() => getByTestId('deposit-submit'));
+
+		expect(getByLabelText('Amount to deposit').disabled).toBe(false);
+
+		await fireEvent.click(getByTestId('stub-start-processing'));
+
+		await waitFor(() => {
+			expect(getByLabelText('Amount to deposit').disabled).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2985

Implemented the migrated `/portfolio/credit/deposit-beta` using the new backend query and mutation. All functionality migrated and matching newstack.

Also a minor experiment cleanup that I noticed while looking through tech debt. Unrelated but super minor so I left it in the branch.

<br />

<img width="1017" height="938" alt="image" src="https://github.com/user-attachments/assets/9124cf11-acf0-49d2-a97f-ca487232d003" />

<br />

<img width="1012" height="713" alt="image" src="https://github.com/user-attachments/assets/d21dca5d-6d33-4380-aca0-8747ca451a70" />

<br />

<img width="402" height="814" alt="image" src="https://github.com/user-attachments/assets/b6e4f7fe-4004-438a-a359-1d931c8a8191" />
