### PR TITLE
feat: [MP-3047] prefill custom tip input with $1.00 in the treatment variant

### DIFF
--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -146,12 +146,14 @@ export default {
 			customInputButton.click();
 		},
 		afterLightboxOpens() {
-			const currentAmount = numeral(this.currentDonationAmount).value() ?? 0;
-			if (this.customTipDefaultVersion === 'b' && currentAmount === 0) {
-				// Suggest a starting amount when the tip is zero; the user's entry always wins
-				this.setInputs(numeral(TREATMENT_PREFILL_AMOUNT).format('$0,0.00'));
-			} else if (this.currentDonationAmount && this.customDonationSelected) {
+			if (this.currentDonationAmount && this.customDonationSelected) {
 				this.setInputs(this.currentDonationAmount);
+			}
+
+			const inputAmount = numeral(this.customDonationAmount).value() ?? 0;
+			if (this.customTipDefaultVersion === 'b' && inputAmount === 0) {
+				// Suggest a starting amount when the input would show zero or empty; the user's entry always wins
+				this.setInputs(numeral(TREATMENT_PREFILL_AMOUNT).format('$0,0.00'));
 			}
 
 			this.$nextTick(() => {

--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -94,6 +94,8 @@
 import numeral from 'numeral';
 import { KvTextInput, KvButton } from '@kiva/kv-components';
 
+const TREATMENT_PREFILL_AMOUNT = 1;
+
 export default {
 	name: 'DonationNudgeBoxes',
 	components: {
@@ -144,7 +146,11 @@ export default {
 			customInputButton.click();
 		},
 		afterLightboxOpens() {
-			if (this.currentDonationAmount && this.customDonationSelected) {
+			const currentAmount = numeral(this.currentDonationAmount).value() ?? 0;
+			if (this.customTipDefaultVersion === 'b' && currentAmount === 0) {
+				// Suggest a starting amount when the tip is zero; the user's entry always wins
+				this.setInputs(numeral(TREATMENT_PREFILL_AMOUNT).format('$0,0.00'));
+			} else if (this.currentDonationAmount && this.customDonationSelected) {
 				this.setInputs(this.currentDonationAmount);
 			}
 

--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -94,7 +94,7 @@
 import numeral from 'numeral';
 import { KvTextInput, KvButton } from '@kiva/kv-components';
 
-const TREATMENT_PREFILL_AMOUNT = 1;
+const TREATMENT_PREFILL_AMOUNT = '$1.00';
 
 export default {
 	name: 'DonationNudgeBoxes',
@@ -150,10 +150,9 @@ export default {
 				this.setInputs(this.currentDonationAmount);
 			}
 
-			const inputAmount = numeral(this.customDonationAmount).value() ?? 0;
-			if (this.customTipDefaultVersion === 'b' && inputAmount === 0) {
+			if (this.customTipDefaultVersion === 'b' && (numeral(this.customDonationAmount).value() ?? 0) === 0) {
 				// Suggest a starting amount when the input would show zero or empty; the user's entry always wins
-				this.setInputs(numeral(TREATMENT_PREFILL_AMOUNT).format('$0,0.00'));
+				this.setInputs(TREATMENT_PREFILL_AMOUNT);
 			}
 
 			this.$nextTick(() => {

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -87,7 +87,7 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 		expect(wrapper.vm.customDonationAmount).toBe('$7.50');
 	});
 
-	it('does not touch the input when the amount matches a preset in the treatment variant', () => {
+	it('prefills $1.00 in the treatment variant when the tip matches a preset and the input is empty', () => {
 		const wrapper = mountBoxes({
 			version: 'b',
 			props: {
@@ -102,6 +102,43 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 
 		wrapper.vm.afterLightboxOpens();
 
+		expect(wrapper.vm.customDonationAmount).toBe('$1.00');
+	});
+
+	it('leaves the input empty for the control variant when the tip matches a preset', () => {
+		const wrapper = mountBoxes({
+			version: 'a',
+			props: {
+				currentDonationAmount: '$15.00',
+				loanReservationTotal: 100,
+				percentageRows: [
+					{ percentage: 15, appeal: 'first' },
+					{ percentage: 20, appeal: 'second' },
+				],
+			},
+		});
+
+		wrapper.vm.afterLightboxOpens();
+
 		expect(wrapper.vm.customDonationAmount).toBe(null);
+	});
+
+	it('preserves a typed but unsubmitted amount on reopen in the treatment variant', () => {
+		const wrapper = mountBoxes({
+			version: 'b',
+			props: {
+				currentDonationAmount: '$15.00',
+				loanReservationTotal: 100,
+				percentageRows: [
+					{ percentage: 15, appeal: 'first' },
+					{ percentage: 20, appeal: 'second' },
+				],
+			},
+		});
+
+		wrapper.vm.setInputs('$5.00');
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe('$5.00');
 	});
 });

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -112,4 +112,31 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 
 		expect(wrapper.vm.customDonationAmount).toBe('$5.00');
 	});
+
+	it('submits the prefilled amount when the custom option is selected', () => {
+		const setDonationAndClose = vi.fn();
+		const wrapper = mountBoxes({
+			version: 'b',
+			props: { currentDonationAmount: '$0.00', setDonationAndClose },
+		});
+
+		wrapper.vm.afterLightboxOpens();
+		wrapper.vm.setCustomDonationAndClose();
+
+		expect(setDonationAndClose).toHaveBeenCalledWith(1, 'Custom amount');
+	});
+
+	it('submits zero when the user edits the prefill back to $0.00', () => {
+		const setDonationAndClose = vi.fn();
+		const wrapper = mountBoxes({
+			version: 'b',
+			props: { currentDonationAmount: '$0.00', setDonationAndClose },
+		});
+
+		wrapper.vm.afterLightboxOpens();
+		wrapper.vm.setInputs('$0.00');
+		wrapper.vm.setCustomDonationAndClose();
+
+		expect(setDonationAndClose).toHaveBeenCalledWith(0, 'Custom amount');
+	});
 });

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -9,29 +9,29 @@ const defaultProps = {
 	setDonationAndClose: () => {},
 };
 
-const mountBoxes = ({ version, props = {} } = {}) => shallowMount(DonationNudgeBoxes, {
+const mountBoxes = ({ version = null, props = {} } = {}) => shallowMount(DonationNudgeBoxes, {
 	props: { ...defaultProps, ...props },
 	global: {
 		...globalOptions,
 		provide: {
 			...globalOptions.provide,
-			...(version !== undefined ? { customTipDefaultVersion: computed(() => version) } : {}),
+			customTipDefaultVersion: computed(() => version),
 		},
 	},
 });
 
+const presetMatchProps = {
+	currentDonationAmount: '$15.00',
+	loanReservationTotal: 100,
+	percentageRows: [
+		{ percentage: 15, appeal: 'first' },
+		{ percentage: 20, appeal: 'second' },
+	],
+};
+
 describe('DonationNudgeBoxes custom tip default experiment', () => {
 	it('resolves the provided experiment version synchronously', () => {
-		const wrapper = shallowMount(DonationNudgeBoxes, {
-			props: defaultProps,
-			global: {
-				...globalOptions,
-				provide: {
-					...globalOptions.provide,
-					customTipDefaultVersion: computed(() => 'b'),
-				},
-			},
-		});
+		const wrapper = mountBoxes({ version: 'b' });
 
 		expect(wrapper.vm.customTipDefaultVersion).toBe('b');
 	});
@@ -71,7 +71,7 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 		expect(wrapper.vm.customDonationAmount).toBe('$0.00');
 	});
 
-	it('keeps $0.00 when no version is provided and the tip is zero', () => {
+	it('keeps $0.00 when the provided version is null and the tip is zero', () => {
 		const wrapper = mountBoxes({ props: { currentDonationAmount: '$0.00' } });
 
 		wrapper.vm.afterLightboxOpens();
@@ -88,17 +88,7 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 	});
 
 	it('prefills $1.00 in the treatment variant when the tip matches a preset and the input is empty', () => {
-		const wrapper = mountBoxes({
-			version: 'b',
-			props: {
-				currentDonationAmount: '$15.00',
-				loanReservationTotal: 100,
-				percentageRows: [
-					{ percentage: 15, appeal: 'first' },
-					{ percentage: 20, appeal: 'second' },
-				],
-			},
-		});
+		const wrapper = mountBoxes({ version: 'b', props: presetMatchProps });
 
 		wrapper.vm.afterLightboxOpens();
 
@@ -106,17 +96,7 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 	});
 
 	it('leaves the input empty for the control variant when the tip matches a preset', () => {
-		const wrapper = mountBoxes({
-			version: 'a',
-			props: {
-				currentDonationAmount: '$15.00',
-				loanReservationTotal: 100,
-				percentageRows: [
-					{ percentage: 15, appeal: 'first' },
-					{ percentage: 20, appeal: 'second' },
-				],
-			},
-		});
+		const wrapper = mountBoxes({ version: 'a', props: presetMatchProps });
 
 		wrapper.vm.afterLightboxOpens();
 
@@ -124,17 +104,7 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 	});
 
 	it('preserves a typed but unsubmitted amount on reopen in the treatment variant', () => {
-		const wrapper = mountBoxes({
-			version: 'b',
-			props: {
-				currentDonationAmount: '$15.00',
-				loanReservationTotal: 100,
-				percentageRows: [
-					{ percentage: 15, appeal: 'first' },
-					{ percentage: 20, appeal: 'second' },
-				],
-			},
-		});
+		const wrapper = mountBoxes({ version: 'b', props: presetMatchProps });
 
 		wrapper.vm.setInputs('$5.00');
 		wrapper.vm.afterLightboxOpens();

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -20,6 +20,7 @@ const mountBoxes = ({ version = null, props = {} } = {}) => shallowMount(Donatio
 	},
 });
 
+// The amount equals the 15% preset for this total, so the restore path is skipped
 const presetMatchProps = {
 	currentDonationAmount: '$15.00',
 	loanReservationTotal: 100,

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -9,6 +9,17 @@ const defaultProps = {
 	setDonationAndClose: () => {},
 };
 
+const mountBoxes = ({ version, props = {} } = {}) => shallowMount(DonationNudgeBoxes, {
+	props: { ...defaultProps, ...props },
+	global: {
+		...globalOptions,
+		provide: {
+			...globalOptions.provide,
+			...(version !== undefined ? { customTipDefaultVersion: computed(() => version) } : {}),
+		},
+	},
+});
+
 describe('DonationNudgeBoxes custom tip default experiment', () => {
 	it('resolves the provided experiment version synchronously', () => {
 		const wrapper = shallowMount(DonationNudgeBoxes, {
@@ -32,5 +43,65 @@ describe('DonationNudgeBoxes custom tip default experiment', () => {
 		});
 
 		expect(wrapper.vm.customTipDefaultVersion).toBe(null);
+	});
+});
+
+describe('DonationNudgeBoxes custom tip prefill on open', () => {
+	it('prefills $1.00 for the treatment variant when the tip is zero', () => {
+		const wrapper = mountBoxes({ version: 'b', props: { currentDonationAmount: '$0.00' } });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe('$1.00');
+	});
+
+	it('prefills $1.00 for the treatment variant when no amount is set', () => {
+		const wrapper = mountBoxes({ version: 'b', props: { currentDonationAmount: '' } });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe('$1.00');
+	});
+
+	it('keeps $0.00 for the control variant when the tip is zero', () => {
+		const wrapper = mountBoxes({ version: 'a', props: { currentDonationAmount: '$0.00' } });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe('$0.00');
+	});
+
+	it('keeps $0.00 when no version is provided and the tip is zero', () => {
+		const wrapper = mountBoxes({ props: { currentDonationAmount: '$0.00' } });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe('$0.00');
+	});
+
+	it('restores a prior custom amount instead of prefilling in the treatment variant', () => {
+		const wrapper = mountBoxes({ version: 'b', props: { currentDonationAmount: '$7.50' } });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe('$7.50');
+	});
+
+	it('does not touch the input when the amount matches a preset in the treatment variant', () => {
+		const wrapper = mountBoxes({
+			version: 'b',
+			props: {
+				currentDonationAmount: '$15.00',
+				loanReservationTotal: 100,
+				percentageRows: [
+					{ percentage: 15, appeal: 'first' },
+					{ percentage: 20, appeal: 'second' },
+				],
+			},
+		});
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(wrapper.vm.customDonationAmount).toBe(null);
 	});
 });


### PR DESCRIPTION
## Summary

In the treatment variant of the checkout tip experiment, the tip modal's custom amount input is prefilled with `$1.00` whenever it would otherwise show zero or empty on open. Control renders byte-identically to production.

- **Change site**: `DonationNudgeBoxes.afterLightboxOpens()` — the method that already owns open-time input priming. The existing restore path runs first (a prior custom tip like `$7.50` always wins, in both variants); then, treatment only, the guard prefills when the input's resulting value is zero or empty.
- **Variant source**: the `customTipDefaultVersion` injection delivered by MP-3046 (#7074). Off-checkout surfaces (corporate-campaign in-context checkout) have no provider, inject `null`, and get control behavior.
- **Never forces a tip**: the prefill only sets input state. The tip mutates solely via the existing Select/submit path — "No donation to Kiva" still sets $0 in both variants, and editing back to `$0.00` submits `0`.
- **No re-application while open**: the prefill runs only from the modal-open call chain, never on re-render, so a typed value is preserved.

Behavior matrix on open:

| Tip state | Control (`a`/null) | Treatment (`b`) |
|---|---|---|
| Zero (`$0.00` or empty) | `$0.00` / empty (unchanged) | `$1.00` prefilled |
| Preset amount (default checkout) | empty (unchanged) | `$1.00` prefilled |
| Prior custom (e.g. `$7.50`) | restored | restored — no prefill |
| Typed but unsubmitted, reopen | preserved | preserved |

## Decisions recorded during implementation

- **Reopen after an explicit $0 choice** (edited to zero, or "No donation to Kiva"): treatment re-prefills `$1.00` on every zero/empty open — no explicit-choice state is tracked. Decision recorded on MP-3039; the user's $0 stands unless they actively submit a different amount.
- **Guard keys off the custom input's post-restore value, not the basket tip amount.** The ticket's original "incoming donation amount is zero" wording missed the default-checkout state (tip equals a preset, custom input empty) — per the AC the custom option must show `$1.00` there too.

Untouched by this PR: preset rows and seasonal rates, modal copy/layout, input validation (`maxlength`, `validateInput`), payment/balance logic, and analytics — exposure tracking ships in the analytics ticket.

## Related links

- Jira story: [MP-3047](https://kiva.atlassian.net/browse/MP-3047)
- Epic: [MP-3039](https://kiva.atlassian.net/browse/MP-3039) (reopen decision recorded in comments)
- Depends on: #7074 (MP-3046 — experiment assignment and variant delivery)

## Related tests

`test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js` (12 tests)

Variant delivery (from MP-3046):
- resolves the provided experiment version synchronously
- defaults to `null` when no provider exists

Prefill on open:
- prefills `$1.00` for the treatment variant when the tip is zero
- prefills `$1.00` for the treatment variant when no amount is set
- keeps `$0.00` for the control variant when the tip is zero
- keeps `$0.00` when the provided version is `null` and the tip is zero
- restores a prior custom amount instead of prefilling in the treatment variant
- prefills `$1.00` in the treatment variant when the tip matches a preset and the input is empty
- leaves the input empty for the control variant when the tip matches a preset
- preserves a typed but unsubmitted amount on reopen in the treatment variant

Submit path:
- submits the prefilled amount when the custom option is selected
- submits zero when the user edits the prefill back to `$0.00`

Full verification: `npm run unit` (285 files / 4261+ tests passing), `npm run lint` (0 errors). An independent requirements-alignment review traced every acceptance criterion and constraint to specific code or tests; no Critical or Important findings.

## Dev verification

1. `/checkout?setuiab=custom_tip_default.b`, open the tip modal from a fresh basket (tip at the default preset) — custom input shows `$1.00`.
2. Set the tip to $0, reopen — custom input shows `$1.00`; the tip itself stays $0 unless submitted.
3. Enter `$7.50`, submit, reopen — shows `$7.50`. Without the force (or with `.a`), all opens match production.
4. "No donation to Kiva" still zeroes the tip in both variants; no exposure event fires anywhere (analytics ticket pending).


[MP-3047]: https://kiva.atlassian.net/browse/MP-3047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ