### PR TITLE
feat(sitemap): resolve and link redirect targets in the route listing

### DIFF
--- a/src/pages/UiSiteMap/RouteListing.vue
+++ b/src/pages/UiSiteMap/RouteListing.vue
@@ -48,15 +48,30 @@
 			</h2>
 			<ul class="tw-list-disc tw-list-inside tw-mb-4">
 				<li v-for="route in redirectRoutes" :key="route.path" class="tw-mb-1">
-					<router-link :to="route.path">
+					<router-link :to="pathWithParams(route)">
 						<!-- eslint-disable-next-line -->
-						{{ route.path.replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
+						{{ pathWithParams(route).replace('/','') }} <small v-if="route.name !== 'no-name'">({{ route.name }})</small>
 					</router-link>
 					&rarr;
-					<router-link :to="route.redirect">
-						<!-- eslint-disable-next-line -->
-						{{ route.redirect }}
+					<router-link v-if="isLinkableRedirect(route.redirect)" :to="redirectTarget(route)">
+						{{ redirectLabel(route) }}
 					</router-link>
+					<!-- A target read out of a redirect function can point outside the app's
+						own routes (/lend-by-category is served externally), so link it with a
+						plain anchor. <router-link> would warn about an unmatched location, and
+						a full browser navigation is what the redirect itself performs. -->
+					<a v-else-if="functionTarget(route)" :href="functionTarget(route)">
+						{{ functionTarget(route) }}
+					</a>
+					<small v-else>{{ redirectLabel(route) }}</small>
+					<input
+						class="tw-ml-1 tw-px-1 tw-border"
+						type="text"
+						v-for="(value, key) in route.params"
+						:key="key"
+						v-model="route.params[key]"
+						:placeholder="`set ${key}`"
+					>
 				</li>
 			</ul>
 		</div>
@@ -104,9 +119,54 @@ export default {
 		});
 	},
 	methods: {
+		// Substitute whatever has been typed into the param inputs, leaving the
+		// `:param` placeholder in place wherever nothing has been entered yet.
+		withParams(path, params) {
+			return path.replace(this.paramRegex, match => params[match] || match);
+		},
 		pathWithParams(route) {
-			return route.path.replace(this.paramRegex, match => route.params[match] || match);
-		}
+			return this.withParams(route.path, route.params);
+		},
+		// vue-router allows `redirect` to be a string, an object, or a function.
+		// Only the first two are valid `to` values for <router-link>.
+		isLinkableRedirect(redirect) {
+			return typeof redirect === 'string'
+				|| (typeof redirect === 'object' && redirect !== null);
+		},
+		redirectTarget(route) {
+			return typeof route.redirect === 'string'
+				? this.withParams(route.redirect, route.params)
+				: route.redirect;
+		},
+		// Best-effort target for a function redirect, read from the function's
+		// source. The function is deliberately never called: redirects like the
+		// /lend/:category one assign to window.location in the browser and throw
+		// on the server, so invoking it here would navigate away from this page.
+		//
+		// Instead take the first path-like literal out of the source and turn any
+		// `${to.params.x}` interpolation back into `:x`, so a dynamic redirect
+		// still shows where it points. Returns null when the shape isn't
+		// recognisable, since a confidently wrong path is worse than no path.
+		parseFunctionRedirect(redirect) {
+			const literal = redirect.toString().match(/[`'"](\/[^`'"\s]*)[`'"]/);
+			if (!literal) return null;
+			const path = literal[1].replace(/\$\{[^}]*\bparams\.(\w+)[^}]*\}/g, ':$1');
+			// Any interpolation we couldn't name means we can't trust the result.
+			return path.includes('${') ? null : path;
+		},
+		// The resolved target of a function redirect, with any typed params
+		// substituted in, or null when the source couldn't be read.
+		functionTarget(route) {
+			if (typeof route.redirect !== 'function') return null;
+			const parsed = this.parseFunctionRedirect(route.redirect);
+			return parsed ? this.withParams(parsed, route.params) : null;
+		},
+		redirectLabel(route) {
+			const { redirect } = route;
+			if (typeof redirect === 'string') return this.withParams(redirect, route.params);
+			if (typeof redirect === 'function') return this.functionTarget(route) ?? '(dynamic redirect)';
+			return JSON.stringify(redirect);
+		},
 	},
 };
 </script>

--- a/test/unit/specs/components/RouteListing.spec.js
+++ b/test/unit/specs/components/RouteListing.spec.js
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/vue';
+import { render, fireEvent } from '@testing-library/vue';
 import RouteListing from '#src/pages/UiSiteMap/RouteListing';
 import routes from '#src/router/routes';
 import { createRouter, createWebHistory } from 'vue-router';
@@ -24,6 +24,16 @@ function getRouteLabel(route) {
 	return `${trimmedPath}${spacing}${name}`;
 }
 
+// Find the <li> in the Redirects list for a given route path
+function redirectRowFor(container, path) {
+	const heading = [...container.querySelectorAll('h2')]
+		.find(h2 => h2.textContent.trim() === 'Redirects');
+	return [...heading.nextElementSibling.querySelectorAll('li')]
+		.find(li => li.textContent.includes(path));
+}
+
+const hrefsIn = row => [...row.querySelectorAll('a')].map(a => a.getAttribute('href'));
+
 describe('RouteListing.vue', () => {
 	it('should render a link for each route', () => {
 		const { getByText } = render(RouteListing, {
@@ -37,5 +47,90 @@ describe('RouteListing.vue', () => {
 			const label = getRouteLabel(route);
 			getByText(byTextContent(label)); // Will throw an error if the route label is not found
 		});
+	});
+
+	it('should link string redirect targets', () => {
+		const { container } = render(RouteListing, {
+			global: {
+				routes: routesWithOutComponents,
+				plugins: [router],
+			}
+		});
+
+		const stringRedirect = routes.find(route => typeof route.redirect === 'string');
+		const link = container.querySelector(`a[href="${stringRedirect.redirect}"]`);
+		expect(link).toBeTruthy();
+		expect(link.textContent.trim()).toBe(stringRedirect.redirect);
+	});
+
+	// vue-router allows `redirect` to be a function, which is not a valid `to`
+	// value. Binding it warned about an invalid prop and rendered the function's
+	// source as the link text. The target is now read out of the function source
+	// and linked with a plain anchor, since it can point outside the app's routes.
+	it('should resolve a function redirect target and link it', () => {
+		const { getByText } = render(RouteListing, {
+			global: {
+				routes: routesWithOutComponents,
+				plugins: [router],
+			}
+		});
+
+		expect(routes.some(route => typeof route.redirect === 'function')).toBe(true);
+
+		const link = getByText('/lend-by-category/:category');
+		expect(link.tagName).toBe('A');
+		expect(link.getAttribute('href')).toBe('/lend-by-category/:category');
+	});
+
+	// The label is derived from the function's source, so anything it can't read
+	// has to degrade to a neutral label rather than guess.
+	it('should fall back to a neutral label when a function redirect is unreadable', () => {
+		const opaqueRouter = createRouter({
+			history: createWebHistory(),
+			routes: [
+				// A '/' route so the initial location resolves without a router warning
+				{ path: '/', component: { name: 'Home', template: '<div></div>' } },
+				// No path-like literal in the source for the label to be read from
+				{ path: '/opaque', redirect: to => to.params.id },
+			],
+		});
+
+		const { getByText } = render(RouteListing, {
+			global: { plugins: [opaqueRouter] }
+		});
+
+		expect(getByText('(dynamic redirect)').tagName).toBe('SMALL');
+	});
+
+	it('should substitute a typed param into both a redirect route and its target', async () => {
+		const { container } = render(RouteListing, {
+			global: {
+				routes: routesWithOutComponents,
+				plugins: [router],
+			}
+		});
+
+		const row = redirectRowFor(container, 'lend-beta/:id');
+		await fireEvent.update(row.querySelector('input'), '2468');
+
+		expect(hrefsIn(row)).toEqual(['/lend-beta/2468', '/lend/2468']);
+	});
+
+	// A typed param should flow into the resolved function target too, so the row
+	// shows the real URL the redirect will produce.
+	it('should substitute a typed param into a function redirect target', async () => {
+		const { container } = render(RouteListing, {
+			global: {
+				routes: routesWithOutComponents,
+				plugins: [router],
+			}
+		});
+
+		const row = redirectRowFor(container, 'lend/:category');
+		await fireEvent.update(row.querySelector('input'), 'agriculture');
+
+		// Both sides are followable: the route via the router, the resolved
+		// external target via a plain anchor.
+		expect(hrefsIn(row)).toEqual(['/lend/agriculture', '/lend-by-category/agriculture']);
 	});
 });


### PR DESCRIPTION
## What

The Redirects section of `/ui-site-map` bound each route's `redirect` straight to
`<router-link>`'s `to`. vue-router also allows `redirect` to be a function, which
isn't a valid `to` — so `/lend/:category` (`routes.js:221`) warned about an
invalid prop and rendered the function's own source as its link text.

You can see this here: https://www.development.kiva.org/ui-site-map particularly the redirect section below. 

Redirect rows now resolve like the prod/dev rows above them, with param inputs
for `/lend/:category`, `/lend-beta/:id` and `/funded/:id`. A typed param flows
into both sides of the row:

    lend/:category   → /lend-by-category/:category
    lend/agriculture → /lend-by-category/agriculture
    lend-beta/2468   → /lend/2468

## How the dynamic target resolves

`parseFunctionRedirect` reads the function's source, taking the first path-like
literal and rewriting `${to.params.x}` to `:x`. It's pattern-based rather than
special-cased, so future dynamic redirects work too, falling back to
`(dynamic redirect)` when the source isn't readable.

Two deliberate constraints:

- **The function is never called.** It assigns `window.location.href` in the
  browser and throws on the server, so calling it to preview the target would
  navigate off the sitemap page.
- **The target is a plain `<a href>`, not a `<router-link>`.**
  `/lend-by-category` is served externally and has no route, so `router-link`
  would warn `No match found for location`.

