### PR TITLE
fix: hide region card if no regions remain on next steps page

### DIFF
--- a/src/pages/MyKiva/MyKivaNextStepsContent.vue
+++ b/src/pages/MyKiva/MyKivaNextStepsContent.vue
@@ -173,6 +173,7 @@
 							-->
 							<AlmostFundedNextStep />
 							<MyKivaRegionExperience
+								v-if="!userLentToAllRegions"
 								class="md:tw-col-span-2"
 								:regions-data="regionsData"
 								:loans="loans"

--- a/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaNextStepsContent.spec.js
@@ -183,14 +183,14 @@ describe('MyKivaNextStepsContent', () => {
 		expect(wrapper.findComponent({ name: 'MyKivaRegionExperience' }).exists()).toBe(true);
 	});
 
-	it('shows "Keep your impact going" for superlenders who have lent to every region', () => {
-		// Superlenders are not in post-lending mode, but the region card moves out of row 1,
-		// so the Almost Funded + region pairing still renders below.
+	it('hides the region card entirely for superlenders who have lent to every region', () => {
+		// Superlenders have no pending regions to recommend, so the region card must not
+		// render in either row. Almost Funded still shows as a valid next step below.
 		const { wrapper } = createWrapper({ props: { userLentToAllRegions: true } });
 
 		expect(wrapper.text()).toContain('Keep your impact going');
 		expect(wrapper.findComponent({ name: 'AlmostFundedNextStep' }).exists()).toBe(true);
-		expect(wrapper.findComponent({ name: 'MyKivaRegionExperience' }).exists()).toBe(true);
+		expect(wrapper.findComponent({ name: 'MyKivaRegionExperience' }).exists()).toBe(false);
 	});
 
 	it('initializes post-lending mode before first render when post-lending cookie exists', async () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3094

Minor bug I encountered today while testing other features: hide the region card on MyKiva next steps if the user has lent to all of the regions, since we don't have an "all regions done" state of the card.