### PR TITLE
feat: [MP-3062] add goals feedback survey to goal in review recap

### DIFF
--- a/.storybook/stories/MyKiva/GoalInReview/GoalInReviewFeedbackForm.stories.js
+++ b/.storybook/stories/MyKiva/GoalInReview/GoalInReviewFeedbackForm.stories.js
@@ -1,0 +1,17 @@
+import GoalInReviewFeedbackForm from '#src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm';
+
+export default {
+	title: 'MyKiva/GoalInReview/GoalInReviewFeedbackForm',
+	component: GoalInReviewFeedbackForm,
+};
+
+const Template = () => ({
+	components: { GoalInReviewFeedbackForm },
+	template: `
+		<div class="tw-bg-eco-green-4 tw-p-4" style="max-width: 640px; margin: 0 auto;">
+			<GoalInReviewFeedbackForm />
+		</div>
+	`,
+});
+
+export const Default = Template.bind({});

--- a/src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm.vue
@@ -1,0 +1,18 @@
+<template>
+	<div data-testid="goal-in-review-feedback-form">
+		<KvFormAssemblyForm
+			class="-tw-mt-2"
+			:form-assembly-id="FEEDBACK_FORM_ID"
+			title="Goals feedback survey"
+			@fa-form-submitted="emit('submitted')"
+		/>
+	</div>
+</template>
+
+<script setup>
+import { KvFormAssemblyForm } from '@kiva/kv-components';
+
+const FEEDBACK_FORM_ID = 659;
+
+const emit = defineEmits(['submitted']);
+</script>

--- a/src/components/MyKiva/GoalInReview/GoalInReviewModal.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewModal.vue
@@ -39,9 +39,11 @@
 				:year="data?.year"
 				:current-year="currentYear"
 				:wrap-up="data?.wrapUp"
+				:feedback-submitted="feedbackSubmitted"
 				@back-to-kiva="handleCta('back-to-kiva')"
 				@finish-goal="handleCta('finish-goal')"
 				@set-goal="handleCta('set-goal')"
+				@feedback-submitted="emit('feedback-submitted')"
 			/>
 		</div>
 	</KvLightbox>
@@ -72,9 +74,13 @@ defineProps({
 		type: Object,
 		default: null,
 	},
+	feedbackSubmitted: {
+		type: Boolean,
+		default: false,
+	},
 });
 
-const emit = defineEmits(['close', 'back-to-kiva', 'finish-goal', 'set-goal']);
+const emit = defineEmits(['close', 'back-to-kiva', 'finish-goal', 'set-goal', 'feedback-submitted']);
 const $kvTrackEvent = inject('$kvTrackEvent', () => {});
 
 // Single source of truth for "now". Add ?recapDate=YYYY-MM-DD to the url for QA specific dates

--- a/src/components/MyKiva/GoalInReview/GoalInReviewSlide7.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewSlide7.vue
@@ -48,14 +48,16 @@
 						/>
 					</button>
 
-					<!-- TODO(MP-3062): replace this placeholder with the real feedback survey -->
+					<!--
+						v-show (not v-if) keeps the survey mounted so re-toggling the CTA
+						doesn't remount and reload the Form Assembly iframe.
+					-->
 					<div
-						v-if="feedbackOpen"
-						class="tw-w-full tw-rounded tw-border tw-border-brand-400 tw-border-dashed
-							tw-text-eco-green-1 tw-text-small tw-py-3 tw-px-2"
+						v-show="feedbackOpen"
+						class="tw-w-full tw-text-eco-green-1"
 						data-testid="goal-in-review-slide-7-feedback-placeholder"
 					>
-						Feedback form coming soon (MP-3062)
+						<GoalInReviewFeedbackForm @submitted="emit('feedback-submitted')" />
 					</div>
 				</template>
 			</div>
@@ -67,6 +69,7 @@
 import { computed, inject, ref } from 'vue';
 import { KvButton, KvMaterialIcon } from '@kiva/kv-components';
 import { mdiChevronDown } from '@mdi/js';
+import GoalInReviewFeedbackForm from '#src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm';
 import leafHeart from '#src/assets/images/leaf_heart.svg?url';
 
 const props = defineProps({
@@ -86,9 +89,13 @@ const props = defineProps({
 		type: [Number, String],
 		default: null,
 	},
+	feedbackSubmitted: {
+		type: Boolean,
+		default: false,
+	},
 });
 
-const emit = defineEmits(['back-to-kiva', 'finish-goal', 'set-goal']);
+const emit = defineEmits(['back-to-kiva', 'finish-goal', 'set-goal', 'feedback-submitted']);
 
 const $kvTrackEvent = inject('$kvTrackEvent', () => {});
 
@@ -129,7 +136,7 @@ const primaryCta = computed(() => {
 	return { label: `Finish my ${props.year} goal`, event: 'finish-goal' };
 });
 
-const showFeedback = computed(() => !isPastGoalYear.value);
+const showFeedback = computed(() => !isPastGoalYear.value && !props.feedbackSubmitted);
 </script>
 
 <style lang="postcss" scoped>

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -859,6 +859,30 @@ export default function useGoalData({ apollo } = {}) {
 		);
 	}
 
+	const goalFeedbackSubmittedByYear = computed(() => {
+		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
+		return parsedPrefs.goalFeedbackSubmitted || {};
+	});
+
+	function hasSubmittedGoalFeedbackForYear(year) {
+		return Boolean(goalFeedbackSubmittedByYear.value?.[year]);
+	}
+
+	async function setGoalFeedbackSubmittedPreference(year = GOALS_CURRENT_YEAR) {
+		if (!year) return;
+		const parsedPrefs = await loadPreferences('network-only');
+		const prev = parsedPrefs?.goalFeedbackSubmitted || {};
+		// Year-keyed flag so a prior year's feedback does not gate the next recap's survey.
+		if (prev[year]) return;
+		const updatedPreference = { goalFeedbackSubmitted: { ...prev, [year]: true } };
+		await updateUserPreferences(
+			apolloClient,
+			userPreferences.value,
+			parsedPrefs,
+			updatedPreference
+		);
+	}
+
 	async function checkCompletedGoal({
 		currentGoalProgress = 0,
 		category = 'post-checkout',
@@ -1272,6 +1296,9 @@ export default function useGoalData({ apollo } = {}) {
 		viewedGoalCompleteByYear,
 		hasViewedCompletedGoalForYear,
 		setViewedGoalCompletePreference,
+		goalFeedbackSubmittedByYear,
+		hasSubmittedGoalFeedbackForYear,
+		setGoalFeedbackSubmittedPreference,
 		getSupportAllLoanCountByYear,
 		setGoalState,
 		removeGoalFromPreferences,

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -191,7 +191,9 @@
 		v-if="showGoalInReviewModal"
 		:show="showGoalInReviewModal"
 		:data="goalInReviewData"
+		:feedback-submitted="goalInReviewFeedbackSubmitted"
 		@close="closeGoalInReviewModal"
+		@feedback-submitted="handleGoalInReviewFeedbackSubmitted"
 	/>
 </template>
 
@@ -346,6 +348,8 @@ export default {
 			loadGoalInReview,
 		} = useGoalInReview();
 
+		const goalData = inject('goalData');
+
 		const {
 			getLoanFindingUrl,
 			isTieredAchievementComplete,
@@ -358,6 +362,9 @@ export default {
 			goalInReviewData,
 			isMobile,
 			loadGoalInReview,
+			hasSubmittedGoalFeedbackForYear: goalData.hasSubmittedGoalFeedbackForYear,
+			setGoalFeedbackSubmittedPreference: goalData.setGoalFeedbackSubmittedPreference,
+			loadGoalPreferences: goalData.loadPreferences,
 		};
 	},
 	data() {
@@ -387,6 +394,7 @@ export default {
 			clientRendered: false,
 			tooltipVisible: false,
 			showGoalInReviewModal: false,
+			goalInReviewFeedbackSubmitted: false,
 			mdiInformationOutline,
 		};
 	},
@@ -712,6 +720,11 @@ export default {
 			if (sectionId === GOAL_RECAP_DEEP_LINK) {
 				const goalInReview = await this.loadGoalInReview();
 				if (goalInReview?.isEligible) {
+					// Snapshot the "already submitted" flag at open time so the survey gate is
+					// evaluated per modal load, not reactively mid-session. network-only so the
+					// gate reflects a submission from another tab/device, not a stale cache.
+					await this.loadGoalPreferences('network-only');
+					this.goalInReviewFeedbackSubmitted = this.hasSubmittedGoalFeedbackForYear(goalInReview.year);
 					this.showGoalInReviewModal = true;
 				}
 				return;
@@ -723,6 +736,9 @@ export default {
 		},
 		closeGoalInReviewModal() {
 			this.showGoalInReviewModal = false;
+		},
+		async handleGoalInReviewFeedbackSubmitted() {
+			await this.setGoalFeedbackSubmittedPreference(this.goalInReviewData?.year);
 		},
 	},
 	created() {

--- a/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm.spec.js
@@ -1,0 +1,44 @@
+import { render, fireEvent } from '@testing-library/vue';
+import GoalInReviewFeedbackForm from '#src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm';
+import { globalOptions } from '../../../../specUtils';
+
+// Stub the library FA component: expose props via data-attrs and buttons that
+// re-emit each lifecycle event so we can assert the wrapper's forwarding.
+vi.mock('@kiva/kv-components', () => ({
+	KvFormAssemblyForm: {
+		name: 'KvFormAssemblyForm',
+		props: ['formAssemblyId', 'title'],
+		emits: ['fa-form-submitted'],
+		template: `
+			<div
+				data-testid="kv-fa-stub"
+				:data-form-id="formAssemblyId"
+				:data-title="title"
+			>
+				<button type="button" data-testid="emit-submitted" @click="$emit('fa-form-submitted')">submit</button>
+			</div>
+		`,
+	},
+}));
+
+const renderForm = () => render(GoalInReviewFeedbackForm, { global: globalOptions });
+
+describe('GoalInReviewFeedbackForm', () => {
+	it('renders the FA form with a numeric form id and an accessible title', () => {
+		const { getByTestId } = renderForm();
+		const stub = getByTestId('kv-fa-stub');
+		expect(Number(stub.getAttribute('data-form-id'))).toBeGreaterThan(0);
+		expect(stub.getAttribute('data-title')).toBe('Goals feedback survey');
+	});
+
+	it('exposes a stable feedback-form test id', () => {
+		const { getByTestId } = renderForm();
+		getByTestId('goal-in-review-feedback-form');
+	});
+
+	it('forwards the submitted event', async () => {
+		const { getByTestId, emitted } = renderForm();
+		await fireEvent.click(getByTestId('emit-submitted'));
+		expect(emitted().submitted).toHaveLength(1);
+	});
+});

--- a/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewSlide7.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewSlide7.spec.js
@@ -2,6 +2,18 @@ import { render, fireEvent } from '@testing-library/vue';
 import GoalInReviewSlide7 from '#src/components/MyKiva/GoalInReview/GoalInReviewSlide7';
 import { globalOptions } from '../../../../specUtils';
 
+vi.mock('#src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm', () => ({
+	default: {
+		name: 'GoalInReviewFeedbackForm',
+		emits: ['submitted'],
+		template: `
+			<div data-testid="goal-in-review-feedback-form">
+				<button type="button" data-testid="fa-submit" @click="$emit('submitted')">submit</button>
+			</div>
+		`,
+	},
+}));
+
 const GOAL_YEAR = 2026;
 const CURRENT_YEAR = 2026;
 const NEXT_YEAR = 2027;
@@ -86,14 +98,32 @@ describe('GoalInReviewSlide7', () => {
 		});
 	});
 
-	it('expands the feedback placeholder when "Share your feedback" is clicked', async () => {
-		const { getByText, queryByTestId, getByTestId } = renderSlide({
+	it('reveals the feedback survey when "Share your feedback" is clicked', async () => {
+		const { getByText, getByTestId } = renderSlide({
 			goalStatus: 'completed', year: GOAL_YEAR, currentYear: CURRENT_YEAR,
 		});
 
-		expect(queryByTestId('goal-in-review-slide-7-feedback-placeholder')).toBeNull();
+		// v-show keeps the survey mounted; the toggle flips its display.
+		const feedback = getByTestId('goal-in-review-slide-7-feedback-placeholder');
+		expect(feedback.style.display).toBe('none');
 		await fireEvent.click(getByText('Share your feedback'));
-		getByTestId('goal-in-review-slide-7-feedback-placeholder');
+		expect(feedback.style.display).toBe('');
+	});
+
+	it('hides the feedback toggle when feedback was already submitted for the year', () => {
+		const { queryByText } = renderSlide({
+			goalStatus: 'completed', year: GOAL_YEAR, currentYear: CURRENT_YEAR, feedbackSubmitted: true,
+		});
+		expect(queryByText('Share your feedback')).toBeNull();
+	});
+
+	it('re-emits feedback-submitted when the survey is submitted', async () => {
+		const { getByText, getByTestId, emitted } = renderSlide({
+			goalStatus: 'completed', year: GOAL_YEAR, currentYear: CURRENT_YEAR,
+		});
+		await fireEvent.click(getByText('Share your feedback'));
+		await fireEvent.click(getByTestId('fa-submit'));
+		expect(emitted()['feedback-submitted']).toHaveLength(1);
 	});
 
 	it('tracks opening the feedback survey', async () => {

--- a/test/unit/specs/components/MyKiva/GoalInReviewModal.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalInReviewModal.spec.js
@@ -35,6 +35,12 @@ vi.mock('@kiva/kv-components', () => ({
 		emits: ['click'],
 		template: '<button type="button" @click="$emit(\'click\')"><slot></slot></button>',
 	},
+	KvFormAssemblyForm: {
+		name: 'KvFormAssemblyForm',
+		props: ['formAssemblyId', 'title'],
+		emits: ['fa-form-submitted'],
+		template: '<button type="button" data-testid="fa-submit" @click="$emit(\'fa-form-submitted\')">submit</button>',
+	},
 }));
 
 describe('GoalInReviewModal', () => {
@@ -84,6 +90,37 @@ describe('GoalInReviewModal', () => {
 
 		expect(trackEvent).toHaveBeenCalledWith('portfolio', 'click', 'goal-in-review-finish-goal');
 		expect(emitted()['finish-goal']).toHaveLength(1);
+	});
+
+	it('passes feedbackSubmitted through to slide 7 to gate the feedback survey', async () => {
+		const currentYear = new Date().getFullYear();
+		const { queryByText, findByText } = render(GoalInReviewModal, {
+			global: globalOptions,
+			props: {
+				show: true,
+				data: { year: currentYear, goalSummary: { status: 'in-progress' } },
+				feedbackSubmitted: true,
+			},
+		});
+
+		await findByText('Thank you!'); // slide 7 rendered
+		expect(queryByText('Share your feedback')).toBeNull();
+	});
+
+	it('forwards feedback-submitted from slide 7', async () => {
+		const currentYear = new Date().getFullYear();
+		const { emitted, findByText, getByTestId } = render(GoalInReviewModal, {
+			global: globalOptions,
+			props: {
+				show: true,
+				data: { year: currentYear, goalSummary: { status: 'in-progress' } },
+			},
+		});
+
+		await fireEvent.click(await findByText('Share your feedback'));
+		await fireEvent.click(getByTestId('fa-submit'));
+
+		expect(emitted()['feedback-submitted']).toHaveLength(1);
 	});
 
 	it('renders the Vishal note (slide 6) only for completed goals', async () => {

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -4727,6 +4727,95 @@ describe('useGoalData', () => {
 		});
 	});
 
+	describe('goalFeedbackSubmitted flag', () => {
+		// `setGoalFeedbackSubmittedPreference` internally calls `loadPreferences('network-only')`
+		// before writing, so the apollo mock must return the same response on every call —
+		// not just once — or the function's own load will hit an empty mock and treat prefs
+		// as cleared.
+		const loadPrefsOnce = async prefsObject => {
+			mockApollo.query = vi.fn().mockResolvedValue({
+				data: {
+					my: {
+						userPreferences: {
+							id: 'pref-gfs',
+							preferences: JSON.stringify(prefsObject),
+						},
+						loans: { totalCount: 0 },
+					},
+				},
+			});
+			await composable.loadPreferences('network-only');
+		};
+
+		it('hasSubmittedGoalFeedbackForYear returns false when key missing', async () => {
+			await loadPrefsOnce({ goals: [] });
+			expect(composable.hasSubmittedGoalFeedbackForYear(GOALS_CURRENT_YEAR)).toBe(false);
+		});
+
+		it('hasSubmittedGoalFeedbackForYear returns true when year flag is set', async () => {
+			await loadPrefsOnce({ goalFeedbackSubmitted: { [GOALS_CURRENT_YEAR]: true } });
+			expect(composable.hasSubmittedGoalFeedbackForYear(GOALS_CURRENT_YEAR)).toBe(true);
+		});
+
+		it('hasSubmittedGoalFeedbackForYear is year-keyed (no cross-year leakage)', async () => {
+			await loadPrefsOnce({ goalFeedbackSubmitted: { [GOALS_CURRENT_YEAR - 1]: true } });
+			expect(composable.hasSubmittedGoalFeedbackForYear(GOALS_CURRENT_YEAR - 1)).toBe(true);
+			expect(composable.hasSubmittedGoalFeedbackForYear(GOALS_CURRENT_YEAR)).toBe(false);
+		});
+
+		it('setGoalFeedbackSubmittedPreference persists a year-keyed flag', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await loadPrefsOnce({ goals: [], hideGoalCard: false });
+			await composable.setGoalFeedbackSubmittedPreference(GOALS_CURRENT_YEAR);
+
+			expect(updateUserPreferences).toHaveBeenCalledTimes(1);
+			const [, , , updatedPreference] = updateUserPreferences.mock.calls[0];
+			expect(updatedPreference).toEqual({
+				goalFeedbackSubmitted: { [GOALS_CURRENT_YEAR]: true },
+			});
+		});
+
+		it('setGoalFeedbackSubmittedPreference merges with existing year entries', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await loadPrefsOnce({
+				goalFeedbackSubmitted: { [GOALS_CURRENT_YEAR - 1]: true },
+			});
+			await composable.setGoalFeedbackSubmittedPreference(GOALS_CURRENT_YEAR);
+
+			expect(updateUserPreferences).toHaveBeenCalledTimes(1);
+			const [, , , updatedPreference] = updateUserPreferences.mock.calls[0];
+			expect(updatedPreference).toEqual({
+				goalFeedbackSubmitted: {
+					[GOALS_CURRENT_YEAR - 1]: true,
+					[GOALS_CURRENT_YEAR]: true,
+				},
+			});
+		});
+
+		it('setGoalFeedbackSubmittedPreference is idempotent — no write when year already set', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await loadPrefsOnce({ goalFeedbackSubmitted: { [GOALS_CURRENT_YEAR]: true } });
+			await composable.setGoalFeedbackSubmittedPreference(GOALS_CURRENT_YEAR);
+
+			expect(updateUserPreferences).not.toHaveBeenCalled();
+		});
+
+		it('setGoalFeedbackSubmittedPreference is a no-op when called with a falsy year', async () => {
+			const { updateUserPreferences } = await import('#src/util/userPreferenceUtils');
+			updateUserPreferences.mockClear();
+
+			await composable.setGoalFeedbackSubmittedPreference(0);
+
+			expect(updateUserPreferences).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('completedGoalsHistory', () => {
 		// Lock the clock to make year math deterministic — the composable reads
 		// new Date().getFullYear() at compute time, so any drift between

--- a/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
@@ -101,8 +101,11 @@ describe('MyKivaPageContent', () => {
 
 	describe('handleGoToDeepLink', () => {
 		const makeContext = overrides => ({
-			loadGoalInReview: vi.fn().mockResolvedValue({ isEligible: true }),
+			loadGoalInReview: vi.fn().mockResolvedValue({ isEligible: true, year: 2026 }),
+			loadGoalPreferences: vi.fn().mockResolvedValue({}),
+			hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(false),
 			showGoalInReviewModal: false,
+			goalInReviewFeedbackSubmitted: false,
 			smoothScrollTo: vi.fn(),
 			...overrides,
 		});
@@ -113,6 +116,20 @@ describe('MyKivaPageContent', () => {
 			await MyKivaPageContent.methods.handleGoToDeepLink.call(context, 'goal-recap');
 
 			expect(context.loadGoalInReview).toHaveBeenCalledTimes(1);
+			expect(context.loadGoalPreferences).toHaveBeenCalledWith('network-only');
+			expect(context.hasSubmittedGoalFeedbackForYear).toHaveBeenCalledWith(2026);
+			expect(context.goalInReviewFeedbackSubmitted).toBe(false);
+			expect(context.showGoalInReviewModal).toBe(true);
+		});
+
+		it('snapshots the already-submitted flag when opening the recap', async () => {
+			const context = makeContext({
+				hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(true),
+			});
+
+			await MyKivaPageContent.methods.handleGoToDeepLink.call(context, 'goal-recap');
+
+			expect(context.goalInReviewFeedbackSubmitted).toBe(true);
 			expect(context.showGoalInReviewModal).toBe(true);
 		});
 
@@ -138,6 +155,20 @@ describe('MyKivaPageContent', () => {
 			expect(context.smoothScrollTo).toHaveBeenCalledWith({ yPosition: 200, millisecondsToAnimate: 750 });
 
 			querySelector.mockRestore();
+		});
+	});
+
+	describe('handleGoalInReviewFeedbackSubmitted', () => {
+		it('persists the feedback-submitted preference for the recap year', async () => {
+			const setGoalFeedbackSubmittedPreference = vi.fn().mockResolvedValue();
+			const context = {
+				goalInReviewData: { year: 2026 },
+				setGoalFeedbackSubmittedPreference,
+			};
+
+			await MyKivaPageContent.methods.handleGoalInReviewFeedbackSubmitted.call(context);
+
+			expect(setGoalFeedbackSubmittedPreference).toHaveBeenCalledWith(2026);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Adds the goals **feedback survey** to the Goal in Review recap. Slide 7's secondary CTA ("Share your feedback") reveals an embedded [Form Assembly](https://kiva.tfaforms.net) survey, and once a lender submits it we persist a per-year flag so the survey isn't shown again for that recap year.

- **Jira:** [MP-3062](https://kiva.atlassian.net/browse/MP-3062) — FE: Feedback survey integration (Form Assembly)
- **Epic:** [MP-2944](https://kiva.atlassian.net/browse/MP-2944) — Goal in review
- **Tracking / measurement (follow-up):** [MP-2956](https://kiva.atlassian.net/browse/MP-2956)
- **Design:** [Figma — Goals V2, Desktop Modal 7](https://www.figma.com/design/ARJWLwdnFJ84FNSvPX4wYz/Goals-V2?node-id=8200-20158)

## What changed

- **`GoalInReviewFeedbackForm.vue`** — a thin, dependency-free wrapper around `@kiva/kv-components`' `KvFormAssemblyForm` (the shared FA component, per the ticket's dev note). Holds the FA form id + title and emits `submitted`.
- **`GoalInReviewSlide7.vue`** — the "Share your feedback" CTA now reveals the survey. `showFeedback` gates on `!isPastGoalYear && !feedbackSubmitted`, so it shows for **current-year completed and in-progress** goals and hides once submitted. Uses `v-show` (not `v-if`) so re-toggling the CTA doesn't remount/reload the iframe and lose entered answers.
- **`useGoalData.js`** — new year-keyed user preference `goalFeedbackSubmitted: { [year]: true }` with `goalFeedbackSubmittedByYear` / `hasSubmittedGoalFeedbackForYear` / `setGoalFeedbackSubmittedPreference`, mirroring the existing `viewedGoalComplete` helpers.
- **`GoalInReviewModal.vue`** — forwards the `feedbackSubmitted` prop down to slide 7 and the `feedback-submitted` event up to the page.
- **`MyKivaPageContent.vue`** — reuses the shared injected `goalData` composable to snapshot the "already submitted" flag at recap open (`network-only`, evaluated per modal load rather than reactively) and persists it on submit.
- **Storybook** — `MyKiva/GoalInReview/GoalInReviewFeedbackForm` story.

## How it works

```
Read  (gate):  MyKivaPageContent → :feedback-submitted → GoalInReviewModal → :feedback-submitted → Slide7
Write (submit): GoalInReviewFeedbackForm → @submitted → Slide7 → @feedback-submitted → Modal → Page → setGoalFeedbackSubmittedPreference(year)
```

## Design decisions

- **Persist trigger = raw FA `submitted`** (no valid-guard): `fa_form_closed` isn't reliably emitted by this form, so we flag on the `fa_form_submitted` postMessage.
- **Snapshot at open, not reactive:** the gate is read once when the modal opens (`network-only`, so it reflects cross-tab/device state) and copied into a page data field — submitting mid-session doesn't yank the form out from under the user.
- **Persistence owned by the page** (via the shared `goalData`); the wrapper and slides stay presentational (no `goalData` coupling), keeping the wrapper reusable and slides pure prop-driven components.

## Observability (AC)

Submission **is** observable from our side: `KvFormAssemblyForm` surfaces the FA `fa_form_submitted` postMessage as its `fa-form-submitted` event, which this PR persists per year. This feeds the tracking/measurement work in [MP-2956](https://kiva.atlassian.net/browse/MP-2956). (The ticket-side observability note is being handled separately.)

## Related tests

| File | Covers |
| --- | --- |
| `test/unit/specs/composables/useGoalData.spec.js` | `goalFeedbackSubmitted` flag — missing key, set/true, year-keyed no-leak, persist, merge, idempotent, falsy-year no-op (7 cases) |
| `.../GoalInReview/GoalInReviewFeedbackForm.spec.js` | wrapper renders FA with numeric id + title, stable testid, forwards `submitted` |
| `.../GoalInReview/GoalInReviewSlide7.spec.js` | reveal via `v-show`, hide when already submitted, re-emit `feedback-submitted`, existing past-year hide |
| `.../MyKiva/GoalInReviewModal.spec.js` | `feedbackSubmitted` prop gates slide 7, `feedback-submitted` forwarded up |
| `.../pages/MyKiva/MyKivaPageContent.spec.js` | snapshots flag at recap open, gates when already submitted, persists on submit |

**Verification:** full unit suite **4463 passed / 6 skipped / 0 failed**; `lint:js` 0 errors, `lint:css` clean.

## Known open items / follow-ups

- **FA form id is a placeholder test value (`659`)** — production id is a pending product dependency; swap before release.
- The recap currently runs on mock data via `useGoalInReview`; the real backend contract is a separate ticket.

## Storybook

`MyKiva/GoalInReview/GoalInReviewFeedbackForm` — note it mounts the real FA iframe with the placeholder id, so it loads the live form.


[MP-3062]: https://kiva.atlassian.net/browse/MP-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2944]: https://kiva.atlassian.net/browse/MP-2944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2956]: https://kiva.atlassian.net/browse/MP-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MP-2956]: https://kiva.atlassian.net/browse/MP-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Screenshots

Desktop:
<img width="542" height="408" alt="Screenshot 2026-07-31 at 11 58 28 a m" src="https://github.com/user-attachments/assets/5717d316-8840-4c71-b7ba-6974fa488a07" />

Mobile:
<img width="421" height="429" alt="Screenshot 2026-07-31 at 11 58 41 a m" src="https://github.com/user-attachments/assets/d37ded7e-a168-4ba1-8b48-301cb9e35825" />

