### PR TITLE
fix: keep borrower profile comment avatar circular when team name wraps

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,0 +1,8 @@
+<!--
+	Vue Teleport target, mirroring the `#teleports` container the app renders in
+	index.html. Components that teleport (CommentReportLightbox,
+	DefinitionsLightbox, SideSheetLoanStory) warn "Failed to locate Teleport
+	target" on mount without it, then throw from TeleportImpl.remove when the
+	story unmounts as you navigate between stories.
+-->
+<div id="teleports"></div>

--- a/.storybook/stories/BorrowerProfile/CommentsAndWhySpecial.stories.js
+++ b/.storybook/stories/BorrowerProfile/CommentsAndWhySpecial.stories.js
@@ -2,13 +2,14 @@ import CommentsAndWhySpecial from '#src/components/BorrowerProfile/CommentsAndWh
 
 import apolloStoryMixin from '../../mixins/apollo-story-mixin';
 import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
-import { fundraisingPartnerLoan, createQueryResult } from './mockLoanFixtures';
+import { fundraisingPartnerLoan, longTeamNameCommentsLoan, createQueryResult } from './mockLoanFixtures';
 
 export default {
 	title: 'Components/BorrowerProfile/CommentsAndWhySpecial',
 	component: CommentsAndWhySpecial,
 };
 
+/** Logged out: no comment menu, so the report flow is unreachable. */
 export const WithComments = () => ({
 	components: { CommentsAndWhySpecial },
 	mixins: [
@@ -22,7 +23,11 @@ export const WithComments = () => ({
 	`,
 });
 
-export const AdminWithDeleteButton = () => ({
+/**
+ * Logged in, which is the only thing isLoggedIn gates: the comment menu button
+ * appears, opening "Report this comment" and the report lightbox.
+ */
+export const LoggedIn = () => ({
 	components: { CommentsAndWhySpecial },
 	mixins: [
 		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
@@ -31,23 +36,26 @@ export const AdminWithDeleteButton = () => ({
 	template: `
 		<comments-and-why-special
 			:loan-id="${fundraisingPartnerLoan.id}"
-			:is-admin="true"
 			:is-logged-in="true"
 		/>
 	`,
 });
 
-export const WithSubscribeToggle = () => ({
+/**
+ * Team name long enough to wrap. The avatar must stay circular rather than
+ * being squeezed into an oval. Step through the carousel to see each avatar
+ * branch: photo, letter, anonymous Kiva K, then a short-name control.
+ */
+export const LongTeamName = () => ({
 	components: { CommentsAndWhySpecial },
 	mixins: [
-		apolloStoryMixin({ queryResult: createQueryResult(fundraisingPartnerLoan) }),
+		apolloStoryMixin({ queryResult: createQueryResult(longTeamNameCommentsLoan) }),
 		cookieStoreStoryMixin(),
 	],
 	template: `
 		<comments-and-why-special
-			:loan-id="${fundraisingPartnerLoan.id}"
+			:loan-id="${longTeamNameCommentsLoan.id}"
 			:is-logged-in="true"
-			:is-subscribed="true"
 		/>
 	`,
 });

--- a/.storybook/stories/BorrowerProfile/LoanComments.stories.js
+++ b/.storybook/stories/BorrowerProfile/LoanComments.stories.js
@@ -3,11 +3,19 @@ import LoanComments from '#src/components/BorrowerProfile/LoanComments';
 import cookieStoreStoryMixin from '../../mixins/cookie-store-story-mixin';
 import kvAuth0StoryMixin from '../../mixins/kv-auth0-story-mixin';
 
+// Authors are a nested CommentAuthor with a lowercase CommentAuthorRole, matching
+// what the loanCommentsFullList query returns. The flat authorName /
+// authorImageUrl fields are deprecated in the schema and are not read here.
+const AVATAR_URL = 'https://www.kiva.org/img/s100/9673d0722a7675b9b8d11f90849d9b44.jpg';
+
 const mockComments = Array.from({ length: 20 }, (_, i) => ({
 	id: i + 1,
-	authorName: i === 3 ? 'Aisha' : `Lender ${i + 1}`,
-	authorImageUrl: i < 5 ? 'https://www.kiva.org/img/s100/9673d0722a7675b9b8d11f90849d9b44.jpg' : null,
-	authorRole: i === 3 ? 'Borrower' : 'Lender',
+	author: {
+		name: i === 3 ? 'Aisha' : `Lender ${i + 1}`,
+		imageUrl: i < 5 ? AVATAR_URL : null,
+		role: i === 3 ? 'borrower' : 'lender',
+		__typename: 'CommentAuthor',
+	},
 	body: i === 3
 		? 'Thank you so much for your support! My dairy business is growing and I can now sell more milk.'
 		: `This is a wonderful loan. I'm happy to support this borrower. Comment #${i + 1}.`,

--- a/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
+++ b/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
@@ -24,28 +24,61 @@ export const loggedInUser = {
 };
 
 // ---------------------------------------------------------------------------
+// Avatar image hashes
+// ---------------------------------------------------------------------------
+
+// Real hashes that resolve against the production photo path, so the photo
+// branch renders an actual image rather than a broken one. Invented hashes 404.
+const PHOTO_HASH = '9673d0722a7675b9b8d11f90849d9b44';
+const PHOTO_HASH_ALT = '093374973a7cfb1f18652d3aac5bbd05';
+
+// kv-components treats this hash as a legacy placeholder, so a comment carrying
+// it renders the letter avatar instead of a photo.
+const LEGACY_PLACEHOLDER_HASH = '4d844ac2c0b77a8a522741b908ea5c32';
+
+const avatarUrl = hash => `https://www.kiva.org/img/s100/${hash}.jpg`;
+
+// ---------------------------------------------------------------------------
 // Base factory
 // ---------------------------------------------------------------------------
 
+/**
+ * Comments in the shape the loanComments queries return: the author is a nested
+ * CommentAuthor, and `role` is the lowercase CommentAuthorRole enum. The flat
+ * `authorName` / `authorImageUrl` / `lendingAction.teams` fields are deprecated
+ * in the schema and are not what the components read.
+ */
 const mockComments = [
 	{
 		id: 101,
-		authorName: 'Sarah',
-		authorImageUrl: 'https://www.kiva.org/img/s100/4d844ac2c0b77a8a522741b908ea5c32.jpg',
-		authorRole: 'Lender',
-		authorLendingAction: {
-			teams: ['Kiva Lending Team'],
-			lender: { id: 201, teams: { values: [{ id: 1, name: 'Kiva Lending Team', teamPublicId: 'kiva' }] } },
+		author: {
+			name: 'Sarah',
+			imageUrl: avatarUrl(PHOTO_HASH_ALT),
+			role: 'lender',
+			lendingAction: {
+				supportingTeams: {
+					values: [{ id: 1, name: 'Kiva Lending Team', teamPublicId: 'kiva' }],
+					__typename: 'TeamCollection',
+				},
+				__typename: 'LendingAction',
+			},
+			__typename: 'CommentAuthor',
 		},
 		body: 'Best wishes for your business! I hope this loan helps you achieve your goals.',
+		date: '2025-03-15T18:30:00.000Z',
 	},
 	{
 		id: 102,
-		authorName: 'Aisha',
-		authorImageUrl: 'https://www.kiva.org/img/s100/9673d0722a7675b9b8d11f90849d9b44.jpg',
-		authorRole: 'Borrower',
-		authorLendingAction: null,
+		author: {
+			name: 'Aisha',
+			imageUrl: avatarUrl(PHOTO_HASH),
+			// Borrowers have no lending action on their own loan.
+			role: 'borrower',
+			lendingAction: null,
+			__typename: 'CommentAuthor',
+		},
 		body: 'Thank you so much for your support! I will use this loan wisely.',
+		date: '2025-03-14T09:15:00.000Z',
 	},
 ];
 
@@ -306,11 +339,62 @@ export function createQueryResult(loan, myUser = null) {
 }
 
 // ---------------------------------------------------------------------------
+// Comment fixtures in the loanComments query shape
+// ---------------------------------------------------------------------------
+
+/**
+ * CommentsAndWhySpecial reads `author.name`, `author.imageUrl` and
+ * `author.lendingAction.supportingTeams`, which is the shape the
+ * loanComments query returns. These fixtures exercise each of the three
+ * avatar branches against a team name long enough to wrap.
+ */
+const LONG_TEAM_NAME = 'LGBTQIA (Lesbian, Gay, Bisexual, Transgender, Queer/Questioning, Intersex, '
+	+ 'and Asexual) Kivans & Friends';
+
+const supportingTeams = (name, teamPublicId) => ({
+	supportingTeams: {
+		values: [{ id: 1, name, teamPublicId }],
+		__typename: 'TeamCollection',
+	},
+	__typename: 'LendingAction',
+});
+
+const longTeamNameComment = (id, name, hash, body, teamName = LONG_TEAM_NAME) => ({
+	id,
+	author: {
+		name,
+		imageUrl: hash ? avatarUrl(hash) : null,
+		role: 'lender',
+		lendingAction: supportingTeams(teamName, teamName === LONG_TEAM_NAME ? 'lgbtqia' : 'kiva'),
+		__typename: 'CommentAuthor',
+	},
+	body,
+	date: '2025-03-15T18:30:00.000Z',
+});
+
+export const longTeamNameComments = [
+	longTeamNameComment(301, 'Sarah', PHOTO_HASH, 'Photo avatar, wrapping team name.'),
+	longTeamNameComment(302, 'Hed', LEGACY_PLACEHOLDER_HASH, 'Letter avatar, wrapping team name.'),
+	longTeamNameComment(303, 'Anonymous', null, 'Anonymous Kiva K avatar, wrapping team name.'),
+	longTeamNameComment(304, 'Mike', PHOTO_HASH_ALT, 'Short team name — control case.', 'Kiva Lending Team'),
+];
+
+// ---------------------------------------------------------------------------
 // Named loan fixtures
 // ---------------------------------------------------------------------------
 
 /** Fundraising partner loan (default). */
 export const fundraisingPartnerLoan = createMockLoan();
+
+/** Loan whose comments carry a team name long enough to wrap. */
+export const longTeamNameCommentsLoan = createMockLoan({
+	id: 2000099,
+	comments: {
+		totalCount: longTeamNameComments.length,
+		values: longTeamNameComments,
+		__typename: 'CommentCollection',
+	},
+});
 
 /** Fundraising direct loan (US-based). */
 export const fundraisingDirectLoan = createMockLoan({

--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -66,9 +66,9 @@
 									Read More
 								</button>
 							</p>
-							<div class="tw-self-end tw-flex tw-align-center tw-mt-1.5">
+							<div class="tw-self-end tw-flex tw-items-start tw-mt-1.5">
 								<div
-									class="tw-mr-1"
+									class="tw-mr-1 tw-shrink-0"
 									:class="{'tw-w-4 tw-h-4': isMobile, 'tw-w-6 tw-h-6': !isMobile}"
 								>
 									<!-- image variations -->
@@ -87,11 +87,11 @@
 										tw-rounded-full
 										tw-text-headline
 										tw-w-full tw-h-full
-										tw-flex tw-align-center tw-justify-center"
+										tw-flex tw-items-center tw-justify-center"
 										:class="randomizedUserClass()"
 									>
 										<!-- First Letter of lender name -->
-										<span class="tw-self-center">
+										<span>
 											{{ comment.lenderNameFirstLetter }}
 										</span>
 									</div>
@@ -102,14 +102,14 @@
 										tw-rounded-full
 										tw-bg-brand
 										tw-w-full tw-h-full
-										tw-flex tw-align-center tw-justify-center"
+										tw-flex tw-items-center tw-justify-center"
 									>
 										<!-- Kiva K logo -->
 										<img :src="kivaKUrl">
 									</div>
 								</div>
 								<!-- name and team info -->
-								<div class="tw-m-auto">
+								<div>
 									<h3>
 										{{ comment.authorName }}
 									</h3>


### PR DESCRIPTION
## Problem

On the borrower profile comments carousel, an exceptionally long team name wraps and squeezes the author avatar into an oval.

The avatar wrapper is a flex item with a fixed `tw-w-*`/`tw-h-*` but no shrink override. Those utilities set a base width, not a floor, so when the team name wraps the row reclaims space from the widest shrinkable item — compressing the avatar's width while its height holds.

## Screenshot

<img width="731" height="476" alt="Screenshot 2026-07-30 at 10 44 39 AM" src="https://github.com/user-attachments/assets/cbb1137f-2640-49a3-b5de-77e384726495" />


## Fix

`tw-shrink-0` on the avatar wrapper, so overflow pressure goes to the text block, which wraps as intended.

While in the file: `tw-align-center` is not a Tailwind class and was a no-op in all three places it appeared. The row now uses `tw-items-start`, keeping the avatar level with the author name as the team name wraps. The two avatar circles use `tw-items-center` — this also stops the Kiva K logo being stretched by the default `align-items: stretch`. The `tw-self-center` and `tw-m-auto` that were compensating for the broken class are removed.

## Storybook

The bug was invisible in Storybook because the comment fixtures were written against deprecated schema fields (`Comment.authorName`, `authorImageUrl`, `LendingAction.teams`), so every comment rendered with a blank name, no team, and the anonymous avatar. Reshaped to the nested `author` the components read, with the lowercase `CommentAuthorRole` enum so `isBorrower` works, real image hashes that resolve, and the dates the fixtures were missing.

Also:
- New `LongTeamName` story covering the wrapping case across all three avatar branches (photo, letter, anonymous).
- `.storybook/preview-body.html` adds the `#teleports` container from `index.html`. Without it, lightboxes warn on mount and throw from `TeleportImpl.remove` when a story unmounts — an existing crash when navigating between any stories containing a lightbox.
- Dropped `AdminWithDeleteButton` and `WithSubscribeToggle`. Both passed props `CommentsAndWhySpecial` does not declare, so they rendered identically to each other and demonstrated nothing; that functionality lives in `LoanComments`, which already covers it. Replaced with `LoggedIn`.

## Testing

Storybook → `Components/BorrowerProfile/CommentsAndWhySpecial` → `LongTeamName`. Narrow to ~500px so the team name wraps — at desktop width it fits on one line and the bug doesn't engage. Step through the carousel for each avatar branch.

Reshaping the fixtures visibly changes existing stories: names, teams, and photos now appear where there were none, and `LoanComments` gains the borrower highlight on Aisha's comment. Those are corrections, but worth a look.
