### PR TITLE
fix: repair error handling defects found while auditing logFormatter

### DIFF
--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -421,7 +421,7 @@ export default {
 				this.$kvTrackEvent('basket', 'Kiva Credit', 'Apply Credit Success');
 				this.$emit('refreshtotals');
 			}).catch(error => {
-				console.error(error);
+				logFormatter(error, 'error');
 				this.setUpdating(false);
 			});
 		},

--- a/src/composables/useBorrowerProfileData.js
+++ b/src/composables/useBorrowerProfileData.js
@@ -108,6 +108,10 @@ export default function useBorrowerProfileData(apolloClient, cookieStore) {
 				variables: { loanIds: [loanDataId] },
 			}).then(result => {
 				achievementsData.value = result;
+			}).catch(e => {
+				// The enclosing try/catch cannot catch this rejection, so without a
+				// handler here a failure is an unhandled rejection.
+				logFormatter(e, 'error');
 			});
 		} catch (e) {
 			subscription.value?.unsubscribe();

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -300,7 +300,7 @@ export default function useGoalData({ apollo } = {}) {
 				variables: { year },
 				fetchPolicy: 'no-cache',
 			});
-			const progress = response.data.userAchievementProgress.tieredLendingAchievements;
+			const progress = response.data?.userAchievementProgress?.tieredLendingAchievements ?? null;
 			return progress;
 		} catch (error) {
 			logFormatter(error, 'Failed to fetch categories progress by year');

--- a/src/pages/InstantActions/ProcessInstantLending.vue
+++ b/src/pages/InstantActions/ProcessInstantLending.vue
@@ -287,9 +287,9 @@ export default {
 							this.$kvTrackEvent(
 								'Instant Lending',
 								'Add-to-Basket',
-								`Failed: ${error.message.substring(0, 40)}...`
+								`Failed: ${(error?.message ?? 'unknown error').substring(0, 40)}...`
 							);
-							Sentry.captureMessage(`Add to Basket: ${error.message}`);
+							Sentry.captureMessage(`Add to Basket: ${error?.message ?? 'unknown error'}`);
 						} catch (e) {
 							// no-op
 						}
@@ -306,7 +306,6 @@ export default {
 					this.handleRedirect();
 				}
 			}).catch(error => {
-				console.log(error);
 				logFormatter(error, 'error');
 				this.$kvTrackEvent('Instant Lending', 'Add-to-Basket', 'Failed to add loan. Please try again.');
 

--- a/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
+++ b/src/pages/LandingPages/CorporateCampaign/CCLandingPage.vue
@@ -1068,7 +1068,7 @@ export default {
 				this.getPromoInformationFromBasket();
 			}).catch(error => {
 				logFormatter(error, 'error');
-				this.promoErrorMessage = error;
+				this.promoErrorMessage = error?.message ?? null;
 				this.loadingPromotion = false;
 				this.promoApplied = false;
 			});

--- a/src/pages/Settings/EmailSettings.vue
+++ b/src/pages/Settings/EmailSettings.vue
@@ -681,8 +681,8 @@ export default {
 					const unsubscribeResponse = await unsubscribeFromAllCommunications;
 					if (unsubscribeResponse.errors) {
 						throw new Error(
-							unsubscribeResponse.errors[0].extensions.code
-								|| unsubscribeResponse.errors[0].message
+							unsubscribeResponse.errors[0]?.extensions?.code
+								|| unsubscribeResponse.errors[0]?.message
 						);
 					}
 
@@ -697,8 +697,8 @@ export default {
 					const subscribeResponse = await updateCommunicationSettings;
 					if (subscribeResponse.errors) {
 						throw new Error(
-							subscribeResponse.errors[0].extensions.code
-								|| subscribeResponse.errors[0].message
+							subscribeResponse.errors[0]?.extensions?.code
+								|| subscribeResponse.errors[0]?.message
 						);
 					}
 				}
@@ -740,8 +740,8 @@ export default {
 					const subscribeResponse = await updateCommunicationSettings;
 					if (subscribeResponse.errors) {
 						throw new Error(
-							subscribeResponse.errors[0].extensions.code
-								|| subscribeResponse.errors[0].message
+							subscribeResponse.errors[0]?.extensions?.code
+								|| subscribeResponse.errors[0]?.message
 						);
 					}
 				}

--- a/src/plugins/borrower-profile-exp-mixin.js
+++ b/src/plugins/borrower-profile-exp-mixin.js
@@ -125,9 +125,9 @@ export default {
 							this.$kvTrackEvent(
 								'Lending',
 								'Add-to-Basket',
-								`Failed: ${error.message.substring(0, 40)}...`
+								`Failed: ${(error?.message ?? 'unknown error').substring(0, 40)}...`
 							);
-							Sentry.captureMessage(`Add to Basket: ${error.message}`);
+							Sentry.captureMessage(`Add to Basket: ${error?.message ?? 'unknown error'}`);
 							if (hasBasketExpired(error?.extensions?.code)) {
 								// eslint-disable-next-line max-len
 								this.$showTipMsg('There was a problem adding the loan to your basket, refresh the page to try again.', 'error');
@@ -139,7 +139,7 @@ export default {
 									}
 								});
 							}
-							this.$showTipMsg(error.message, 'error');
+							this.$showTipMsg(error?.message ?? 'There was a problem adding this loan', 'error');
 						} catch (e) {
 							// no-op
 						}

--- a/src/util/basketUtils.js
+++ b/src/util/basketUtils.js
@@ -14,7 +14,7 @@ function logSetLendAmountError(loanId, err) {
 	logFormatter(err, 'error');
 	try {
 		Sentry.withScope(scope => {
-			scope.setTag('loan_id', this.loanId);
+			scope.setTag('loan_id', loanId);
 			scope.setTag('mutation', 'addToBasket');
 			Sentry.captureException(err);
 		});


### PR DESCRIPTION
## What

Nine error-handling defects found while auditing `logFormatter` call sites across
the repo. None of them are logFormatter misuse — they're bugs that happened to live
in the same catch blocks, so it was cheaper to find them than to find them later.

Independent of #7118 and reviewable on its own.

## The significant one

**`basketUtils.js:17` — set-lend-amount errors have never reached Sentry.**

```js
function logSetLendAmountError(loanId, err) {
    logFormatter(err, 'error');
    try {
        Sentry.withScope(scope => {
            scope.setTag('loan_id', this.loanId);   // ← `this` is undefined here
            scope.setTag('mutation', 'addToBasket');
            Sentry.captureException(err);            // ← never runs
        });
    } catch (e) {
        // no-op                                     ← hides all of it
    }
}
```

This is an ES module, so strict mode, and the function is called as a plain function
(`:69`, `:77`) — `this` is `undefined`. It throws a `TypeError` on the first
`setTag`, so `captureException` on the next line never executes, and the no-op catch
swallows the evidence. Verified by reproduction. Fix is `loanId`.

## Unguarded property access that masks the real error

- **`useGoalData.js:303`** — `response.data.userAchievementProgress` had no optional
  chaining, so a response without `data` threw a `TypeError` and the catch logged
  *that* rather than the actual query failure.

  Worth merging alongside #7118: once Errors stop serializing to `{}`, this site
  starts reporting `"Cannot read properties of undefined (reading
  'userAchievementProgress')"` instead of the real cause.

- **`EmailSettings.vue`** ×3 — `errors[0].extensions.code` could throw *inside* the
  `throw`, masking the real error. `errors[0]` can itself be undefined, since the
  guard is `if (response.errors)` and `[]` is truthy.

- **`borrower-profile-exp-mixin.js`** ×3 and **`ProcessInstantLending.vue`** ×2 —
  unguarded `error.message` inside no-op catch blocks. Same shape as the
  `basketUtils` bug: it throws before the `Sentry.captureMessage` on the next line,
  and the empty catch hides it.

## The rest

- **`useBorrowerProfileData.js:109`** — a `.then()` with no `.catch`, where the
  enclosing `try/catch` cannot catch the rejection. Silent unhandled rejection on a
  postCheckoutAchievements failure.
- **`CCLandingPage.vue:1070`** — an `Error` object was assigned to
  `promoErrorMessage`, which is passed to child components and rendered, so it
  leaked `"Error: "` into user-facing copy. Every other assignment in that file
  stores `errors[0].message`.
- **`OrderTotals.vue:424`** — a raw `console.error` bypassing the structured log
  format entirely.
- **`ProcessInstantLending.vue`** — removed a stray `console.log(error)` left in
  production directly above the logFormatter call.

## Deliberately not changed

The remaining `catch { // no-op }` blocks stay. They're intentional guards around
third-party and analytics calls, and now that the unguarded `error.message` inside
them is fixed, they no longer mask real failures.

Log calls use the existing `logFormatter(e, 'error')` shape, matching the rest of
this repo and cms-page-server. This PR introduces no new logging convention.

## Testing

- `npm run unit` — 302 files / 4447 tests pass, exit 0
- `npm run lint` — clean
- No test assertions needed updating
