### PR TITLE
fix(MinimalBorrowerProfile): defer recommendations until loan loads AD-287

### DIFF
--- a/src/components/BorrowerProfile/MinimalBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/MinimalBorrowerProfile.vue
@@ -215,6 +215,7 @@ export default {
 				this.loanData = data.lend.loan;
 			}
 			this.isSummaryLoading = false;
+			this.initRecommendations();
 		},
 	},
 	props: {
@@ -293,51 +294,59 @@ export default {
 		},
 	},
 	mounted() {
-		this.createViewportObserver();
-		this.rows = [
-			{
-				identifier: 'sector',
-				rowIndex: 1,
-				heading: 'Support these ',
-				subHeading: '',
-				onlyLoan: false,
-				limit: 3,
-				filter: { sector: { eq: this.loanData?.sector?.name } },
-				loanIds: []
-			},
-			{
-				identifier: 'recommended',
-				rowIndex: 2,
-				heading: 'Recommended Borrower',
-				subHeading: 'We selected this loan for you because it\'s similar to ',
-				onlyLoan: true,
-				limit: 1,
-				filter: null,
-				loan: null
-			},
-			{
-				identifier: 'gender',
-				rowIndex: 3,
-				heading: 'Support these ',
-				subHeading: '',
-				onlyLoan: false,
-				limit: 3,
-				filter: { gender: { eq: this.loanData?.gender } },
-				loanIds: []
-			},
-			{
-				identifier: 'country',
-				rowIndex: 4,
-				heading: 'Support these borrowers in ',
-				subHeading: '',
-				onlyLoan: false,
-				limit: 3,
-				filter: { countryIsoCode: { eq: this.loanData?.geocode?.country?.isoCode } },
-				loanIds: []
-			},
-		];
+		this.initRecommendations();
 	},
 	methods: {
+		initRecommendations() {
+			// Build the rows only once the loan's own query has populated loanData
+			// (loanData.sector); building from an empty loan yields "undefined" headings.
+			if (this.rows || !this.loanData?.sector?.name) {
+				return;
+			}
+			this.rows = [
+				{
+					identifier: 'sector',
+					rowIndex: 1,
+					heading: 'Support these ',
+					subHeading: '',
+					onlyLoan: false,
+					limit: 3,
+					filter: { sector: { eq: this.loanData?.sector?.name } },
+					loanIds: []
+				},
+				{
+					identifier: 'recommended',
+					rowIndex: 2,
+					heading: 'Recommended Borrower',
+					subHeading: 'We selected this loan for you because it\'s similar to ',
+					onlyLoan: true,
+					limit: 1,
+					filter: null,
+					loan: null
+				},
+				{
+					identifier: 'gender',
+					rowIndex: 3,
+					heading: 'Support these ',
+					subHeading: '',
+					onlyLoan: false,
+					limit: 3,
+					filter: { gender: { eq: this.loanData?.gender } },
+					loanIds: []
+				},
+				{
+					identifier: 'country',
+					rowIndex: 4,
+					heading: 'Support these borrowers in ',
+					subHeading: '',
+					onlyLoan: false,
+					limit: 3,
+					filter: { countryIsoCode: { eq: this.loanData?.geocode?.country?.isoCode } },
+					loanIds: []
+				},
+			];
+			this.createViewportObserver();
+		},
 		refIsVisible() {
 			const { top, bottom } = this.$refs?.preBottom?.getBoundingClientRect() ?? {};
 			const vHeight = (window.innerHeight || document.documentElement.clientHeight);

--- a/test/unit/specs/components/BorrowerProfile/MinimalBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/MinimalBorrowerProfile.spec.js
@@ -3,6 +3,7 @@ import MinimalBorrowerProfile from '#src/components/BorrowerProfile/MinimalBorro
 describe('MinimalBorrowerProfile.apollo.result', () => {
 	const invokeResult = (ctx, data) => {
 		expect(typeof MinimalBorrowerProfile.apollo.result).toBe('function');
+		ctx.initRecommendations = ctx.initRecommendations ?? (() => {});
 		MinimalBorrowerProfile.apollo.result.call(ctx, { data });
 	};
 
@@ -29,6 +30,7 @@ describe('MinimalBorrowerProfile.apollo.result', () => {
 
 describe('MinimalBorrowerProfile.apollo.result isSummaryLoading', () => {
 	const invokeResult = (ctx, data) => {
+		ctx.initRecommendations = ctx.initRecommendations ?? (() => {});
 		MinimalBorrowerProfile.apollo.result.call(ctx, { data });
 	};
 
@@ -42,5 +44,45 @@ describe('MinimalBorrowerProfile.apollo.result isSummaryLoading', () => {
 		const ctx = { loanData: { id: 123, name: 'Maria' }, isSummaryLoading: true };
 		invokeResult(ctx, { lend: { loan: null } });
 		expect(ctx.isSummaryLoading).toBe(false);
+	});
+});
+
+describe('MinimalBorrowerProfile.methods.initRecommendations', () => {
+	const invokeInit = ctx => MinimalBorrowerProfile.methods.initRecommendations.call(ctx);
+
+	it('defers building the rows until the loan has loaded (no sector yet)', () => {
+		const createViewportObserver = vi.fn();
+		const ctx = { rows: null, loanData: {}, createViewportObserver };
+		invokeInit(ctx);
+		expect(ctx.rows).toBeNull();
+		expect(createViewportObserver).not.toHaveBeenCalled();
+	});
+
+	it('builds all four rows from the loaded loan and starts the observer', () => {
+		const createViewportObserver = vi.fn();
+		const ctx = {
+			rows: null,
+			loanData: {
+				sector: { name: 'Retail' },
+				gender: 'female',
+				geocode: { country: { isoCode: 'GT' } },
+			},
+			createViewportObserver,
+		};
+		invokeInit(ctx);
+		expect(ctx.rows).toHaveLength(4);
+		expect(ctx.rows[0].filter).toEqual({ sector: { eq: 'Retail' } });
+		expect(ctx.rows[2].filter).toEqual({ gender: { eq: 'female' } });
+		expect(ctx.rows[3].filter).toEqual({ countryIsoCode: { eq: 'GT' } });
+		expect(createViewportObserver).toHaveBeenCalledOnce();
+	});
+
+	it('does not rebuild the rows once they are already built', () => {
+		const createViewportObserver = vi.fn();
+		const existing = [{ identifier: 'sector' }];
+		const ctx = { rows: existing, loanData: { sector: { name: 'Retail' } }, createViewportObserver };
+		invokeInit(ctx);
+		expect(ctx.rows).toBe(existing);
+		expect(createViewportObserver).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
On client-side navigation the recommendation rows can be built before the component's own query resolves, freezing an empty loan into the UI as "Support these undefined loans". This fixes that by building the rows (FLSS filters and headings) only once loanData is populated, driven from the apollo result, so the sector, gender, and country rows are all derived from a loaded loan. This was discovered before the borrower profile migration work.

### Before
<img width="837" height="377" alt="ad287-before" src="https://github.com/user-attachments/assets/d60e20d6-3141-4ab6-b34b-715cbda0891f" />


### After
<img width="848" height="393" alt="ad287-after" src="https://github.com/user-attachments/assets/e7195a59-1c98-434d-b2c1-2975dacf58e0" />
