### PR TITLE
feat: implement fe of the /portfolio/estimated-repayments migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -187,45 +187,6 @@
 				"npm": ">= 10.2.4"
 			}
 		},
-		"../kv-ui-elements/@kiva/kv-shop": {
-			"version": "1.7.7",
-			"extraneous": true,
-			"dependencies": {
-				"@apollo/client": "^3.7.14",
-				"@kiva/kv-analytics": "^1.3.0",
-				"@kiva/kv-components": "^3.52.1",
-				"@types/braintree-web-drop-in": "^1.34.2",
-				"braintree-web-drop-in": "^1.37.0",
-				"numeral": "^2.0.6",
-				"vue-demi": "^0.14.1"
-			},
-			"devDependencies": {
-				"@typescript-eslint/eslint-plugin": "^5.59.7",
-				"@typescript-eslint/parser": "^5.59.7",
-				"@vue/eslint-config-typescript": "^11.0.3",
-				"eslint-plugin-vue": "^9.14.0",
-				"jest": "^29.5.0",
-				"jest-environment-jsdom": "^29.5.0",
-				"ts-jest": "^29.1.0",
-				"tsup": "^6.7.0",
-				"typescript": "^5.0.4",
-				"vue": "2.6",
-				"vue-eslint-parser": "^9.3.0"
-			},
-			"peerDependencies": {
-				"@vue/composition-api": "^1.0.0-rc.1",
-				"vue": "^2.0.0 || >=3.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@vue/composition-api": {
-					"optional": true
-				}
-			}
-		},
-		"build/promise": {
-			"version": "1.0.0",
-			"extraneous": true
-		},
 		"node_modules/@aacassandra/vue3-progressbar": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@aacassandra/vue3-progressbar/-/vue3-progressbar-1.0.3.tgz",

--- a/src/components/Deposit/DepositDropInPaymentWrapper.vue
+++ b/src/components/Deposit/DepositDropInPaymentWrapper.vue
@@ -180,7 +180,7 @@ export default {
 			});
 		},
 		handleSuccess(transactionId, paymentType, amount) {
-			// Legacy parity: mirrors DepositView.js trackAddCredit — the value is the deposit in cents.
+			// The tracked value is the deposit in cents.
 			this.$kvTrackEvent(
 				'Lending',
 				'Add Credit',

--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer.vue
@@ -1,41 +1,32 @@
 <template>
 	<div class="tw-text-small tw-text-secondary tw-mt-3" data-testid="repayments-disclaimer">
-		<!-- eslint-disable-next-line vue/no-v-html -- static/trusted copy from DISCLAIMER_PARAGRAPHS -->
-		<p
-			v-for="(paragraph, index) in paragraphs"
-			:key="index"
-			:class="{ 'tw-mt-1': index > 0 }"
-			v-html="paragraph"
-		></p>
+		<p>
+			*Scheduled repayment estimates are calculated based on the <em>original</em> repayment schedule for
+			each of your loans. Please note, these estimates don't account for delinquencies, defaults,
+			currency loss, or for when borrowers pay more than was scheduled and the principal has been
+			paid down. Click the amounts in the detailed view to see the advanced repayment details for
+			each loan.
+		</p>
+		<p class="tw-mt-1">
+			Each month's repayment estimation is rounded down to the nearest penny for each loan, and
+			therefore actual repayment amounts received may differ from what is estimated. The due
+			date for repayments is on the 1st of the month. Many of Kiva's Lending Partners begin
+			paying lenders earlier, on the settlement date which is the 17th of the month
+			<em>prior</em> to the due date. However, repayments may continue post to lender accounts
+			anytime between the 17th and the 1st before they're considered delinquent. For example:
+			Often a majority of the amount estimated for December 1st will be returned to the
+			lender's account on November 17th, but some may post later than the 17th. The "Due"
+			column shows the actual due dates, not the dates when repayments post to your account.
+		</p>
+		<p class="tw-mt-1">
+			These figures also don't imply that repayments are in any way guaranteed, as lending through
+			Kiva involves risk of principal loss.
+		</p>
 	</div>
 </template>
 
 <script>
 export default {
 	name: 'RepaymentsDisclaimer',
-	data() {
-		return {
-			// The legacy page's static disclaimer, ported verbatim. Rendered via v-html
-			// (all content is static/trusted here), so inline markup like <em> is allowed.
-			paragraphs: [
-				'*Scheduled repayment estimates are calculated based on the <em>original</em> repayment schedule for '
-					+ 'each of your loans. Please note, these estimates don\'t account for delinquencies, defaults, '
-					+ 'currency loss, or for when borrowers pay more than was scheduled and the principal has been '
-					+ 'paid down. Click the amounts in the detailed view to see the advanced repayment details for '
-					+ 'each loan.',
-				'Each month\'s repayment estimation is rounded down to the nearest penny for each loan, and '
-					+ 'therefore actual repayment amounts received may differ from what is estimated. The due '
-					+ 'date for repayments is on the 1st of the month. Many of Kiva\'s Lending Partners begin '
-					+ 'paying lenders earlier, on the settlement date which is the 17th of the month '
-					+ '<em>prior</em> to the due date. However, repayments may continue post to lender accounts '
-					+ 'anytime between the 17th and the 1st before they\'re considered delinquent. For example: '
-					+ 'Often a majority of the amount estimated for December 1st will be returned to the '
-					+ 'lender\'s account on November 17th, but some may post later than the 17th. The "Due" '
-					+ 'column shows the actual due dates, not the dates when repayments post to your account.',
-				'These figures also don\'t imply that repayments are in any way guaranteed, as lending through '
-					+ 'Kiva involves risk of principal loss.',
-			],
-		};
-	},
 };
 </script>

--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer.vue
@@ -1,0 +1,24 @@
+<template>
+	<div class="tw-text-small tw-text-secondary tw-mt-3" data-testid="repayments-disclaimer">
+		<!-- eslint-disable-next-line vue/no-v-html -- static/trusted copy from DISCLAIMER_PARAGRAPHS -->
+		<p
+			v-for="(paragraph, index) in paragraphs"
+			:key="index"
+			:class="{ 'tw-mt-1': index > 0 }"
+			v-html="paragraph"
+		></p>
+	</div>
+</template>
+
+<script>
+import { DISCLAIMER_PARAGRAPHS } from '#src/util/estimatedRepayments/estimatedRepaymentsConstants';
+
+export default {
+	name: 'RepaymentsDisclaimer',
+	data() {
+		return {
+			paragraphs: DISCLAIMER_PARAGRAPHS,
+		};
+	},
+};
+</script>

--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer.vue
@@ -11,13 +11,30 @@
 </template>
 
 <script>
-import { DISCLAIMER_PARAGRAPHS } from '#src/util/estimatedRepayments/estimatedRepaymentsConstants';
-
 export default {
 	name: 'RepaymentsDisclaimer',
 	data() {
 		return {
-			paragraphs: DISCLAIMER_PARAGRAPHS,
+			// The legacy page's static disclaimer, ported verbatim. Rendered via v-html
+			// (all content is static/trusted here), so inline markup like <em> is allowed.
+			paragraphs: [
+				'*Scheduled repayment estimates are calculated based on the <em>original</em> repayment schedule for '
+					+ 'each of your loans. Please note, these estimates don\'t account for delinquencies, defaults, '
+					+ 'currency loss, or for when borrowers pay more than was scheduled and the principal has been '
+					+ 'paid down. Click the amounts in the detailed view to see the advanced repayment details for '
+					+ 'each loan.',
+				'Each month\'s repayment estimation is rounded down to the nearest penny for each loan, and '
+					+ 'therefore actual repayment amounts received may differ from what is estimated. The due '
+					+ 'date for repayments is on the 1st of the month. Many of Kiva\'s Lending Partners begin '
+					+ 'paying lenders earlier, on the settlement date which is the 17th of the month '
+					+ '<em>prior</em> to the due date. However, repayments may continue post to lender accounts '
+					+ 'anytime between the 17th and the 1st before they\'re considered delinquent. For example: '
+					+ 'Often a majority of the amount estimated for December 1st will be returned to the '
+					+ 'lender\'s account on November 17th, but some may post later than the 17th. The "Due" '
+					+ 'column shows the actual due dates, not the dates when repayments post to your account.',
+				'These figures also don\'t imply that repayments are in any way guaranteed, as lending through '
+					+ 'Kiva involves risk of principal loss.',
+			],
 		};
 	},
 };

--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.vue
@@ -1,0 +1,158 @@
+<template>
+	<div data-testid="repayments-month-detail">
+		<h2 class="tw-mb-0.5">
+			Estimated repayments due by {{ heading }}
+		</h2>
+		<p class="tw-text-small tw-text-tertiary tw-italic tw-mb-2">
+			{{ settlementNote }}
+		</p>
+
+		<KvLoadingPlaceholder v-if="loading" style="height: 160px;" data-testid="detail-loading" />
+
+		<p v-else-if="!rows.length" data-testid="detail-empty" class="tw-text-secondary">
+			No repayments are scheduled for this month.
+		</p>
+
+		<template v-else>
+			<table class="tw-w-full tw-text-left tw-text-small">
+				<thead>
+					<tr class="tw-border-b tw-border-tertiary tw-text-tertiary tw-text-upper">
+						<th scope="col" class="tw-max-w-16 tw-py-1 tw-font-medium">
+							Borrower
+						</th>
+						<th scope="col" class="tw-py-1 tw-font-medium tw-text-right tw-whitespace-nowrap">
+							Scheduled
+						</th>
+						<th scope="col" class="tw-py-1 tw-px-2 tw-font-medium tw-text-right tw-whitespace-nowrap">
+							#
+						</th>
+						<th scope="col" class="tw-w-full tw-py-1 tw-font-medium">
+							Notes
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr
+						v-for="(row, index) in rows"
+						:key="row.loan ? row.loan.id : index"
+						class="tw-border-b tw-border-tertiary tw-align-top"
+					>
+						<!-- The Borrower column is capped (tw-max-w-16) and ellipsizes longer
+							names via CSS (tw-truncate); the full name stays in the DOM and is exposed
+							on hover/AT via :title. The numeric columns keep their natural width
+							(tw-whitespace-nowrap), and the Notes column absorbs the remaining width
+							(tw-w-full on its cells) so its longer copy wraps rather than being squeezed. -->
+						<td class="tw-max-w-16 tw-truncate tw-py-1">
+							<a
+								v-if="row.loan"
+								:href="loanUrl(row.loan.id)"
+								:title="row.loan.name"
+								class="tw-text-action data-hj-suppress"
+								target="_blank"
+								rel="noopener"
+								v-kv-track-event="[
+									'portfolio',
+									'click',
+									'Estimated repayments borrower',
+									row.loan.name,
+									row.loan.id,
+								]"
+							>
+								{{ row.loan.name }}
+							</a>
+						</td>
+						<td class="tw-py-1 tw-text-right tw-whitespace-nowrap">
+							{{ $filters.numeral(row.amount, '$0,0.00') }}
+						</td>
+						<td class="tw-py-1 tw-px-2 tw-text-right tw-whitespace-nowrap">
+							{{ row.pastRepayments }}/{{ row.totalRepayments }}
+						</td>
+						<td class="tw-w-full tw-py-1">
+							<span v-if="promoText(row)">{{ promoText(row) }}</span>
+							<span v-if="row.isDelinquent" class="tw-text-danger tw-ml-0.5">Delinquent</span>
+							<span v-if="isFinal(row)" class="tw-text-tertiary tw-ml-0.5">Final</span>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+
+			<p v-if="truncated" class="tw-text-small tw-text-tertiary tw-mt-2" data-testid="detail-truncated">
+				{{ truncationNotice }}
+			</p>
+		</template>
+	</div>
+</template>
+
+<script>
+import { KvLoadingPlaceholder } from '@kiva/kv-components';
+import {
+	PROMO_CREDIT_FALLBACK_LABEL,
+	PROMO_TYPE_LABELS,
+	SETTLEMENT_NOTE,
+	DETAIL_LIMIT,
+} from '#src/util/estimatedRepayments/estimatedRepaymentsConstants';
+
+export default {
+	name: 'RepaymentsMonthDetail',
+	components: {
+		KvLoadingPlaceholder,
+	},
+	props: {
+		/** Human-readable due date, e.g. "July 1, 2026". */
+		heading: {
+			type: String,
+			default: '',
+		},
+		loading: {
+			type: Boolean,
+			default: false,
+		},
+		/** Raw detail rows from expectedRepaymentsDetail. */
+		rows: {
+			type: Array,
+			default: () => [],
+		},
+		/** True when the detail list hit the server-side cap. */
+		truncated: {
+			type: Boolean,
+			default: false,
+		},
+		/** Total repaying loans for the month (pre-cap); shown in the truncation notice. */
+		totalCount: {
+			type: Number,
+			default: 0,
+		},
+	},
+	data() {
+		return {
+			settlementNote: SETTLEMENT_NOTE,
+			detailLimit: DETAIL_LIMIT,
+		};
+	},
+	computed: {
+		// When we know the true total (loansMakingRepayments), name it so lenders see
+		// how many loans are hidden; otherwise fall back to just the cap.
+		truncationNotice() {
+			const of = this.totalCount > 0 ? ` of ${this.$filters.numeral(this.totalCount, '0,0')}` : '';
+			return `Notice: List of repaying loans only displays the first ${this.detailLimit}${of} `
+				+ 'in descending order of repayment amount.';
+		},
+	},
+	methods: {
+		loanUrl(loanId) {
+			return `/lend/${loanId}`;
+		},
+		isFinal(row) {
+			return row.totalRepayments != null && row.pastRepayments === row.totalRepayments;
+		},
+		promoText(row) {
+			if (!row.promoAmount || Number(row.promoAmount) <= 0) {
+				return '';
+			}
+			const type = PROMO_TYPE_LABELS[row.promoType] || PROMO_CREDIT_FALLBACK_LABEL;
+			const amount = this.$filters.numeral(row.promoAmount, '$0,0.00');
+			return `Includes ${amount} of ${type} (repaid to Kiva or sponsor)`;
+		},
+	},
+};
+</script>

--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable.vue
@@ -1,0 +1,96 @@
+<template>
+	<table class="tw-w-full tw-text-small tw-border-collapse" data-testid="repayments-summary-table">
+		<thead>
+			<tr class="tw-bg-gray-200">
+				<th
+					scope="col"
+					class="tw-w-full tw-max-w-0 tw-truncate tw-px-1 lg:tw-px-2 tw-py-1 tw-font-bold tw-text-left"
+				>
+					Due
+				</th>
+				<th scope="col" class="tw-px-1 lg:tw-px-2 tw-py-1 tw-font-bold tw-text-left tw-whitespace-nowrap">
+					Scheduled
+				</th>
+				<th scope="col" class="tw-px-1 lg:tw-px-2 tw-py-1 tw-font-bold tw-text-left tw-whitespace-nowrap">
+					Loans
+				</th>
+			</tr>
+		</thead>
+		<tbody>
+			<template v-for="month in months" :key="`${month.year}-${month.month}`">
+				<!-- Year sub-header row, emitted when the year changes (legacy parity) -->
+				<tr v-if="month.showYearHeader" class="tw-bg-gray-200">
+					<th
+						scope="colgroup"
+						colspan="3"
+						class="tw-px-1 lg:tw-px-2 tw-py-0.5 tw-font-bold tw-text-tertiary tw-text-left"
+					>
+						{{ month.year }}
+					</th>
+				</tr>
+				<!-- The whole row is clickable (legacy parity); the inner button keeps the
+					interaction keyboard-accessible. @click.stop on the button prevents the
+					row handler from double-firing when the button itself is clicked. -->
+				<tr
+					class="tw-bg-primary hover:tw-bg-secondary tw-cursor-pointer"
+					:class="{ '!tw-bg-brand-100': isSelected(month) }"
+					:data-testid="`repayments-month-row-${month.year}-${month.month}`"
+					@click="selectMonth(month)"
+				>
+					<!-- The Due column absorbs the flexible width (tw-w-full + tw-max-w-0) and
+						ellipsizes (tw-truncate) so the table fits its parent without a horizontal
+						scrollbar; the numeric columns are tw-whitespace-nowrap and keep their natural width. -->
+					<td class="tw-w-full tw-max-w-0 tw-truncate tw-px-1 lg:tw-px-2 tw-py-1">
+						<button
+							type="button"
+							class="tw-text-action tw-underline"
+							:title="month.monthLabel"
+							:aria-current="isSelected(month) ? 'true' : undefined"
+							@click.stop="selectMonth(month)"
+						>
+							{{ month.monthLabel }}
+						</button>
+					</td>
+					<td class="tw-px-1 lg:tw-px-2 tw-py-1 tw-text-right tw-whitespace-nowrap">
+						{{ $filters.numeral(month.total, '$0,0.00') }}
+					</td>
+					<td class="tw-px-1 lg:tw-px-2 tw-py-1 tw-text-right tw-whitespace-nowrap">
+						{{ month.loansMakingRepayments }}
+					</td>
+				</tr>
+			</template>
+		</tbody>
+	</table>
+</template>
+
+<script>
+export default {
+	name: 'RepaymentsSummaryTable',
+	props: {
+		/** Bucketed months: { year, month, monthLabel, total, loansMakingRepayments, showYearHeader }. */
+		months: {
+			type: Array,
+			required: true,
+		},
+		/** Currently selected month object (or null). */
+		selected: {
+			type: Object,
+			default: null,
+		},
+	},
+	emits: ['select'],
+	methods: {
+		isSelected(month) {
+			return !!this.selected
+				&& this.selected.year === month.year
+				&& this.selected.month === month.month;
+		},
+		selectMonth(month) {
+			// Track from here (not a directive) so row-clicks and button-clicks are
+			// recorded identically.
+			this.$kvTrackEvent('portfolio', 'click', 'Estimated repayments month', month.monthLabel);
+			this.$emit('select', month);
+		},
+	},
+};
+</script>

--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable.vue
@@ -18,7 +18,7 @@
 		</thead>
 		<tbody>
 			<template v-for="month in months" :key="`${month.year}-${month.month}`">
-				<!-- Year sub-header row, emitted when the year changes (legacy parity) -->
+				<!-- Year sub-header row, emitted when the year changes -->
 				<tr v-if="month.showYearHeader" class="tw-bg-gray-200">
 					<th
 						scope="colgroup"
@@ -28,9 +28,9 @@
 						{{ month.year }}
 					</th>
 				</tr>
-				<!-- The whole row is clickable (legacy parity); the inner button keeps the
-					interaction keyboard-accessible. @click.stop on the button prevents the
-					row handler from double-firing when the button itself is clicked. -->
+				<!-- The whole row is clickable; the inner button keeps the interaction keyboard-accessible.
+					@click.stop on the button prevents the row handler from double-firing when the button itself
+					is clicked. -->
 				<tr
 					class="tw-bg-primary hover:tw-bg-secondary tw-cursor-pointer"
 					:class="{ '!tw-bg-brand-100': isSelected(month) }"

--- a/src/components/Portfolio/LoanList.vue
+++ b/src/components/Portfolio/LoanList.vue
@@ -434,9 +434,8 @@ export default {
 			return amount != null && parseFloat(amount) > 0 && !this.hasRepaidToLender(loan);
 		},
 		repaidAmount(loan) {
-			// Legacy parity (LoanRowView mustache): headline is repaidAmountToYou when the
-			// lender got something, else repaidAmountTotal — so a Kiva-only return shows the
-			// Kiva figure, not $0. The "repaid to …" subtitle carries the label only.
+			// The headline is repaidAmountToYou when the lender got something, else repaidAmountTotal —
+			// so a Kiva-only return shows the Kiva figure, not $0. The "repaid to …" subtitle carries the label only.
 			const balance = loan.userProperties?.loanBalance;
 			const amount = this.hasRepaidToLender(loan)
 				? balance?.amountRepaidToLender

--- a/src/components/Portfolio/LoanStatsTable.vue
+++ b/src/components/Portfolio/LoanStatsTable.vue
@@ -146,12 +146,10 @@ export default {
 			// Guards against duplicate in-flight requests if a tooltip re-fires `show` before
 			// its fetch resolves. Plain (non-reactive) guard — nothing in the template reads it.
 			pendingSolutions: {},
-			// isTabbed / showInWhite / showInGray mirror the legacy setupCompareStat() flags
-			// in LoansView.php: tabbed rows indent under their parent metric, and the explicit
-			// white/gray banding groups related rows (replacing the flat migrated grid).
-			// salesforceId mirrors the legacy setupCompareStat($salesforce_id) wiring in
-			// LoansView.php; each row's help-text tooltip lazy-fetches general.salesforceSolution
-			// for this id.
+			// isTabbed / showInWhite / showInGray control row grouping: tabbed rows indent
+			// under their parent metric, and the explicit white/gray banding groups related
+			// rows (replacing the flat migrated grid). salesforceId wires each row's help-text
+			// tooltip to lazy-fetch general.salesforceSolution for this id.
 			statsRows: [
 				{
 					label: 'Amount lent',

--- a/src/graphql/query/portfolio/estimatedRepayments.graphql
+++ b/src/graphql/query/portfolio/estimatedRepayments.graphql
@@ -1,0 +1,14 @@
+query EstimatedRepayments {
+	my {
+		id
+		userAccount {
+			id
+			expectedRepayments {
+				repaymentDate
+				userRepayments
+				promoRepayments
+				loansMakingRepayments
+			}
+		}
+	}
+}

--- a/src/graphql/query/portfolio/estimatedRepaymentsDetail.graphql
+++ b/src/graphql/query/portfolio/estimatedRepaymentsDetail.graphql
@@ -1,9 +1,9 @@
-query EstimatedRepaymentsDetail($year: Int, $month: Int) {
+query EstimatedRepaymentsDetail($year: Int, $month: Int, $limit: Int) {
 	my {
 		id
 		userAccount {
 			id
-			expectedRepaymentsDetail(year: $year, month: $month) {
+			expectedRepaymentsDetail(year: $year, month: $month, limit: $limit) {
 				repaymentDate
 				amount
 				userAmount

--- a/src/graphql/query/portfolio/estimatedRepaymentsDetail.graphql
+++ b/src/graphql/query/portfolio/estimatedRepaymentsDetail.graphql
@@ -1,0 +1,22 @@
+query EstimatedRepaymentsDetail($year: Int, $month: Int) {
+	my {
+		id
+		userAccount {
+			id
+			expectedRepaymentsDetail(year: $year, month: $month) {
+				repaymentDate
+				amount
+				userAmount
+				promoAmount
+				isDelinquent
+				pastRepayments
+				totalRepayments
+				promoType
+				loan {
+					id
+					name
+				}
+			}
+		}
+	}
+}

--- a/src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.vue
+++ b/src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.vue
@@ -118,8 +118,7 @@ import bonusCreditHistoryQuery from '#src/graphql/query/portfolio/bonusCreditHis
 // and paged in the browser (mirrors the design's "paginate client-side" decision).
 const PAGE_LIMIT = 10;
 
-// Maps the FreeCreditStatus enum to a human label + badge colour. Labels preserve the
-// legacy BonusHistoryView wording ("Part redeemed", etc.).
+// Maps the FreeCreditStatus enum to a human label + badge colour ("Part redeemed", etc.).
 const STATUS_META = {
 	AVAILABLE: { label: 'Available', badge: 'tw-bg-eco-green-1 tw-text-eco-green-4' },
 	PART_REDEEMED: { label: 'Part redeemed', badge: 'tw-bg-marigold-1 tw-text-marigold-3' },
@@ -226,9 +225,8 @@ export default {
 		statusBadgeClass(status) {
 			return STATUS_META[status]?.badge ?? STATUS_META.REDEEMED.badge;
 		},
-		// Reproduces the legacy award-type sentences (BonusHistoryView::initializeData). For a
-		// partially-redeemed credit it appends the unredeemed amount, "expired" once past the
-		// expiration date and "remaining" otherwise.
+		// Composes the award-type sentence. For a partially-redeemed credit it appends the unredeemed amount,
+		// "expired" once past the expiration date and "remaining" otherwise.
 		composeNote(record) {
 			const date = this.getFormattedDate(record.createTime);
 			let note;

--- a/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
+++ b/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
@@ -1,0 +1,285 @@
+<template>
+	<PortfolioShell>
+		<div class="tw-rounded md:tw-bg-primary tw-p-2 tw-py-3 md:tw-p-3">
+			<h1 class="tw-mb-1">
+				Estimated repayments
+			</h1>
+
+			<!-- Loading -->
+			<KvLoadingPlaceholder v-if="loading" style="height: 320px;" data-testid="repayments-loading" />
+
+			<!-- Error / unable to compute (covers the legacy large-portfolio bail) -->
+			<div v-else-if="loadError" data-testid="repayments-load-error">
+				<p>
+					We couldn't calculate your estimated repayments right now. Accounts with very large
+					portfolios may not be able to display an estimate.
+				</p>
+				<KvButton
+					class="tw-mt-2"
+					@click="fetchRepayments"
+					v-kv-track-event="['portfolio', 'click', 'Estimated repayments retry load']"
+				>
+					Try again
+				</KvButton>
+			</div>
+
+			<!-- Empty state -->
+			<div v-else-if="!months.length" data-testid="repayments-empty">
+				<p>You don't have any upcoming repayments scheduled.</p>
+				<KvButton
+					to="/lend/filter"
+					class="tw-mt-2"
+					v-kv-track-event="['portfolio', 'click', 'Estimated repayments empty find a loan']"
+				>
+					Find a loan
+				</KvButton>
+			</div>
+
+			<template v-else>
+				<KvStackedBarGraph
+					class="tw-mb-3"
+					:points="chartPoints"
+					:series="series"
+					:format-value="value => $filters.numeral(value, '$0,0.00')"
+					title="Estimated repayments by month, split by where each repayment is returned"
+					axis-label="Estimated repayments by month"
+					bar-action-label="Select to view repayments for this month."
+					@bar-click="onChartBarClick"
+				/>
+
+				<!-- On mobile the tables (and the disclaimer below) sit on a white surface
+					that spans the rest of the page, while the graph above stays on the page
+					background. On md+ the whole section is already a white card, so the
+					mobile-only background/bleed resets to transparent. -->
+				<div
+					class="
+						tw-grid tw-grid-cols-12 tw-gap-3
+						tw-bg-primary tw--mx-2 tw-px-2 tw-pt-3
+						md:tw-bg-transparent md:tw-mx-0 md:tw-px-0 md:tw-pt-0
+					"
+				>
+					<div class="tw-col-span-12 lg:tw-col-span-4 tw-min-w-0">
+						<RepaymentsSummaryTable
+							:months="months"
+							:selected="selectedMonth"
+							@select="onSelectMonth"
+						/>
+					</div>
+					<div class="tw-col-span-12 lg:tw-col-span-8 tw-min-w-0">
+						<RepaymentsMonthDetail
+							:heading="selectedMonth ? selectedMonth.dueLabel : ''"
+							:loading="detailLoading"
+							:rows="detailRows"
+							:truncated="detailTruncated"
+							:total-count="selectedMonth ? selectedMonth.loansMakingRepayments : 0"
+						/>
+					</div>
+				</div>
+			</template>
+
+			<!-- tw-overflow-hidden establishes a block formatting context so the
+				disclaimer's own top margin stays inside this white surface (rather than
+				collapsing through the top and showing the page background between the
+				tables and the disclaimer on mobile). -->
+			<div
+				v-if="!loading && !loadError"
+				class="
+					tw-overflow-hidden tw-bg-primary tw--mx-2 tw-px-2 tw-pb-3 tw--mb-3
+					md:tw-overflow-visible md:tw-bg-transparent md:tw-mx-0 md:tw-px-0 md:tw-pb-0 md:tw-mb-0
+				"
+			>
+				<RepaymentsDisclaimer />
+			</div>
+		</div>
+	</PortfolioShell>
+</template>
+
+<script>
+import { format } from 'date-fns';
+import { KvButton, KvLoadingPlaceholder, KvStackedBarGraph } from '@kiva/kv-components';
+import PortfolioShell from '#src/components/WwwFrame/PortfolioShell';
+import RepaymentsSummaryTable from '#src/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable';
+import RepaymentsMonthDetail from '#src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail';
+import RepaymentsDisclaimer from '#src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer';
+import logFormatter from '#src/util/logFormatter';
+import expectedRepaymentsQuery from '#src/graphql/query/portfolio/estimatedRepayments.graphql';
+import expectedRepaymentsDetailQuery from '#src/graphql/query/portfolio/estimatedRepaymentsDetail.graphql';
+import {
+	REPAYMENT_SERIES,
+	DETAIL_LIMIT,
+} from '#src/util/estimatedRepayments/estimatedRepaymentsConstants';
+
+// Parse the Date scalar (may arrive as 'YYYY-MM-DD', ISO string, or unix seconds)
+// into calendar parts without letting timezone shift the month.
+function parseRepaymentDate(raw) {
+	if (raw == null) {
+		return null;
+	}
+	const isoMatch = typeof raw === 'string' && raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+	if (isoMatch) {
+		return { year: Number(isoMatch[1]), month: Number(isoMatch[2]) };
+	}
+	const numeric = Number(raw);
+	const date = Number.isNaN(numeric) ? new Date(raw) : new Date(numeric * 1000);
+	if (Number.isNaN(date.getTime())) {
+		return null;
+	}
+	return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1 };
+}
+
+export default {
+	name: 'EstimatedRepaymentsPage',
+	components: {
+		PortfolioShell,
+		KvButton,
+		KvLoadingPlaceholder,
+		KvStackedBarGraph,
+		RepaymentsSummaryTable,
+		RepaymentsMonthDetail,
+		RepaymentsDisclaimer,
+	},
+	inject: ['apollo'],
+	data() {
+		return {
+			series: REPAYMENT_SERIES,
+			loading: true,
+			loadError: false,
+			months: [],
+			selectedMonth: null,
+			detailLoading: false,
+			detailRows: [],
+			detailTruncated: false,
+		};
+	},
+	computed: {
+		// The graph shows a 12-month window anchored to the FIRST repayment month
+		// (inclusive of both endpoints → up to 13 bars), matching legacy
+		// (kiva: Portfolio_EstimatedRepaymentsView::initializeData). Anchoring to
+		// the first repayment month rather than "now" keeps the final month visible
+		// when repayments start next month (e.g. today is the 17th and the 1st has
+		// already passed). It stays readable no matter how long the full schedule
+		// is; the summary table below still lists every month. Because repayment
+		// months are chronological, this is always a leading prefix of `months`.
+		chartMonths() {
+			if (!this.months.length) {
+				return [];
+			}
+			const first = this.months[0];
+			// first.month is 1-12; +12 months lands on the same month next year.
+			const cutoffYear = first.year + 1;
+			const cutoffMonth = first.month;
+			return this.months.filter(
+				m => m.year < cutoffYear || (m.year === cutoffYear && m.month <= cutoffMonth),
+			);
+		},
+		chartPoints() {
+			return this.chartMonths.map(m => ({
+				label: m.chartLabel,
+				segments: [
+					{ seriesKey: 'user', value: m.userRepayments },
+					{ seriesKey: 'promo', value: m.promoRepayments },
+				],
+			}));
+		},
+	},
+	methods: {
+		// Clicking a bar selects that month and records the interaction.
+		onChartBarClick(index) {
+			// Index into chartMonths (the one-year window the graph renders), not
+			// the full months list, so the clicked bar maps to the right month.
+			const month = this.chartMonths[index];
+			if (!month) {
+				return;
+			}
+			this.$kvTrackEvent('portfolio', 'click', 'Estimated repayments chart bar', month.monthLabel);
+			this.onSelectMonth(month);
+		},
+		async fetchRepayments() {
+			this.loading = true;
+			this.loadError = false;
+			try {
+				const response = await this.apollo.query({
+					query: expectedRepaymentsQuery,
+					fetchPolicy: 'network-only',
+				});
+				const list = response?.data?.my?.userAccount?.expectedRepayments;
+				if (!Array.isArray(list)) {
+					this.loadError = true;
+					return;
+				}
+				this.months = this.buildMonths(list);
+				if (this.months.length) {
+					this.onSelectMonth(this.months[0]);
+				}
+			} catch (error) {
+				this.loadError = true;
+				logFormatter(`Error fetching estimated repayments: ${error}`, 'error');
+			} finally {
+				this.loading = false;
+			}
+		},
+		buildMonths(list) {
+			let lastYear = null;
+			return list
+				.map(item => {
+					const parts = parseRepaymentDate(item.repaymentDate);
+					if (!parts) {
+						return null;
+					}
+					const userRepayments = Number(item.userRepayments) || 0;
+					const promoRepayments = Number(item.promoRepayments) || 0;
+					// Build the Date from the already-parsed integer parts (local constructor,
+					// day 1) so formatting can't reintroduce the UTC-parse timezone shift that
+					// parseRepaymentDate avoids.
+					const date = new Date(parts.year, parts.month - 1, 1);
+					return {
+						year: parts.year,
+						month: parts.month,
+						userRepayments,
+						promoRepayments,
+						total: userRepayments + promoRepayments,
+						loansMakingRepayments: item.loansMakingRepayments ?? 0,
+						monthLabel: format(date, 'MMM'),
+						chartLabel: format(date, "MMM ''yy"),
+						dueLabel: format(date, 'MMM d, yyyy'),
+					};
+				})
+				.filter(Boolean)
+				.map(month => {
+					const showYearHeader = month.year !== lastYear;
+					lastYear = month.year;
+					return { ...month, showYearHeader };
+				});
+		},
+		async onSelectMonth(month) {
+			this.selectedMonth = month;
+			this.detailLoading = true;
+			this.detailRows = [];
+			this.detailTruncated = false;
+			try {
+				const response = await this.apollo.query({
+					query: expectedRepaymentsDetailQuery,
+					variables: { year: month.year, month: month.month },
+					fetchPolicy: 'network-only',
+				});
+				const rows = response?.data?.my?.userAccount?.expectedRepaymentsDetail ?? [];
+				this.detailRows = rows;
+				// The list length maxes out at the server cap, so it can't reveal truncation
+				// on its own. loansMakingRepayments (from the summary query, same filters) is
+				// the true pre-cap total: flag truncation only when we filled the cap and the
+				// total exceeds it.
+				this.detailTruncated = rows.length >= DETAIL_LIMIT
+					&& (month.loansMakingRepayments ?? 0) > DETAIL_LIMIT;
+			} catch (error) {
+				this.detailRows = [];
+				logFormatter(`Error fetching estimated repayment detail: ${error}`, 'error');
+			} finally {
+				this.detailLoading = false;
+			}
+		},
+	},
+	mounted() {
+		this.fetchRepayments();
+	},
+};
+</script>

--- a/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
+++ b/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
@@ -129,6 +129,11 @@ function parseRepaymentDate(raw) {
 
 export default {
 	name: 'EstimatedRepaymentsPage',
+	head() {
+		return {
+			title: 'Estimated Repayments',
+		};
+	},
 	components: {
 		PortfolioShell,
 		KvButton,
@@ -258,9 +263,18 @@ export default {
 			try {
 				const response = await this.apollo.query({
 					query: expectedRepaymentsDetailQuery,
-					variables: { year: month.year, month: month.month },
+					// Pass the cap explicitly so the truncation check below stays correct
+					// even if the resolver's default limit changes.
+					variables: { year: month.year, month: month.month, limit: DETAIL_LIMIT },
 					fetchPolicy: 'network-only',
 				});
+				// The queries are network-only and unguarded, so responses can resolve
+				// out of order (e.g. click Aug while Jul is still in flight). Discard any
+				// response whose month is no longer selected so it can't overwrite the
+				// current month's rows.
+				if (this.selectedMonth !== month) {
+					return;
+				}
 				const rows = response?.data?.my?.userAccount?.expectedRepaymentsDetail ?? [];
 				this.detailRows = rows;
 				// The list length maxes out at the server cap, so it can't reveal truncation
@@ -270,10 +284,18 @@ export default {
 				this.detailTruncated = rows.length >= DETAIL_LIMIT
 					&& (month.loansMakingRepayments ?? 0) > DETAIL_LIMIT;
 			} catch (error) {
+				// A stale request that errored must not wipe the current month's rows.
+				if (this.selectedMonth !== month) {
+					return;
+				}
 				this.detailRows = [];
 				logFormatter(`Error fetching estimated repayment detail: ${error}`, 'error');
 			} finally {
-				this.detailLoading = false;
+				// Only the request for the still-selected month owns the spinner; a stale
+				// request returning early must not clear it for the newer in-flight one.
+				if (this.selectedMonth === month) {
+					this.detailLoading = false;
+				}
 			}
 		},
 	},

--- a/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
+++ b/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
@@ -153,11 +153,10 @@ export default {
 	},
 	computed: {
 		// The graph shows a 12-month window anchored to the FIRST repayment month
-		// (inclusive of both endpoints → up to 13 bars), matching legacy
-		// (kiva: Portfolio_EstimatedRepaymentsView::initializeData). Anchoring to
-		// the first repayment month rather than "now" keeps the final month visible
-		// when repayments start next month (e.g. today is the 17th and the 1st has
-		// already passed). It stays readable no matter how long the full schedule
+		// (inclusive of both endpoints → up to 13 bars), matching legacy behavior.
+		// Anchoring to the first repayment month rather than "now" keeps the final
+		// month visible when repayments start next month (e.g. today is the 17th and
+		// the 1st has already passed). It stays readable no matter how long the full schedule
 		// is; the summary table below still lists every month. Because repayment
 		// months are chronological, this is always a leading prefix of `months`.
 		chartMonths() {

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -293,10 +293,9 @@ export default {
 			}).then(({ data }) => {
 				const numChanged = data?.my?.reassignLoanTeam ?? 0;
 				if (numChanged > 0) {
-					// Update just this row's attributed team in place (legacy parity) rather
-					// than refetching the page: a reassignment can't change eligibility
-					// (status + 14-day window are unaffected), so a full reload would only
-					// flash the loading skeleton over the whole table for no new data.
+					// Update just this row's attributed team in place rather than refetching the page:
+					// a reassignment can't change eligibility (status + 14-day window are unaffected),
+					// so a full reload would only flash the loading skeleton over the whole table for no new data.
 					this.applyTeamAssignment(loanId, teamId);
 					this.$showTipMsg('Team updated.');
 					return;

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,5 +1,6 @@
 import { WITHDRAW_ROUTE, WITHDRAW_PROCESS } from '#src/util/withdraw/withdrawConstants';
 import { DEPOSIT_ROUTE } from '#src/util/deposit/depositConstants';
+import { ESTIMATED_REPAYMENTS_ROUTE } from '#src/util/estimatedRepayments/estimatedRepaymentsConstants';
 
 export default [
 	{
@@ -371,6 +372,14 @@ export default [
 	{
 		path: '/portfolio/credit/bonus-history-beta',
 		component: () => import('#src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage'),
+		meta: {
+			authenticationRequired: true,
+			excludeFromStaticSitemap: true,
+		}
+	},
+	{
+		path: ESTIMATED_REPAYMENTS_ROUTE,
+		component: () => import('#src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage'),
 		meta: {
 			authenticationRequired: true,
 			excludeFromStaticSitemap: true,

--- a/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
+++ b/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
@@ -40,26 +40,5 @@ export const REPAYMENT_SERIES = [
 	},
 ];
 
-// The legacy page's static disclaimer, ported verbatim. Rendered via v-html (all
-// content is static/trusted here), so inline markup like <em> is allowed.
-export const DISCLAIMER_PARAGRAPHS = [
-	'*Scheduled repayment estimates are calculated based on the <em>original</em> repayment schedule for '
-		+ 'each of your loans. Please note, these estimates don\'t account for delinquencies, defaults, '
-		+ 'currency loss, or for when borrowers pay more than was scheduled and the principal has been '
-		+ 'paid down. Click the amounts in the detailed view to see the advanced repayment details for '
-		+ 'each loan.',
-	'Each month\'s repayment estimation is rounded down to the nearest penny for each loan, and '
-		+ 'therefore actual repayment amounts received may differ from what is estimated. The due date '
-		+ 'for repayments is on the 1st of the month. Many of Kiva\'s Lending Partners begin paying '
-		+ 'lenders earlier, on the settlement date which is the 17th of the month <em>prior</em> to the due date. '
-		+ 'However, repayments may continue post to lender accounts anytime between the 17th and the 1st '
-		+ 'before they\'re considered delinquent. For example: Often a majority of the amount estimated '
-		+ 'for December 1st will be returned to the lender\'s account on November 17th, but some may post '
-		+ 'later than the 17th. The "Due" column shows the actual due dates, not the '
-		+ 'dates when repayments post to your account.',
-	'These figures also don\'t imply that repayments are in any way guaranteed, as lending through '
-		+ 'Kiva involves risk of principal loss.',
-];
-
 export const SETTLEMENT_NOTE = '(Typically repaid by the "Settlement Date," which is the 17th of '
 	+ 'the month prior to the "Due Date")';

--- a/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
+++ b/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
@@ -14,11 +14,9 @@ export const DETAIL_LIMIT = 500;
 export const PROMO_CREDIT_FALLBACK_LABEL = 'promotional credit';
 
 // Human-readable labels for the raw `promoType` enum returned by
-// expectedRepaymentsDetail. Ported verbatim from the legacy view's switch
-// (kiva: Portfolio_EstimatedRepaymentsByMonthSubView::initializeData) so the
-// detail note reads "bonus credit" rather than the raw `reward_credit`. Any
-// type not listed here falls back to PROMO_CREDIT_FALLBACK_LABEL, mirroring the
-// legacy `default` branch.
+// expectedRepaymentsDetail, so the detail note reads "bonus credit" rather than
+// the raw `reward_credit`. Any type not listed here falls back to
+// PROMO_CREDIT_FALLBACK_LABEL.
 export const PROMO_TYPE_LABELS = {
 	reward_credit: 'bonus credit',
 	free_trial: 'free trial credit',

--- a/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
+++ b/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
@@ -1,0 +1,67 @@
+// Route path, chart palette, and legacy copy for the estimated-repayments beta page.
+// Colours mirror the legacy stacked chart's two series and were validated (dataviz
+// skill) for colour-blind separation and surface contrast in light and dark modes.
+import kvTokensPrimitives from '@kiva/kv-tokens';
+
+const { colors } = kvTokensPrimitives;
+
+export const ESTIMATED_REPAYMENTS_ROUTE = '/portfolio/estimated-repayments-beta';
+
+// The legacy detail query caps the per-month loan list; surface a truncation notice
+// when the returned list reaches this size. Mirrors the resolver's default limit.
+export const DETAIL_LIMIT = 500;
+
+export const PROMO_CREDIT_FALLBACK_LABEL = 'promotional credit';
+
+// Human-readable labels for the raw `promoType` enum returned by
+// expectedRepaymentsDetail. Ported verbatim from the legacy view's switch
+// (kiva: Portfolio_EstimatedRepaymentsByMonthSubView::initializeData) so the
+// detail note reads "bonus credit" rather than the raw `reward_credit`. Any
+// type not listed here falls back to PROMO_CREDIT_FALLBACK_LABEL, mirroring the
+// legacy `default` branch.
+export const PROMO_TYPE_LABELS = {
+	reward_credit: 'bonus credit',
+	free_trial: 'free trial credit',
+};
+
+// Fixed series order (never cycled). `color` overrides the library's default
+// palette; colors are pulled from the kv-tokens core palette (theme-independent,
+// so they stay constant across light/dark per the kv-components chart convention).
+// Order matters: KvStackedBarGraph renders the FIRST series at the top of the
+// stack (and lists it first in the legend), so `promo` leads to sit on top.
+export const REPAYMENT_SERIES = [
+	{
+		key: 'promo',
+		label: 'Repaid to Kiva or sponsor (free trials, bonuses, and general promotional credit)',
+		color: colors.marigold['3'],
+	},
+	{
+		key: 'user',
+		label: 'Repaid to your account',
+		color: colors.brand['700'],
+	},
+];
+
+// The legacy page's static disclaimer, ported verbatim. Rendered via v-html (all
+// content is static/trusted here), so inline markup like <em> is allowed.
+export const DISCLAIMER_PARAGRAPHS = [
+	'*Scheduled repayment estimates are calculated based on the <em>original</em> repayment schedule for '
+		+ 'each of your loans. Please note, these estimates don\'t account for delinquencies, defaults, '
+		+ 'currency loss, or for when borrowers pay more than was scheduled and the principal has been '
+		+ 'paid down. Click the amounts in the detailed view to see the advanced repayment details for '
+		+ 'each loan.',
+	'Each month\'s repayment estimation is rounded down to the nearest penny for each loan, and '
+		+ 'therefore actual repayment amounts received may differ from what is estimated. The due date '
+		+ 'for repayments is on the 1st of the month. Many of Kiva\'s Lending Partners begin paying '
+		+ 'lenders earlier, on the settlement date which is the 17th of the month <em>prior</em> to the due date. '
+		+ 'However, repayments may continue post to lender accounts anytime between the 17th and the 1st '
+		+ 'before they\'re considered delinquent. For example: Often a majority of the amount estimated '
+		+ 'for December 1st will be returned to the lender\'s account on November 17th, but some may post '
+		+ 'later than the 17th. The "Due" column shows the actual due dates, not the '
+		+ 'dates when repayments post to your account.',
+	'These figures also don\'t imply that repayments are in any way guaranteed, as lending through '
+		+ 'Kiva involves risk of principal loss.',
+];
+
+export const SETTLEMENT_NOTE = '(Typically repaid by the "Settlement Date," which is the 17th of '
+	+ 'the month prior to the "Due Date")';

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -8,7 +8,7 @@ export const ERL_COOKIE_NAME = 'kverlfivedollarnotes';
 export const TOP_UP_CAMPAIGN = 'TOPUP-VB-BALANCE-MPV1';
 export const BASE_CAMPAIGN = 'BASE-VB_BALANCE_MPV1';
 
-// Mirrors monolith Kc_Loan_Psc::getAllPublicStatuses() — non-privileged viewers can only see these.
+// Non-privileged viewers can only see these public loan statuses.
 const PUBLIC_STATUSES = [FUNDRAISING, FUNDED, EXPIRED, RAISED, PAYING_BACK, REFUNDED, ENDED, DEFAULTED];
 
 /**

--- a/test/unit/specs/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.spec.js
+++ b/test/unit/specs/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.spec.js
@@ -1,0 +1,81 @@
+import { render } from '@testing-library/vue';
+import numeral from 'numeral';
+import RepaymentsMonthDetail from '#src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail';
+
+const renderDetail = (props = {}) => render(RepaymentsMonthDetail, {
+	props: {
+		heading: 'July 1, 2026',
+		loading: false,
+		rows: [],
+		truncated: false,
+		...props,
+	},
+	global: {
+		directives: { 'kv-track-event': {} },
+		mocks: { $filters: { numeral: (value, format) => numeral(value).format(format) } },
+		stubs: { KvLoadingPlaceholder: { template: '<div data-testid="loading" />' } },
+	},
+});
+
+const row = overrides => ({
+	amount: 50,
+	userAmount: 40,
+	promoAmount: 0,
+	promoType: null,
+	isDelinquent: false,
+	pastRepayments: 3,
+	totalRepayments: 8,
+	loan: { id: '1', name: 'Maria' },
+	...overrides,
+});
+
+describe('RepaymentsMonthDetail', () => {
+	it('shows the loading placeholder when loading', () => {
+		const { getByTestId } = renderDetail({ loading: true });
+		expect(getByTestId('detail-loading')).toBeTruthy();
+	});
+
+	it('shows the empty message when there are no rows', () => {
+		const { getByTestId } = renderDetail();
+		expect(getByTestId('detail-empty')).toBeTruthy();
+	});
+
+	it('maps the raw promoType enum to its human-readable label (legacy parity)', () => {
+		const { getByText } = renderDetail({
+			rows: [row({ promoAmount: 10, promoType: 'reward_credit' })],
+		});
+		expect(getByText(/Includes \$10\.00 of bonus credit \(repaid to Kiva or sponsor\)/)).toBeTruthy();
+	});
+
+	it('maps the free_trial promoType to "free trial credit"', () => {
+		const { getByText } = renderDetail({
+			rows: [row({ promoAmount: 7.5, promoType: 'free_trial' })],
+		});
+		expect(getByText(/Includes \$7\.50 of free trial credit \(repaid to Kiva or sponsor\)/)).toBeTruthy();
+	});
+
+	it('falls back to a generic promo label for an unknown or missing promoType', () => {
+		const { getByText } = renderDetail({
+			rows: [row({ promoAmount: 5, promoType: 'something_new' })],
+		});
+		expect(getByText(/of promotional credit/)).toBeTruthy();
+	});
+
+	it('flags delinquent and final repayments', () => {
+		const { getByText } = renderDetail({
+			rows: [row({ isDelinquent: true, pastRepayments: 8, totalRepayments: 8 })],
+		});
+		expect(getByText('Delinquent')).toBeTruthy();
+		expect(getByText('Final')).toBeTruthy();
+	});
+
+	it('links the borrower to the loan page', () => {
+		const { getByText } = renderDetail({ rows: [row()] });
+		expect(getByText('Maria').getAttribute('href')).toBe('/lend/1');
+	});
+
+	it('shows the truncation notice when truncated', () => {
+		const { getByTestId } = renderDetail({ rows: [row()], truncated: true });
+		expect(getByTestId('detail-truncated')).toBeTruthy();
+	});
+});

--- a/test/unit/specs/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable.spec.js
+++ b/test/unit/specs/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable.spec.js
@@ -1,0 +1,50 @@
+import { render, fireEvent } from '@testing-library/vue';
+import numeral from 'numeral';
+import RepaymentsSummaryTable from '#src/components/Portfolio/EstimatedRepayments/RepaymentsSummaryTable';
+
+const months = [
+	{
+		year: 2026, month: 7, monthLabel: 'July', total: 400, loansMakingRepayments: 6, showYearHeader: true
+	},
+	{
+		year: 2026, month: 8, monthLabel: 'August', total: 250, loansMakingRepayments: 4, showYearHeader: false
+	},
+];
+
+const renderTable = (props = {}) => {
+	const kvTrackEvent = vi.fn();
+	return {
+		kvTrackEvent,
+		...render(RepaymentsSummaryTable, {
+			props: { months, selected: null, ...props },
+			global: {
+				mocks: {
+					$kvTrackEvent: kvTrackEvent,
+					$filters: { numeral: (value, format) => numeral(value).format(format) },
+				},
+			},
+		}),
+	};
+};
+
+describe('RepaymentsSummaryTable', () => {
+	it('renders a row per month with totals and counts', () => {
+		const { getByText, getByTestId } = renderTable();
+		expect(getByText('July')).toBeTruthy();
+		expect(getByText('$400.00')).toBeTruthy();
+		expect(getByTestId('repayments-month-row-2026-7')).toBeTruthy();
+	});
+
+	it('selects the month and tracks when the row (not just the link) is clicked', async () => {
+		const { getByTestId, emitted, kvTrackEvent } = renderTable();
+		await fireEvent.click(getByTestId('repayments-month-row-2026-8'));
+		expect(emitted().select[0][0]).toMatchObject({ year: 2026, month: 8 });
+		expect(kvTrackEvent).toHaveBeenCalledWith('portfolio', 'click', 'Estimated repayments month', 'August');
+	});
+
+	it('selects once (no double-fire) when the month button is clicked', async () => {
+		const { getByText, emitted } = renderTable();
+		await fireEvent.click(getByText('August'));
+		expect(emitted().select).toHaveLength(1);
+	});
+});

--- a/test/unit/specs/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.spec.js
@@ -1,0 +1,222 @@
+import { render, fireEvent, waitFor } from '@testing-library/vue';
+import numeral from 'numeral';
+import EstimatedRepaymentsPage from '#src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage';
+
+const listResponse = (expectedRepayments = [
+	{
+		repaymentDate: '2026-07-01', userRepayments: 300, promoRepayments: 100, loansMakingRepayments: 6
+	},
+	{
+		repaymentDate: '2026-08-01', userRepayments: 200, promoRepayments: 0, loansMakingRepayments: 4
+	},
+]) => ({
+	my: { id: 'my-1', userAccount: { id: 'ua-1', expectedRepayments } },
+});
+
+const julyDetail = [
+	{
+		repaymentDate: '2026-07-01',
+		amount: 50,
+		userAmount: 40,
+		promoAmount: 10,
+		promoType: 'reward_credit',
+		isDelinquent: false,
+		pastRepayments: 3,
+		totalRepayments: 8,
+		loan: { id: '123', name: 'Maria' },
+	},
+	{
+		repaymentDate: '2026-07-01',
+		amount: 25,
+		userAmount: 25,
+		promoAmount: 0,
+		promoType: null,
+		isDelinquent: true,
+		pastRepayments: 8,
+		totalRepayments: 8,
+		loan: { id: '456', name: 'Juan' },
+	},
+];
+
+const augustDetail = [
+	{
+		repaymentDate: '2026-08-01',
+		amount: 200,
+		userAmount: 200,
+		promoAmount: 0,
+		promoType: null,
+		isDelinquent: false,
+		pastRepayments: 1,
+		totalRepayments: 12,
+		loan: { id: '789', name: 'Amara' },
+	},
+];
+
+const detailResponse = rows => ({
+	my: { id: 'my-1', userAccount: { id: 'ua-1', expectedRepaymentsDetail: rows } },
+});
+
+const renderPage = ({ expectedRepayments, rejects = false } = {}) => {
+	const query = vi.fn().mockImplementation(({ variables } = {}) => {
+		if (rejects) {
+			return Promise.reject(new Error('boom'));
+		}
+		if (variables) {
+			const rows = variables.month === 8 ? augustDetail : julyDetail;
+			return Promise.resolve({ data: detailResponse(rows) });
+		}
+		return Promise.resolve({ data: listResponse(expectedRepayments) });
+	});
+
+	return {
+		query,
+		...render(EstimatedRepaymentsPage, {
+			global: {
+				provide: { apollo: { query }, cookieStore: {} },
+				mocks: {
+					$router: { push: vi.fn() },
+					$kvTrackEvent: vi.fn(),
+					$filters: { numeral: (value, format) => numeral(value).format(format) },
+				},
+				directives: { 'kv-track-event': {} },
+				stubs: {
+					PortfolioShell: { template: '<div><slot /></div>' },
+					KvButton: { props: ['to'], template: '<button><slot /></button>' },
+					KvLoadingPlaceholder: { template: '<div data-testid="loading" />' },
+					KvStackedBarGraph: {
+						props: ['points'],
+						template: '<div data-testid="chart" :data-bars="points.length" />',
+					},
+				},
+			},
+		}),
+	};
+};
+
+describe('EstimatedRepaymentsPage', () => {
+	it('loads the summary and auto-selects the first month detail', async () => {
+		const { getByTestId, getByText } = renderPage();
+		await waitFor(() => {
+			expect(getByTestId('repayments-summary-table')).toBeTruthy();
+		});
+		// first (July) month detail auto-loaded
+		expect(getByText('Maria')).toBeTruthy();
+		expect(getByText('Estimated repayments due by Jul 1, 2026')).toBeTruthy();
+	});
+
+	it('renders the promo, delinquent, and final note flags (legacy parity)', async () => {
+		const { getByText } = renderPage();
+		await waitFor(() => {
+			expect(getByText(/Includes \$10\.00 of bonus credit \(repaid to Kiva or sponsor\)/)).toBeTruthy();
+		});
+		expect(getByText('Delinquent')).toBeTruthy();
+		expect(getByText('Final')).toBeTruthy();
+	});
+
+	it('loads a different month detail when a month row is clicked', async () => {
+		const { getByText, query } = renderPage();
+		await waitFor(() => expect(getByText('Aug')).toBeTruthy());
+		await fireEvent.click(getByText('Aug'));
+		await waitFor(() => expect(getByText('Amara')).toBeTruthy());
+		expect(query).toHaveBeenCalledWith(expect.objectContaining({
+			variables: { year: 2026, month: 8 },
+		}));
+	});
+
+	it('anchors the 12-month graph window to the first repayment month, not "now"', async () => {
+		// The window follows the data, not the clock: with repayments starting in
+		// August (the 1st has passed, so "now" is mid-July) the graph must still run
+		// a full year from August — anchoring to "now" would clip the final month.
+		// Fake only Date so the async apollo/waitFor timing keeps using real timers.
+		vi.useFakeTimers({ toFake: ['Date'] });
+		vi.setSystemTime(new Date('2026-07-15T00:00:00Z'));
+		try {
+			// 15 monthly points starting the month AFTER now: 2026-08 through 2027-10.
+			const months = Array.from({ length: 15 }, (unused, i) => {
+				const year = 2026 + Math.floor((7 + i) / 12);
+				const month = ((7 + i) % 12) + 1;
+				return {
+					repaymentDate: `${year}-${String(month).padStart(2, '0')}-01`,
+					userRepayments: 100 + i,
+					promoRepayments: 10,
+					loansMakingRepayments: 2,
+				};
+			});
+			const { getByTestId, getAllByTestId } = renderPage({ expectedRepayments: months });
+			await waitFor(() => expect(getByTestId('repayments-summary-table')).toBeTruthy());
+			// Graph: 2026-08 through 2027-08 inclusive = 13 bars (2027-09, 2027-10 excluded).
+			// A "now"-anchored window would have stopped at 2027-07 = 12 bars.
+			expect(getByTestId('chart').getAttribute('data-bars')).toBe('13');
+			// Table still lists all 15 months.
+			expect(getAllByTestId(/^repayments-month-row-/)).toHaveLength(15);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it('flags truncation with the true total only when the server cap is actually hit', async () => {
+		// July summary reports 1200 loans; the capped detail returns exactly 500 rows.
+		const capped = Array.from({ length: 500 }, (unused, i) => ({
+			repaymentDate: '2026-07-01',
+			amount: 10,
+			userAmount: 10,
+			promoAmount: 0,
+			promoType: null,
+			isDelinquent: false,
+			pastRepayments: 1,
+			totalRepayments: 8,
+			loan: { id: `L${i}`, name: `Borrower ${i}` },
+		}));
+		const query = vi.fn().mockImplementation(({ variables } = {}) => {
+			if (variables) {
+				return Promise.resolve({ data: detailResponse(capped) });
+			}
+			return Promise.resolve({
+				data: listResponse([{
+					repaymentDate: '2026-07-01', userRepayments: 1, promoRepayments: 0, loansMakingRepayments: 1200,
+				}]),
+			});
+		});
+		const { getByTestId } = render(EstimatedRepaymentsPage, {
+			global: {
+				provide: { apollo: { query }, cookieStore: {} },
+				mocks: {
+					$router: { push: vi.fn() },
+					$kvTrackEvent: vi.fn(),
+					$filters: { numeral: (value, format) => numeral(value).format(format) },
+				},
+				directives: { 'kv-track-event': {} },
+				stubs: {
+					PortfolioShell: { template: '<div><slot /></div>' },
+					KvButton: { props: ['to'], template: '<button><slot /></button>' },
+					KvLoadingPlaceholder: { template: '<div data-testid="loading" />' },
+					KvStackedBarGraph: { props: ['points'], template: '<div data-testid="chart" />' },
+				},
+			},
+		});
+		const notice = await waitFor(() => getByTestId('detail-truncated'));
+		expect(notice.textContent).toContain('first 500 of 1,200');
+	});
+
+	it('does not flag truncation when the month has fewer loans than the cap', async () => {
+		// July summary reports 6 loans but the detail mock returns only 2 (summary/detail
+		// drift): the cap was never hit, so no misleading "first 500 of 6" notice.
+		const { queryByTestId, getByText } = renderPage();
+		await waitFor(() => expect(getByText('Maria')).toBeTruthy());
+		expect(queryByTestId('detail-truncated')).toBeNull();
+	});
+
+	it('shows the empty state when there are no upcoming repayments', async () => {
+		const { getByTestId } = renderPage({ expectedRepayments: [] });
+		await waitFor(() => {
+			expect(getByTestId('repayments-empty')).toBeTruthy();
+		});
+	});
+
+	it('shows the error state when the query fails', async () => {
+		const { getByTestId } = renderPage({ rejects: true });
+		await waitFor(() => {
+			expect(getByTestId('repayments-load-error')).toBeTruthy();
+		});
+	});
+});

--- a/test/unit/specs/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.spec.js
@@ -1,4 +1,6 @@
 import { render, fireEvent, waitFor } from '@testing-library/vue';
+// eslint-disable-next-line import/no-extraneous-dependencies -- devDependency used only in tests
+import { flushPromises } from '@vue/test-utils';
 import numeral from 'numeral';
 import EstimatedRepaymentsPage from '#src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage';
 
@@ -119,8 +121,51 @@ describe('EstimatedRepaymentsPage', () => {
 		await fireEvent.click(getByText('Aug'));
 		await waitFor(() => expect(getByText('Amara')).toBeTruthy());
 		expect(query).toHaveBeenCalledWith(expect.objectContaining({
-			variables: { year: 2026, month: 8 },
+			variables: { year: 2026, month: 8, limit: 500 },
 		}));
+	});
+
+	it('ignores a stale detail response that resolves after a newer month is selected', async () => {
+		// Select July (auto), then August while July is still in flight, and make July
+		// resolve LAST. The stale July response must not overwrite August's rows.
+		let resolveJuly;
+		const query = vi.fn().mockImplementation(({ variables } = {}) => {
+			if (!variables) {
+				return Promise.resolve({ data: listResponse() });
+			}
+			if (variables.month === 7) {
+				return new Promise(resolve => { resolveJuly = () => resolve({ data: detailResponse(julyDetail) }); });
+			}
+			return Promise.resolve({ data: detailResponse(augustDetail) });
+		});
+		const { getByText, queryByText } = render(EstimatedRepaymentsPage, {
+			global: {
+				provide: { apollo: { query }, cookieStore: {} },
+				mocks: {
+					$router: { push: vi.fn() },
+					$kvTrackEvent: vi.fn(),
+					$filters: { numeral: (value, format) => numeral(value).format(format) },
+				},
+				directives: { 'kv-track-event': {} },
+				stubs: {
+					PortfolioShell: { template: '<div><slot /></div>' },
+					KvButton: { props: ['to'], template: '<button><slot /></button>' },
+					KvLoadingPlaceholder: { template: '<div data-testid="loading" />' },
+					KvStackedBarGraph: { props: ['points'], template: '<div data-testid="chart" />' },
+				},
+			},
+		});
+		// July is auto-selected on load and its detail request is pending (unresolved).
+		await waitFor(() => expect(getByText('Aug')).toBeTruthy());
+		// Select August; its detail resolves immediately.
+		await fireEvent.click(getByText('Aug'));
+		await waitFor(() => expect(getByText('Amara')).toBeTruthy());
+		// Now let the stale July response resolve and flush its continuation + re-render.
+		// It must be discarded: August's rows stay, July's never appear.
+		resolveJuly();
+		await flushPromises();
+		expect(getByText('Amara')).toBeTruthy();
+		expect(queryByText('Maria')).toBeNull();
 	});
 
 	it('anchors the 12-month graph window to the first repayment month, not "now"', async () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2983

Completed migration of `/portfolio/estimated-repayments-beta`. All functionality (new stacked graph, clickable tables to see monthly repayments, how data is displayed in table, etc.) parity with legacy. Improvement added where graph months are now clickable, and the table on the left shows which month is selected. Mobile experience also improved -> legacy just scrolled the desktop version in mobile.

Included some lock file changes that seemed like fine cleanup after an `npm i`.

<img width="2467" height="1910" alt="image" src="https://github.com/user-attachments/assets/bc69dcfc-7ebc-4b98-a4c8-45183a2c7dda" />

<img width="442" height="946" alt="image" src="https://github.com/user-attachments/assets/810e5103-baf5-4225-b2cb-a821f3a0971e" />

