### PR TITLE
fix(optimizeContentfulUrl): apply image params to proxied asset URLs AD-438

### DIFF
--- a/src/util/imageUtils.js
+++ b/src/util/imageUtils.js
@@ -1,3 +1,5 @@
+import logFormatter from '#src/util/logFormatter';
+
 /**
  * Determine if browser supports Webp with transparency
  *
@@ -56,11 +58,12 @@ export function preloadImage(src) {
 export function optimizeContentfulUrl(baseUrl, width = null, height = null) {
 	if (!baseUrl) return '';
 
-	// check if it's a Contentful URL
+	// warn if it's not a Contentful URL
 	const isContentfulUrl = baseUrl.includes('images.ctfassets.net')
-		|| baseUrl.includes('assets.contentful.com');
+		|| baseUrl.includes('assets.contentful.com')
+		|| baseUrl.includes('kiva.org/ctfassets/');
 	if (!isContentfulUrl) {
-		return baseUrl;
+		logFormatter(`Non-Contentful URL passed to optimizeContentfulUrl: ${baseUrl}`, 'warn');
 	}
 	const params = new URLSearchParams();
 	if (width) params.set('w', width);

--- a/test/unit/specs/util/imageUtils.spec.js
+++ b/test/unit/specs/util/imageUtils.spec.js
@@ -1,6 +1,9 @@
 import {
 	checkAvifSupport, checkWebpSupport, preloadImage, optimizeContentfulUrl
 } from '#src/util/imageUtils';
+import logFormatter from '#src/util/logFormatter';
+
+vi.mock('#src/util/logFormatter');
 
 describe('imageUtils.js', () => {
 	let originalImage;
@@ -154,39 +157,45 @@ describe('imageUtils.js', () => {
 });
 
 describe('optimizeContentfulUrl', () => {
-	it('returns empty string when baseUrl is falsy', () => {
+	// The proxied host is what the UI actually receives: contentful-apollo-server rewrites
+	// every asset URL in the GraphQL response before it reaches the client.
+	const proxiedUrl = '//www.kiva.org/ctfassets/images/2F0fMUNds6qhAj6CyQ0kn4/360430aae7/image.jpg';
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns empty string without warning when baseUrl is falsy', () => {
 		expect(optimizeContentfulUrl(null)).toBe('');
 		expect(optimizeContentfulUrl(undefined)).toBe('');
 		expect(optimizeContentfulUrl('')).toBe('');
+		expect(logFormatter).not.toHaveBeenCalled();
 	});
 
 	it('returns optimized URL with width only', () => {
-		const baseUrl = 'https://images.ctfassets.net/image.jpg';
-		const optimizedUrl = optimizeContentfulUrl(baseUrl, 336);
+		const optimizedUrl = optimizeContentfulUrl(proxiedUrl, 336);
 
 		const expectedParams = new URLSearchParams();
 		expectedParams.set('w', '336');
 		expectedParams.set('fm', 'webp');
 		expectedParams.set('q', '80');
 
-		expect(optimizedUrl).toBe(`${baseUrl}?${expectedParams.toString()}`);
+		expect(optimizedUrl).toBe(`${proxiedUrl}?${expectedParams.toString()}`);
 	});
 
 	it('returns optimized URL with height only', () => {
-		const baseUrl = 'https://images.ctfassets.net/image.jpg';
-		const optimizedUrl = optimizeContentfulUrl(baseUrl, null, 200);
+		const optimizedUrl = optimizeContentfulUrl(proxiedUrl, null, 200);
 
 		const expectedParams = new URLSearchParams();
 		expectedParams.set('h', '200');
 		expectedParams.set('fm', 'webp');
 		expectedParams.set('q', '80');
 
-		expect(optimizedUrl).toBe(`${baseUrl}?${expectedParams.toString()}`);
+		expect(optimizedUrl).toBe(`${proxiedUrl}?${expectedParams.toString()}`);
 	});
 
 	it('returns optimized URL with both width and height', () => {
-		const baseUrl = 'https://images.ctfassets.net/image.jpg';
-		const optimizedUrl = optimizeContentfulUrl(baseUrl, 336, 200);
+		const optimizedUrl = optimizeContentfulUrl(proxiedUrl, 336, 200);
 
 		const expectedParams = new URLSearchParams();
 		expectedParams.set('w', '336');
@@ -194,26 +203,35 @@ describe('optimizeContentfulUrl', () => {
 		expectedParams.set('fm', 'webp');
 		expectedParams.set('q', '80');
 
-		expect(optimizedUrl).toBe(`${baseUrl}?${expectedParams.toString()}`);
+		expect(optimizedUrl).toBe(`${proxiedUrl}?${expectedParams.toString()}`);
 	});
 
-	it('optimizes assets.contentful.com URLs', () => {
-		const baseUrl = 'https://assets.contentful.com/space/image.jpg';
+	it.each([
+		['production proxied host', '//www.kiva.org/ctfassets/images/space/hash/image.jpg'],
+		['development proxied host', '//www.development.kiva.org/ctfassets/images/space/hash/image.jpg'],
+		['unproxied protocol-relative asset', '//images.ctfassets.net/j0p9a6ql0rn7/space/hash/image.jpg'],
+		['unproxied absolute asset', 'https://images.ctfassets.net/j0p9a6ql0rn7/space/hash/image.jpg'],
+		['management API asset', 'https://assets.contentful.com/space/image.jpg'],
+	])('optimizes a %s without warning', (_, baseUrl) => {
 		const optimizedUrl = optimizeContentfulUrl(baseUrl, 100);
 
-		expect(optimizedUrl).toContain('fm=webp');
 		expect(optimizedUrl).toContain('w=100');
+		expect(optimizedUrl).toContain('fm=webp');
+		expect(logFormatter).not.toHaveBeenCalled();
 	});
 
-	it('returns original URL for non-Contentful images', () => {
+	it('optimizes a non-Contentful URL and warns about it', () => {
 		const baseUrl = 'https://example.com/image.jpg';
 		const optimizedUrl = optimizeContentfulUrl(baseUrl, 100, 100);
-		expect(optimizedUrl).toBe('https://example.com/image.jpg');
+
+		expect(optimizedUrl).toContain('w=100');
+		expect(optimizedUrl).toContain('h=100');
+		expect(optimizedUrl).toContain('fm=webp');
+		expect(logFormatter).toHaveBeenCalledWith(expect.stringContaining(baseUrl), 'warn');
 	});
 
 	it('handles URL with no dimensions', () => {
-		const baseUrl = 'https://images.ctfassets.net/image.jpg';
-		const optimizedUrl = optimizeContentfulUrl(baseUrl);
+		const optimizedUrl = optimizeContentfulUrl(proxiedUrl);
 
 		expect(optimizedUrl).toContain('fm=webp');
 		expect(optimizedUrl).toContain('q=80');
@@ -222,8 +240,7 @@ describe('optimizeContentfulUrl', () => {
 	});
 
 	it('handles zero width and height', () => {
-		const baseUrl = 'https://images.ctfassets.net/image.jpg';
-		const optimizedUrl = optimizeContentfulUrl(baseUrl, 0, 0);
+		const optimizedUrl = optimizeContentfulUrl(proxiedUrl, 0, 0);
 
 		// Zero is falsy, so should not include width/height params
 		expect(optimizedUrl).toContain('fm=webp');


### PR DESCRIPTION
optimizeContentfulUrl is not checking for our CDN-proxied Contenful URLs, so it is skipping adding optimization parameters to all image URLs in every environment besides local, so full, unoptimized images are being loaded instead. This fixes that by adding the proxy URL format to the list of recognized Contentful URLs, and also by changing the gate into only a warning message, so the optimization parameters are always appended regardless of what is passed to it.