### PR TITLE
fix: resolve loan matcher tooltip in production

### DIFF
--- a/src/components/Checkout/LoanMatcher.vue
+++ b/src/components/Checkout/LoanMatcher.vue
@@ -34,8 +34,12 @@ export default {
 		KvMaterialIcon,
 		KvTooltip,
 	},
-	data() {
-		return { mdiInformationOutline };
+	setup() {
+		const { uid } = getCurrentInstance();
+		return {
+			tooltipId: `loan-matcher-tooltip-${uid}`,
+			mdiInformationOutline,
+		};
 	},
 	props: {
 		matchingText: {
@@ -52,9 +56,6 @@ export default {
 		},
 	},
 	computed: {
-		tooltipId() {
-			return `loan-matcher-tooltip-${getCurrentInstance().uid}`;
-		},
 		totalRatio() {
 			// 1 base match + each org's ratio. e.g. 3 orgs each with ratio 1 => 1 + 1 + 1 + 1 = 4x
 			// or 1 org at ratio 2 + 2 orgs at ratio 1 => 1 + 2 + 1 + 1 = 5x


### PR DESCRIPTION
## Summary
- `getCurrentInstance()` called inside a `computed` property is not valid in Vue 3 — it only works by coincidence of timing during dev rendering, and returns `null` in production SSR builds
- This caused `tooltipId` to be undefined, breaking the `KvTooltip` controller binding
- Moved UID capture to `setup()` where `getCurrentInstance()` is guaranteed to be called with the correct instance context

## Why it worked in dev but not production

`getCurrentInstance()` returns Vue's internal `currentInstance` variable, which is only set during `setup()`, lifecycle hooks, and rendering. Inside a computed property, there's no guarantee it's set.

In development, computed properties are evaluated lazily on first access, which typically happens during the initial template render — a moment when `currentInstance` happens to be set. So it appears to work.

In production SSR, Vue's rendering pipeline is more optimized and the order of evaluation changes. The computed can be evaluated outside the normal render cycle, at a point where `currentInstance` is `null`. The resulting `TypeError` is swallowed silently in production (no dev-mode warnings), so the tooltip ID never gets set and `KvTooltip` can't find its trigger element.