### PR TITLE
feat: implement fe for /portfolio/credit/bonus-history migration

### DIFF
--- a/src/graphql/query/portfolio/bonusCreditHistory.graphql
+++ b/src/graphql/query/portfolio/bonusCreditHistory.graphql
@@ -1,0 +1,21 @@
+query bonusCreditHistory {
+	my {
+		id
+		userAccount {
+			id
+			lenderPromoCredits {
+				id
+				amountAtCreation
+				amountUnredeemed
+				expireTime
+				createTime
+				awardType
+				promoFund {
+					id
+					displayName
+				}
+				status
+			}
+		}
+	}
+}

--- a/src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.vue
+++ b/src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.vue
@@ -1,0 +1,261 @@
+<template>
+	<PortfolioShell>
+		<div class="tw-rounded md:tw-bg-primary tw-p-2 tw-py-3 md:tw-p-3" data-hj-suppress>
+			<h1 class="tw-text-headline tw-mb-1">
+				Free credit history
+			</h1>
+
+			<!-- Loading -->
+			<KvLoadingPlaceholder
+				v-if="loading"
+				style="height: 120px;"
+			/>
+
+			<!-- Error loading the read model -->
+			<div v-else-if="loadError" data-testid="free-credit-load-error">
+				<p>An error occurred. Please try again.</p>
+				<KvButton
+					class="tw-mt-2"
+					@click="fetchBonusCreditHistory"
+					v-kv-track-event="['portfolio', 'click', 'Free credit history retry load']"
+				>
+					Try again
+				</KvButton>
+			</div>
+
+			<!-- Empty state -->
+			<div v-else-if="!hasRecords" data-testid="free-credit-empty">
+				<p>
+					You have not earned any free credits.
+					<a
+						href="/bonus/learnmore"
+						class="tw-no-underline"
+						v-kv-track-event="['portfolio', 'click', 'Free credit history learn more']"
+					>Learn More »</a>
+				</p>
+			</div>
+
+			<!-- History table -->
+			<template v-else>
+				<div class="tw-overflow-x-auto">
+					<table class="tw-w-full tw-text-left tw-text-small md:tw-text-base" data-testid="free-credit-table">
+						<thead>
+							<tr class="tw-bg-gray-200">
+								<th class="tw-p-1">
+									Amount
+								</th>
+								<th class="tw-p-1 tw-max-w-9 md:tw-max-w-none">
+									<span class="tw-block tw-truncate">Expiration</span>
+								</th>
+								<th class="tw-p-1">
+									Status
+								</th>
+								<th class="tw-p-1 tw-max-w-8 md:tw-max-w-none">
+									<span class="tw-block tw-truncate">Sponsor</span>
+								</th>
+								<th class="tw-p-1">
+									Notes
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr
+								v-for="(record, i) in pagedRecords"
+								:key="record.id"
+								class="tw-bg-primary"
+								:class="{ '!tw-bg-gray-50': i % 2 === 1 }"
+							>
+								<td class="tw-p-1 tw-break-words">
+									{{ formatMoney(record.amountAtCreation) }}
+								</td>
+								<td class="tw-p-1 tw-break-words tw-max-w-9 md:tw-max-w-none">
+									{{ getFormattedDate(record.expireTime) }}
+								</td>
+								<td class="tw-p-1 tw-break-words">
+									<span
+										class="tw-inline-block tw-rounded-full tw-px-1.5 tw-py-0.5
+											tw-text-small tw-font-medium"
+										:class="statusBadgeClass(record.status)"
+									>
+										{{ statusLabel(record.status) }}
+									</span>
+								</td>
+								<td class="tw-p-1 tw-max-w-8 md:tw-max-w-none">
+									<span class="tw-block tw-truncate">{{ record.promoFund?.displayName }}</span>
+								</td>
+								<td class="tw-p-1 tw-break-words">
+									{{ composeNote(record) }}
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
+
+				<KvPagination
+					v-if="showPagination"
+					class="tw-mt-3"
+					:limit="limit"
+					:offset="offset"
+					:total="total"
+					:scroll-to-top="false"
+					:kv-track-function="$kvTrackEvent"
+					track-event-category="portfolio"
+					@page-changed="handlePageChange"
+				/>
+			</template>
+		</div>
+	</PortfolioShell>
+</template>
+
+<script>
+import numeral from 'numeral';
+import { KvButton, KvLoadingPlaceholder, KvPagination } from '@kiva/kv-components';
+import PortfolioShell from '#src/components/WwwFrame/PortfolioShell';
+import logFormatter from '#src/util/logFormatter';
+import bonusCreditHistoryQuery from '#src/graphql/query/portfolio/bonusCreditHistory.graphql';
+
+// Client-side page size — the list is small per user, so all rows are fetched once
+// and paged in the browser (mirrors the design's "paginate client-side" decision).
+const PAGE_LIMIT = 10;
+
+// Maps the FreeCreditStatus enum to a human label + badge colour. Labels preserve the
+// legacy BonusHistoryView wording ("Part redeemed", etc.).
+const STATUS_META = {
+	AVAILABLE: { label: 'Available', badge: 'tw-bg-eco-green-1 tw-text-eco-green-4' },
+	PART_REDEEMED: { label: 'Part redeemed', badge: 'tw-bg-marigold-1 tw-text-marigold-3' },
+	REDEEMED: { label: 'Redeemed', badge: 'tw-bg-gray-100 tw-text-secondary' },
+	EXPIRED: { label: 'Expired', badge: 'tw-bg-gray-200 tw-text-danger' },
+};
+
+export default {
+	name: 'BonusCreditHistoryPage',
+	inject: ['apollo'],
+	head() {
+		return {
+			title: 'Free Credit History',
+		};
+	},
+	components: {
+		PortfolioShell,
+		KvButton,
+		KvLoadingPlaceholder,
+		KvPagination,
+	},
+	data() {
+		return {
+			loading: true,
+			loadError: false,
+			records: [],
+			offset: 0,
+			limit: PAGE_LIMIT,
+		};
+	},
+	computed: {
+		hasRecords() {
+			return this.records.length > 0;
+		},
+		total() {
+			return this.records.length;
+		},
+		showPagination() {
+			return this.total > this.limit;
+		},
+		pagedRecords() {
+			return this.records.slice(this.offset, this.offset + this.limit);
+		},
+	},
+	mounted() {
+		this.fetchBonusCreditHistory();
+	},
+	methods: {
+		async fetchBonusCreditHistory() {
+			this.loading = true;
+			this.loadError = false;
+			try {
+				const response = await this.apollo.query({
+					query: bonusCreditHistoryQuery,
+					fetchPolicy: 'network-only',
+				});
+				const history = response?.data?.my?.userAccount?.lenderPromoCredits;
+				if (!history) {
+					this.loadError = true;
+					return;
+				}
+				this.records = history;
+				this.offset = 0;
+			} catch (error) {
+				this.loadError = true;
+				logFormatter(`Error fetching free credit history: ${error}`, 'error');
+			} finally {
+				this.loading = false;
+			}
+		},
+		handlePageChange({ pageOffset }) {
+			this.offset = pageOffset;
+		},
+		formatMoney(value) {
+			return numeral(value ?? 0).format('$0,0.00');
+		},
+		// Parses a GraphQL Date scalar (ISO 8601 string) to a Date, or null when absent/invalid.
+		toDate(value) {
+			if (value === null || value === undefined || value === '') {
+				return null;
+			}
+			const date = new Date(value);
+			return Number.isNaN(date.getTime()) ? null : date;
+		},
+		// Normalises a Date scalar to a "Mar 5, 2023" label.
+		getFormattedDate(value) {
+			const date = this.toDate(value);
+			if (!date) {
+				return '';
+			}
+			return date.toLocaleDateString('en-US', {
+				month: 'short',
+				day: 'numeric',
+				year: 'numeric',
+			});
+		},
+		isExpired(record) {
+			const date = this.toDate(record.expireTime);
+			return date ? date.getTime() < Date.now() : false;
+		},
+		statusLabel(status) {
+			return STATUS_META[status]?.label ?? status;
+		},
+		statusBadgeClass(status) {
+			return STATUS_META[status]?.badge ?? STATUS_META.REDEEMED.badge;
+		},
+		// Reproduces the legacy award-type sentences (BonusHistoryView::initializeData). For a
+		// partially-redeemed credit it appends the unredeemed amount, "expired" once past the
+		// expiration date and "remaining" otherwise.
+		composeNote(record) {
+			const date = this.getFormattedDate(record.createTime);
+			let note;
+			switch (record.awardType) {
+				case 'invitation':
+					note = `Successful invite on ${date}.`;
+					break;
+				case 'promo_code':
+				case 'lending_reward':
+				case 'admin':
+					note = `Free credit added on ${date}.`;
+					break;
+				case 'donation':
+					note = `Donation reward on ${date}.`;
+					break;
+				case 'free_trial':
+					note = `Free trial reward on ${date}.`;
+					break;
+				default:
+					note = `Free credit added ${date}.`;
+			}
+			if (record.status === 'PART_REDEEMED') {
+				const verb = this.isExpired(record) ? 'expired' : 'remaining';
+				note += ` ${this.formatMoney(record.amountUnredeemed)} ${verb}.`;
+			}
+			return note;
+		},
+	},
+};
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -368,6 +368,14 @@ export default [
 		}
 	},
 	{
+		path: '/portfolio/credit/bonus-history-beta',
+		component: () => import('#src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage'),
+		meta: {
+			authenticationRequired: true,
+			excludeFromStaticSitemap: true,
+		}
+	},
+	{
 		path: WITHDRAW_ROUTE.BASE,
 		component: () => import('#src/pages/Withdraw/WithdrawPage'),
 		meta: {

--- a/test/unit/specs/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.spec.js
@@ -1,0 +1,232 @@
+import { render, waitFor, fireEvent } from '@testing-library/vue';
+import BonusCreditHistoryPage from '#src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage';
+
+const YEAR_MS = 60 * 60 * 24 * 365 * 1000;
+const TEN_DAYS_MS = 60 * 60 * 24 * 10 * 1000;
+// A far-future expiration keeps part-redeemed notes on the "remaining" branch.
+const FUTURE_EXPIRATION = new Date(Date.now() + YEAR_MS).toISOString();
+// A past expiration drives the EXPIRED status / "expired" note verb.
+const PAST_EXPIRATION = new Date(Date.now() - TEN_DAYS_MS).toISOString();
+// ISO 8601 string, matching the GraphQL Date scalar (asISO8601 output).
+const CREATED_ISO = '2023-03-01T00:00:00.000Z';
+
+const record = (overrides = {}) => ({
+	id: 1,
+	amountAtCreation: 25,
+	amountUnredeemed: 25,
+	expireTime: FUTURE_EXPIRATION,
+	createTime: CREATED_ISO,
+	awardType: 'invitation',
+	promoFund: { id: 10, displayName: 'Kiva' },
+	status: 'AVAILABLE',
+	...overrides,
+});
+
+const historyResponse = (lenderPromoCredits = []) => ({
+	my: {
+		id: 'my-id',
+		userAccount: {
+			id: 3,
+			lenderPromoCredits,
+		},
+	},
+});
+
+const renderPage = ({ response = historyResponse(), rejects = false, query } = {}) => {
+	const q = query ?? (rejects
+		? vi.fn().mockRejectedValue(new Error('boom'))
+		: vi.fn().mockResolvedValue({ data: response }));
+
+	return {
+		query: q,
+		...render(BonusCreditHistoryPage, {
+			global: {
+				provide: { apollo: { query: q }, cookieStore: {} },
+				mocks: { $kvTrackEvent: vi.fn() },
+				directives: { 'kv-track-event': {} },
+				stubs: {
+					PortfolioShell: { template: '<div><slot /></div>' },
+					// Parent @click falls through to this root <button> natively, so the
+					// "Try again" retry path fires exactly once per click.
+					KvButton: { template: '<button><slot /></button>' },
+					KvLoadingPlaceholder: { template: '<div data-testid="loading" />' },
+					// Emit page-changed with the next page's offset when clicked.
+					KvPagination: {
+						props: ['limit', 'offset', 'total'],
+						emits: ['page-changed'],
+						template: '<button data-testid="pagination"'
+							+ ' @click="$emit(\'page-changed\', { pageOffset: 10 })">page</button>',
+					},
+				},
+			},
+		}),
+	};
+};
+
+describe('BonusCreditHistoryPage', () => {
+	it('shows the loading placeholder before the query resolves', () => {
+		const { getByTestId } = renderPage();
+		expect(getByTestId('loading')).toBeTruthy();
+	});
+
+	it('shows the empty state when there is no history', async () => {
+		const { getByTestId, getByText } = renderPage({ response: historyResponse([]) });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-empty')).toBeTruthy();
+		});
+		expect(getByText('You have not earned any free credits.', { exact: false })).toBeTruthy();
+		const learnMore = getByText('Learn More', { exact: false });
+		expect(learnMore.getAttribute('href')).toBe('/bonus/learnmore');
+	});
+
+	it('renders a row per record with formatted amount, status badge and note', async () => {
+		const { getByTestId, getByText } = renderPage({
+			response: historyResponse([record()]),
+		});
+		await waitFor(() => {
+			expect(getByTestId('free-credit-table')).toBeTruthy();
+		});
+		// Amount formatted as currency
+		expect(getByText('$25.00')).toBeTruthy();
+		// Status badge label + colour class
+		const badge = getByText('Available');
+		expect(badge.className).toContain('tw-bg-eco-green-1');
+		// FE-composed note from awardType + createTime
+		expect(getByText('Successful invite on', { exact: false })).toBeTruthy();
+	});
+
+	it('appends the remaining amount for a part-redeemed credit', async () => {
+		const { getByText } = renderPage({
+			response: historyResponse([record({
+				status: 'PART_REDEEMED',
+				amountUnredeemed: 2,
+				awardType: 'promo_code',
+			})]),
+		});
+		await waitFor(() => {
+			expect(getByText('Part redeemed')).toBeTruthy();
+		});
+		expect(getByText('$2.00 remaining.', { exact: false })).toBeTruthy();
+	});
+
+	it('appends "expired" for a part-redeemed credit past its expiration', async () => {
+		const { getByText } = renderPage({
+			response: historyResponse([record({
+				status: 'PART_REDEEMED',
+				amountUnredeemed: 3,
+				awardType: 'promo_code',
+				expireTime: PAST_EXPIRATION,
+			})]),
+		});
+		await waitFor(() => {
+			expect(getByText('$3.00 expired.', { exact: false })).toBeTruthy();
+		});
+	});
+
+	it.each([
+		['lending_reward', 'Free credit added on'],
+		['admin', 'Free credit added on'],
+		['donation', 'Donation reward on'],
+		['free_trial', 'Free trial reward on'],
+	])('composes the note for award type %s', async (awardType, expectedPrefix) => {
+		const { getByText } = renderPage({ response: historyResponse([record({ awardType })]) });
+		await waitFor(() => {
+			expect(getByText(expectedPrefix, { exact: false })).toBeTruthy();
+		});
+	});
+
+	it('composes the default note (no "on") for an unknown award type', async () => {
+		const { getByText, queryByText } = renderPage({
+			response: historyResponse([record({ awardType: 'universal_code' })]),
+		});
+		await waitFor(() => {
+			expect(getByText('Free credit added', { exact: false })).toBeTruthy();
+		});
+		expect(queryByText('added on', { exact: false })).toBeNull();
+	});
+
+	it('renders the Redeemed badge', async () => {
+		const { getByText } = renderPage({
+			response: historyResponse([record({ status: 'REDEEMED', amountUnredeemed: 0 })]),
+		});
+		await waitFor(() => {
+			const badge = getByText('Redeemed');
+			expect(badge.className).toContain('tw-bg-gray-100');
+		});
+	});
+
+	it('renders the Expired badge', async () => {
+		const { getByText } = renderPage({
+			response: historyResponse([record({ status: 'EXPIRED', expireTime: PAST_EXPIRATION })]),
+		});
+		await waitFor(() => {
+			const badge = getByText('Expired');
+			expect(badge.className).toContain('tw-text-danger');
+		});
+	});
+
+	it('paginates client-side: shows 10 of >10 rows and advances on page change', async () => {
+		const many = Array.from({ length: 15 }, (_, i) => record({ id: i + 1, amountAtCreation: 100 + i }));
+		const { container, getByTestId, queryByTestId } = renderPage({ response: historyResponse(many) });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-table')).toBeTruthy();
+		});
+		// First page: 10 rows + pagination control present.
+		expect(container.querySelectorAll('tbody tr')).toHaveLength(10);
+		expect(queryByTestId('pagination')).toBeTruthy();
+		// Advance a page -> the remaining 5 rows.
+		await fireEvent.click(getByTestId('pagination'));
+		await waitFor(() => {
+			expect(container.querySelectorAll('tbody tr')).toHaveLength(5);
+		});
+	});
+
+	it('hides pagination when there are 10 or fewer rows', async () => {
+		const few = Array.from({ length: 5 }, (_, i) => record({ id: i + 1 }));
+		const { container, getByTestId, queryByTestId } = renderPage({ response: historyResponse(few) });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-table')).toBeTruthy();
+		});
+		expect(container.querySelectorAll('tbody tr')).toHaveLength(5);
+		expect(queryByTestId('pagination')).toBeNull();
+	});
+
+	it('shows the error state when the query rejects', async () => {
+		const { getByTestId } = renderPage({ rejects: true });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-load-error')).toBeTruthy();
+		});
+	});
+
+	it('shows the error state when the query resolves without a history list', async () => {
+		const { getByTestId } = renderPage({ response: historyResponse(null) });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-load-error')).toBeTruthy();
+		});
+	});
+
+	it('retries the fetch when "Try again" is clicked', async () => {
+		const query = vi.fn()
+			.mockRejectedValueOnce(new Error('boom'))
+			.mockResolvedValue({ data: historyResponse([record()]) });
+		const { getByTestId, getByText } = renderPage({ query });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-load-error')).toBeTruthy();
+		});
+		await fireEvent.click(getByText('Try again'));
+		await waitFor(() => {
+			expect(getByTestId('free-credit-table')).toBeTruthy();
+		});
+		expect(query).toHaveBeenCalledTimes(2);
+	});
+
+	it('wraps displayed user data in a HotJar-suppressed container', async () => {
+		const { container, getByTestId } = renderPage({ response: historyResponse([record()]) });
+		await waitFor(() => {
+			expect(getByTestId('free-credit-table')).toBeTruthy();
+		});
+		const suppressed = container.querySelector('[data-hj-suppress]');
+		expect(suppressed).toBeTruthy();
+		expect(suppressed.contains(getByTestId('free-credit-table'))).toBe(true);
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2986

Frontend for `/portfolio/credit/bonus-history` migration. Relatively simple page with table of FE-paged data. Table and styles match other newstack portfolio pages.

<img width="981" height="699" alt="image" src="https://github.com/user-attachments/assets/4d997c78-3a35-49e0-875c-badc6a1e3e5e" />

<img width="437" height="948" alt="image" src="https://github.com/user-attachments/assets/90ee865a-1e34-411b-9037-2f1c455ca871" />
