### PR TITLE
fix: hide journal section for anonymized loans

### DIFF
--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -86,7 +86,7 @@
 		</content-container>
 		<content-container>
 			<journal-updates
-				v-if="showUpdates"
+				v-if="showUpdatesSection"
 				data-testid="bp-updates"
 				class="tw-mb-5 md:tw-mb-6 lg:tw-mb-8"
 				:loan-id="loanId"
@@ -367,6 +367,13 @@ export default {
 			// Only privileged users (e.g. lenders on this loan) can see the comment
 			// section, and only while the loan is not anonymized (full/pii).
 			return this.isPrivileged && !this.isAnonymized;
+		},
+		showUpdatesSection() {
+			// Hide the journal updates section entirely for anonymized (full/pii) loans:
+			// their single-loan journal bodies are stripped during PII anonymization, so any
+			// remaining entries render empty. Mass journals, the only kind that keeps content,
+			// are not shown here anyway.
+			return this.showUpdates && !this.isAnonymized;
 		},
 		shareCampaign() {
 			return this.inPfp ? 'social_share_bp_pfp' : 'social_share_bp';

--- a/src/components/BorrowerProfile/FullBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/FullBorrowerProfile.vue
@@ -369,11 +369,12 @@ export default {
 			return this.isPrivileged && !this.isAnonymized;
 		},
 		showUpdatesSection() {
-			// Hide the journal updates section entirely for anonymized (full/pii) loans:
-			// their single-loan journal bodies are stripped during PII anonymization, so any
-			// remaining entries render empty. Mass journals, the only kind that keeps content,
-			// are not shown here anyway.
-			return this.showUpdates && !this.isAnonymized;
+			// Hide the journal updates section entirely for PII-anonymized loans: their
+			// single-loan journal bodies are stripped during PII anonymization, so any
+			// remaining entries render empty. Scoped to 'pii' specifically — 'full' (refunded)
+			// loans keep their journal content and are already excluded server-side by the
+			// borrower-privacy rules.
+			return this.showUpdates && this.loanData?.anonymizationLevel !== 'pii';
 		},
 		shareCampaign() {
 			return this.inPfp ? 'social_share_bp_pfp' : 'social_share_bp';

--- a/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
@@ -1,6 +1,11 @@
 import FullBorrowerProfile from '#src/components/BorrowerProfile/FullBorrowerProfile';
 
-const { isAnonymized, isPrivileged, showAddCommentsSection } = FullBorrowerProfile.computed;
+const {
+	isAnonymized,
+	isPrivileged,
+	showAddCommentsSection,
+	showUpdatesSection,
+} = FullBorrowerProfile.computed;
 
 // Evaluates a computed with a mock `this` context, resolving other computeds it depends on.
 function evalShowComments({ privileged = false, anonymizationLevel = 'none' } = {}) {
@@ -13,6 +18,16 @@ function evalShowComments({ privileged = false, anonymizationLevel = 'none' } = 
 	context.isAnonymized = isAnonymized.call(context);
 	context.isPrivileged = isPrivileged.call(context);
 	return showAddCommentsSection.call(context);
+}
+
+// Evaluates showUpdatesSection with a mock `this`, resolving the isAnonymized computed it depends on.
+function evalShowUpdates({ showUpdates = true, anonymizationLevel = 'none' } = {}) {
+	const context = {
+		showUpdates,
+		loanData: { anonymizationLevel },
+	};
+	context.isAnonymized = isAnonymized.call(context);
+	return showUpdatesSection.call(context);
 }
 
 describe('FullBorrowerProfile comment section visibility', () => {
@@ -58,5 +73,21 @@ describe('FullBorrowerProfile comment section visibility', () => {
 				expect(evalShowComments({ privileged: false, anonymizationLevel: 'pii' })).toBe(false);
 			});
 		});
+	});
+});
+
+describe('FullBorrowerProfile updates section visibility', () => {
+	it('shows updates on a non-anonymized loan', () => {
+		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: 'none' })).toBe(true);
+		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: undefined })).toBe(true);
+	});
+
+	it('hides updates on a full/pii anonymized loan (MP-3083)', () => {
+		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: 'full' })).toBe(false);
+		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: 'pii' })).toBe(false);
+	});
+
+	it('stays hidden once the child has emitted hide-section, even when not anonymized', () => {
+		expect(evalShowUpdates({ showUpdates: false, anonymizationLevel: 'none' })).toBe(false);
 	});
 });

--- a/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/FullBorrowerProfile.spec.js
@@ -20,13 +20,12 @@ function evalShowComments({ privileged = false, anonymizationLevel = 'none' } = 
 	return showAddCommentsSection.call(context);
 }
 
-// Evaluates showUpdatesSection with a mock `this`, resolving the isAnonymized computed it depends on.
+// Evaluates showUpdatesSection with a mock `this`.
 function evalShowUpdates({ showUpdates = true, anonymizationLevel = 'none' } = {}) {
 	const context = {
 		showUpdates,
 		loanData: { anonymizationLevel },
 	};
-	context.isAnonymized = isAnonymized.call(context);
 	return showUpdatesSection.call(context);
 }
 
@@ -82,12 +81,15 @@ describe('FullBorrowerProfile updates section visibility', () => {
 		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: undefined })).toBe(true);
 	});
 
-	it('hides updates on a full/pii anonymized loan (MP-3083)', () => {
-		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: 'full' })).toBe(false);
+	it('hides updates on a pii-anonymized loan (MP-3083)', () => {
 		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: 'pii' })).toBe(false);
 	});
 
-	it('stays hidden once the child has emitted hide-section, even when not anonymized', () => {
+	it('still shows updates on a full-anonymized loan (bodies are not stripped for full)', () => {
+		expect(evalShowUpdates({ showUpdates: true, anonymizationLevel: 'full' })).toBe(true);
+	});
+
+	it('stays hidden once the child has emitted hide-section', () => {
 		expect(evalShowUpdates({ showUpdates: false, anonymizationLevel: 'none' })).toBe(false);
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3083

Haven't been able to track down a loan yet to repro the "empty journal body" issue for an anonymized loan, but this should be the simple fix regardless.