### PR TITLE
feat: [CP-2930] gate borrower profile comment section by anonymizatio…

### DIFF
--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -379,7 +379,8 @@ export default {
 		showComments() {
 			// Comments remain privileged-only; additionally hide the section entirely on
 			// anonymized (full/pii) loans for anyone who is not an admin.
-			return this.isPrivileged && !(this.isAnonymized && !this.isAdmin);
+			const nonAdminViewingAnonymousLoan = this.isAnonymized && !this.isAdmin;
+			return this.isPrivileged && !nonAdminViewingAnonymousLoan;
 		},
 		shareCampaign() {
 			return this.inPfp ? 'social_share_bp_pfp' : 'social_share_bp';

--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -157,7 +157,7 @@
 				@hide-section="showTags = false"
 			/>
 			<loan-comments
-				v-if="isPrivileged"
+				v-if="showComments"
 				class="tw-mb-5 md:tw-mb-6 lg:tw-mb-8"
 				:loan-id="loanId"
 			/>
@@ -232,6 +232,7 @@ export const fullProfileQuery = gql`
 		}
 		my {
 			id
+			isAdmin
 			userPreferences {
 				id
 				preferences
@@ -285,6 +286,7 @@ export default {
 		},
 		result({ data }) {
 			this.loanData = data?.lend?.loan ?? {};
+			this.isAdmin = data?.my?.isAdmin ?? false;
 			this.userPreferences = data?.my?.userPreferences ?? null;
 			// Reconcile with localStorage (client-only); account preference still wins.
 			this.showDetailsInRail = resolveRailPreference({
@@ -343,6 +345,7 @@ export default {
 			// Initialize from the SSR-resolved prop so logged-in opted-in renders without flash.
 			showDetailsInRail: this.initialShowDetailsInRail,
 			userPreferences: null,
+			isAdmin: false,
 		};
 	},
 	computed: {
@@ -368,6 +371,15 @@ export default {
 		},
 		isPrivileged() {
 			return this.loanData?.userProperties?.isPrivileged ?? false;
+		},
+		isAnonymized() {
+			const level = this.loanData?.anonymizationLevel;
+			return level === 'full' || level === 'pii';
+		},
+		showComments() {
+			// Comments remain privileged-only; additionally hide the section entirely on
+			// anonymized (full/pii) loans for anyone who is not an admin.
+			return this.isPrivileged && !(this.isAnonymized && !this.isAdmin);
 		},
 		shareCampaign() {
 			return this.inPfp ? 'social_share_bp_pfp' : 'social_share_bp';

--- a/src/components/BorrowerProfile/LoanComments.vue
+++ b/src/components/BorrowerProfile/LoanComments.vue
@@ -184,10 +184,6 @@ const commentsQuery = gql`query loanCommentsFullList($loanId: Int!) {
 		loan(id: $loanId) {
 			id
 			status
-			borrowers {
-				id
-				firstName
-			}
 			comments {
 				values {
 					id
@@ -214,6 +210,9 @@ const commentsQuery = gql`query loanCommentsFullList($loanId: Int!) {
 	my {
 		id
 		isAdmin
+		mostRecentBorrowedLoan {
+			id
+		}
 		trustee {
 			id
 		}
@@ -283,10 +282,9 @@ export default {
 			isSubscribed: false,
 			// Fields backing the add-comment permission check
 			loanStatus: '',
-			loanBorrowerIds: [],
 			loanTrusteeId: null,
 			isLoanPrivileged: false,
-			myId: null,
+			myBorrowedLoanId: null,
 			myTrusteeId: null,
 			myLoanCount: 0,
 			newCommentText: '',
@@ -325,9 +323,11 @@ export default {
 		isTrusteeToLoan() {
 			return !!this.myTrusteeId && this.myTrusteeId === this.loanTrusteeId;
 		},
-		// The logged-in user is one of the borrowers/entrepreneurs on this loan
+		// The logged-in user is the borrower of this loan. The API has no per-loan borrower
+		// flag, so we approximate with the viewer's most recent borrowed loan id (the same
+		// signal ShareButton uses). This misses borrowers whose most recent loan isn't this one.
 		isBorrowerOfLoan() {
-			return this.myId != null && this.loanBorrowerIds.includes(this.myId);
+			return this.myBorrowedLoanId != null && Number(this.myBorrowedLoanId) === this.loanId;
 		},
 		// The logged-in user has lent to at least one loan
 		hasLentToAnyLoan() {
@@ -361,10 +361,9 @@ export default {
 			this.isSubscribed = loan?.userProperties?.subscribed ?? false;
 			this.isAdmin = data?.my?.isAdmin ?? false;
 			this.loanStatus = loan?.status ?? '';
-			this.loanBorrowerIds = (loan?.borrowers ?? []).map(b => b.id);
 			this.loanTrusteeId = loan?.trustee?.id ?? null;
 			this.isLoanPrivileged = loan?.userProperties?.isPrivileged ?? false;
-			this.myId = data?.my?.id ?? null;
+			this.myBorrowedLoanId = data?.my?.mostRecentBorrowedLoan?.id ?? null;
 			this.myTrusteeId = data?.my?.trustee?.id ?? null;
 			this.myLoanCount = data?.my?.lender?.loanCount ?? 0;
 		},

--- a/src/components/BorrowerProfile/LoanComments.vue
+++ b/src/components/BorrowerProfile/LoanComments.vue
@@ -210,7 +210,7 @@ const commentsQuery = gql`query loanCommentsFullList($loanId: Int!) {
 	my {
 		id
 		isAdmin
-		mostRecentBorrowedLoan {
+		borrowedLoans {
 			id
 		}
 		trustee {
@@ -284,7 +284,7 @@ export default {
 			loanStatus: '',
 			loanTrusteeId: null,
 			isLoanPrivileged: false,
-			myBorrowedLoanId: null,
+			myBorrowedLoanIds: [],
 			myTrusteeId: null,
 			myLoanCount: 0,
 			newCommentText: '',
@@ -323,11 +323,10 @@ export default {
 		isTrusteeToLoan() {
 			return !!this.myTrusteeId && this.myTrusteeId === this.loanTrusteeId;
 		},
-		// The logged-in user is the borrower of this loan. The API has no per-loan borrower
-		// flag, so we approximate with the viewer's most recent borrowed loan id (the same
-		// signal ShareButton uses). This misses borrowers whose most recent loan isn't this one.
+		// The logged-in user is the borrower of this loan, i.e. this loan is in the full
+		// collection of loans they have borrowed (my.borrowedLoans).
 		isBorrowerOfLoan() {
-			return this.myBorrowedLoanId != null && Number(this.myBorrowedLoanId) === this.loanId;
+			return this.myBorrowedLoanIds.includes(this.loanId);
 		},
 		// The logged-in user has lent to at least one loan
 		hasLentToAnyLoan() {
@@ -363,7 +362,7 @@ export default {
 			this.loanStatus = loan?.status ?? '';
 			this.loanTrusteeId = loan?.trustee?.id ?? null;
 			this.isLoanPrivileged = loan?.userProperties?.isPrivileged ?? false;
-			this.myBorrowedLoanId = data?.my?.mostRecentBorrowedLoan?.id ?? null;
+			this.myBorrowedLoanIds = (data?.my?.borrowedLoans ?? []).map(l => l.id);
 			this.myTrusteeId = data?.my?.trustee?.id ?? null;
 			this.myLoanCount = data?.my?.lender?.loanCount ?? 0;
 		},

--- a/src/components/BorrowerProfile/LoanComments.vue
+++ b/src/components/BorrowerProfile/LoanComments.vue
@@ -7,18 +7,21 @@
 
 		<!-- Comment form -->
 		<div class="tw-mb-3">
-			<label for="bp-comment-field" class="tw-sr-only">
-				Comment
-			</label>
-			<textarea
-				id="bp-comment-field"
-				v-model="newCommentText"
-				class="tw-w-full tw-border tw-border-tertiary tw-rounded tw-p-1 tw-mb-1"
-				rows="4"
-				data-testid="bp-comment-form-textarea"
-			></textarea>
+			<template v-if="canAddComment">
+				<label for="bp-comment-field" class="tw-sr-only">
+					Comment
+				</label>
+				<textarea
+					id="bp-comment-field"
+					v-model="newCommentText"
+					class="tw-w-full tw-border tw-border-tertiary tw-rounded tw-p-1 tw-mb-1"
+					rows="4"
+					data-testid="bp-comment-form-textarea"
+				></textarea>
+			</template>
 			<div class="tw-flex tw-items-center tw-gap-2">
 				<kv-button
+					v-if="canAddComment"
 					variant="secondary"
 					data-testid="bp-comment-form-submit"
 					:state="isSubmitting ? 'loading' : ''"
@@ -180,6 +183,11 @@ const commentsQuery = gql`query loanCommentsFullList($loanId: Int!) {
 	lend {
 		loan(id: $loanId) {
 			id
+			status
+			borrowers {
+				id
+				firstName
+			}
 			comments {
 				values {
 					id
@@ -193,13 +201,26 @@ const commentsQuery = gql`query loanCommentsFullList($loanId: Int!) {
 				}
 			}
 			userProperties {
+				isPrivileged
 				subscribed
+			}
+			... on LoanDirect {
+				trustee {
+					id
+				}
 			}
 		}
 	}
 	my {
 		id
 		isAdmin
+		trustee {
+			id
+		}
+		lender {
+			id
+			loanCount
+		}
 	}
 }`;
 
@@ -260,6 +281,14 @@ export default {
 			deletedIds: [],
 			isAdmin: false,
 			isSubscribed: false,
+			// Fields backing the add-comment permission check
+			loanStatus: '',
+			loanBorrowerIds: [],
+			loanTrusteeId: null,
+			isLoanPrivileged: false,
+			myId: null,
+			myTrusteeId: null,
+			myLoanCount: 0,
 			newCommentText: '',
 			isSubmitting: false,
 			showAll: false,
@@ -285,6 +314,32 @@ export default {
 					timeFlagged: this.flaggedById[c.id],
 				}));
 		},
+		isFundraising() {
+			return this.loanStatus === 'fundraising';
+		},
+		// The logged-in user is a trustee (of any loan)
+		isTrustee() {
+			return !!this.myTrusteeId;
+		},
+		// The logged-in user is the trustee for this specific loan
+		isTrusteeToLoan() {
+			return !!this.myTrusteeId && this.myTrusteeId === this.loanTrusteeId;
+		},
+		// The logged-in user is one of the borrowers/entrepreneurs on this loan
+		isBorrowerOfLoan() {
+			return this.myId != null && this.loanBorrowerIds.includes(this.myId);
+		},
+		// The logged-in user has lent to at least one loan
+		hasLentToAnyLoan() {
+			return this.myLoanCount >= 1;
+		},
+		canAddComment() {
+			return this.isFundraising
+				|| this.isTrustee
+				|| this.isAdmin
+				|| this.isTrusteeToLoan
+				|| (this.isLoanPrivileged && (this.hasLentToAnyLoan || this.isBorrowerOfLoan));
+		},
 		hasSpillover() {
 			return this.comments.length > INITIAL_COMMENT_COUNT;
 		},
@@ -305,6 +360,13 @@ export default {
 			}));
 			this.isSubscribed = loan?.userProperties?.subscribed ?? false;
 			this.isAdmin = data?.my?.isAdmin ?? false;
+			this.loanStatus = loan?.status ?? '';
+			this.loanBorrowerIds = (loan?.borrowers ?? []).map(b => b.id);
+			this.loanTrusteeId = loan?.trustee?.id ?? null;
+			this.isLoanPrivileged = loan?.userProperties?.isPrivileged ?? false;
+			this.myId = data?.my?.id ?? null;
+			this.myTrusteeId = data?.my?.trustee?.id ?? null;
+			this.myLoanCount = data?.my?.lender?.loanCount ?? 0;
 		},
 		async refreshComments() {
 			if (!this.loanId) return;
@@ -331,6 +393,7 @@ export default {
 			});
 		},
 		async submitComment() {
+			if (!this.canAddComment) return;
 			if (!this.newCommentText.trim()) return;
 			this.isSubmitting = true;
 			this.$kvTrackEvent('borrower-profile', 'click', 'comment-submit', null, this.loanId);

--- a/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
@@ -1,0 +1,53 @@
+import FullBorrowerProfile from '#src/components/BorrowerProfile/FullBorrowerProfile';
+
+const { isAnonymized, showComments } = FullBorrowerProfile.computed;
+
+// Evaluates a computed with a mock `this` context, resolving other computeds it depends on.
+function evalShowComments({ isPrivileged = false, isAdmin = false, anonymizationLevel = 'none' } = {}) {
+	const context = {
+		isPrivileged,
+		isAdmin,
+		loanData: { anonymizationLevel },
+	};
+	context.isAnonymized = isAnonymized.call(context);
+	return showComments.call(context);
+}
+
+describe('FullBorrowerProfile comment section visibility', () => {
+	describe('isAnonymized', () => {
+		it.each([
+			['full', true],
+			['pii', true],
+			['none', false],
+			[undefined, false],
+			['', false],
+		])('anonymizationLevel "%s" -> %s', (level, expected) => {
+			expect(isAnonymized.call({ loanData: { anonymizationLevel: level } })).toBe(expected);
+		});
+	});
+
+	describe('showComments', () => {
+		it('hides for a non-privileged user regardless of anonymization', () => {
+			expect(evalShowComments({ isPrivileged: false, anonymizationLevel: 'none' })).toBe(false);
+			expect(evalShowComments({ isPrivileged: false, anonymizationLevel: 'full' })).toBe(false);
+		});
+
+		it('shows for a privileged user on a non-anonymized loan', () => {
+			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'none' })).toBe(true);
+		});
+
+		it('hides for a privileged non-admin user on a full/pii anonymized loan', () => {
+			expect(evalShowComments({ isPrivileged: true, isAdmin: false, anonymizationLevel: 'full' })).toBe(false);
+			expect(evalShowComments({ isPrivileged: true, isAdmin: false, anonymizationLevel: 'pii' })).toBe(false);
+		});
+
+		it('shows for an admin (privileged) on a full/pii anonymized loan', () => {
+			expect(evalShowComments({ isPrivileged: true, isAdmin: true, anonymizationLevel: 'full' })).toBe(true);
+			expect(evalShowComments({ isPrivileged: true, isAdmin: true, anonymizationLevel: 'pii' })).toBe(true);
+		});
+
+		it('still hides for a non-privileged admin (section stays privileged-only)', () => {
+			expect(evalShowComments({ isPrivileged: false, isAdmin: true, anonymizationLevel: 'full' })).toBe(false);
+		});
+	});
+});

--- a/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
@@ -25,7 +25,7 @@ function buildApiResponse(comments, {
 	isPrivileged = false,
 	loanTrusteeId = null,
 	isAdmin = false,
-	borrowedLoanId = null,
+	borrowedLoanIds = [],
 	myTrusteeId = null,
 	loanCount = 0,
 } = {}) {
@@ -43,12 +43,12 @@ function buildApiResponse(comments, {
 			? {
 				id: 1,
 				isAdmin,
-				mostRecentBorrowedLoan: borrowedLoanId ? { id: borrowedLoanId } : null,
+				borrowedLoans: borrowedLoanIds.map(id => ({ id })),
 				trustee: myTrusteeId ? { id: myTrusteeId } : null,
 				lender: { id: 1, loanCount },
 			}
 			: {
-				id: null, isAdmin: false, mostRecentBorrowedLoan: null, trustee: null, lender: null,
+				id: null, isAdmin: false, borrowedLoans: [], trustee: null, lender: null,
 			},
 	};
 }
@@ -268,7 +268,7 @@ describe('LoanComments', () => {
 			myTrusteeId: null,
 			loanTrusteeId: null,
 			loanCount: 0,
-			borrowedLoanId: null,
+			borrowedLoanIds: [],
 		};
 
 		function renderWith(responseOverrides) {
@@ -315,13 +315,13 @@ describe('LoanComments', () => {
 		});
 
 		it('shows the form for the loan borrower even when they have not lent to any loan', () => {
-			// loanId is 123; the viewer's most recent borrowed loan is this loan.
-			const { getByTestId } = renderWith({ isPrivileged: true, loanCount: 0, borrowedLoanId: 123 });
+			// loanId is 123; this loan is among the viewer's borrowed loans (not necessarily the most recent).
+			const { getByTestId } = renderWith({ isPrivileged: true, loanCount: 0, borrowedLoanIds: [456, 123] });
 			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
 		});
 
-		it('does not treat a privileged user whose most recent borrowed loan is a different loan as borrower', () => {
-			const { queryByTestId } = renderWith({ isPrivileged: true, loanCount: 0, borrowedLoanId: 456 });
+		it('does not treat a privileged user who has not borrowed this loan as the borrower', () => {
+			const { queryByTestId } = renderWith({ isPrivileged: true, loanCount: 0, borrowedLoanIds: [456, 789] });
 			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
 		});
 	});

--- a/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
@@ -17,16 +17,40 @@ const mockApiComments = [
 	},
 ];
 
-function buildApiResponse(comments, { lentTo = true, subscribed = false, loggedIn = true } = {}) {
+function buildApiResponse(comments, {
+	subscribed = false,
+	loggedIn = true,
+	// Defaults make canAddComment true (fundraising loan) so form-focused tests render the form.
+	status = 'fundraising',
+	isPrivileged = false,
+	borrowers = [],
+	loanTrusteeId = null,
+	isAdmin = false,
+	myId = 1,
+	myTrusteeId = null,
+	loanCount = 0,
+} = {}) {
 	return {
 		lend: {
 			loan: {
 				id: 123,
+				status,
+				borrowers,
 				comments: { values: comments },
-				userProperties: { lentTo, subscribed },
+				userProperties: { isPrivileged, subscribed },
+				trustee: loanTrusteeId ? { id: loanTrusteeId } : null,
 			},
 		},
-		my: loggedIn ? { id: 1, userAccount: { id: 1 } } : { id: null, userAccount: null },
+		my: loggedIn
+			? {
+				id: myId,
+				isAdmin,
+				trustee: myTrusteeId ? { id: myTrusteeId } : null,
+				lender: { id: 1, loanCount },
+			}
+			: {
+				id: null, isAdmin: false, trustee: null, lender: null,
+			},
 	};
 }
 
@@ -233,6 +257,78 @@ describe('LoanComments', () => {
 		await rerender({ loanId: 456 });
 
 		expect(queryByText(/Flagged on/)).toBeNull();
+	});
+
+	describe('add-comment permission gating', () => {
+		// Base response that on its own does NOT allow commenting: ended loan, not privileged,
+		// not admin, not a trustee, no loans lent, not a borrower on this loan.
+		const notAllowedResponse = {
+			status: 'ended',
+			isPrivileged: false,
+			isAdmin: false,
+			myTrusteeId: null,
+			loanTrusteeId: null,
+			loanCount: 0,
+			borrowers: [],
+			myId: 1,
+		};
+
+		function renderWith(responseOverrides) {
+			const mapped = applyMockData(mockApiComments, { ...notAllowedResponse, ...responseOverrides });
+			return renderLoanComments(mapped);
+		}
+
+		it('hides the comment form when the user is not allowed to add a comment', () => {
+			const { queryByTestId } = renderWith({});
+			expect(queryByTestId('bp-comment-form-textarea')).toBeNull();
+			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
+			// Subscribe controls remain available
+			expect(queryByTestId('bp-comment-subscribe')).toBeTruthy();
+		});
+
+		it('shows the form when the loan is fundraising', () => {
+			const { getByTestId } = renderWith({ status: 'fundraising' });
+			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('shows the form for an admin', () => {
+			const { getByTestId } = renderWith({ isAdmin: true });
+			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('shows the form for a trustee (of any loan)', () => {
+			const { getByTestId } = renderWith({ myTrusteeId: 55 });
+			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('shows the form for the trustee of this loan', () => {
+			const { getByTestId } = renderWith({ myTrusteeId: 55, loanTrusteeId: 55 });
+			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('shows the form for a privileged user who has lent to at least one loan', () => {
+			const { getByTestId } = renderWith({ isPrivileged: true, loanCount: 3 });
+			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('hides the form for a privileged user who has not lent and is not the borrower', () => {
+			const { queryByTestId } = renderWith({ isPrivileged: true, loanCount: 0 });
+			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
+		});
+
+		it('shows the form for the loan borrower even when they have not lent to any loan', () => {
+			const { getByTestId } = renderWith({
+				isPrivileged: true, loanCount: 0, borrowers: [{ id: 1, firstName: 'Aisha' }], myId: 1,
+			});
+			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('does not treat a privileged non-borrower whose id is absent from borrowers as the borrower', () => {
+			const { queryByTestId } = renderWith({
+				isPrivileged: true, loanCount: 0, borrowers: [{ id: 999, firstName: 'Someone' }], myId: 1,
+			});
+			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
+		});
 	});
 
 	it('show all reveals spillover comments and tracks show-all then hide', async () => {

--- a/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
@@ -23,10 +23,9 @@ function buildApiResponse(comments, {
 	// Defaults make canAddComment true (fundraising loan) so form-focused tests render the form.
 	status = 'fundraising',
 	isPrivileged = false,
-	borrowers = [],
 	loanTrusteeId = null,
 	isAdmin = false,
-	myId = 1,
+	borrowedLoanId = null,
 	myTrusteeId = null,
 	loanCount = 0,
 } = {}) {
@@ -35,7 +34,6 @@ function buildApiResponse(comments, {
 			loan: {
 				id: 123,
 				status,
-				borrowers,
 				comments: { values: comments },
 				userProperties: { isPrivileged, subscribed },
 				trustee: loanTrusteeId ? { id: loanTrusteeId } : null,
@@ -43,13 +41,14 @@ function buildApiResponse(comments, {
 		},
 		my: loggedIn
 			? {
-				id: myId,
+				id: 1,
 				isAdmin,
+				mostRecentBorrowedLoan: borrowedLoanId ? { id: borrowedLoanId } : null,
 				trustee: myTrusteeId ? { id: myTrusteeId } : null,
 				lender: { id: 1, loanCount },
 			}
 			: {
-				id: null, isAdmin: false, trustee: null, lender: null,
+				id: null, isAdmin: false, mostRecentBorrowedLoan: null, trustee: null, lender: null,
 			},
 	};
 }
@@ -269,8 +268,7 @@ describe('LoanComments', () => {
 			myTrusteeId: null,
 			loanTrusteeId: null,
 			loanCount: 0,
-			borrowers: [],
-			myId: 1,
+			borrowedLoanId: null,
 		};
 
 		function renderWith(responseOverrides) {
@@ -317,16 +315,13 @@ describe('LoanComments', () => {
 		});
 
 		it('shows the form for the loan borrower even when they have not lent to any loan', () => {
-			const { getByTestId } = renderWith({
-				isPrivileged: true, loanCount: 0, borrowers: [{ id: 1, firstName: 'Aisha' }], myId: 1,
-			});
+			// loanId is 123; the viewer's most recent borrowed loan is this loan.
+			const { getByTestId } = renderWith({ isPrivileged: true, loanCount: 0, borrowedLoanId: 123 });
 			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
 		});
 
-		it('does not treat a privileged non-borrower whose id is absent from borrowers as the borrower', () => {
-			const { queryByTestId } = renderWith({
-				isPrivileged: true, loanCount: 0, borrowers: [{ id: 999, firstName: 'Someone' }], myId: 1,
-			});
+		it('does not treat a privileged user whose most recent borrowed loan is a different loan as borrower', () => {
+			const { queryByTestId } = renderWith({ isPrivileged: true, loanCount: 0, borrowedLoanId: 456 });
 			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
 		});
 	});


### PR DESCRIPTION
…n and add-permission

Hide the LoanComments section entirely on full/pii anonymized loans for non-admin users, and only show the add-comment form when the loan is fundraising, or the user is an admin/trustee/trustee-to-the-loan, or is a privileged user to the loan who has lent to >=1 loan (or is the borrower of this loan).


Claude-Session: https://claude.ai/code/session_014sgTcV3cp97cKkp5gp5UA2

Ticket: https://kiva.atlassian.net/browse/CP-2930

During PII anonymization validation, we realized the comment creation box was still displaying for PII-anonymized loans. Reviewing the logic in the monolith, it looks like the entire comment section wasn't visible if [$borrower_privacy->showSocialInfo](https://github.com/kiva/kiva/blob/dbcff827bf51e4d8d5874838bf8a5da95da3b15a/sites/www_kiva/server/views/Xb/Loan/LoanView.php#L198C8-L200) returns `false`. That method returns false when the ACL is `user` and the loan has an `anonymization_level` of `pii` or `full` OR if the ACL is public and the loan is not fundraising or the loan doesn't have the `anonymization_level` of `none`. Said a bit more succinctly:
> 	 * Rules for showing social information:
	 *  1) Admins and partners can see everything
	 *  2) Users can't see social info if the loan's been fully anonymized
	 *  3) Public can't see social info for non-fundraising or anonymized loans (both full and public levels)

That simply determines if the comment section is displayed at all. Adding comments is enabled in [these cases](https://github.com/kiva/kiva/blob/dbcff827bf51e4d8d5874838bf8a5da95da3b15a/sites/www_kiva/server/views/Xb/Loan/LoanView.php#L1090-L1111):

1. The logged-in user is a trustee
2. The logged-in user is an admin
3. The logged-in user is a trustee to the loan
4. They're a privileged user (trustee to the loan, partner to the loan, the borrower on the loan, or a lender on the loan) AND they've lent to at least one loan or it's a direct loan and they're the borrower for that loan
5. The loan is fundraising and they're a lender on the loan

This PR is an attempt to update the logic on the new UI to also hide/display the add comment functionality for the same reasons. I didn't thoroughly review the other comment-related logic from the legacy profile, though I see we set other booleans in the same section that we may want to review.