### PR TITLE
chore(test): silence Vue warnings in the unit test suite

### DIFF
--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -1,6 +1,37 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import vueSnapshotSerializer from 'jest-serializer-vue';
+import { config } from '@vue/test-utils';
 
 expect.addSnapshotSerializer(vueSnapshotSerializer);
+
+// Suite-wide defaults so specs don't have to opt in to the basics. Anything a
+// spec passes in its own `global` block merges on top of (and wins over) these.
+//
+// Three constraints on what may go here:
+// 1. Stateless only. `clearMocks` is off and setup runs once per file, so a
+//    shared spy would leak assertions between tests.
+// 2. No `#src` imports. They load app modules before a spec's `vi.mock()` can
+//    apply — importing KvAuth0 here broke syncDate.spec.js, which mocks
+//    `timesync`, because KvAuth0 imports syncDate.
+// 3. Nothing that a spec might also install as a plugin. Registering RouterLink
+//    or providing vue-router's routerKey globally collides with the specs that
+//    build a real router (Vue warns "already registered" and the real
+//    <router-link> stops rendering an anchor). Those live in specUtils.js as
+//    opt-in helpers instead.
+config.global.directives = {
+	...config.global.directives,
+	kvTrackEvent: () => {},
+};
+
+config.global.provide = {
+	...config.global.provide,
+	apollo: {
+		readFragment: () => {},
+		query: () => Promise.resolve({}),
+		readQuery: () => {},
+		mutate: () => Promise.resolve({}),
+	},
+};
 
 // Mirror index.html so components that `<Teleport to="#teleports">` (lightboxes)
 // have a valid target when rendered. Guarded because some specs run in the node

--- a/test/unit/specUtils.js
+++ b/test/unit/specUtils.js
@@ -1,3 +1,4 @@
+import { h, ref } from 'vue';
 import numeralFilter from '#src/plugins/numeral-filter';
 import CookieStore from '#src/util/cookieStore';
 import { MockKvAuth0 } from '#src/util/KvAuth0';
@@ -8,6 +9,52 @@ const mockRouter = {
 
 const emptyComponent = {
 	template: '<div></div>',
+};
+
+// Opt-in `<router-link>` stub for specs that mount a component in isolation
+// without installing vue-router. Renders a literal `<router-link to="...">`
+// element, matching what Vue emitted when the component was unresolved, so
+// specs that query `router-link[to="..."]` keep working — the point is only to
+// silence the resolve warning, not to change any DOM.
+//
+// Do NOT promote this to `config.global` in setup.js: it would also replace the
+// real RouterLink in specs that install a router, where <router-link> is
+// expected to render an anchor with role="link".
+const routerLinkStub = {
+	name: 'RouterLink',
+	props: {
+		to: { type: [String, Object], default: '' },
+	},
+	setup(props, { slots }) {
+		return () => h('router-link', { to: props.to }, slots.default?.());
+	},
+};
+
+// Opt-in stand-in for vue-router's injected router, for components that call
+// `useRouter()` in setup(). Plain no-ops rather than spies so it stays
+// stateless; a spec asserting navigation should provide its own. `currentRoute`
+// is a Ref on the real router and components read `.currentRoute.value`
+// without guarding it, so it has to be present.
+//
+// Provide it under vue-router's `routerKey`, imported by the spec rather than
+// here: several specs `vi.mock('vue-router')` without re-exporting routerKey,
+// and importing it in this shared module breaks their collection.
+const mockRouterObject = {
+	currentRoute: ref({
+		path: '/',
+		fullPath: '/',
+		name: undefined,
+		hash: '',
+		query: {},
+		params: {},
+		meta: {},
+	}),
+	push: () => Promise.resolve(),
+	replace: () => Promise.resolve(),
+	go: () => {},
+	back: () => {},
+	forward: () => {},
+	resolve: to => ({ href: typeof to === 'string' ? to : '' }),
 };
 
 // Extracts the operation name from a gql document, e.g. to assert which
@@ -42,6 +89,8 @@ const globalOptions = {
 
 export {
 	mockRouter,
+	mockRouterObject,
+	routerLinkStub,
 	emptyComponent,
 	globalOptions,
 	getOperationName

--- a/test/unit/specs/components/BorrowerProfile/LoanTags.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanTags.spec.js
@@ -1,6 +1,6 @@
 import { render, fireEvent } from '@testing-library/vue';
 import LoanTags from '#src/components/BorrowerProfile/LoanTags';
-import { globalOptions } from '../../../specUtils';
+import { globalOptions, routerLinkStub } from '../../../specUtils';
 
 const mockAvailableTags = [
 	{
@@ -15,6 +15,7 @@ const mockAvailableTags = [
 ];
 
 const stubs = {
+	RouterLink: routerLinkStub,
 	KvCheckbox: {
 		template: `<label data-testid="bp-loan-tag-checkbox">
 			<input type="checkbox" :checked="modelValue"

--- a/test/unit/specs/components/BorrowerProfile/PreviousLoanDescription.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/PreviousLoanDescription.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { mount } from '@vue/test-utils';
 import PreviousLoanDescription from '#src/components/BorrowerProfile/PreviousLoanDescription';
-import { globalOptions } from '../../../specUtils';
+import { globalOptions, routerLinkStub } from '../../../specUtils';
 
 function mountPreviousLoanDescription() {
 	const openDefinition = vi.fn();
@@ -13,6 +13,7 @@ function mountPreviousLoanDescription() {
 		},
 		global: {
 			...globalOptions,
+			stubs: { RouterLink: routerLinkStub },
 			provide: {
 				...globalOptions.provide,
 				openDefinition,

--- a/test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { mount } from '@vue/test-utils';
 import SummaryCard from '#src/components/BorrowerProfile/SummaryCard';
-import { globalOptions } from '../../../specUtils';
+import { globalOptions, routerLinkStub } from '../../../specUtils';
 
 function mountSummaryCard({ anonymizationLevel } = {}) {
 	const openDefinition = vi.fn();
@@ -16,6 +16,7 @@ function mountSummaryCard({ anonymizationLevel } = {}) {
 		},
 		global: {
 			...globalOptions,
+			stubs: { RouterLink: routerLinkStub },
 			mocks: {
 				...globalOptions.mocks,
 				$route: { params: { id: '12345' } },

--- a/test/unit/specs/components/LendingTeams/MyTeams/MyTeamsList.spec.js
+++ b/test/unit/specs/components/LendingTeams/MyTeams/MyTeamsList.spec.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import MyTeamsList from '#src/components/LendingTeams/MyTeams/MyTeamsList';
-import { globalOptions } from '../../../../specUtils';
+import { globalOptions, routerLinkStub } from '../../../../specUtils';
 
 const mockTeam = (id, overrides = {}) => ({
 	id,
@@ -36,6 +36,7 @@ describe('MyTeamsList', () => {
 			global: {
 				...globalOptions,
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvButton: { template: '<button><slot /></button>' },
 					KvLoadingPlaceholder: { template: '<div class="skeleton"></div>' },
 					TeamCard: { template: '<div></div>' },
@@ -61,6 +62,7 @@ describe('MyTeamsList', () => {
 					},
 				},
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvButton: { template: '<button><slot /></button>' },
 					KvLoadingPlaceholder: { template: '<div></div>' },
 					TeamCard: { template: '<div></div>' },
@@ -88,6 +90,7 @@ describe('MyTeamsList', () => {
 					},
 				},
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvButton: { template: '<button><slot /></button>' },
 					KvLoadingPlaceholder: { template: '<div></div>' },
 					TeamCard: { template: '<div><slot /></div>' },
@@ -116,6 +119,7 @@ describe('MyTeamsList', () => {
 					},
 				},
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvButton: { template: '<button><slot /></button>' },
 					KvLoadingPlaceholder: { template: '<div></div>' },
 					TeamCard: { template: '<div></div>' },
@@ -160,6 +164,7 @@ describe('MyTeamsList', () => {
 					},
 				},
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvButton: { template: '<button @click="$attrs.onClick"><slot /></button>' },
 					KvLoadingPlaceholder: { template: '<div></div>' },
 					TeamCard: { template: '<div></div>' },

--- a/test/unit/specs/components/LendingTeams/MyTeams/TeamCard.spec.js
+++ b/test/unit/specs/components/LendingTeams/MyTeams/TeamCard.spec.js
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/vue';
 import TeamCard from '#src/components/LendingTeams/MyTeams/TeamCard';
-import { globalOptions } from '../../../../specUtils';
+import { globalOptions, routerLinkStub } from '../../../../specUtils';
 
 const mockTeam = {
 	id: 1,
@@ -18,6 +18,7 @@ describe('TeamCard', () => {
 			global: {
 				...globalOptions,
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvMaterialIcon: { template: '<span></span>' },
 					KvDropdown: { template: '<div><slot /></div>' },
 				},
@@ -37,6 +38,7 @@ describe('TeamCard', () => {
 			global: {
 				...globalOptions,
 				stubs: {
+					RouterLink: routerLinkStub,
 					KvMaterialIcon: { template: '<span></span>' },
 					KvDropdown: { template: '<div><slot /></div>' },
 				},

--- a/test/unit/specs/components/LendingTeams/MyTeams/TeamMessageCard.spec.js
+++ b/test/unit/specs/components/LendingTeams/MyTeams/TeamMessageCard.spec.js
@@ -1,6 +1,11 @@
 import { render, screen } from '@testing-library/vue';
 import TeamMessageCard from '#src/components/LendingTeams/MyTeams/TeamMessageCard';
-import { globalOptions } from '../../../../specUtils';
+import { globalOptions, routerLinkStub } from '../../../../specUtils';
+
+const globalWithRouterLink = {
+	...globalOptions,
+	stubs: { RouterLink: routerLinkStub },
+};
 
 const mockMessage = (id, overrides = {}) => ({
 	id: `${id}`,
@@ -29,7 +34,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		expect(screen.getByText('Sender 1')).toBeTruthy();
@@ -43,7 +48,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithRef }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const links = container.querySelectorAll('a[href*="msgID=12345"]');
@@ -56,7 +61,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithRef }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const links = container.querySelectorAll('p a[href*="msgID="]');
@@ -69,7 +74,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithUrl }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const link = container.querySelector('p a[href="https://www.kiva.org/lend"]');
@@ -85,7 +90,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithUrl }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const link = container.querySelector('p a');
@@ -101,7 +106,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithJavascript }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const links = container.querySelectorAll('p a');
@@ -115,7 +120,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithFragment }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const externalLink = container.querySelector('p a[href="https://example.com/post#123"]');
@@ -129,7 +134,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const deepLink = container.querySelector('a[href*="msgID=1#msg_1"]');
@@ -143,7 +148,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithSpecialChars }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		// Should not create links from numbers that appear in escaped HTML entities
@@ -167,7 +172,7 @@ describe('TeamMessageCard', () => {
 			props: {
 				message: mockMessage(1, { body: bodyWithLineBreaks }),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const messageBody = container.querySelector('p');
@@ -187,7 +192,7 @@ describe('TeamMessageCard', () => {
 					},
 				}),
 			},
-			global: globalOptions,
+			global: globalWithRouterLink,
 		});
 
 		const senderLink = container.querySelector('router-link[to="/lender/sender123"]');

--- a/test/unit/specs/components/Thanks/BadgeMilestone.spec.js
+++ b/test/unit/specs/components/Thanks/BadgeMilestone.spec.js
@@ -96,7 +96,7 @@ describe('BadgeMilestone', () => {
 					isGuest: false,
 					loans: [{ id: 1 }],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			const badgeImg = await findByAltText('Badge');
@@ -120,7 +120,7 @@ describe('BadgeMilestone', () => {
 					isGuest: false,
 					loans: [{ id: 1 }],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			const badgeImg = await findByAltText('Badge');
@@ -144,7 +144,7 @@ describe('BadgeMilestone', () => {
 					isGuest: false,
 					loans: [{ id: 1 }],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			const badgeImg = await findByAltText('Badge');
@@ -170,7 +170,7 @@ describe('BadgeMilestone', () => {
 					badgeAchievedIds: [],
 					loans: [{ id: 1 }],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			// Trigger the contentful data watch by setting after render
@@ -190,7 +190,7 @@ describe('BadgeMilestone', () => {
 					badgeAchievedIds: [],
 					loans: [],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			expect(queryByRole('button', { name: /continue/i })).toBeNull();
@@ -206,7 +206,7 @@ describe('BadgeMilestone', () => {
 					badgeAchievedIds: [],
 					loans: [{ id: 1 }],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			// Trigger the badge data watch to resolve loading state
@@ -238,7 +238,7 @@ describe('BadgeMilestone', () => {
 					isGuest: false,
 					loans: [{ id: 1 }],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			await findByText('Women are change makers', { exact: false });
@@ -254,7 +254,7 @@ describe('BadgeMilestone', () => {
 					achievementsCompleted: false,
 					loans: [],
 				},
-				...globalOptions,
+				global: globalOptions,
 			});
 
 			expect(queryByRole('button', { name: /continue/i })).toBeNull();

--- a/test/unit/specs/composables/useMyKivaHome.spec.js
+++ b/test/unit/specs/composables/useMyKivaHome.spec.js
@@ -30,7 +30,16 @@ describe('useMyKivaHome.js', () => {
 			}
 		});
 
-		const composable = useMyKivaHome(mockApollo);
+		let composable;
+		const TestComponent = {
+			template: '<div></div>',
+			setup() {
+				composable = useMyKivaHome(mockApollo);
+				return composable;
+			}
+		};
+
+		render(TestComponent);
 
 		expect(composable.homePagePath).toBeDefined();
 		expect(composable.portfolioPath).toBeDefined();
@@ -231,9 +240,22 @@ describe('useMyKivaHome.js', () => {
 			}
 		});
 
-		const { homePagePath, portfolioPath } = useMyKivaHome(mockApollo);
+		let homePagePath;
+		let portfolioPath;
+		const TestComponent = {
+			template: '<div></div>',
+			setup() {
+				const composable = useMyKivaHome(mockApollo);
+				({ homePagePath, portfolioPath } = composable);
+				return composable;
+			}
+		};
 
-		// Before mount completes, should be false
+		render(TestComponent);
+
+		// Asserted synchronously: onMounted has fired, but its apollo query
+		// resolves on a later microtask, so the paths are still at their
+		// pre-fetch defaults here.
 		expect(homePagePath.value).toBe('/');
 		expect(portfolioPath.value).toBe('/portfolio');
 	});

--- a/test/unit/specs/util/goalCardCopyUtils.spec.js
+++ b/test/unit/specs/util/goalCardCopyUtils.spec.js
@@ -8,6 +8,12 @@ import {
 	ID_WOMENS_EQUALITY,
 } from '#src/composables/useBadgeData';
 import GoalProgressRing from '#src/components/MyKiva/GoalProgressRing';
+import { routerKey } from 'vue-router';
+import { mockRouterObject } from '../../specUtils';
+
+// GoalProgressRing calls useRouter() in setup(), so it needs the router
+// injection even though these tests only assert on rendered copy.
+const global = { provide: { [routerKey]: mockRouterObject } };
 
 describe('GoalProgressRing.vue', () => {
 	describe('modalDescriptionText computed property', () => {
@@ -21,6 +27,7 @@ describe('GoalProgressRing.vue', () => {
 
 			const { container } = render(GoalProgressRing, {
 				props: testProps,
+				global,
 			});
 
 			const description = container.querySelector('.modal-description-text');
@@ -39,6 +46,7 @@ describe('GoalProgressRing.vue', () => {
 
 			const { container } = render(GoalProgressRing, {
 				props: testProps,
+				global,
 			});
 
 			const description = container.querySelector('.modal-description-text');
@@ -57,6 +65,7 @@ describe('GoalProgressRing.vue', () => {
 
 			const { container } = render(GoalProgressRing, {
 				props: testProps,
+				global,
 			});
 
 			const description = container.querySelector('.modal-description-text');
@@ -75,6 +84,7 @@ describe('GoalProgressRing.vue', () => {
 
 			const { container } = render(GoalProgressRing, {
 				props: testProps,
+				global,
 			});
 
 			const description = container.querySelector('.modal-description-text');
@@ -93,6 +103,7 @@ describe('GoalProgressRing.vue', () => {
 
 			const { container } = render(GoalProgressRing, {
 				props: testProps,
+				global,
 			});
 
 			const description = container.querySelector('.modal-description-text');
@@ -111,6 +122,7 @@ describe('GoalProgressRing.vue', () => {
 
 			const { container } = render(GoalProgressRing, {
 				props: testProps,
+				global,
 			});
 
 			const description = container.querySelector('.modal-description-text');


### PR DESCRIPTION
## What

Cuts `[Vue warn]` output from `npm run unit` from **75 to 3**, with no change
to what the suite covers: 299 files / 4412 tests pass before and after, none
added, skipped, or removed.

The noise made it hard to spot a real failure in CI output, and two of the
warnings turned out to be masking actual spec bugs (see below).

## Why the shared config is split two ways

`test/unit/setup.js` gets the defaults that can't collide — the `kvTrackEvent`
directive and an `apollo` provide, via VTU `config.global`. Specs' own `global`
blocks merge on top and still win.

`test/unit/specUtils.js` gets `routerLinkStub` and `mockRouterObject` as
**opt-in** helpers. These deliberately are not global: registering `RouterLink`
or providing vue-router's `routerKey` suite-wide collides with the three specs
that build a real router (`BasketItem`, `ThanksPageSingleVersion`,
`RouteListing`), where `<router-link>` is expected to render an anchor with
`role="link"`. My first attempt did make them global and broke
`BasketItem`'s `getByRole('link')`.

`routerLinkStub` renders a literal `<router-link to="...">` element, matching
the DOM Vue emitted while the component was unresolved. That's intentional:
specs query `router-link[to="..."]` (`TeamMessageCard`) and `getAttribute('to')`
(`TeamCard`). The goal is to silence the resolve warning, not to change rendered
output — so this PR changes no assertions.

## Two spec bugs the warnings were hiding

- **`BadgeMilestone.spec.js`** spread `globalOptions` at the *top level* of its
  render options, where VTU ignores `directives`/`provide`/`mocks` entirely.
  Its mocks were inert across all 8 tests. Now `global: globalOptions`.
- **`useMyKivaHome.spec.js`** called the composable bare in 2 of 11 tests, so
  its `onMounted` had no instance to attach to. Both now wrap it in a
  `TestComponent` like the other nine.

  The `reactive computed properties` test asserts pre-fetch defaults, which
  depends on the mount hook not having completed. Its assertions stay
  **synchronous** after `render()`: `onMounted` fires, but its apollo query
  resolves on a later microtask, so the values are still the defaults. The flip
  to `/mykiva` after resolution is covered by two sibling tests, which confirms
  that assertion isn't trivially true.

## Two import-order constraints, documented in the files

Both cost a debugging cycle, so they're comments where the next person will hit
them:

- `setup.js` must not import from `#src`. Importing `KvAuth0` pulled in
  `syncDate` before `syncDate.spec.js` could `vi.mock('timesync')`, breaking all
  10 of its tests.
- `specUtils.js` must not import `routerKey` from `vue-router`. Several specs
  `vi.mock('vue-router')` without re-exporting it, and the import broke their
  collection. The one spec that needs the key imports it directly.

## The 3 remaining warnings

All intentional or out of scope:

| Warning | Status |
|---|---|
| `injection "apollo" not found` | Intentional — test named *"should not query when apollo is not provided"*; uses raw `createApp`, so `config.global` never applies |
| `Invalid prop: custom validator "state"` | Intentional — `FeaturedGoalCard` deliberately passes `state="something-unsupported"` |
| `Invalid prop: type check "to"` | Pre-existing bug in `RouteListing.vue:56`, tackled separately |

## Testing

- `npm run unit` — 299 files / 4412 tests pass, exit 0
- `npm run lint` — exit 0 (the 7 remaining warnings are pre-existing GraphQL
  schema warnings in untouched files)
- No product code changed; `test/` only
