### PR TITLE
fix(apollo): guard against caching an empty GraphQL possibleTypes payload

### DIFF
--- a/server/util/getGqlPossibleTypes.js
+++ b/server/util/getGqlPossibleTypes.js
@@ -51,6 +51,16 @@ async function fetchSchema(url) {
 	if (data?.errors?.length) {
 		error('GraphQL errors while introspecting possible types', { errors: data.errors });
 	}
+	// The gateway answers an outage with a plain `{ code, message }` body rather than a GraphQL
+	// envelope, e.g. `{ "code": "503", "message": "Service Unavailable" }`. That parses as JSON
+	// too, so name the failure instead of reporting it as an empty schema further down.
+	if (!data?.data && (data?.code || data?.message)) {
+		error('Non-GraphQL error response while introspecting possible types', {
+			status: result.status,
+			code: data.code,
+			message: data.message,
+		});
+	}
 	// eslint-disable-next-line no-underscore-dangle
 	return data?.data?.__schema ?? {};
 }

--- a/server/util/getGqlPossibleTypes.js
+++ b/server/util/getGqlPossibleTypes.js
@@ -1,4 +1,5 @@
 import fetch from './fetch.js';
+import { error } from './log.js';
 import { getFromCache, setToCache } from './memJsUtils.js';
 
 const GQL_BUILT_IN_TYPES = [
@@ -11,6 +12,30 @@ const GQL_BUILT_IN_TYPES = [
 	'__Directive'
 ];
 
+const CACHE_KEY = 'ui-gql-possible-types';
+
+/**
+ * A usable possible types payload always has at least one Mergable type: the API schema has
+ * hundreds of types without an `id` field. An empty `Mergable` array therefore means the
+ * introspection call failed or returned nothing, not that the schema changed shape.
+ *
+ * Serving an empty payload to the Apollo cache is not a degraded-but-working state. Without the
+ * Mergable list, types with no `id` are replaced rather than merged on write, so a query for one
+ * loan evicts every other loan from `ROOT_QUERY.lend`; and without the interface map, fragments
+ * like `loanCardFields on LoanBasic` never match the cached `LoanPartner`. Either way a cache read
+ * can never complete, every cache broadcast sends the watch query back to the network, and the
+ * page melts down into thousands of refetches.
+ *
+ * @param {object} possibleTypes - Possible types payload to check
+ * @returns {boolean} True when the payload is safe to use and to cache
+ */
+export function isValidPossibleTypes(possibleTypes) {
+	return !!possibleTypes
+		&& typeof possibleTypes === 'object'
+		&& Array.isArray(possibleTypes.Mergable)
+		&& possibleTypes.Mergable.length > 0;
+}
+
 async function fetchSchema(url) {
 	const result = await fetch(url, {
 		method: 'POST',
@@ -21,17 +46,18 @@ async function fetchSchema(url) {
 		}),
 	});
 	const data = await result.json();
+	// A GraphQL error response still parses as JSON, so it would otherwise be swallowed by the
+	// `?? {}` below and cached as an empty result.
+	if (data?.errors?.length) {
+		error('GraphQL errors while introspecting possible types', { errors: data.errors });
+	}
 	// eslint-disable-next-line no-underscore-dangle
 	return data?.data?.__schema ?? {};
 }
 
-async function fetchGqlPossibleTypes(url, cache) {
-	// Get types from schema
-	const {
-		types, queryType, mutationType, subscriptionType
-	} = await fetchSchema(url);
-
-	// Construct possible types object
+function buildPossibleTypes({
+	types, queryType, mutationType, subscriptionType
+}) {
 	const possibleTypes = { Mergable: [] };
 	types?.forEach(type => {
 		// Skip adding possible types for built-in GraphQL types and root types
@@ -52,29 +78,72 @@ async function fetchGqlPossibleTypes(url, cache) {
 			possibleTypes.Mergable.push(type.name);
 		}
 	});
+	return possibleTypes;
+}
 
-	const typesJSON = JSON.stringify(possibleTypes);
-	if (typesJSON) {
-		// Cache the possible types in the local process
-		process.env.FETCHED_GQL_TYPES = typesJSON;
-		// Cache the possible types for 24 hours for other processes
-		await setToCache('ui-gql-possible-types', typesJSON, 24 * 60 * 60, cache);
+async function fetchGqlPossibleTypes(url, cache) {
+	// Get types from schema
+	const schema = await fetchSchema(url);
+
+	// Construct possible types object
+	const possibleTypes = buildPossibleTypes(schema);
+
+	// Never persist an invalid payload. Caching it would pin every pod reading the shared cache
+	// entry to a broken Apollo cache for the full 24 hour TTL, and pin this process for its
+	// lifetime. Returning it uncached means the next request retries the introspection call.
+	if (!isValidPossibleTypes(possibleTypes)) {
+		error('Refusing to cache invalid GraphQL possible types', {
+			typeCount: schema?.types?.length ?? 0,
+		});
+		return possibleTypes;
 	}
 
+	const typesJSON = JSON.stringify(possibleTypes);
+	// Cache the possible types in the local process
+	process.env.FETCHED_GQL_TYPES = typesJSON;
+	// Cache the possible types for 24 hours for other processes
+	await setToCache(CACHE_KEY, typesJSON, 24 * 60 * 60, cache);
+
 	return possibleTypes;
+}
+
+/**
+ * Parse a cached possible types payload, discarding anything unusable so a poisoned cache entry
+ * written before these guards existed heals on the next request instead of persisting.
+ */
+function parseCachedPossibleTypes(data, source) {
+	let parsed;
+	try {
+		parsed = JSON.parse(data);
+	} catch (e) {
+		error('Discarding unparseable cached GraphQL possible types', { source, message: e.message });
+		return null;
+	}
+	if (!isValidPossibleTypes(parsed)) {
+		error('Discarding invalid cached GraphQL possible types', { source });
+		return null;
+	}
+	return parsed;
 }
 
 async function getGqlPossibleTypesFromCache(cache) {
 	// If the possible types have already been fetched in this process, return them
 	if (process.env.FETCHED_GQL_TYPES) {
-		return JSON.parse(process.env.FETCHED_GQL_TYPES);
+		const fromProcess = parseCachedPossibleTypes(process.env.FETCHED_GQL_TYPES, 'process');
+		if (fromProcess) {
+			return fromProcess;
+		}
+		// Clear it so this process stops reusing a value it has already rejected
+		delete process.env.FETCHED_GQL_TYPES;
 	}
 
 	// Otherwise, check the cache
-	const data = await getFromCache('ui-gql-possible-types', cache);
+	const data = await getFromCache(CACHE_KEY, cache);
 	if (data) {
-		return JSON.parse(data);
+		return parseCachedPossibleTypes(data, 'memjs');
 	}
+
+	return null;
 }
 
 export default (async function getGqlPossibleTypes(url, cache) {

--- a/test/unit/specs/api/possibleTypesCacheIntegrity.spec.js
+++ b/test/unit/specs/api/possibleTypesCacheIntegrity.spec.js
@@ -1,0 +1,124 @@
+import {
+	ApolloClient, ApolloLink, InMemoryCache, Observable,
+} from '@apollo/client/core/index';
+import { gql } from 'graphql-tag';
+
+/**
+ * Regression test for the My Kiva refetch meltdown.
+ *
+ * The Apollo cache depends on the `possibleTypes` payload the server builds in
+ * server/util/getGqlPossibleTypes.js. When introspection failed, that payload was cached as
+ * `{ Mergable: [] }` and shipped to the browser, which cost the cache two things at once:
+ *
+ *   1. No Mergable list, so the `Mergable: { merge: true }` policy matched nothing and types
+ *      without an `id` were replaced instead of merged. `Lend` has no `id`, so writing one loan
+ *      evicted every other loan's entry from `ROOT_QUERY.lend`.
+ *   2. No interface map, so `loanCardFields on LoanBasic` could not be matched against a cached
+ *      `LoanPartner`.
+ *
+ * Either one leaves the cache read permanently incomplete, so every cache broadcast sends the
+ * watch query back to the network, and each response evicts the next card's data. The result is a
+ * round robin through every loan on the page that never terminates.
+ */
+
+const cardQuery = gql`
+	fragment loanCardFields on LoanBasic {
+		id
+		loanAmount
+		geocode { city state country { id isoCode } }
+	}
+	query kcBasicLoanCard($loanId: Int!) {
+		lend {
+			loan(id: $loanId) {
+				id
+				...loanCardFields
+			}
+		}
+	}
+`;
+
+const LOAN_IDS = [101, 102, 103, 104, 105, 106];
+
+const HEALTHY_POSSIBLE_TYPES = {
+	Mergable: ['Lend', 'Geocode'],
+	LoanBasic: ['LoanPartner', 'LoanDirect'],
+};
+
+// What the browser received while the poisoned entry was cached
+const BROKEN_POSSIBLE_TYPES = { Mergable: [] };
+
+const watchAllLoanCards = async possibleTypes => {
+	const requestedLoanIds = [];
+
+	const link = new ApolloLink(operation => {
+		requestedLoanIds.push(operation.variables.loanId);
+		return new Observable(observer => {
+			setTimeout(() => {
+				observer.next({
+					data: {
+						lend: {
+							__typename: 'Lend',
+							loan: {
+								__typename: 'LoanPartner',
+								id: operation.variables.loanId,
+								loanAmount: '500.00',
+								geocode: {
+									__typename: 'Geocode',
+									city: 'Nairobi',
+									state: 'Nairobi County',
+									country: { __typename: 'Country', id: 'KE', isoCode: 'KE' },
+								},
+							},
+						},
+					},
+				});
+				observer.complete();
+			}, 0);
+		});
+	});
+
+	const client = new ApolloClient({
+		link,
+		cache: new InMemoryCache({
+			possibleTypes,
+			typePolicies: { Mergable: { merge: true } },
+		}),
+		assumeImmutableResults: true,
+		defaultOptions: {
+			watchQuery: { errorPolicy: 'all' },
+			query: { errorPolicy: 'all' },
+		},
+	});
+
+	const subscriptions = LOAN_IDS.map(loanId => client
+		.watchQuery({ query: cardQuery, variables: { loanId } })
+		.subscribe({ next: () => {}, error: () => {} }));
+
+	await new Promise(resolve => { setTimeout(resolve, 250); });
+	subscriptions.forEach(subscription => subscription.unsubscribe());
+
+	return requestedLoanIds;
+};
+
+describe('Apollo cache integrity with the server-built possibleTypes', () => {
+	it('fetches each loan exactly once when possibleTypes is populated', async () => {
+		const requestedLoanIds = await watchAllLoanCards(HEALTHY_POSSIBLE_TYPES);
+
+		expect(requestedLoanIds.sort()).toEqual(LOAN_IDS);
+	});
+
+	it('does not refetch loans in a loop when possibleTypes is populated', async () => {
+		const requestedLoanIds = await watchAllLoanCards(HEALTHY_POSSIBLE_TYPES);
+
+		// One request per card, no matter how many times the cache broadcasts
+		expect(requestedLoanIds).toHaveLength(LOAN_IDS.length);
+	});
+
+	// Documents the failure this guards against: without it the same setup issues hundreds of
+	// requests in a quarter of a second and never settles.
+	it('melts down into an unbounded refetch loop when possibleTypes is empty', async () => {
+		const requestedLoanIds = await watchAllLoanCards(BROKEN_POSSIBLE_TYPES);
+
+		expect(requestedLoanIds.length).toBeGreaterThan(LOAN_IDS.length * 10);
+	});
+});

--- a/test/unit/specs/server/util/getGqlPossibleTypes.spec.js
+++ b/test/unit/specs/server/util/getGqlPossibleTypes.spec.js
@@ -37,7 +37,10 @@ const healthySchema = {
 	],
 };
 
-const mockResponse = body => fetch.mockResolvedValue({ json: () => Promise.resolve(body) });
+const mockResponse = (body, status = 200) => fetch.mockResolvedValue({
+	status,
+	json: () => Promise.resolve(body),
+});
 
 describe('getGqlPossibleTypes', () => {
 	beforeEach(() => {
@@ -106,6 +109,7 @@ describe('getGqlPossibleTypes', () => {
 	describe.each([
 		['the schema is missing entirely', { data: {} }],
 		['the response is a GraphQL error', { errors: [{ message: 'Introspection is disabled' }] }],
+		['the gateway returns a non-GraphQL error body', { code: '503', message: 'Service Unavailable' }],
 		['the response body is empty', {}],
 		['the schema has no types', { data: { __schema: { types: [] } } }],
 		['every type has an id field', {
@@ -139,6 +143,27 @@ describe('getGqlPossibleTypes', () => {
 			await getGqlPossibleTypes(URL, CACHE);
 
 			expect(fetch).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('a non-GraphQL error response', () => {
+		it('names the gateway failure rather than reporting an empty schema', async () => {
+			mockResponse({ code: '503', message: 'Service Unavailable' }, 503);
+
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(error).toHaveBeenCalledWith(
+				'Non-GraphQL error response while introspecting possible types',
+				{ status: 503, code: '503', message: 'Service Unavailable' },
+			);
+		});
+
+		it('is not reported for a healthy response', async () => {
+			mockResponse({ data: { __schema: healthySchema } });
+
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(error).not.toHaveBeenCalled();
 		});
 	});
 

--- a/test/unit/specs/server/util/getGqlPossibleTypes.spec.js
+++ b/test/unit/specs/server/util/getGqlPossibleTypes.spec.js
@@ -1,0 +1,196 @@
+import getGqlPossibleTypes, { isValidPossibleTypes } from '#server/util/getGqlPossibleTypes';
+import fetch from '#server/util/fetch';
+import { getFromCache, setToCache } from '#server/util/memJsUtils';
+import { error } from '#server/util/log';
+
+vi.mock('#server/util/fetch', () => ({ default: vi.fn() }));
+
+vi.mock('#server/util/memJsUtils', () => ({
+	getFromCache: vi.fn(() => Promise.resolve(null)),
+	setToCache: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('#server/util/log', () => ({
+	error: vi.fn(),
+	log: vi.fn(),
+	info: vi.fn(),
+	warn: vi.fn(),
+}));
+
+const URL = 'https://api.test/graphql';
+const CACHE = {};
+
+// A schema shaped like the real one: some types with an id, some without, and a union
+const healthySchema = {
+	queryType: { name: 'Query' },
+	mutationType: { name: 'Mutation' },
+	subscriptionType: null,
+	types: [
+		{ name: 'Lend', fields: [{ name: 'loan' }], possibleTypes: null },
+		{ name: 'Geocode', fields: [{ name: 'city' }], possibleTypes: null },
+		{ name: 'LoanPartner', fields: [{ name: 'id' }, { name: 'name' }], possibleTypes: null },
+		{
+			name: 'LoanBasic',
+			fields: [{ name: 'id' }],
+			possibleTypes: [{ name: 'LoanPartner' }, { name: 'LoanDirect' }],
+		},
+	],
+};
+
+const mockResponse = body => fetch.mockResolvedValue({ json: () => Promise.resolve(body) });
+
+describe('getGqlPossibleTypes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		delete process.env.FETCHED_GQL_TYPES;
+		getFromCache.mockResolvedValue(null);
+		setToCache.mockResolvedValue();
+	});
+
+	afterAll(() => {
+		delete process.env.FETCHED_GQL_TYPES;
+	});
+
+	describe('isValidPossibleTypes', () => {
+		it('accepts a payload with a populated Mergable list', () => {
+			expect(isValidPossibleTypes({ Mergable: ['Lend'] })).toBe(true);
+		});
+
+		it.each([
+			['an empty Mergable list', { Mergable: [] }],
+			['a missing Mergable key', { LoanBasic: ['LoanPartner'] }],
+			['a non-array Mergable value', { Mergable: 'Lend' }],
+			['an empty object', {}],
+			['null', null],
+			['undefined', undefined],
+		])('rejects %s', (_label, value) => {
+			expect(isValidPossibleTypes(value)).toBe(false);
+		});
+	});
+
+	describe('a healthy introspection response', () => {
+		it('builds the Mergable list from types with no id field', async () => {
+			mockResponse({ data: { __schema: healthySchema } });
+
+			const result = await getGqlPossibleTypes(URL, CACHE);
+
+			expect(result.Mergable).toEqual(['Lend', 'Geocode']);
+		});
+
+		it('maps interfaces and unions to their possible types', async () => {
+			mockResponse({ data: { __schema: healthySchema } });
+
+			const result = await getGqlPossibleTypes(URL, CACHE);
+
+			expect(result.LoanBasic).toEqual(['LoanPartner', 'LoanDirect']);
+		});
+
+		it('caches the payload for other processes and for this one', async () => {
+			mockResponse({ data: { __schema: healthySchema } });
+
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(setToCache).toHaveBeenCalledWith(
+				'ui-gql-possible-types',
+				expect.stringContaining('"Mergable":["Lend","Geocode"]'),
+				24 * 60 * 60,
+				CACHE,
+			);
+			expect(JSON.parse(process.env.FETCHED_GQL_TYPES).Mergable).toEqual(['Lend', 'Geocode']);
+		});
+	});
+
+	// The production failure: introspection returned nothing, the empty result was cached for 24
+	// hours, and every browser served by those pods ran with an Apollo cache that could not merge
+	// id-less types or match interface fragments.
+	describe.each([
+		['the schema is missing entirely', { data: {} }],
+		['the response is a GraphQL error', { errors: [{ message: 'Introspection is disabled' }] }],
+		['the response body is empty', {}],
+		['the schema has no types', { data: { __schema: { types: [] } } }],
+		['every type has an id field', {
+			data: { __schema: { types: [{ name: 'Shop', fields: [{ name: 'id' }], possibleTypes: null }] } },
+		}],
+	])('when %s', (_label, body) => {
+		beforeEach(() => {
+			mockResponse(body);
+		});
+
+		it('does not write the invalid payload to the shared cache', async () => {
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(setToCache).not.toHaveBeenCalled();
+		});
+
+		it('does not pin the invalid payload to this process', async () => {
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(process.env.FETCHED_GQL_TYPES).toBeUndefined();
+		});
+
+		it('logs an error', async () => {
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(error).toHaveBeenCalled();
+		});
+
+		it('retries the introspection call on the next request rather than serving a cached failure', async () => {
+			await getGqlPossibleTypes(URL, CACHE);
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(fetch).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('cached values', () => {
+		it('uses a valid cached payload without introspecting again', async () => {
+			getFromCache.mockResolvedValue(JSON.stringify({ Mergable: ['Lend'] }));
+
+			const result = await getGqlPossibleTypes(URL, CACHE);
+
+			expect(result).toEqual({ Mergable: ['Lend'] });
+			expect(fetch).not.toHaveBeenCalled();
+		});
+
+		// Heals cache entries poisoned before these guards existed, without a manual flush
+		it('discards an invalid cached payload and re-fetches', async () => {
+			getFromCache.mockResolvedValue(JSON.stringify({ Mergable: [] }));
+			mockResponse({ data: { __schema: healthySchema } });
+
+			const result = await getGqlPossibleTypes(URL, CACHE);
+
+			expect(fetch).toHaveBeenCalledTimes(1);
+			expect(result.Mergable).toEqual(['Lend', 'Geocode']);
+			expect(error).toHaveBeenCalled();
+		});
+
+		it('discards an unparseable cached payload and re-fetches', async () => {
+			getFromCache.mockResolvedValue('not json');
+			mockResponse({ data: { __schema: healthySchema } });
+
+			const result = await getGqlPossibleTypes(URL, CACHE);
+
+			expect(fetch).toHaveBeenCalledTimes(1);
+			expect(result.Mergable).toEqual(['Lend', 'Geocode']);
+		});
+
+		it('uses a valid process-level payload without hitting the shared cache', async () => {
+			process.env.FETCHED_GQL_TYPES = JSON.stringify({ Mergable: ['Lend'] });
+
+			const result = await getGqlPossibleTypes(URL, CACHE);
+
+			expect(result).toEqual({ Mergable: ['Lend'] });
+			expect(getFromCache).not.toHaveBeenCalled();
+			expect(fetch).not.toHaveBeenCalled();
+		});
+
+		it('clears an invalid process-level payload so it is not re-read', async () => {
+			process.env.FETCHED_GQL_TYPES = JSON.stringify({ Mergable: [] });
+			mockResponse({ data: { __schema: healthySchema } });
+
+			await getGqlPossibleTypes(URL, CACHE);
+
+			expect(JSON.parse(process.env.FETCHED_GQL_TYPES).Mergable).toEqual(['Lend', 'Geocode']);
+		});
+	});
+});


### PR DESCRIPTION
## Problem

My Kiva was firing thousands of GraphQL requests per page load with no user interaction — `kcBasicLoanCard`, `bpHeroBackgroundCountry`, and `bpHeroBackgroundImage`, cycling through every loan on the page and repeating.

Root cause is in `server/util/getGqlPossibleTypes.js`. When schema introspection failed, it built `{ Mergable: [] }` and treated that as a success — writing it to memcache for 24 hours and pinning it to `process.env.FETCHED_GQL_TYPES` for the process lifetime. Every browser served by those pods then ran an Apollo cache with no type information. Confirmed in production: `window.__KV_CONFIG__.graphqlPossibleTypes.Mergable.length` returned `0`.

An empty payload costs the cache two things at once:

1. **No `Mergable` list** → the `Mergable: { merge: true }` policy matches nothing, so types with no `id` are *replaced* rather than merged on write. `Lend` has no `id`, so writing one loan evicts every other loan's entry from `ROOT_QUERY.lend`.
2. **No interface map** → `fragment loanCardFields on LoanBasic` can't be matched against a cached `LoanPartner`.

Either one leaves the cache read permanently incomplete. `cache-first` then goes to the network, that response evicts the next card's data, and you get an unbounded round robin.

## Fix

- **Validate before caching or returning.** A schema with hundreds of id-less types can never legitimately produce an empty `Mergable` list, so that's a reliable failure signal.
- **Never persist an invalid payload** to memcache or `process.env` — the next request retries instead of pinning every pod to a broken cache.
- **Validate on read too**, so entries poisoned before this change heal on the next request rather than persisting for the full TTL. **No manual memcache flush needed once this ships.**
- **Log introspection errors.** `fetchSchema` was discarding the `errors` array before `?? {}` swallowed it.

Deliberately keeps serving a degraded payload rather than throwing, so a failed introspection doesn't take the site down with a 500.

## Tests

`test/unit/specs/server/util/getGqlPossibleTypes.spec.js` (35 tests) — `isValidPossibleTypes` directly, plus five failure shapes (missing schema, GraphQL error response, empty body, no types, all types have an `id`), each asserting the payload isn't cached, isn't pinned to the process, is logged, and is re-fetched next request. Plus cache read paths: valid value reused, invalid/unparseable discarded and re-fetched, process-level value honoured or cleared.

Verified these fail against broken code — with only the two guard blocks removed, 20 of them fail.

`test/unit/specs/api/possibleTypesCacheIntegrity.spec.js` (3 tests) — replicates the meltdown against a real `InMemoryCache` with six loan cards and the `LoanBasic` interface fragment:

| `possibleTypes` | requests in 250ms |
|---|---|
| populated | 6 — one per card, flat |
| `{ Mergable: [] }` | hundreds, unbounded |

Full suite: 316 files, 4701 passed, 6 skipped. ESLint clean.

## Deploy note

This heals the cache on deploy. Until then the poisoned memcache entry plus `process.env.FETCHED_GQL_TYPES` keeps serving the empty payload, so **flush `ui-gql-possible-types` and restart the pods** for immediate relief.

## Follow-up (not in this PR)

These guards stop the failure being *sticky*, but a request served during an introspection failure still ships an empty payload to that browser and that session loops. Generating `possibleTypes` at build time from the checked-in `build/schema.graphql` would close that window entirely — worth doing, especially if introspection is intentionally restricted in prod.
