### PR TITLE
feat: [MP-3049] fire experiment exposure when tip modal is viewed

### DIFF
--- a/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
+++ b/src/components/Checkout/DonationNudge/DonationNudgeBoxes.vue
@@ -93,6 +93,9 @@
 <script>
 import numeral from 'numeral';
 import { KvTextInput, KvButton } from '@kiva/kv-components';
+import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
+
+export const CUSTOM_TIP_DEFAULT_EXP_KEY = 'custom_tip_default';
 
 const TREATMENT_PREFILL_AMOUNT = '$1.00';
 
@@ -103,6 +106,7 @@ export default {
 		KvTextInput
 	},
 	inject: {
+		apollo: { from: 'apollo' },
 		// Assigned version provided by the checkout page; null when rendered elsewhere
 		customTipDefaultVersion: { default: null },
 	},
@@ -146,6 +150,17 @@ export default {
 			customInputButton.click();
 		},
 		afterLightboxOpens() {
+			// Count exposure only where the treatment could apply, using the same provided version as the prefill
+			if (this.customTipDefaultVersion) {
+				trackExperimentVersion(
+					this.apollo,
+					this.$kvTrackEvent,
+					'basket',
+					CUSTOM_TIP_DEFAULT_EXP_KEY,
+					'EXP-MP-3039-July2026',
+				);
+			}
+
 			if (this.currentDonationAmount && this.customDonationSelected) {
 				this.setInputs(this.currentDonationAmount);
 			}

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -348,6 +348,7 @@ import updateLoanReservation from '#src/graphql/mutation/updateLoanReservation.g
 import * as Sentry from '@sentry/vue';
 import _forEach from 'lodash/forEach';
 import MatchedLoansLightbox from '#src/components/Checkout/MatchedLoansLightbox';
+import { CUSTOM_TIP_DEFAULT_EXP_KEY } from '#src/components/Checkout/DonationNudge/DonationNudgeBoxes';
 import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
 import fiveDollarsTest, { FIVE_DOLLARS_NOTES_EXP } from '#src/plugins/five-dollars-test-mixin';
 import FtdsMessage from '#src/components/Checkout/FtdsMessage';
@@ -379,7 +380,6 @@ const BANDIT_UPSELL_EXP_KEY = 'checkout_bandit_upsell_enable';
 const EXPIRING_SOON_EXP_KEY = 'checkout_expiring_soon_upsell';
 const KIVA_CREDIT_REPLACEMENT_EXP_KEY = 'checkout_kiva_credit_copy_replacement';
 const STOP_HIDING_TIP_EXP_KEY = 'stop_hiding_tip_campaign';
-const CUSTOM_TIP_DEFAULT_EXP_KEY = 'custom_tip_default';
 const TIP_PERCENTAGE = 0.2;
 
 // Assigned during SSR so versions are available before hydration

--- a/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
+++ b/test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js
@@ -9,13 +9,31 @@ const defaultProps = {
 	setDonationAndClose: () => {},
 };
 
-const mountBoxes = ({ version = null, props = {} } = {}) => shallowMount(DonationNudgeBoxes, {
+const mountBoxes = ({
+	version = null,
+	props = {},
+	experimentVersion,
+	kvTrackEvent = vi.fn(),
+} = {}) => shallowMount(DonationNudgeBoxes, {
 	props: { ...defaultProps, ...props },
 	global: {
 		...globalOptions,
 		provide: {
 			...globalOptions.provide,
+			apollo: {
+				...globalOptions.provide.apollo,
+				// Require the exact cache id so a drifted experiment key fails these tests
+				readFragment: ({ id }) => (
+					id === 'Experiment:custom_tip_default' && experimentVersion
+						? { version: experimentVersion }
+						: null
+				),
+			},
 			customTipDefaultVersion: computed(() => version),
+		},
+		mocks: {
+			...globalOptions.mocks,
+			$kvTrackEvent: kvTrackEvent,
 		},
 	},
 });
@@ -138,5 +156,75 @@ describe('DonationNudgeBoxes custom tip prefill on open', () => {
 		wrapper.vm.setCustomDonationAndClose();
 
 		expect(setDonationAndClose).toHaveBeenCalledWith(0, 'Custom amount');
+	});
+});
+
+describe('DonationNudgeBoxes experiment exposure on open', () => {
+	it('fires the exposure event with the control label when the modal opens', () => {
+		const kvTrackEvent = vi.fn();
+		const wrapper = mountBoxes({ version: 'a', experimentVersion: 'a', kvTrackEvent });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(kvTrackEvent).toHaveBeenCalledWith('basket', 'EXP-MP-3039-July2026', 'a', undefined);
+	});
+
+	it('fires the exposure event with the treatment label and still prefills when the modal opens', () => {
+		const kvTrackEvent = vi.fn();
+		const wrapper = mountBoxes({
+			version: 'b',
+			experimentVersion: 'b',
+			kvTrackEvent,
+			props: { currentDonationAmount: '$0.00' },
+		});
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(kvTrackEvent).toHaveBeenCalledWith('basket', 'EXP-MP-3039-July2026', 'b', undefined);
+		expect(wrapper.vm.customDonationAmount).toBe('$1.00');
+	});
+
+	it('fires once per open with no de-duplication', () => {
+		const kvTrackEvent = vi.fn();
+		const wrapper = mountBoxes({ version: 'a', experimentVersion: 'a', kvTrackEvent });
+
+		wrapper.vm.afterLightboxOpens();
+		wrapper.vm.afterLightboxOpens();
+
+		expect(kvTrackEvent).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not fire from rendering alone before the modal is opened', () => {
+		const kvTrackEvent = vi.fn();
+		mountBoxes({ version: 'a', experimentVersion: 'a', kvTrackEvent });
+
+		expect(kvTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('does not fire when the user is unassigned', () => {
+		const kvTrackEvent = vi.fn();
+		const wrapper = mountBoxes({ version: 'unassigned', experimentVersion: 'unassigned', kvTrackEvent });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(kvTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('does not fire when no assignment exists in the cache', () => {
+		const kvTrackEvent = vi.fn();
+		const wrapper = mountBoxes({ version: 'a', kvTrackEvent });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(kvTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('does not fire without a provided version even if the cache holds an assignment', () => {
+		const kvTrackEvent = vi.fn();
+		const wrapper = mountBoxes({ experimentVersion: 'a', kvTrackEvent });
+
+		wrapper.vm.afterLightboxOpens();
+
+		expect(kvTrackEvent).not.toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
## Summary

Fires the checkout tip experiment's exposure event when the tip modal is viewed — not at basket entry — so the experiment measures only users who actually saw the modal. Payload: `se_category: basket`, `se_action: EXP-MP-3039-July2026`, `label: a|b`.

- **Change site**: `DonationNudgeBoxes.afterLightboxOpens()` — the terminus of the only modal-open chain (`DonationItem.openNudgeLightbox` → `DonationNudgeLightbox.expandNudgeLightbox` → `afterLightboxOpens`). The call is the method's first statement, so exposure fires even when the user closes the modal without changing the tip.
- **Destination**: `trackExperimentVersion()` — reads the assignment from the Apollo cache and emits through `$kvTrackEvent`, filtering `unassigned`/absent assignments, so both real variants count and out-of-population users never fire.
- **Gate**: the call requires the injected `customTipDefaultVersion` — the same provided version that drives the treatment prefill. Surfaces without the checkout provider (corporate-campaign in-context checkout) inject `null` and never fire, preventing over-count from a stale cache assignment left by a prior `/checkout` visit.
- **Shared key**: `CUSTOM_TIP_DEFAULT_EXP_KEY` is now a named export of `DonationNudgeBoxes`, imported by `CheckoutPage` (this direction avoids a circular import). Removes the duplicated string whose silent drift would have killed the event with no error.

Exposure matrix:

| Scenario | Event |
|---|---|
| Opens modal, assigned `a` | fires, label `a` |
| Opens modal, assigned `b` | fires, label `b` |
| Opens modal twice | fires twice — no client-side dedup |
| Opens and closes without changing the tip | fires |
| Reaches checkout, never opens the modal | none |
| Unassigned / no cache assignment | none |
| In-context checkout (no provider) | none |

## Decisions recorded during implementation

- **Exposure fires on every modal open, no client-side de-duplication** — consistent with the other checkout exposure events; analytics de-dupes by user downstream. Decision recorded on MP-3040.
- **Exposure is gated on the injected version, not the cache alone** — exposure should count only users whose modal behavior the experiment could affect; the in-context checkout surface proves this gate is load-bearing, not defensive.

Untouched by this PR: all existing tip and checkout events (`click-open nudge`, `Update Nudge Donation`, `tip-donation-amount`), experiment assignment and SSR prefetch (MP-3046), and prefill behavior (MP-3047).

## Related links

- Jira story: [MP-3049](https://kiva.atlassian.net/browse/MP-3049)
- Epic: [MP-3039](https://kiva.atlassian.net/browse/MP-3039)
- Tracking spec: [MP-3040](https://kiva.atlassian.net/browse/MP-3040) (Product tracking ticket — same event contract; reporting segments on this event)
- Depends on: #7074 (MP-3046 — assignment and variant delivery), #7076 (MP-3047 — treatment prefill)

## Related tests

`test/unit/specs/components/Checkout/DonationNudge/DonationNudgeBoxes.spec.js` (19 tests: 12 pre-existing, 7 new)

Exposure on open (new):
- fires the exposure event with the control label when the modal opens
- fires the exposure event with the treatment label and still prefills when the modal opens
- fires once per open with no de-duplication
- does not fire from rendering alone before the modal is opened
- does not fire when the user is unassigned
- does not fire when no assignment exists in the cache
- does not fire without a provided version even if the cache holds an assignment

The tests exercise the real `trackExperimentVersion` against an id-sensitive Apollo cache mock, so a drifted experiment key fails loudly instead of passing vacuously. `CheckoutPage` coverage (assignment without exposure at page load, SSR prefetch, provide wiring) is pre-existing and passes unchanged against the imported key.

Full verification: `npm run unit` (288 files / 4290 tests passing), `npm run lint` (0 errors). An independent requirements-alignment review traced every acceptance criterion end-to-end, including the `$kvTrackEvent` → snowplow `se_` field mapping; no Critical findings, one lint nit fixed.

## Dev verification

1. `/checkout?setuiab=custom_tip_default.a`, open the tip modal — one event with `se_category: basket`, `se_action: EXP-MP-3039-July2026`, label `a`. Repeat opens fire repeat events.
2. Same with `.b` — label `b`, and the `$1.00` prefill still applies.
3. Load `/checkout` and complete checkout without opening the tip modal — no exposure event.
4. Corporate-campaign in-context checkout: open the tip nudge — no exposure event.


[MP-3049]: https://kiva.atlassian.net/browse/MP-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ