### PR TITLE
feat: [MP-3046] assign custom tip default experiment and provide variant to tip modal

### DIFF
--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -100,6 +100,9 @@ export default {
 		KvButton,
 		KvTextInput
 	},
+	inject: {
+		customTipDefaultVersion: { default: null },
+	},
 	props: {
 		loanReservationTotal: {
 			type: Number,

--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -101,6 +101,7 @@ export default {
 		KvTextInput
 	},
 	inject: {
+		// Tip experiment version provided by the checkout page; null when rendered elsewhere
 		customTipDefaultVersion: { default: null },
 	},
 	props: {

--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -101,7 +101,7 @@ export default {
 		KvTextInput
 	},
 	inject: {
-		// Tip experiment version provided by the checkout page; null when rendered elsewhere
+		// Assigned version provided by the checkout page; null when rendered elsewhere
 		customTipDefaultVersion: { default: null },
 	},
 	props: {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -382,7 +382,7 @@ const STOP_HIDING_TIP_EXP_KEY = 'stop_hiding_tip_campaign';
 const CUSTOM_TIP_DEFAULT_EXP_KEY = 'custom_tip_default';
 const TIP_PERCENTAGE = 0.2;
 
-// Experiments assigned during SSR preFetch so versions are cached before hydration
+// Assigned during SSR so versions are available before hydration
 const PREFETCH_EXPERIMENT_IDS = [
 	DEPOSIT_REWARD_EXP_KEY,
 	ASYNC_CHECKOUT_EXP,

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -382,6 +382,17 @@ const STOP_HIDING_TIP_EXP_KEY = 'stop_hiding_tip_campaign';
 const CUSTOM_TIP_DEFAULT_EXP_KEY = 'custom_tip_default';
 const TIP_PERCENTAGE = 0.2;
 
+// Experiments assigned during SSR preFetch so versions are cached before hydration
+const PREFETCH_EXPERIMENT_IDS = [
+	DEPOSIT_REWARD_EXP_KEY,
+	ASYNC_CHECKOUT_EXP,
+	CHECKOUT_LOGIN_CTA_EXP,
+	GUEST_CHECKOUT_CTA_EXP,
+	FIVE_DOLLARS_NOTES_EXP,
+	KIVA_CREDIT_REPLACEMENT_EXP_KEY,
+	CUSTOM_TIP_DEFAULT_EXP_KEY,
+];
+
 // Query to gather user Teams
 const myTeamsQuery = gql`query myTeamsQuery {
 	my {
@@ -537,13 +548,9 @@ export default {
 				.then(() => {
 					return Promise.all([
 						client.query({ query: initializeCheckout, fetchPolicy: 'network-only' }),
-						client.query({ query: experimentAssignmentQuery, variables: { id: DEPOSIT_REWARD_EXP_KEY } }),
-						client.query({ query: experimentAssignmentQuery, variables: { id: ASYNC_CHECKOUT_EXP } }),
-						client.query({ query: experimentAssignmentQuery, variables: { id: CHECKOUT_LOGIN_CTA_EXP } }),
-						client.query({ query: experimentAssignmentQuery, variables: { id: GUEST_CHECKOUT_CTA_EXP } }),
-						client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
-						client.query({ query: experimentAssignmentQuery, variables: { id: KIVA_CREDIT_REPLACEMENT_EXP_KEY } }), // eslint-disable-line max-len
-						client.query({ query: experimentAssignmentQuery, variables: { id: CUSTOM_TIP_DEFAULT_EXP_KEY } }), // eslint-disable-line max-len
+						...PREFETCH_EXPERIMENT_IDS.map(
+							id => client.query({ query: experimentAssignmentQuery, variables: { id } })
+						),
 					]);
 				})
 				.then(response => {

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -309,6 +309,7 @@
 </template>
 
 <script>
+import { computed } from 'vue';
 import { gql } from 'graphql-tag';
 import _get from 'lodash/get';
 import _filter from 'lodash/filter';
@@ -438,6 +439,11 @@ export default {
 		KvMaterialIcon,
 	},
 	inject: ['apollo', 'cookieStore', 'kvAuth0'],
+	provide() {
+		return {
+			customTipDefaultVersion: computed(() => this.customTipDefaultVersion),
+		};
+	},
 	mixins: [checkoutUtils, fiveDollarsTest],
 	head: {
 		title: 'Checkout'

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -452,6 +452,7 @@ export default {
 	inject: ['apollo', 'cookieStore', 'kvAuth0'],
 	provide() {
 		return {
+			// Computed so injecting descendants stay reactive to version reassignment
 			customTipDefaultVersion: computed(() => this.customTipDefaultVersion),
 		};
 	},

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -378,6 +378,7 @@ const BANDIT_UPSELL_EXP_KEY = 'checkout_bandit_upsell_enable';
 const EXPIRING_SOON_EXP_KEY = 'checkout_expiring_soon_upsell';
 const KIVA_CREDIT_REPLACEMENT_EXP_KEY = 'checkout_kiva_credit_copy_replacement';
 const STOP_HIDING_TIP_EXP_KEY = 'stop_hiding_tip_campaign';
+const CUSTOM_TIP_DEFAULT_EXP_KEY = 'custom_tip_default';
 const TIP_PERCENTAGE = 0.2;
 
 // Query to gather user Teams
@@ -497,6 +498,7 @@ export default {
 			isKivaCreditReplacementExpEnabled: false,
 			enableAdminRewardTipFlag: false,
 			isStopHidingTipExpEnabled: false,
+			customTipDefaultVersion: null,
 		};
 	},
 	apollo: {
@@ -535,6 +537,7 @@ export default {
 						client.query({ query: experimentAssignmentQuery, variables: { id: GUEST_CHECKOUT_CTA_EXP } }),
 						client.query({ query: experimentAssignmentQuery, variables: { id: FIVE_DOLLARS_NOTES_EXP } }),
 						client.query({ query: experimentAssignmentQuery, variables: { id: KIVA_CREDIT_REPLACEMENT_EXP_KEY } }), // eslint-disable-line max-len
+						client.query({ query: experimentAssignmentQuery, variables: { id: CUSTOM_TIP_DEFAULT_EXP_KEY } }), // eslint-disable-line max-len
 					]);
 				})
 				.then(response => {
@@ -695,6 +698,8 @@ export default {
 			'EXP-MP-2577-Apr2026',
 			'basket',
 		);
+
+		this.initializeCustomTipDefaultExperiment();
 	},
 	watch: {
 		async emptyBasket(newValue) {
@@ -1421,6 +1426,18 @@ export default {
 				this.$kvTrackEvent,
 				'EXP-MP-2852-Jun2026',
 				'basket',
+			);
+		},
+		initializeCustomTipDefaultExperiment() {
+			// Assignment only; exposure is tracked separately when the tip modal is viewed
+			initializeExperiment(
+				this.cookieStore,
+				this.apollo,
+				this.$route,
+				CUSTOM_TIP_DEFAULT_EXP_KEY,
+				version => {
+					this.customTipDefaultVersion = version ?? null;
+				},
 			);
 		},
 	},

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -1,0 +1,40 @@
+import { computed } from 'vue';
+/* eslint-disable-next-line import/no-extraneous-dependencies -- devDependency used only in tests */
+import { mount } from '@vue/test-utils';
+import DonationNudgeBoxes from '#src/components/Checkout/DonationNudge/DonationNudgeBoxes';
+import { globalOptions } from '../../../../specUtils';
+
+const defaultProps = {
+	loanReservationTotal: 100,
+	percentageRows: [
+		{ percentage: 15, appeal: 'Cover the cost to facilitate this loan' },
+		{ percentage: 20, appeal: 'Reach more people around the world!' },
+	],
+	setDonationAndClose: vi.fn(),
+};
+
+describe('DonationNudgeBoxes custom tip default experiment', () => {
+	it('resolves the provided experiment version synchronously', () => {
+		const wrapper = mount(DonationNudgeBoxes, {
+			props: defaultProps,
+			global: {
+				...globalOptions,
+				provide: {
+					...globalOptions.provide,
+					customTipDefaultVersion: computed(() => 'b'),
+				},
+			},
+		});
+
+		expect(wrapper.vm.customTipDefaultVersion).toBe('b');
+	});
+
+	it('defaults to null when no provider exists', () => {
+		const wrapper = mount(DonationNudgeBoxes, {
+			props: defaultProps,
+			global: { ...globalOptions },
+		});
+
+		expect(wrapper.vm.customTipDefaultVersion).toBe(null);
+	});
+});

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -1,21 +1,17 @@
 import { computed } from 'vue';
 /* eslint-disable-next-line import/no-extraneous-dependencies -- devDependency used only in tests */
-import { mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import DonationNudgeBoxes from '#src/components/Checkout/DonationNudge/DonationNudgeBoxes';
 import { globalOptions } from '../../../../specUtils';
 
 const defaultProps = {
-	loanReservationTotal: 100,
-	percentageRows: [
-		{ percentage: 15, appeal: 'Cover the cost to facilitate this loan' },
-		{ percentage: 20, appeal: 'Reach more people around the world!' },
-	],
-	setDonationAndClose: vi.fn(),
+	percentageRows: [],
+	setDonationAndClose: () => {},
 };
 
 describe('DonationNudgeBoxes custom tip default experiment', () => {
 	it('resolves the provided experiment version synchronously', () => {
-		const wrapper = mount(DonationNudgeBoxes, {
+		const wrapper = shallowMount(DonationNudgeBoxes, {
 			props: defaultProps,
 			global: {
 				...globalOptions,
@@ -30,9 +26,9 @@ describe('DonationNudgeBoxes custom tip default experiment', () => {
 	});
 
 	it('defaults to null when no provider exists', () => {
-		const wrapper = mount(DonationNudgeBoxes, {
+		const wrapper = shallowMount(DonationNudgeBoxes, {
 			props: defaultProps,
-			global: { ...globalOptions },
+			global: globalOptions,
 		});
 
 		expect(wrapper.vm.customTipDefaultVersion).toBe(null);

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -9,6 +9,7 @@ vi.mock('#src/util/logReadQueryError', () => ({
 }));
 
 let CheckoutPage;
+let initializeExperiment;
 
 beforeAll(async () => {
 	vi.mock('#src/graphql/query/checkout/getCheckoutAlmostFundedRecommendation.graphql', () => ({ default: 'mock' }));
@@ -26,6 +27,7 @@ beforeAll(async () => {
 
 	const mod = await import('#src/pages/Checkout/CheckoutPage');
 	CheckoutPage = mod.default;
+	({ initializeExperiment } = await import('#src/util/experiment/experimentUtils'));
 });
 
 describe('CheckoutPage ensureTipDonationExists', () => {
@@ -188,5 +190,46 @@ describe('CheckoutPage ensureTipDonationExists', () => {
 		expect(context.setUpdatingTotals).toHaveBeenCalledWith(false);
 		expect(context.donations).toHaveLength(0);
 		expect(context.refreshTotals).not.toHaveBeenCalled();
+	});
+});
+
+describe('CheckoutPage initializeCustomTipDefaultExperiment', () => {
+	beforeEach(() => {
+		initializeExperiment.mockClear();
+	});
+
+	it('assigns the experiment without exposure tracking args', () => {
+		const context = {
+			cookieStore: {},
+			apollo: {},
+			$route: {},
+			customTipDefaultVersion: null,
+		};
+
+		CheckoutPage.methods.initializeCustomTipDefaultExperiment.call(context);
+
+		expect(initializeExperiment).toHaveBeenCalledTimes(1);
+		const args = initializeExperiment.mock.calls[0];
+		expect(args[3]).toBe('custom_tip_default');
+		// Only 5 args passed, so trackEvent stays null and no exposure event can fire
+		expect(args.length).toBe(5);
+	});
+
+	it('stores the assigned version in component state', () => {
+		const context = {
+			cookieStore: {},
+			apollo: {},
+			$route: {},
+			customTipDefaultVersion: null,
+		};
+
+		CheckoutPage.methods.initializeCustomTipDefaultExperiment.call(context);
+		const callback = initializeExperiment.mock.calls[0][4];
+
+		callback('b');
+		expect(context.customTipDefaultVersion).toBe('b');
+
+		callback(undefined);
+		expect(context.customTipDefaultVersion).toBe(null);
 	});
 });

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -1,6 +1,7 @@
 import { reactive } from 'vue';
 import { setDonationAmount } from '#src/util/basketUtils';
 import logReadQueryError from '#src/util/logReadQueryError';
+import { initializeExperiment } from '#src/util/experiment/experimentUtils';
 
 vi.mock('#src/util/basketUtils', () => ({
 	setDonationAmount: vi.fn(),
@@ -10,7 +11,6 @@ vi.mock('#src/util/logReadQueryError', () => ({
 }));
 
 let CheckoutPage;
-let initializeExperiment;
 
 beforeAll(async () => {
 	vi.mock('#src/graphql/query/checkout/getCheckoutAlmostFundedRecommendation.graphql', () => ({ default: 'mock' }));
@@ -28,7 +28,6 @@ beforeAll(async () => {
 
 	const mod = await import('#src/pages/Checkout/CheckoutPage');
 	CheckoutPage = mod.default;
-	({ initializeExperiment } = await import('#src/util/experiment/experimentUtils'));
 });
 
 describe('CheckoutPage ensureTipDonationExists', () => {
@@ -195,34 +194,31 @@ describe('CheckoutPage ensureTipDonationExists', () => {
 });
 
 describe('CheckoutPage initializeCustomTipDefaultExperiment', () => {
+	const makeContext = () => ({
+		cookieStore: {},
+		apollo: {},
+		$route: {},
+		customTipDefaultVersion: null,
+	});
+
 	beforeEach(() => {
 		initializeExperiment.mockClear();
 	});
 
 	it('assigns the experiment without exposure tracking args', () => {
-		const context = {
-			cookieStore: {},
-			apollo: {},
-			$route: {},
-			customTipDefaultVersion: null,
-		};
+		const context = makeContext();
 
 		CheckoutPage.methods.initializeCustomTipDefaultExperiment.call(context);
 
 		expect(initializeExperiment).toHaveBeenCalledTimes(1);
 		const args = initializeExperiment.mock.calls[0];
 		expect(args[3]).toBe('custom_tip_default');
-		// Only 5 args passed, so trackEvent stays null and no exposure event can fire
-		expect(args.length).toBe(5);
+		// The trackEvent slot must stay empty so no exposure event can fire
+		expect(args[5]).toBeUndefined();
 	});
 
 	it('stores the assigned version in component state', () => {
-		const context = {
-			cookieStore: {},
-			apollo: {},
-			$route: {},
-			customTipDefaultVersion: null,
-		};
+		const context = makeContext();
 
 		CheckoutPage.methods.initializeCustomTipDefaultExperiment.call(context);
 		const callback = initializeExperiment.mock.calls[0][4];

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -24,6 +24,9 @@ beforeAll(async () => {
 	vi.mock('#src/util/experiment/experimentUtils', () => ({
 		initializeExperiment: vi.fn(),
 	}));
+	vi.mock('#src/util/myKivaUtils', () => ({
+		fetchPostCheckoutAchievements: vi.fn(),
+	}));
 	vi.mock('@sentry/vue', () => ({ captureException: vi.fn(), captureMessage: vi.fn() }));
 
 	const mod = await import('#src/pages/Checkout/CheckoutPage');
@@ -228,6 +231,21 @@ describe('CheckoutPage initializeCustomTipDefaultExperiment', () => {
 
 		callback(undefined);
 		expect(context.customTipDefaultVersion).toBe(null);
+	});
+});
+
+describe('CheckoutPage apollo preFetch', () => {
+	it('prefetches the custom tip default experiment assignment during SSR', async () => {
+		const client = {
+			mutate: vi.fn().mockResolvedValue({}),
+			query: vi.fn().mockResolvedValue({ data: {} }),
+		};
+
+		await CheckoutPage.apollo.preFetch(CheckoutPage.apollo, client);
+
+		expect(client.query).toHaveBeenCalledWith(
+			expect.objectContaining({ variables: { id: 'custom_tip_default' } })
+		);
 	});
 });
 

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -1,3 +1,4 @@
+import { reactive } from 'vue';
 import { setDonationAmount } from '#src/util/basketUtils';
 import logReadQueryError from '#src/util/logReadQueryError';
 
@@ -231,5 +232,18 @@ describe('CheckoutPage initializeCustomTipDefaultExperiment', () => {
 
 		callback(undefined);
 		expect(context.customTipDefaultVersion).toBe(null);
+	});
+});
+
+describe('CheckoutPage provide', () => {
+	it('provides customTipDefaultVersion as a reactive computed', () => {
+		const context = reactive({ customTipDefaultVersion: null });
+
+		const provided = CheckoutPage.provide.call(context);
+
+		expect(provided.customTipDefaultVersion.value).toBe(null);
+
+		context.customTipDefaultVersion = 'b';
+		expect(provided.customTipDefaultVersion.value).toBe('b');
 	});
 });


### PR DESCRIPTION
## Summary

Assigns the `custom_tip_default` experiment (50/50) on checkout page load and delivers the assigned variant to the tip modal, without firing the exposure event — exposure fires later, on tip-modal view, via the analytics ticket.

- **Assignment without exposure**: `initializeExperiment()` is called with no `trackEvent`/`action` args, so it assigns (cookie/SSR-cache read, plus `setuiab` re-query support) but never tracks. Exposure stays fully decoupled for the follow-up ticket.
- **SSR prefetch**: the assignment is prefetched in `CheckoutPage`'s apollo `preFetch`, so the version is in the serialized Apollo cache and `uiab` cookie before hydration — the variant is always resolved before the modal can open (no visible `$0.00 → $1.00` flip when the prefill ticket lands).
- **No behavior change**: tip amounts, copy, layout, and payment logic are untouched. `DonationNudgeBoxes` receives the variant but nothing consumes it yet.

## Approach: provide/inject (flagging per ticket)

The variant travels via provide/inject rather than 5-level prop drilling or a direct cookie read in the modal:

- `CheckoutPage` provides `customTipDefaultVersion` as a reactive `computed` (same pattern as `ThanksPage`).
- `DonationNudgeBoxes` injects it with `default: null` — which also scopes the experiment: component trees without the provider (e.g. `InContextCheckout` on corporate-campaign pages) fall back to control with no exposure leakage.

Also collapsed the seven copy-pasted `experimentAssignmentQuery` prefetch lines into a `PREFETCH_EXPERIMENT_IDS` array — behavior-identical (`response[0]` basket indexing unchanged, same queries/order/parallelism), removes two `max-len` suppressions, and makes the prefetched set greppable.

## Related links

- Jira story: [MP-3046](https://kiva.atlassian.net/browse/MP-3046)
- Epic: [MP-3039](https://kiva.atlassian.net/browse/MP-3039)

## Related tests

`test/unit/specs/pages/Checkout/CheckoutPage.spec.js`
- assigns the experiment with the `custom_tip_default` key and an empty `trackEvent` slot (the no-exposure invariant)
- stores the assigned version in component state (`'b'`; `undefined → null`)
- SSR `preFetch` requests the `custom_tip_default` assignment (mutation-tested: removing the key from `PREFETCH_EXPERIMENT_IDS` fails exactly this test)
- `provide()` exposes the version as a computed that stays reactive to reassignment

`test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js`
- resolves the provided version synchronously (available to `afterLightboxOpens()`)
- defaults to `null` when no provider exists (non-checkout surfaces stay on control)

Full verification: `npm run unit` (285 files / 4252 tests passing) and `npm run lint` (0 errors).

## Dev verification

1. Visit `/checkout?setuiab=custom_tip_default.b` (key is live in Kiva Admin with a 50/50 split) — `CheckoutPage.customTipDefaultVersion` and the modal's injected value should read `b`.
2. View-source: SSR `__APOLLO_STATE__` contains `Experiment:custom_tip_default`; the `uiab` cookie carries the assignment.
3. Confirm no exposure event with action `EXP-MP-3039-July2026` fires on page load or modal open.
4. The tip modal renders identically to production (custom amount still `$0.00`).


[MP-3046]: https://kiva.atlassian.net/browse/MP-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ