### PR TITLE
fix: prevent infinite UserPreferences refetch loop on MyKiva page

### DIFF
--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -391,23 +391,36 @@ export default {
 				this.getGoalSummary();
 			}
 
-			this.apollo.watchQuery({
-				query: gql`
-					query UserPreferences {
-						my {
+			const userPreferencesQuery = gql`
+				query UserPreferences {
+					my {
+						id
+						userPreferences {
+							preferences
 							id
-							userPreferences {
-								preferences
-								id
-							}
 						}
 					}
-				`,
+				}
+			`;
+
+			// Watch the cache only; a watcher with a network fetch policy refetches on
+			// every cache broadcast, which loops indefinitely (hammering the gateway)
+			// if the resolver keeps returning partial data (200 + errors).
+			this.userPreferencesSubscription = this.apollo.watchQuery({
+				query: userPreferencesQuery,
+				fetchPolicy: 'cache-only',
 			}).subscribe({
 				next: ({ data }) => {
 					this.userInfo = { ...this.userInfo, userPreferences: data?.my?.userPreferences };
 				},
+				error: error => {
+					logReadQueryError(error, 'MyKivaPage userPreferences cache watcher');
+				},
 			});
+
+			// Single network fetch to populate the cache; the watcher above receives
+			// this result and any later userPreferences mutation writes.
+			await this.apollo.query({ query: userPreferencesQuery });
 
 			// Param to force goals renewal in a specific year
 			const { renewYear } = this.$route.query;
@@ -446,6 +459,9 @@ export default {
 			transactions: this.transactions,
 			checkMyKivaCompletedGoalAfterLoad: true,
 		});
+	},
+	beforeUnmount() {
+		this.userPreferencesSubscription?.unsubscribe();
 	},
 };
 </script>

--- a/test/unit/specs/pages/MyKiva/MyKivaPage.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaPage.spec.js
@@ -344,7 +344,8 @@ describe('MyKivaPage', () => {
 				apollo: {
 					watchQuery: vi.fn(() => ({
 						subscribe: vi.fn(),
-					}))
+					})),
+					query: vi.fn().mockResolvedValue({ data: {} }),
 				},
 				$route: { query: {} },
 				loadGoalData: vi.fn().mockResolvedValue(),
@@ -364,6 +365,39 @@ describe('MyKivaPage', () => {
 			expect(context.loadGoalData).toHaveBeenCalledWith(
 				expect.objectContaining({ checkMyKivaCompletedGoalAfterLoad: true })
 			);
+		});
+
+		it('watches userPreferences from the cache only and fetches over the network once', async () => {
+			const unsubscribe = vi.fn();
+			const subscribe = vi.fn(() => ({ unsubscribe }));
+			const watchQuery = vi.fn(() => ({ subscribe }));
+			const query = vi.fn().mockResolvedValue({ data: {} });
+			const context = {
+				apollo: { watchQuery, query },
+				$route: { query: {} },
+				loadGoalData: vi.fn().mockResolvedValue(),
+				renewAnnualGoal: vi.fn().mockResolvedValue({
+					showRenewedAnnualGoalToast: false,
+					expiredGoals: [],
+				}),
+				fixIncorrectlyCompletedGoals: vi.fn().mockResolvedValue({ wasFixed: false }),
+				setHideGoalCardPreference: vi.fn().mockResolvedValue(),
+				goalRefreshKey: 0,
+				userInfo: {},
+			};
+
+			await MyKivaPage.mounted.call(context);
+
+			// The watcher must never be able to trigger network requests itself,
+			// otherwise partial responses cause an infinite refetch loop
+			expect(watchQuery).toHaveBeenCalledTimes(1);
+			expect(watchQuery).toHaveBeenCalledWith(
+				expect.objectContaining({ fetchPolicy: 'cache-only' })
+			);
+			expect(query).toHaveBeenCalledTimes(1);
+
+			MyKivaPage.beforeUnmount.call(context);
+			expect(unsubscribe).toHaveBeenCalledTimes(1);
 		});
 	});
 


### PR DESCRIPTION
The UserPreferences watchQuery in mounted() had no error handling and
refetched on every cache broadcast. With errorPolicy 'all' (the client
default), a resolver returning partial data (200 + errors) writes an
incomplete result to the cache, so the watched query can never be
satisfied and Apollo reobserves/refetches in a tight loop (~14 POST/s
per tab against Stellate, observed during the 2026-08-06 maintenance
window).
Watch the cache only (cache-only watchers can never trigger network
requests), populate it with a single one-shot query, log watcher
errors, and unsubscribe on unmount.