### PR TITLE
fix: pfp copy update spacing

### DIFF
--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -25,7 +25,7 @@
 			</content-container>
 		</div>
 		<div
-			:class="inPfp ? 'lg:tw-pt-16 lg:tw-mt-4' : 'lg:tw-pt-8'"
+			:class="inPfp ? 'lg:tw-pt-16 lg:tw-mt-8' : 'lg:tw-pt-8'"
 			class="lg:tw-absolute tw-pointer-events-none lg:tw-w-full lg:tw-h-full lg:tw-top-0 tw-z-docked"
 		>
 			<sidebar-container

--- a/src/components/BorrowerProfile/TopBannerPfp.vue
+++ b/src/components/BorrowerProfile/TopBannerPfp.vue
@@ -27,11 +27,11 @@
 					<div class="tw-flex-auto">
 						<!-- eslint-disable-next-line max-len -->
 						<p>{{ borrowerName }} has {{ daysLeftLanguage }} to earn the support of {{ lendersNeeded }} lenders through their network. Once they reach this goal, we'll share their loan with Kiva's global lending community.</p>
-						<p>
+						<p class="tw-mt-2">
 							<!-- eslint-disable-next-line max-len -->
 							The <strong>Private Fundraising Period</strong> is a core part of Kiva's social underwriting model, which relies on community trust rather than credit scores or collateral. Your contribution is a signal that says: <em>“I know this person. I trust their character. I believe they will use this loan responsibly and repay it.”</em>
 						</p>
-						<p>
+						<p class="tw-mt-2">
 							<strong>Your loan is not a donation</strong>
 							—you'll be repaid as the borrower makes scheduled loan payments.
 						</p>


### PR DESCRIPTION
Following up on [this ticket](https://kiva.atlassian.net/browse/KUSPMTM-29).

I've added some spacing to the pfp banner copy, and adjusted the container accordingly.

<details><summary>Before</summary>
<img width="2128" height="424" alt="image" src="https://github.com/user-attachments/assets/325bed5c-db1b-4cf3-ac17-a5fe828707d9" />
</details> 

<details><summary>After</summary>
<img width="1340" height="732" alt="CleanShot 2026-07-30 at 11 20 04@2x" src="https://github.com/user-attachments/assets/792e0542-bfd5-40db-83fa-3fc452d8411d" />

</details> 