### PR TITLE
fix(logFormatter): stop losing caught errors, and fix 17 wrong-level calls

### DIFF
--- a/src/components/MyKiva/BailoutChips.vue
+++ b/src/components/MyKiva/BailoutChips.vue
@@ -90,7 +90,7 @@ const fetchCategories = () => {
 		});
 		categories.value = categories.value.sort((a, b) => a.name.localeCompare(b.name));
 	}).catch(error => {
-		logFormatter(error, 'MyKiva LendMenuQuery');
+		logFormatter('Failed to load MyKiva lend menu categories', 'error', { error });
 	});
 };
 
@@ -127,7 +127,7 @@ const fetchCountries = () => {
 			};
 		});
 	}).catch(error => {
-		logFormatter(error, 'MyKiva CountryListQuery');
+		logFormatter('Failed to load MyKiva country list', 'error', { error });
 	});
 };
 

--- a/src/components/WwwFrame/Header/KvAtbModalContainer.vue
+++ b/src/components/WwwFrame/Header/KvAtbModalContainer.vue
@@ -112,7 +112,7 @@ const fetchUserData = async () => {
 		userData.value = data ?? null;
 		hasEverLoggedIn.value = data?.hasEverLoggedIn ?? false;
 	}).catch(e => {
-		logFormatter(e, 'Modal ATB User Data');
+		logFormatter('Failed to load add-to-basket modal user data', 'error', { error: e });
 	});
 };
 
@@ -128,7 +128,10 @@ const fetchBasketData = async () => {
 			return total + (parseFloat(item.price) || 0);
 		}, 0);
 	}).catch(e => {
-		logFormatter(e, 'Modal ATB Basket Data');
+		logFormatter('Failed to load add-to-basket modal basket data', 'error', {
+			error: e,
+			basketId: cookieStore.get('kvbskt') || null,
+		});
 	});
 };
 
@@ -237,7 +240,10 @@ const fetchPostCheckoutAchievements = async loanIds => {
 			}
 			updateTierTable();
 		}).catch(e => {
-			logFormatter(e, 'Modal ATB Post Checkout Achievements Query');
+			logFormatter('Failed to load post-checkout achievements for add-to-basket modal', 'error', {
+				error: e,
+				loanIds,
+			});
 		});
 	}
 };
@@ -252,7 +258,10 @@ const fetchAchievementFromBasket = async () => {
 		contributingAchievements.value = [...contributingLoanAchievements];
 		updateTierTable();
 	}).catch(e => {
-		logFormatter(e, 'Modal ATB Basket Achievements Query ');
+		logFormatter('Failed to load basket achievements for add-to-basket modal', 'error', {
+			error: e,
+			loanIds: loansIdsInBasket.value,
+		});
 	});
 };
 
@@ -264,7 +273,7 @@ const hasUserLentToAddedLoan = async loanId => {
 		const hasLentToLoan = data?.lend?.loan?.userProperties?.lentTo ?? false;
 		return hasLentToLoan;
 	}).catch(e => {
-		logFormatter(e, 'Modal ATB User Lent To Loan Query');
+		logFormatter('Failed to check whether user has lent to loan', 'error', { error: e, loanId });
 		return false;
 	});
 };

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -303,7 +303,7 @@ export default function useGoalData({ apollo } = {}) {
 			const progress = response.data.userAchievementProgress.tieredLendingAchievements;
 			return progress;
 		} catch (error) {
-			logFormatter(error, 'Failed to fetch categories progress by year');
+			logFormatter('Failed to fetch categories progress by year', 'error', { error, year });
 			return null;
 		}
 	}
@@ -329,7 +329,7 @@ export default function useGoalData({ apollo } = {}) {
 				amount: stats?.amount || 0,
 			};
 		} catch (error) {
-			logFormatter(error, 'Failed to fetch loan stats by year');
+			logFormatter('Failed to fetch loan stats by year', 'error', { error, year });
 			return null;
 		}
 	}
@@ -343,7 +343,7 @@ export default function useGoalData({ apollo } = {}) {
 			const stats = await getLoanStatsByYear(year, fetchPolicy);
 			return stats.count || 0;
 		} catch (error) {
-			logFormatter(error, 'Failed to fetch previous support-all loan count');
+			logFormatter('Failed to fetch previous support-all loan count', 'error', { error, year });
 			return null;
 		}
 	};
@@ -366,7 +366,7 @@ export default function useGoalData({ apollo } = {}) {
 			const count = progress?.find(entry => entry.id === categoryId)?.progressForYear || 0;
 			return count;
 		} catch (error) {
-			logFormatter(error, 'Failed to fetch category loan count by year');
+			logFormatter('Failed to fetch category loan count by year', 'error', { error, categoryId, year });
 			return null;
 		}
 	}
@@ -379,7 +379,7 @@ export default function useGoalData({ apollo } = {}) {
 			userPreferences.value = prefsData;
 			return prefsData ? JSON.parse(prefsData.preferences || '{}') : {};
 		} catch (error) {
-			logFormatter(error, 'Failed to load preferences');
+			logFormatter('Failed to load preferences', 'error', { error });
 			return null;
 		}
 	}
@@ -581,7 +581,7 @@ export default function useGoalData({ apollo } = {}) {
 			rawCurrentYearProgress.value = progress?.map(p => ({ ...p })) || [];
 			currentYearProgress.value = applyFreshProgressToGoalData(progress, freshProgressAdjustments);
 		} catch (error) {
-			logFormatter(error, 'Failed to load progress');
+			logFormatter('Failed to load progress', 'error', { error, year });
 			return null;
 		}
 	}
@@ -662,7 +662,7 @@ export default function useGoalData({ apollo } = {}) {
 			}
 			return { totalProgress, hasContributingLoans };
 		} catch (error) {
-			logFormatter(error, 'Failed to get post-checkout progress');
+			logFormatter('Failed to get post-checkout progress', 'error', { error, year });
 			return { totalProgress: null, hasContributingLoans: false };
 		}
 	}

--- a/src/composables/useMyKivaHome.js
+++ b/src/composables/useMyKivaHome.js
@@ -16,7 +16,7 @@ export default function useMyKivaHome(apollo) {
 		}).then(({ data }) => {
 			userData.value = data?.my ?? null;
 		}).catch(e => {
-			logFormatter(e, 'useMyKivaHome composable');
+			logFormatter('Failed to fetch user ID for MyKiva home', 'error', { error: e });
 		});
 	};
 

--- a/src/pages/Thanks/ThanksPage.vue
+++ b/src/pages/Thanks/ThanksPage.vue
@@ -209,7 +209,7 @@ export default {
 				if (!transactionId) {
 					logFormatter(
 						'Thanks page preFetch skipped due to missing transaction_id.',
-						'warning',
+						'warn',
 					);
 					return Promise.resolve();
 				}
@@ -367,7 +367,7 @@ export default {
 		if (!transactionId) {
 			logFormatter(
 				'Thanks page readQuery skipped due to missing transaction_id.',
-				'warning',
+				'warn',
 			);
 			return false;
 		}

--- a/src/util/logFormatter.js
+++ b/src/util/logFormatter.js
@@ -1,13 +1,33 @@
 // generate various console types using a stringified message
 // and a format that matcher our server request logs
 
+// An Error's `message` and `stack` are non-enumerable, so JSON.stringify reduces
+// a plain Error to `{}` and the failure is lost. Callers should pass text as the
+// message and hand the error to `meta`, but unwrap Errors here as well so that a
+// stray one still records something, and so `{ error }` is always safe to write
+// at a call site regardless of what kind of error was caught.
+const errorMessage = value => {
+	if (!(value instanceof Error)) return null;
+	// An Error carrying an empty message would be dropped by the falsy guard
+	// below, turning a real failure back into no log at all, so fall back to its
+	// string form ('Error', or 'TypeError: ...' for a subclass).
+	return value.message || String(value);
+};
+
 export default (message, type, meta = {}) => {
-	if (!message || message === '') return false;
+	const text = errorMessage(message) ?? message;
+
+	if (!text || text === '') return false;
+
+	const detail = { ...meta };
+	Object.keys(detail).forEach(key => {
+		detail[key] = errorMessage(detail[key]) ?? detail[key];
+	});
 
 	const stringifiedMessage = JSON.stringify({
-		meta,
+		meta: detail,
 		level: type || 'log',
-		message,
+		message: text,
 	});
 
 	switch (type) {

--- a/src/util/logFormatter.js
+++ b/src/util/logFormatter.js
@@ -15,14 +15,19 @@ const errorMessage = value => {
 };
 
 export default (message, type, meta = {}) => {
-	const text = errorMessage(message) ?? message;
-
-	if (!text || text === '') return false;
-
 	const detail = { ...meta };
 	Object.keys(detail).forEach(key => {
 		detail[key] = errorMessage(detail[key]) ?? detail[key];
 	});
+
+	let text = errorMessage(message) ?? message;
+
+	// A call with no message but real context still describes something that
+	// happened, so drop it only when there would be nothing at all to record.
+	if (!text || text === '') {
+		if (!Object.keys(detail).length) return false;
+		text = '(no message)';
+	}
 
 	const stringifiedMessage = JSON.stringify({
 		meta: detail,

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -471,7 +471,7 @@ describe('useGoalData', () => {
 
 			await composable.loadGoalData();
 
-			expect(logFormatter).toHaveBeenCalledWith(error, 'Failed to load preferences');
+			expect(logFormatter).toHaveBeenCalledWith('Failed to load preferences', 'error', { error });
 		});
 
 		it('should handle progress query error', async () => {
@@ -491,7 +491,11 @@ describe('useGoalData', () => {
 
 			await composable.loadGoalData();
 
-			expect(logFormatter).toHaveBeenCalledWith(error, 'Failed to fetch categories progress by year');
+			expect(logFormatter).toHaveBeenCalledWith(
+				'Failed to fetch categories progress by year',
+				'error',
+				{ error, year: expect.any(Number) },
+			);
 		});
 
 		it('should use freshProgressLoans for fresh progress adjustments', async () => {

--- a/test/unit/specs/util/logFormatter.spec.js
+++ b/test/unit/specs/util/logFormatter.spec.js
@@ -170,6 +170,92 @@ describe('logFormatter.js', () => {
 		);
 	});
 
+	// An Error's message and stack are non-enumerable, so without unwrapping,
+	// JSON.stringify reduces one to `{}` and the failure is lost entirely.
+	it('should use an Error message as the log message', () => {
+		logFormatter(new Error('Network error: 503'), 'error');
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: {},
+				level: 'error',
+				message: 'Network error: 503',
+			})
+		);
+	});
+
+	it('should use the message from an Error subclass', () => {
+		class ApolloishError extends Error {}
+
+		logFormatter(new ApolloishError('Query failed'), 'error');
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: {},
+				level: 'error',
+				message: 'Query failed',
+			})
+		);
+	});
+
+	// This is what makes `logFormatter('...', 'error', { error })` safe to write
+	// at a call site whatever kind of error was caught.
+	it('should reduce an Error in metadata to its message', () => {
+		logFormatter('Failed to post loan comment', 'error', {
+			error: new Error('Comment not added'),
+			loanId: 12345,
+		});
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: { error: 'Comment not added', loanId: 12345 },
+				level: 'error',
+				message: 'Failed to post loan comment',
+			})
+		);
+	});
+
+	// Plain objects serialize fine on their own, so they must pass through whole
+	// rather than being flattened to an undefined message.
+	it('should preserve a plain object in metadata', () => {
+		const auth0Error = { error: 'unknown_error', error_description: 'Something went wrong' };
+
+		logFormatter('Auth0 reported an unknown error', 'error', { error: auth0Error });
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: { error: auth0Error },
+				level: 'error',
+				message: 'Auth0 reported an unknown error',
+			})
+		);
+	});
+
+	// An empty message must not silence the log — the failure is still real.
+	it('should fall back to the string form for an Error with an empty message', () => {
+		logFormatter(new Error(''), 'error');
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: {},
+				level: 'error',
+				message: 'Error',
+			})
+		);
+	});
+
+	it('should use the string form of a subclass with an empty message', () => {
+		logFormatter(new TypeError(''), 'error');
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: {},
+				level: 'error',
+				message: 'TypeError',
+			})
+		);
+	});
+
 	it('should handle complex metadata', () => {
 		const meta = {
 			user: { id: 1, name: 'Test' },

--- a/test/unit/specs/util/logFormatter.spec.js
+++ b/test/unit/specs/util/logFormatter.spec.js
@@ -36,6 +36,26 @@ describe('logFormatter.js', () => {
 		expect(consoleSpy.log).not.toHaveBeenCalled();
 	});
 
+	it('should return false when there is neither a message nor metadata', () => {
+		const result = logFormatter(null, 'error', {});
+
+		expect(result).toBe(false);
+		expect(consoleSpy.error).not.toHaveBeenCalled();
+	});
+
+	// Dropping the log would discard the level and the context along with it.
+	it('should log a fallback message when there is no message but metadata exists', () => {
+		logFormatter(null, 'error', { operationName: 'LoanQuery' });
+
+		expect(consoleSpy.error).toHaveBeenCalledWith(
+			JSON.stringify({
+				meta: { operationName: 'LoanQuery' },
+				level: 'error',
+				message: '(no message)',
+			})
+		);
+	});
+
 	it('should call console.log with stringified message for default type', () => {
 		logFormatter('Test message');
 


### PR DESCRIPTION
## The problem

`logFormatter(message, type, meta)` serializes with `JSON.stringify`, and a plain
`Error`'s `message` and `stack` are non-enumerable. So a caught Error passed as the
message logged this:

```
{"meta":{},"level":"error","message":{}}
```

The failure itself was gone. 28 log lines in `npm run unit` read `"message":{}`,
which is how this was found.

Separately, **17 call sites passed a failure description where the level belongs**,
so it matched no case in the switch and fell through to `console.log` — those
errors went to **stdout at log level and never reached error alerting**:

```js
logFormatter(error, 'Failed to fetch categories progress by year');
// → stdout: {"meta":{},"level":"Failed to fetch categories progress by year","message":{}}
```

Two of them passed `'warning'`, which is not a level either (`'warn'` is).

## The fix — two commits

**1. The utility unwraps Errors**, in the message slot and inside `meta`.

This deliberately makes kiva/ui match **cms-page-server**, whose `logFormatter`
already does the same thing (`message.message ?? message`). kiva/ui was the
outlier. After this, `logFormatter(e, 'error')` behaves the same in both repos.

Level handling is untouched: an unrecognised type still logs as a plain log. That's
the documented contract, three existing tests pin it, and CPS behaves identically —
not something a call-site bug should override.

**2. The 17 level fixes** — description moved to the message slot, `'error'` (or
`'warn'`) into the level slot, with context that was already in scope:

```js
- logFormatter(error, 'Failed to fetch loan stats by year');
+ logFormatter('Failed to fetch loan stats by year', 'error', { error, year });
```

This is a bug rather than a format choice. CPS can't have it because its `LogLevel`
is a typed union, so nothing here diverges from that repo.

## Why the call sites are otherwise untouched

An earlier revision of this PR rewrote all 62 call sites to
`logFormatter('what failed', 'error', { error })`. **That was reverted.**

`logFormatter(e, 'error')` is the dominant shape in cms-page-server — 115 of its 169
call sites — and that repo's utility already handles it correctly. Rewriting
kiva/ui's call sites would have made the two repos diverge on the common shape for
no functional gain, since the utility change alone stops the data loss.

If we later want richer logs (a description of *what* broke plus context, with the
error in meta), that's worth doing — but as a deliberate convention change across
both repos, not unilaterally inside a bug fix.

## Eight message strings changed text

In `KvAtbModalContainer`, `BailoutChips` and `useMyKivaHome`, the strings named a
query (`'MyKiva LendMenuQuery'`) or a location (`'useMyKivaHome composable'`) rather
than a failure; one had a trailing space. Since these were logging at `log` level to
stdout, nothing could have been alerting on the old strings — but shout if a
dashboard greps them. The seven in `useGoalData` were already prose and are
unchanged.

## Result

| | before | after |
|---|---|---|
| Lines logging `"message":{}` | 28 | **0** |
| Sites logging at `log` instead of `error` | 17 | **0** |
| `logFormatter.spec.js` | 15 tests | 21 tests |

The utility change alone fixed all 28 — it does not depend on call sites being
updated, which is what makes the revert above safe.

## Testing

- `npm run unit` — 302 files / 4453 tests pass
- `npm run lint` — clean
- All 15 pre-existing `logFormatter` tests pass **untouched**; 6 added, each verified
  to fail against the previous implementation. One is a regression guard proving a
  plain object in `meta` still passes through whole rather than being flattened —
  the case that separates this from CPS's looser `message.message ?? message`
- 2 assertions in `useGoalData.spec.js` pinned the old call shape and are updated

## Follow-up

#7119 fixes 10 unrelated error-handling defects the audit surfaced in the same catch
blocks — including `basketUtils`, where `this.loanId` in a plain module function
throws and stops `Sentry.captureException` from ever running. It now targets `main`
directly and can be reviewed independently of this PR.
