### PR TITLE
fix(LoanTags): derive selected tag state from the current user's tags AD-357

### DIFF
--- a/src/components/BorrowerProfile/LoanTags.vue
+++ b/src/components/BorrowerProfile/LoanTags.vue
@@ -11,8 +11,8 @@
 				Tags
 			</h2>
 			<!-- Applied tags -->
-			<p v-if="selectedTags.length > 0">
-				<span v-for="(tag, index) in selectedTags" :key="tag.id || 0">
+			<p v-if="visibleTags.length > 0">
+				<span v-for="(tag, index) in visibleTags" :key="tag.id || 0">
 					<router-link
 						:to="`/lend/filter?tag=${tag.id}`"
 						class="tw-no-underline tw-font-medium"
@@ -128,9 +128,11 @@ export default {
 				return { loanId: this.loanId };
 			},
 			result({ data }) {
-				if (data?.lend?.loan?.tags) {
-					this.currentTagNames = data.lend.loan.tags;
+				const loan = data?.lend?.loan;
+				if (loan?.tags) {
+					this.loanTagNames = loan.tags;
 				}
+				this.userTagNames = loan?.userProperties?.appliedTags ?? [];
 				this.loanTagsLoaded = true;
 				this.emitHideSectionIfEmpty();
 			},
@@ -139,7 +141,8 @@ export default {
 	data() {
 		return {
 			availableTags: [],
-			currentTagNames: [],
+			loanTagNames: [],
+			userTagNames: [],
 			selectorVisible: false,
 			availableTagsLoaded: false,
 			loanTagsLoaded: false,
@@ -153,23 +156,29 @@ export default {
 			const states = {};
 			this.availableTags.forEach(tag => {
 				if (tag.id != null && tag.name != null) {
-					states[tag.id] = this.currentTagNames.includes(tag.name);
+					states[tag.id] = this.userTagNames.includes(tag.name);
 				}
 			});
 			return states;
 		},
+		// Tags this user personally applied.
 		selectedTags() {
 			return this.availableTags.filter(tag => this.tagStates[tag.id] === true);
+		},
+		// The displayed list: every tag applied to the loan (by anyone) plus this user's own.
+		visibleTags() {
+			return this.availableTags.filter(tag => tag.name != null
+				&& (this.loanTagNames.includes(tag.name) || this.userTagNames.includes(tag.name)));
 		},
 	},
 	methods: {
 		emitHideSectionIfEmpty() {
-			if (!this.loading && this.selectedTags.length === 0 && !this.isLoggedIn) {
+			if (!this.loading && this.visibleTags.length === 0 && !this.isLoggedIn) {
 				this.$emit('hide-section');
 			}
 		},
 		getTagDivider(index) {
-			return index < this.selectedTags.length - 1 ? ' | ' : '';
+			return index < this.visibleTags.length - 1 ? ' | ' : '';
 		},
 		async handleTagToggle(tagId, checked) {
 			const tag = this.availableTags.find(t => t.id === tagId);
@@ -179,11 +188,12 @@ export default {
 				return;
 			}
 
-			// Optimistic update; the refetched tag list reconciles it with the server
+			// Optimistically update this user's own tags only; the loan-level list is a
+			// server-side aggregate over all users, so the network-only refetch reconciles it.
 			if (checked) {
-				this.currentTagNames = [...this.currentTagNames, tag.name];
+				this.userTagNames = [...this.userTagNames, tag.name];
 			} else {
-				this.currentTagNames = this.currentTagNames.filter(n => n !== tag.name);
+				this.userTagNames = this.userTagNames.filter(n => n !== tag.name);
 			}
 
 			try {
@@ -203,9 +213,9 @@ export default {
 				logFormatter(e, 'error');
 				// Revert the optimistic update
 				if (checked) {
-					this.currentTagNames = this.currentTagNames.filter(n => n !== tag.name);
+					this.userTagNames = this.userTagNames.filter(n => n !== tag.name);
 				} else {
-					this.currentTagNames = [...this.currentTagNames, tag.name];
+					this.userTagNames = [...this.userTagNames, tag.name];
 				}
 				this.$showTipMsg('There was a problem saving the tag change', 'error');
 			}

--- a/src/graphql/query/borrowerProfileLoanTags.graphql
+++ b/src/graphql/query/borrowerProfileLoanTags.graphql
@@ -3,6 +3,9 @@ query BorrowerProfileLoanTags($loanId: Int!) {
 		loan(id: $loanId) {
 			id
 			tags
+			userProperties {
+				appliedTags
+			}
 		}
 	}
 }

--- a/test/unit/specs/components/BorrowerProfile/LoanTags.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanTags.spec.js
@@ -35,7 +35,10 @@ function renderLoanTags(dataOverrides = {}, propsOverrides = {}) {
 			return {
 				...LoanTags.data.call(this),
 				availableTags: mockAvailableTags,
-				currentTagNames: ['Education', 'Sustainable Agriculture'],
+				// Both tags are applied to the loan, but the current user only applied Education;
+				// Sustainable Agriculture was applied by another lender.
+				loanTagNames: ['Education', 'Sustainable Agriculture'],
+				userTagNames: ['Education'],
 				availableTagsLoaded: true,
 				loanTagsLoaded: true,
 				...dataOverrides,
@@ -78,6 +81,30 @@ describe('LoanTags', () => {
 		const { getByTestId, getAllByTestId } = renderLoanTags();
 		await fireEvent.click(getByTestId('bp-loan-tag-toggle'));
 		expect(getAllByTestId('bp-loan-tag-checkbox')).toHaveLength(3);
+	});
+
+	it('displays every tag applied to the loan, regardless of who applied it', () => {
+		const { getAllByTestId } = renderLoanTags();
+		const displayed = getAllByTestId('bp-loan-tag').map(el => el.textContent.trim());
+		expect(displayed).toEqual(['Education', 'Sustainable Agriculture']);
+	});
+
+	it('checks only tags the current user applied, not tags applied by others (AD-357)', async () => {
+		const { getByTestId, getAllByTestId } = renderLoanTags();
+		await fireEvent.click(getByTestId('bp-loan-tag-toggle'));
+		const checked = getAllByTestId('bp-loan-tag-checkbox')
+			.map(el => el.querySelector('input').checked);
+		// availableTags order: Education, Sustainable Agriculture, Women-Owned Business
+		expect(checked).toEqual([true, false, false]);
+	});
+
+	it('optimistically checks a tag the user selects', async () => {
+		const { getByTestId, getAllByTestId } = renderLoanTags();
+		await fireEvent.click(getByTestId('bp-loan-tag-toggle'));
+		const womenOwned = getAllByTestId('bp-loan-tag-checkbox')[2].querySelector('input');
+		expect(womenOwned.checked).toBe(false);
+		await fireEvent.click(womenOwned);
+		expect(womenOwned.checked).toBe(true);
 	});
 
 	it('calls the mutation and refetches the tag list when toggling a tag', async () => {


### PR DESCRIPTION
The borrower profile marked a tag selected whenever the loan carried it, regardless of who applied it. That doesn't match the behavior of the monolith, which only shows tags as selected if the current user applied them. This fixes that by using the new per-user `Loan.userProperties.appliedTags` field so a tag is selected only when the current user applied it, matching the monolith. The displayed list still shows every tag applied to the loan by anyone.

