### PR TITLE
fix(esiHead): read the basket cookie instead of creating a basket AD-371

### DIFF
--- a/src/esiTags/head.js
+++ b/src/esiTags/head.js
@@ -6,7 +6,6 @@ import renderDocumentCookies from '#src/rendering/documentCookies';
 import { renderOptInExternals } from '#src/rendering/externals';
 import renderGlobals from '#src/rendering/globals';
 import { renderAppInstallPrompt, shouldShowAppInstallPrompt } from '#src/util/appInstallPrompt';
-import setBasketCookie from '#src/util/basketCookie';
 import { assignAllActiveExperiments } from '#src/util/experiment/experimentUtils';
 import { setUserDataCookies } from '#src/util/optimizelyUserMetrics';
 import setVisitorIdCookie from '#src/util/visitorCookie';
@@ -20,8 +19,9 @@ import {
 import { userAvatarFragment, userAvatarData } from './globalData/userAvatar';
 
 async function fetchUserDataGlobals(apollo, cookieStore) {
+	const basketId = cookieStore.get('kvbskt');
 	const { data } = await apollo.query({
-		query: gql`query esiHead($basketId: String) {
+		query: gql`query esiHead($basketId: String, $hasBasket: Boolean!) {
 			contentful {
 				...GlobalPromoFragment
 			}
@@ -30,7 +30,7 @@ async function fetchUserDataGlobals(apollo, cookieStore) {
 				...UserAvatar
 				...UserPromoBalance
 			}
-			shop(basketId: $basketId) {
+			shop(basketId: $basketId) @include(if: $hasBasket) {
 				id
 				...BasketCount
 				...BasketPromoAvailable
@@ -43,7 +43,8 @@ async function fetchUserDataGlobals(apollo, cookieStore) {
 		${userPromoBalanceFragment}
 		`,
 		variables: {
-			basketId: cookieStore.get('kvbskt'),
+			basketId,
+			hasBasket: !!basketId,
 		}
 	});
 
@@ -88,9 +89,6 @@ export default async function renderESIHead({
 
 	// Set the visitor id cookie before other cookies or requests
 	setVisitorIdCookie(cookieStore);
-
-	// Set the basket cookie before starting other requests so that the basket ID is available
-	await setBasketCookie(cookieStore, apollo);
 
 	// Start remaining async methods in parallel
 	const [showPrompt, userDataGlobals] = await Promise.all([

--- a/test/unit/specs/esiTags/head.spec.js
+++ b/test/unit/specs/esiTags/head.spec.js
@@ -5,7 +5,6 @@ import renderDocumentCookies from '#src/rendering/documentCookies';
 import { renderOptInExternals } from '#src/rendering/externals';
 import renderGlobals from '#src/rendering/globals';
 import { shouldShowAppInstallPrompt, renderAppInstallPrompt } from '#src/util/appInstallPrompt';
-import setBasketCookie from '#src/util/basketCookie';
 import { assignAllActiveExperiments } from '#src/util/experiment/experimentUtils';
 import { setUserDataCookies } from '#src/util/optimizelyUserMetrics';
 import setVisitorIdCookie from '#src/util/visitorCookie';
@@ -83,10 +82,6 @@ vi.mock('#src/rendering/globals', () => ({
 vi.mock('#src/util/appInstallPrompt', () => ({
 	shouldShowAppInstallPrompt: vi.fn(async () => true),
 	renderAppInstallPrompt: vi.fn(() => '<div>app-install</div>'),
-}));
-
-vi.mock('#src/util/basketCookie', () => ({
-	default: vi.fn(async () => {}),
 }));
 
 vi.mock('#src/util/experiment/experimentUtils', () => ({
@@ -246,17 +241,6 @@ describe('renderESIHead', () => {
 		expect(setVisitorIdCookie).toHaveBeenCalledWith(mockCookieStore);
 	});
 
-	it('should set basket cookie', async () => {
-		await renderESIHead({
-			cookieStore: mockCookieStore,
-			context: mockContext,
-			fetch: mockFetch,
-			kvAuth0: mockKvAuth0,
-		});
-
-		expect(setBasketCookie).toHaveBeenCalledWith(mockCookieStore, mockApollo);
-	});
-
 	it('should fetch user data globals with basket ID', async () => {
 		await renderESIHead({
 			cookieStore: mockCookieStore,
@@ -269,9 +253,26 @@ describe('renderESIHead', () => {
 			expect.objectContaining({
 				variables: {
 					basketId: 'test-basket-id',
+					hasBasket: true,
 				},
 			})
 		);
+	});
+
+	it('does not create a basket for a visitor without one', async () => {
+		const emptyCookieStore = {
+			get: vi.fn(() => null),
+			set: vi.fn(),
+		};
+
+		await renderESIHead({
+			cookieStore: emptyCookieStore,
+			context: mockContext,
+			fetch: mockFetch,
+			kvAuth0: mockKvAuth0,
+		});
+
+		expect(emptyCookieStore.set).not.toHaveBeenCalled();
 	});
 
 	it('should check if user has ever logged in', async () => {
@@ -460,6 +461,7 @@ describe('renderESIHead', () => {
 			expect.objectContaining({
 				variables: {
 					basketId: null,
+					hasBasket: false,
 				},
 			})
 		);


### PR DESCRIPTION
On a visitor's first page load of a borrower profile, the ESI head and the page render each created their own basket. The head's basket won the cookie, but only the page render had cached that basket's `items`, so the profile's prefetched cache read came back incomplete. `readQuery` returned `null`, the routing operation's `result()` never ran, and the page briefly rendered the minimal "funded" view titled `undefined from undefined's loan has been funded!`.

## Changes

`src/esiTags/head.js`:

- Removed the `setBasketCookie` call, so the head only reads `kvbskt`. Basket creation now happens in exactly one place, the full page render (`src/server-app-render.js:74`), so the cookie always refers to the basket whose `items` were fetched.
- Gated the `shop` field with `@include(if: $hasBasket)` so it is not queried when there is no basket id

Not having the shop data is fine because `basketCountData` reads `data?.shop?.nonTrivialItemCount ?? 0`, so an absent or errored `shop` hides the basket count exactly as a no-basket render does.

## Testing

1. Verify against a production build (`npm run build`, then `npm start -- --config=local-dev`). The Vite dev server cannot reproduce the bug, since it mounts into an empty `#app` instead of hydrating.
2. Clear cookies so no `kvbskt` exists, then load a fundraising loan.
3. Confirm the full view renders immediately with no `undefined from undefined` flash and no hydration mismatch warning, and that `kvbskt` matches the basket id in `__APOLLO_STATE__`.
4. Add the loan to the basket and reload to confirm the header basket count and promo balance still render once a basket exists.
