### PR TITLE
fix: hide why special when null

### DIFF
--- a/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
+++ b/src/components/BorrowerProfile/CommentsAndWhySpecial.vue
@@ -7,11 +7,11 @@
 			/>
 		</div>
 
-		<h2 class="tw-sr-only">
+		<h2 v-if="!loading && showSection" class="tw-sr-only">
 			Loan Comments
 		</h2>
 		<div
-			v-if="!loading" class="tw-py-2 md:tw-py-3 lg:tw-py-5"
+			v-if="!loading && showSection" class="tw-py-2 md:tw-py-3 lg:tw-py-5"
 			:key="`comments-${loanId}`"
 		>
 			<kv-carousel :multiple-slides-visible="false" :embla-options="{ loop: false, draggable: false }">
@@ -135,10 +135,10 @@
 						</div>
 					</div>
 				</template>
-				<template v-if="!loading" #why-special>
+				<template v-if="showWhySpecial" #why-special>
 					<why-special
 						data-testid="bp-why-special"
-						:loan-id="loanId"
+						:why-special="whySpecial"
 					/>
 				</template>
 			</kv-carousel>
@@ -166,6 +166,7 @@ import { mdiDotsHorizontalCircle } from '@mdi/js';
 import { gql } from 'graphql-tag';
 
 import useIsMobile from '#src/composables/useIsMobile';
+import { formatWhySpecial } from '#src/util/loanUtils';
 import WhySpecial from '#src/components/BorrowerProfile/WhySpecial';
 import CommentReportLightbox from '#src/components/BorrowerProfile/CommentReportLightbox';
 import clickOutside from '#src/plugins/click-outside';
@@ -208,6 +209,7 @@ export default {
 			mdiDotsHorizontalCircle,
 			loading: true,
 			comments: [],
+			whySpecial: '',
 			commentMenuShown: false,
 			isReportLightboxVisible: false,
 			isCommentLightboxVisible: false,
@@ -244,6 +246,16 @@ export default {
 				};
 			});
 		},
+		showWhySpecial() {
+			// formatWhySpecial returns '' for empty/null input, so this is false when there is
+			// no why-special content — preventing an empty carousel slide.
+			return !!formatWhySpecial(this.whySpecial);
+		},
+		showSection() {
+			// Hide the whole comments/why-special section when there is nothing to show,
+			// rather than rendering an empty carousel.
+			return this.enhancedComments.length > 0 || this.showWhySpecial;
+		},
 	},
 	apollo: {
 		lazy: true,
@@ -251,6 +263,7 @@ export default {
 			lend {
 				loan(id: $loanId) {
 					id
+					whySpecial
 					comments {
 						values {
 							id
@@ -278,6 +291,7 @@ export default {
 		},
 		result({ data }) {
 			this.comments = data?.lend?.loan?.comments?.values ?? [];
+			this.whySpecial = data?.lend?.loan?.whySpecial ?? '';
 			this.loading = false;
 		},
 		fetchPolicy: 'network-only',

--- a/src/components/BorrowerProfile/WhySpecial.vue
+++ b/src/components/BorrowerProfile/WhySpecial.vue
@@ -1,67 +1,29 @@
 <template>
 	<article>
-		<div v-if="loading" class="tw-w-full">
-			<kv-loading-placeholder class="tw-w-full tw-mb-2 lg:tw-mb-3" :style="{height: '1.6rem'}" />
-			<kv-loading-placeholder
-				class="tw-mb-2" :style="{width: 60 + (Math.random() * 15) + '%', height: '1.6rem'}"
-			/>
-		</div>
-
 		<h2 class="tw-sr-only">
 			Why this loan is special
 		</h2>
-		<p v-if="!loading" class="tw-text-headline tw-my-1">
+		<p class="tw-text-headline tw-my-1">
 			{{ fullWhySpecial }}
 		</p>
 	</article>
 </template>
 
 <script>
-import { gql } from 'graphql-tag';
 import { formatWhySpecial } from '#src/util/loanUtils';
-
-import { KvLoadingPlaceholder } from '@kiva/kv-components';
 
 export default {
 	name: 'WhySpecial',
-	inject: ['apollo', 'cookieStore'],
-	components: {
-		KvLoadingPlaceholder,
-	},
 	props: {
-		loanId: {
-			type: Number,
-			default: 0,
+		whySpecial: {
+			type: String,
+			default: '',
 		},
-	},
-	data() {
-		return {
-			loading: true,
-			whySpecial: '',
-		};
 	},
 	computed: {
 		fullWhySpecial() {
 			return formatWhySpecial(this.whySpecial);
 		}
-	},
-	apollo: {
-		lazy: true,
-		query: gql`query whySpecial($loanId: Int!) {
-			lend {
-				loan(id: $loanId) {
-					id
-					whySpecial
-				}
-			}
-		}`,
-		variables() {
-			return { loanId: this.loanId };
-		},
-		result({ data }) {
-			this.whySpecial = data?.lend?.loan?.whySpecial ?? '';
-			this.loading = false;
-		},
 	},
 };
 </script>

--- a/test/unit/specs/components/BorrowerProfile/CommentsAndWhySpecial.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/CommentsAndWhySpecial.spec.js
@@ -1,0 +1,42 @@
+import CommentsAndWhySpecial from '#src/components/BorrowerProfile/CommentsAndWhySpecial';
+
+const { showWhySpecial, showSection } = CommentsAndWhySpecial.computed;
+
+function evalShowWhySpecial(whySpecial) {
+	return showWhySpecial.call({ whySpecial });
+}
+
+// showSection depends on enhancedComments + showWhySpecial; resolve showWhySpecial from whySpecial.
+function evalShowSection({ comments = [], whySpecial = '' } = {}) {
+	const context = { enhancedComments: comments, whySpecial };
+	context.showWhySpecial = showWhySpecial.call(context);
+	return showSection.call(context);
+}
+
+describe('CommentsAndWhySpecial why-special slide visibility (MP-3083)', () => {
+	describe('showWhySpecial', () => {
+		it('is false when there is no why-special text', () => {
+			expect(evalShowWhySpecial('')).toBe(false);
+			expect(evalShowWhySpecial(null)).toBe(false);
+			expect(evalShowWhySpecial(undefined)).toBe(false);
+		});
+
+		it('is true when why-special text is present', () => {
+			expect(evalShowWhySpecial('she is a hard worker')).toBe(true);
+		});
+	});
+
+	describe('showSection', () => {
+		it('shows when there is at least one comment, even with no why-special', () => {
+			expect(evalShowSection({ comments: [{ id: 1 }], whySpecial: '' })).toBe(true);
+		});
+
+		it('shows when there is why-special text, even with no comments', () => {
+			expect(evalShowSection({ comments: [], whySpecial: 'she is a hard worker' })).toBe(true);
+		});
+
+		it('hides when there are no comments and no why-special text', () => {
+			expect(evalShowSection({ comments: [], whySpecial: '' })).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3065

Digging into the empty journal entry issue identified that we're actually also seeing an empty "why special" situation, as shown below. This hides the why special when it's empty.

<img width="1018" height="508" alt="image" src="https://github.com/user-attachments/assets/6aa896ca-502a-4f1a-a5db-2541e927b025" />
