### PR TITLE
fix: [CP-2930] fix comment visibility

### DIFF
--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -373,10 +373,15 @@ export default {
 			const level = this.loanData?.anonymizationLevel;
 			return level === 'full' || level === 'pii';
 		},
+		isFundraising() {
+			return this.loanData?.status === 'fundraising';
+		},
 		showComments() {
-			// Comments remain privileged-only; additionally hide the section entirely on
-			// anonymized (full/pii) loans.
-			return this.isPrivileged && !this.isAnonymized;
+			// Mirrors legacy showSocialInfo: logged-in users see the section unless
+			// the loan is anonymized (full/pii); logged-out visitors see it only on
+			// fundraising loans with no anonymization at all.
+			if (this.isLoggedIn) return !this.isAnonymized;
+			return this.isFundraising && (this.loanData?.anonymizationLevel ?? 'none') === 'none';
 		},
 		shareCampaign() {
 			return this.inPfp ? 'social_share_bp_pfp' : 'social_share_bp';

--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -232,7 +232,6 @@ export const fullProfileQuery = gql`
 		}
 		my {
 			id
-			isAdmin
 			userPreferences {
 				id
 				preferences
@@ -286,7 +285,6 @@ export default {
 		},
 		result({ data }) {
 			this.loanData = data?.lend?.loan ?? {};
-			this.isAdmin = data?.my?.isAdmin ?? false;
 			this.userPreferences = data?.my?.userPreferences ?? null;
 			// Reconcile with localStorage (client-only); account preference still wins.
 			this.showDetailsInRail = resolveRailPreference({
@@ -345,7 +343,6 @@ export default {
 			// Initialize from the SSR-resolved prop so logged-in opted-in renders without flash.
 			showDetailsInRail: this.initialShowDetailsInRail,
 			userPreferences: null,
-			isAdmin: false,
 		};
 	},
 	computed: {
@@ -378,9 +375,8 @@ export default {
 		},
 		showComments() {
 			// Comments remain privileged-only; additionally hide the section entirely on
-			// anonymized (full/pii) loans for anyone who is not an admin.
-			const nonAdminViewingAnonymousLoan = this.isAnonymized && !this.isAdmin;
-			return this.isPrivileged && !nonAdminViewingAnonymousLoan;
+			// anonymized (full/pii) loans.
+			return this.isPrivileged && !this.isAnonymized;
 		},
 		shareCampaign() {
 			return this.inPfp ? 'social_share_bp_pfp' : 'social_share_bp';

--- a/src/components/BorrowerProfile/LoanComments.vue
+++ b/src/components/BorrowerProfile/LoanComments.vue
@@ -19,6 +19,13 @@
 					data-testid="bp-comment-form-textarea"
 				></textarea>
 			</template>
+			<p
+				v-else-if="showMustBeLenderMessage"
+				class="tw-text-secondary tw-mb-1"
+				data-testid="bp-comment-must-be-lender"
+			>
+				You must be a lender to comment on this loan.
+			</p>
 			<div class="tw-flex tw-items-center tw-gap-2">
 				<kv-button
 					v-if="canAddComment"
@@ -344,6 +351,11 @@ export default {
 				|| this.isAdmin
 				|| this.isTrusteeToLoan
 				|| (this.isLoanPrivileged && (this.hasLentToAnyLoan || this.isBorrowerOfLoan));
+		},
+		// Prompt shown in place of the form on fundraising loans when the viewer
+		// is not eligible to comment (i.e. has not lent to this loan).
+		showMustBeLenderMessage() {
+			return this.isFundraising && !this.canAddComment;
 		},
 		hasSpillover() {
 			return this.comments.length > INITIAL_COMMENT_COUNT;

--- a/src/components/BorrowerProfile/LoanComments.vue
+++ b/src/components/BorrowerProfile/LoanComments.vue
@@ -198,6 +198,7 @@ const commentsQuery = gql`query loanCommentsFullList($loanId: Int!) {
 			}
 			userProperties {
 				isPrivileged
+				lentTo
 				subscribed
 			}
 			... on LoanDirect {
@@ -284,6 +285,7 @@ export default {
 			loanStatus: '',
 			loanTrusteeId: null,
 			isLoanPrivileged: false,
+			lentToLoan: false,
 			myBorrowedLoanIds: [],
 			myTrusteeId: null,
 			myLoanCount: 0,
@@ -332,8 +334,12 @@ export default {
 		hasLentToAnyLoan() {
 			return this.myLoanCount >= 1;
 		},
+		// The logged-in user has lent to this specific loan
+		isLenderOfLoan() {
+			return this.lentToLoan;
+		},
 		canAddComment() {
-			return this.isFundraising
+			return (this.isFundraising && this.isLenderOfLoan)
 				|| this.isTrustee
 				|| this.isAdmin
 				|| this.isTrusteeToLoan
@@ -362,6 +368,7 @@ export default {
 			this.loanStatus = loan?.status ?? '';
 			this.loanTrusteeId = loan?.trustee?.id ?? null;
 			this.isLoanPrivileged = loan?.userProperties?.isPrivileged ?? false;
+			this.lentToLoan = loan?.userProperties?.lentTo ?? false;
 			this.myBorrowedLoanIds = (data?.my?.borrowedLoans ?? []).map(l => l.id);
 			this.myTrusteeId = data?.my?.trustee?.id ?? null;
 			this.myLoanCount = data?.my?.lender?.loanCount ?? 0;

--- a/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
@@ -3,10 +3,9 @@ import FullBorrowerProfile from '#src/components/BorrowerProfile/FullBorrowerPro
 const { isAnonymized, showComments } = FullBorrowerProfile.computed;
 
 // Evaluates a computed with a mock `this` context, resolving other computeds it depends on.
-function evalShowComments({ isPrivileged = false, isAdmin = false, anonymizationLevel = 'none' } = {}) {
+function evalShowComments({ isPrivileged = false, anonymizationLevel = 'none' } = {}) {
 	const context = {
 		isPrivileged,
-		isAdmin,
 		loanData: { anonymizationLevel },
 	};
 	context.isAnonymized = isAnonymized.call(context);
@@ -36,18 +35,9 @@ describe('FullBorrowerProfile comment section visibility', () => {
 			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'none' })).toBe(true);
 		});
 
-		it('hides for a privileged non-admin user on a full/pii anonymized loan', () => {
-			expect(evalShowComments({ isPrivileged: true, isAdmin: false, anonymizationLevel: 'full' })).toBe(false);
-			expect(evalShowComments({ isPrivileged: true, isAdmin: false, anonymizationLevel: 'pii' })).toBe(false);
-		});
-
-		it('shows for an admin (privileged) on a full/pii anonymized loan', () => {
-			expect(evalShowComments({ isPrivileged: true, isAdmin: true, anonymizationLevel: 'full' })).toBe(true);
-			expect(evalShowComments({ isPrivileged: true, isAdmin: true, anonymizationLevel: 'pii' })).toBe(true);
-		});
-
-		it('still hides for a non-privileged admin (section stays privileged-only)', () => {
-			expect(evalShowComments({ isPrivileged: false, isAdmin: true, anonymizationLevel: 'full' })).toBe(false);
+		it('hides for a privileged user on a full/pii anonymized loan', () => {
+			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'full' })).toBe(false);
+			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'pii' })).toBe(false);
 		});
 	});
 });

--- a/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
@@ -1,14 +1,15 @@
 import FullBorrowerProfile from '#src/components/BorrowerProfile/FullBorrowerProfile';
 
-const { isAnonymized, showComments } = FullBorrowerProfile.computed;
+const { isAnonymized, isFundraising, showComments } = FullBorrowerProfile.computed;
 
 // Evaluates a computed with a mock `this` context, resolving other computeds it depends on.
-function evalShowComments({ isPrivileged = false, anonymizationLevel = 'none' } = {}) {
+function evalShowComments({ isLoggedIn = false, status = 'fundraising', anonymizationLevel = 'none' } = {}) {
 	const context = {
-		isPrivileged,
-		loanData: { anonymizationLevel },
+		isLoggedIn,
+		loanData: { status, anonymizationLevel },
 	};
 	context.isAnonymized = isAnonymized.call(context);
+	context.isFundraising = isFundraising.call(context);
 	return showComments.call(context);
 }
 
@@ -26,18 +27,38 @@ describe('FullBorrowerProfile comment section visibility', () => {
 	});
 
 	describe('showComments', () => {
-		it('hides for a non-privileged user regardless of anonymization', () => {
-			expect(evalShowComments({ isPrivileged: false, anonymizationLevel: 'none' })).toBe(false);
-			expect(evalShowComments({ isPrivileged: false, anonymizationLevel: 'full' })).toBe(false);
+		describe('logged-in user', () => {
+			it('shows unless the loan is anonymized, regardless of status', () => {
+				expect(evalShowComments({ isLoggedIn: true, status: 'fundraising' })).toBe(true);
+				expect(evalShowComments({ isLoggedIn: true, status: 'ended' })).toBe(true);
+				expect(evalShowComments({ isLoggedIn: true, status: 'payingBack' })).toBe(true);
+			});
+
+			it('hides on a full/pii anonymized loan', () => {
+				expect(evalShowComments({ isLoggedIn: true, anonymizationLevel: 'full' })).toBe(false);
+				expect(evalShowComments({ isLoggedIn: true, anonymizationLevel: 'pii' })).toBe(false);
+			});
 		});
 
-		it('shows for a privileged user on a non-anonymized loan', () => {
-			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'none' })).toBe(true);
-		});
+		describe('logged-out visitor', () => {
+			it('shows only on a fundraising loan with no anonymization', () => {
+				expect(evalShowComments({ isLoggedIn: false, status: 'fundraising', anonymizationLevel: 'none' }))
+					.toBe(true);
+			});
 
-		it('hides for a privileged user on a full/pii anonymized loan', () => {
-			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'full' })).toBe(false);
-			expect(evalShowComments({ isPrivileged: true, anonymizationLevel: 'pii' })).toBe(false);
+			it('hides when the loan is not fundraising', () => {
+				expect(evalShowComments({ isLoggedIn: false, status: 'ended' })).toBe(false);
+				expect(evalShowComments({ isLoggedIn: false, status: 'payingBack' })).toBe(false);
+			});
+
+			it('hides when the loan has any anonymization', () => {
+				expect(evalShowComments({ isLoggedIn: false, anonymizationLevel: 'full' })).toBe(false);
+				expect(evalShowComments({ isLoggedIn: false, anonymizationLevel: 'pii' })).toBe(false);
+			});
+
+			it('treats a missing anonymizationLevel as none', () => {
+				expect(evalShowComments({ isLoggedIn: false, anonymizationLevel: undefined })).toBe(true);
+			});
 		});
 	});
 });

--- a/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
@@ -20,8 +20,10 @@ const mockApiComments = [
 function buildApiResponse(comments, {
 	subscribed = false,
 	loggedIn = true,
-	// Defaults make canAddComment true (fundraising loan) so form-focused tests render the form.
+	// Defaults make canAddComment true (fundraising loan the user has lent to) so
+	// form-focused tests render the form.
 	status = 'fundraising',
+	lentTo = true,
 	isPrivileged = false,
 	loanTrusteeId = null,
 	isAdmin = false,
@@ -35,7 +37,7 @@ function buildApiResponse(comments, {
 				id: 123,
 				status,
 				comments: { values: comments },
-				userProperties: { isPrivileged, subscribed },
+				userProperties: { isPrivileged, lentTo, subscribed },
 				trustee: loanTrusteeId ? { id: loanTrusteeId } : null,
 			},
 		},
@@ -259,10 +261,12 @@ describe('LoanComments', () => {
 	});
 
 	describe('add-comment permission gating', () => {
-		// Base response that on its own does NOT allow commenting: ended loan, not privileged,
-		// not admin, not a trustee, no loans lent, not a borrower on this loan.
+		// Base response that on its own does NOT allow commenting: ended loan, not a lender
+		// on this loan, not privileged, not admin, not a trustee, no loans lent, not a
+		// borrower on this loan.
 		const notAllowedResponse = {
 			status: 'ended',
+			lentTo: false,
 			isPrivileged: false,
 			isAdmin: false,
 			myTrusteeId: null,
@@ -284,9 +288,19 @@ describe('LoanComments', () => {
 			expect(queryByTestId('bp-comment-subscribe')).toBeTruthy();
 		});
 
-		it('shows the form when the loan is fundraising', () => {
-			const { getByTestId } = renderWith({ status: 'fundraising' });
+		it('shows the form when the loan is fundraising and the user has lent to it', () => {
+			const { getByTestId } = renderWith({ status: 'fundraising', lentTo: true });
 			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();
+		});
+
+		it('hides the form when the loan is fundraising but the user has not lent to it', () => {
+			const { queryByTestId } = renderWith({ status: 'fundraising', lentTo: false });
+			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
+		});
+
+		it('hides the form for a lender on the loan when it is no longer fundraising', () => {
+			const { queryByTestId } = renderWith({ status: 'ended', lentTo: true });
+			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
 		});
 
 		it('shows the form for an admin', () => {

--- a/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanComments.spec.js
@@ -303,6 +303,21 @@ describe('LoanComments', () => {
 			expect(queryByTestId('bp-comment-form-submit')).toBeNull();
 		});
 
+		it('shows the must-be-lender message on a fundraising loan the user has not lent to', () => {
+			const { getByTestId } = renderWith({ status: 'fundraising', lentTo: false });
+			expect(getByTestId('bp-comment-must-be-lender')).toBeTruthy();
+		});
+
+		it('does not show the must-be-lender message when the user can comment', () => {
+			const { queryByTestId } = renderWith({ status: 'fundraising', lentTo: true });
+			expect(queryByTestId('bp-comment-must-be-lender')).toBeNull();
+		});
+
+		it('does not show the must-be-lender message when the loan is not fundraising', () => {
+			const { queryByTestId } = renderWith({ status: 'ended', lentTo: false });
+			expect(queryByTestId('bp-comment-must-be-lender')).toBeNull();
+		});
+
 		it('shows the form for an admin', () => {
 			const { getByTestId } = renderWith({ isAdmin: true });
 			expect(getByTestId('bp-comment-form-submit')).toBeTruthy();


### PR DESCRIPTION
Follow up to #7080

Ticket: https://kiva.atlassian.net/browse/CP-2930

Updates logic around comments to address the following inconsistencies with the legacy profile:

* Comments should be visible unless the loan is anonymized, or the user is logged out and the loan is not in fundraising or doesn't have an anonymization level of `none`
* If comments are visible but the user cannot add comments, we show a message indicating that they cannot comment
* You can only comment on a fundraising loan if you have lent to that loan (tightens up this check), unless you meet one of the other cases

This matches our logic on the [legacy borrower profile](https://github.com/kiva/kiva/blob/dbcff827bf51e4d8d5874838bf8a5da95da3b15a/sites/www_kiva/server/views/Xb/Loan/LoanView.php#L1090-L1118). The logged-out/non-lender view on the legacy profile looks like this:

<img width="875" height="426" alt="Screenshot 2026-07-22 at 4 08 22 PM" src="https://github.com/user-attachments/assets/c2861845-802c-4887-82d1-bac98f7eacba" />
