### PR TITLE
fix: improve load time of goal express checkout on thanks page

### DIFF
--- a/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
+++ b/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
@@ -5,8 +5,23 @@
 		:prevent-close="paying"
 		@lightbox-closed="closeLightbox"
 	>
+		<div
+			v-if="lightboxOpen && !ready"
+			style="width: 30rem;"
+			class="tw-mx-auto"
+			data-testid="express-checkout-loading"
+			role="status"
+			aria-busy="true"
+		>
+			<KvLoadingPlaceholder class="!tw-h-4 !tw-w-3/4 tw-mb-2" />
+			<KvLoadingPlaceholder class="!tw-h-4 tw-mb-4" />
+			<KvLoadingPlaceholder class="!tw-h-16 tw-mb-4" />
+			<KvLoadingPlaceholder class="!tw-h-3 tw-mb-1" />
+			<KvLoadingPlaceholder class="!tw-h-3 !tw-w-5/6 tw-mb-7 md:!tw-mb-2" />
+			<KvLoadingPlaceholder class="!tw-h-6 tw-my-1" />
+		</div>
 		<form
-			v-if="lightboxOpen"
+			v-if="ready"
 			style="max-width: 25rem;"
 			class="tw-mx-auto"
 			@submit.prevent="onSubmit"
@@ -73,7 +88,7 @@ import {
 	useBraintreeDropIn,
 	watchBasketTotals,
 } from '@kiva/kv-shop';
-import { KvButton, KvLightbox } from '@kiva/kv-components';
+import { KvButton, KvLightbox, KvLoadingPlaceholder } from '@kiva/kv-components';
 import ExpressCheckoutTotals from '#src/components/Thanks/ExpressCheckout/ExpressCheckoutTotals';
 import useTipMessage from '#src/composables/useTipMessage';
 import {
@@ -104,6 +119,7 @@ const googlePayMerchantId = $appConfig?.googlePay?.merchantId ?? '';
 const dropInName = 'express-checkout';
 
 const lightboxOpen = ref(false);
+const ready = ref(false);
 const paying = ref(false);
 const totalDue = ref('0.00');
 const transactionsEnabled = ref(false);
@@ -134,14 +150,30 @@ const subscribeTotals = () => {
 	});
 };
 
-const closeLightbox = () => {
+// Programmatic close for error/redirect aborts: same state reset as
+// closeLightbox but without emitting 'close', so the user-initiated
+// close analytics ('close-express-checkout') don't fire for aborts.
+const abortLightbox = () => {
 	lightboxOpen.value = false;
+	ready.value = false;
 	totalsSubscription?.unsubscribe();
 	totalsSubscription = null;
+};
+
+const closeLightbox = () => {
+	abortLightbox();
 	emit('close');
 };
 
-const openLightbox = async () => {
+// Show the modal shell in its skeleton state. Synchronous on purpose:
+// this is what makes the modal appear the instant "Support now" is
+// clicked, before any network round-trip.
+const openLoading = () => {
+	lightboxOpen.value = true;
+	ready.value = false;
+};
+
+const loadPaymentDetails = async () => {
 	try {
 		// Prime the basket totals cache so the watch subscription (and the
 		// totals component) bind to the freshly-mutated basket. The
@@ -164,8 +196,14 @@ const openLightbox = async () => {
 		return false;
 	}
 
+	// Reveal guard: the user may have dismissed the skeleton while the
+	// queries above were in flight — don't reveal the form after close.
+	if (!lightboxOpen.value) {
+		return false;
+	}
+
 	subscribeTotals();
-	lightboxOpen.value = true;
+	ready.value = true;
 	return true;
 };
 
@@ -248,6 +286,10 @@ onBeforeUnmount(() => {
 });
 
 defineExpose({
-	openLightbox,
+	openLoading,
+	loadPaymentDetails,
+	abortLightbox,
+	closeLightbox,
+	isOpen: () => lightboxOpen.value,
 });
 </script>

--- a/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
+++ b/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
@@ -124,6 +124,9 @@ const totalDue = ref('0.00');
 const transactionsEnabled = ref(false);
 const dropInAuthToken = ref('');
 let totalsSubscription = null;
+// Holds the in-flight client-token fetch started in openLoading() so
+// loadPaymentDetails() can await it instead of firing a fresh serial request.
+let clientTokenPromise = null;
 
 const depositRequired = computed(() => (numeral(totalDue.value).value() ?? 0) > 0);
 
@@ -157,6 +160,7 @@ const abortLightbox = () => {
 	ready.value = false;
 	totalsSubscription?.unsubscribe();
 	totalsSubscription = null;
+	clientTokenPromise = null;
 };
 
 const closeLightbox = () => {
@@ -170,6 +174,13 @@ const closeLightbox = () => {
 const openLoading = () => {
 	lightboxOpen.value = true;
 	ready.value = false;
+	// Prefetch the Braintree client token now so its (cache-first) round trip
+	// overlaps the basket work that runs before loadPaymentDetails(), instead
+	// of adding a serial fetch at reveal time. loadPaymentDetails() awaits this
+	// promise; the no-op catch keeps a pre-reveal abort (which never awaits it)
+	// from surfacing as an unhandled rejection.
+	clientTokenPromise = getClientToken(apollo);
+	clientTokenPromise.catch(() => {});
 };
 
 const loadPaymentDetails = async () => {
@@ -179,16 +190,22 @@ const loadPaymentDetails = async () => {
 		// updateLoanReservation mutation that runs before this modal opens
 		// does not include totals in its response, so Apollo has no way to
 		// invalidate the cached totals on its own.
-		await apollo.query({
-			query: basketTotalsQuery,
-			variables: { basketId: getBasketID() },
-			fetchPolicy: 'network-only',
-		});
-
-		// Only renders this modal for logged-in users
-		// (GoalEntrypoint is gated by `v-if="!isGuest"`), so we always fetch
-		// the customer-scoped client token here.
-		dropInAuthToken.value = await getClientToken(apollo) ?? '';
+		//
+		// Run it in parallel with the client-token fetch kicked off in
+		// openLoading() (customer-scoped; this modal only renders for
+		// logged-in users, gated by GoalEntrypoint's `v-if="!isGuest"`). The
+		// two are independent, so the reveal waits on max(totals, token), not
+		// their sum. Fall back to a direct fetch if loadPaymentDetails() is
+		// somehow reached without openLoading() having primed the promise.
+		const [, token] = await Promise.all([
+			apollo.query({
+				query: basketTotalsQuery,
+				variables: { basketId: getBasketID() },
+				fetchPolicy: 'network-only',
+			}),
+			clientTokenPromise ?? getClientToken(apollo),
+		]);
+		dropInAuthToken.value = token ?? '';
 	} catch (e) {
 		const message = e?.message || 'Something went wrong. Please, refresh the page and try again.';
 		$showTipMsg(message, 'error');

--- a/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
+++ b/src/components/Thanks/ExpressCheckout/ExpressCheckoutModal.vue
@@ -2,13 +2,12 @@
 	<KvLightbox
 		title="Confirm Payment"
 		:visible="lightboxOpen"
-		:prevent-close="paying"
+		:prevent-close="!ready || paying"
 		@lightbox-closed="closeLightbox"
 	>
 		<div
 			v-if="lightboxOpen && !ready"
-			style="width: 30rem;"
-			class="tw-mx-auto"
+			class="express-checkout-skeleton tw-w-full tw-mx-auto"
 			data-testid="express-checkout-loading"
 			role="status"
 			aria-busy="true"
@@ -293,3 +292,11 @@ defineExpose({
 	isOpen: () => lightboxOpen.value,
 });
 </script>
+
+<style scoped>
+@screen md {
+	.express-checkout-skeleton {
+		width: 30rem;
+	}
+}
+</style>

--- a/src/composables/useExpressCheckoutModal.js
+++ b/src/composables/useExpressCheckoutModal.js
@@ -72,13 +72,35 @@ export default function useExpressCheckoutModal({
 		}
 	}
 
+	// Programmatic close of the express checkout modal (no 'close' emit →
+	// no user-close analytics). Used on every path that leaves the modal
+	// flow after openLoading() has already shown the skeleton: errors and
+	// the redirect-to-/basket branch.
+	function abortExpressCheckout() {
+		expressCheckoutModalRef.value?.abortLightbox();
+	}
+
 	async function openExpressCheckout(payload) {
+		// User dismissed the skeleton while the basket work was in flight —
+		// don't initialize checkout, fetch a token, or log a modal-open.
+		if (!expressCheckoutModalRef.value?.isOpen?.()) return false;
+
 		const initialized = await initializeExpressCheckoutBasket();
-		if (!initialized) return false;
+		if (!initialized) {
+			abortExpressCheckout();
+			return false;
+		}
 
 		kvTrackEvent?.(EVENT_CATEGORY, 'open', 'open-express-checkout');
 		expressCheckoutLoan.value = payload.loan ?? null;
-		return expressCheckoutModalRef.value?.openLightbox();
+		const loaded = await expressCheckoutModalRef.value?.loadPaymentDetails();
+		if (!loaded) {
+			// loadPaymentDetails already showed a toast on error (and stays
+			// silent when the user closed the skeleton mid-load).
+			abortExpressCheckout();
+			return false;
+		}
+		return true;
 	}
 
 	async function handleAddRecommendedLoanToBasket(payload) {
@@ -99,59 +121,88 @@ export default function useExpressCheckoutModal({
 			return;
 		}
 
-		// Decide between the three express-checkout sub-flows based on the
-		// current basket state: open the modal, re-open it (Checkout now
-		// re-entry), or redirect to /basket for the full checkout.
-		await loadInitialBasketItems();
-		let items = unref(basketItems) ?? [];
+		// The mixin's addToBasket silently no-ops when loanId/lendAmount is
+		// missing (no onSuccess, no onError), which would strand the loading
+		// modal open forever. Bail out before opening anything.
+		if (!payload?.loanId || !payload?.lendAmount) return;
 
-		// Clear an auto-added tip donation when it's the only thing in the
-		// basket so the express checkout total reflects only the recommended
-		// loan. Abort on failure to avoid charging an unexpected total.
-		if (hasOnlyOneDonation(items)) {
-			try {
-				await clearBasketDonation({
-					apollo,
-					basketId: cookieStore.get('kvbskt'),
-					donation: items[0],
-				});
-				items = [];
-			} catch (error) {
-				$showTipMsg(
-					'Something went wrong. Please, refresh the page and try again.',
-					'error',
-				);
-				logFormatter(error, 'error');
+		// Open the modal shell in its skeleton state immediately — before
+		// any network round-trip — so the modal appears the instant the
+		// user clicks. Every path below either fills it in
+		// (loadPaymentDetails) or closes it (abortExpressCheckout).
+		expressCheckoutModalRef.value?.openLoading();
+
+		// Everything past openLoading() runs inside a try: an unexpected throw
+		// would otherwise strand the skeleton open with no feedback.
+		try {
+			// Decide between the three express-checkout sub-flows based on the
+			// current basket state: open the modal, re-open it (Checkout now
+			// re-entry), or redirect to /basket for the full checkout.
+			await loadInitialBasketItems();
+			let items = unref(basketItems) ?? [];
+
+			// Clear an auto-added tip donation when it's the only thing in the
+			// basket so the express checkout total reflects only the recommended
+			// loan. Abort on failure to avoid charging an unexpected total.
+			if (hasOnlyOneDonation(items)) {
+				try {
+					await clearBasketDonation({
+						apollo,
+						basketId: cookieStore.get('kvbskt'),
+						donation: items[0],
+					});
+					items = [];
+				} catch (error) {
+					abortExpressCheckout();
+					$showTipMsg(
+						'Something went wrong. Please, refresh the page and try again.',
+						'error',
+					);
+					logFormatter(error, 'error');
+					return;
+				}
+			}
+
+			// Re-entry via "Checkout now": the recommended loan is already in
+			// the basket — reopen the modal without re-adding it.
+			if (shouldReopenExpressCheckout(items, payload)) {
+				await openExpressCheckout(payload);
 				return;
 			}
-		}
 
-		// Re-entry via "Checkout now": the recommended loan is already in
-		// the basket — reopen the modal without re-adding it.
-		if (shouldReopenExpressCheckout(items, payload)) {
-			await openExpressCheckout(payload);
-			return;
-		}
+			const empty = isBasketEmpty(items);
+			if (!empty) {
+				// Redirect path: the express modal isn't used, but keep the
+				// skeleton open through the navigation so it reads as a
+				// loading state rather than flashing closed before the
+				// redirect. The error handler below still aborts it if the
+				// add fails and no navigation happens.
+				isRedirecting.value = true;
+			}
 
-		const empty = isBasketEmpty(items);
-		if (!empty) {
-			isRedirecting.value = true;
+			const previousOnError = payload.onError;
+			addToBasket({
+				...payload,
+				onSuccess: async () => {
+					if (empty) {
+						return openExpressCheckout(payload);
+					}
+					return router.push('/basket');
+				},
+				onError: () => {
+					isRedirecting.value = false;
+					abortExpressCheckout();
+					previousOnError?.();
+				},
+			});
+		} catch (error) {
+			abortExpressCheckout();
+			$showTipMsg(
+				'Something went wrong. Please, refresh the page and try again.',
+				'error',
+			);
+			logFormatter(error, 'error');
 		}
-
-		const previousOnError = payload.onError;
-		addToBasket({
-			...payload,
-			onSuccess: async () => {
-				if (empty) {
-					return openExpressCheckout(payload);
-				}
-				return router.push('/basket');
-			},
-			onError: () => {
-				isRedirecting.value = false;
-				previousOnError?.();
-			},
-		});
 	}
 
 	function handleExpressCheckoutComplete({ transactionId }) {

--- a/test/unit/specs/components/Thanks/ExpressCheckout/ExpressCheckoutModal.spec.js
+++ b/test/unit/specs/components/Thanks/ExpressCheckout/ExpressCheckoutModal.spec.js
@@ -219,9 +219,11 @@ describe('ExpressCheckoutModal', () => {
 			expect(wrapper.find('[data-testid="lightbox"]').exists()).toBe(true);
 			expect(wrapper.find('[data-testid="express-checkout-loading"]').exists()).toBe(true);
 			expect(wrapper.find('form').exists()).toBe(false);
-			// No network calls were needed to show the skeleton
+			// Skeleton renders synchronously without a totals fetch. The client
+			// token is prefetched here (fire-and-forget) but not awaited for the
+			// render, so the skeleton still appears instantly.
 			expect(apollo.query).not.toHaveBeenCalled();
-			expect(mockGetClientToken).not.toHaveBeenCalled();
+			expect(mockGetClientToken).toHaveBeenCalledTimes(1);
 		});
 
 		it('loadPaymentDetails swaps the skeleton for the form and returns true', async () => {
@@ -234,6 +236,22 @@ describe('ExpressCheckoutModal', () => {
 			expect(result).toBe(true);
 			expect(wrapper.find('form').exists()).toBe(true);
 			expect(wrapper.find('[data-testid="express-checkout-loading"]').exists()).toBe(false);
+		});
+
+		it('prefetches the client token in openLoading and reuses it in loadPaymentDetails', async () => {
+			mountClosed();
+
+			wrapper.vm.openLoading();
+			// Token fetch starts the instant the skeleton opens...
+			expect(mockGetClientToken).toHaveBeenCalledTimes(1);
+
+			await wrapper.vm.loadPaymentDetails();
+			await flushPromises();
+
+			// ...and loadPaymentDetails awaits that same in-flight promise rather
+			// than firing a second serial request.
+			expect(mockGetClientToken).toHaveBeenCalledTimes(1);
+			expect(wrapper.find('form').exists()).toBe(true);
 		});
 
 		it('prevents dismissing the skeleton while loading', async () => {
@@ -255,8 +273,9 @@ describe('ExpressCheckoutModal', () => {
 
 		it('loadPaymentDetails shows a toast and returns false when the token fetch fails', async () => {
 			mountClosed();
-			wrapper.vm.openLoading();
+			// Reject the prefetch that openLoading() kicks off.
 			mockGetClientToken.mockRejectedValueOnce(new Error('token boom'));
+			wrapper.vm.openLoading();
 
 			const result = await wrapper.vm.loadPaymentDetails();
 			await flushPromises();
@@ -268,13 +287,13 @@ describe('ExpressCheckoutModal', () => {
 
 		it('does not reveal the form when the lightbox was closed while loading (reveal guard)', async () => {
 			mountClosed();
-			wrapper.vm.openLoading();
 
-			// Hold the token fetch open so we can close mid-load
+			// Hold the token fetch (started by openLoading) open so we can close mid-load
 			let resolveToken;
 			mockGetClientToken.mockImplementationOnce(
 				() => new Promise(resolve => { resolveToken = resolve; }),
 			);
+			wrapper.vm.openLoading();
 
 			const loadPromise = wrapper.vm.loadPaymentDetails();
 			await flushPromises();

--- a/test/unit/specs/components/Thanks/ExpressCheckout/ExpressCheckoutModal.spec.js
+++ b/test/unit/specs/components/Thanks/ExpressCheckout/ExpressCheckoutModal.spec.js
@@ -45,7 +45,7 @@ vi.mock('@kiva/kv-components', () => ({
 	},
 	KvLightbox: {
 		props: ['preventClose', 'title', 'visible'],
-		template: '<div v-if="visible" data-testid="lightbox"><slot /></div>',
+		template: '<div v-if="visible" data-testid="lightbox" :data-prevent-close="preventClose"><slot /></div>',
 	},
 	KvLoadingPlaceholder: {
 		template: '<div data-testid="loading-placeholder"></div>',
@@ -234,6 +234,23 @@ describe('ExpressCheckoutModal', () => {
 			expect(result).toBe(true);
 			expect(wrapper.find('form').exists()).toBe(true);
 			expect(wrapper.find('[data-testid="express-checkout-loading"]').exists()).toBe(false);
+		});
+
+		it('prevents dismissing the skeleton while loading', async () => {
+			mountClosed();
+			wrapper.vm.openLoading();
+			await wrapper.vm.$nextTick();
+
+			expect(wrapper.find('[data-testid="lightbox"]').attributes('data-prevent-close')).toBe('true');
+		});
+
+		it('allows dismissing once the form is loaded', async () => {
+			mountClosed();
+			wrapper.vm.openLoading();
+			await wrapper.vm.loadPaymentDetails();
+			await flushPromises();
+
+			expect(wrapper.find('[data-testid="lightbox"]').attributes('data-prevent-close')).toBe('false');
 		});
 
 		it('loadPaymentDetails shows a toast and returns false when the token fetch fails', async () => {

--- a/test/unit/specs/components/Thanks/ExpressCheckout/ExpressCheckoutModal.spec.js
+++ b/test/unit/specs/components/Thanks/ExpressCheckout/ExpressCheckoutModal.spec.js
@@ -47,6 +47,9 @@ vi.mock('@kiva/kv-components', () => ({
 		props: ['preventClose', 'title', 'visible'],
 		template: '<div v-if="visible" data-testid="lightbox"><slot /></div>',
 	},
+	KvLoadingPlaceholder: {
+		template: '<div data-testid="loading-placeholder"></div>',
+	},
 }));
 
 vi.mock('@kiva/kv-shop', () => ({
@@ -84,7 +87,7 @@ describe('ExpressCheckoutModal', () => {
 	let apollo;
 	let totalsSubscription;
 
-	const mountComponent = async () => {
+	const mountClosed = () => {
 		totalsSubscription = { unsubscribe: vi.fn() };
 		apollo = {
 			query: vi.fn().mockResolvedValue({ data: {} }),
@@ -118,7 +121,12 @@ describe('ExpressCheckoutModal', () => {
 				loan: { id: 123, name: 'Amina' },
 			},
 		});
-		await wrapper.vm.openLightbox();
+	};
+
+	const mountComponent = async () => {
+		mountClosed();
+		wrapper.vm.openLoading();
+		await wrapper.vm.loadPaymentDetails();
 		await flushPromises();
 	};
 
@@ -199,5 +207,105 @@ describe('ExpressCheckoutModal', () => {
 		expect(mockExecuteOneTimeCheckout).toHaveBeenCalled();
 		expect(mockTrackFBTransaction).not.toHaveBeenCalled();
 		expect(mockGetCheckoutTrackingData).not.toHaveBeenCalled();
+	});
+
+	describe('loading state', () => {
+		it('openLoading shows the lightbox with the skeleton and no form, synchronously', async () => {
+			mountClosed();
+
+			wrapper.vm.openLoading();
+			await wrapper.vm.$nextTick();
+
+			expect(wrapper.find('[data-testid="lightbox"]').exists()).toBe(true);
+			expect(wrapper.find('[data-testid="express-checkout-loading"]').exists()).toBe(true);
+			expect(wrapper.find('form').exists()).toBe(false);
+			// No network calls were needed to show the skeleton
+			expect(apollo.query).not.toHaveBeenCalled();
+			expect(mockGetClientToken).not.toHaveBeenCalled();
+		});
+
+		it('loadPaymentDetails swaps the skeleton for the form and returns true', async () => {
+			mountClosed();
+			wrapper.vm.openLoading();
+
+			const result = await wrapper.vm.loadPaymentDetails();
+			await flushPromises();
+
+			expect(result).toBe(true);
+			expect(wrapper.find('form').exists()).toBe(true);
+			expect(wrapper.find('[data-testid="express-checkout-loading"]').exists()).toBe(false);
+		});
+
+		it('loadPaymentDetails shows a toast and returns false when the token fetch fails', async () => {
+			mountClosed();
+			wrapper.vm.openLoading();
+			mockGetClientToken.mockRejectedValueOnce(new Error('token boom'));
+
+			const result = await wrapper.vm.loadPaymentDetails();
+			await flushPromises();
+
+			expect(result).toBe(false);
+			expect(mockShowTipMsg).toHaveBeenCalledWith('token boom', 'error');
+			expect(wrapper.find('form').exists()).toBe(false);
+		});
+
+		it('does not reveal the form when the lightbox was closed while loading (reveal guard)', async () => {
+			mountClosed();
+			wrapper.vm.openLoading();
+
+			// Hold the token fetch open so we can close mid-load
+			let resolveToken;
+			mockGetClientToken.mockImplementationOnce(
+				() => new Promise(resolve => { resolveToken = resolve; }),
+			);
+
+			const loadPromise = wrapper.vm.loadPaymentDetails();
+			await flushPromises();
+
+			// User dismisses the skeleton while the token is in flight
+			wrapper.vm.closeLightbox();
+			resolveToken('client-token');
+
+			const result = await loadPromise;
+			await flushPromises();
+
+			expect(result).toBe(false);
+			expect(wrapper.find('form').exists()).toBe(false);
+			expect(mockWatchBasketTotals).not.toHaveBeenCalled();
+		});
+
+		it('abortLightbox closes without emitting close; closeLightbox emits close', async () => {
+			mountClosed();
+			wrapper.vm.openLoading();
+			await wrapper.vm.$nextTick();
+			// isOpen lets the composable skip checkout work when the skeleton is gone
+			expect(wrapper.vm.isOpen()).toBe(true);
+
+			wrapper.vm.abortLightbox();
+			await wrapper.vm.$nextTick();
+			expect(wrapper.find('[data-testid="lightbox"]').exists()).toBe(false);
+			expect(wrapper.vm.isOpen()).toBe(false);
+			expect(wrapper.emitted('close')).toBeUndefined();
+
+			wrapper.vm.openLoading();
+			await wrapper.vm.$nextTick();
+			wrapper.vm.closeLightbox();
+			await wrapper.vm.$nextTick();
+			expect(wrapper.emitted('close')).toHaveLength(1);
+		});
+
+		it('reopening after close starts back in the skeleton state', async () => {
+			await mountComponent();
+			expect(wrapper.find('form').exists()).toBe(true);
+
+			wrapper.vm.closeLightbox();
+			await wrapper.vm.$nextTick();
+
+			wrapper.vm.openLoading();
+			await wrapper.vm.$nextTick();
+
+			expect(wrapper.find('[data-testid="express-checkout-loading"]').exists()).toBe(true);
+			expect(wrapper.find('form').exists()).toBe(false);
+		});
 	});
 });

--- a/test/unit/specs/composables/useExpressCheckoutModal.spec.js
+++ b/test/unit/specs/composables/useExpressCheckoutModal.spec.js
@@ -34,6 +34,14 @@ describe('useExpressCheckoutModal', () => {
 		...overrides,
 	});
 
+	const makeModalMock = (overrides = {}) => ({
+		openLoading: vi.fn(),
+		loadPaymentDetails: vi.fn().mockResolvedValue(true),
+		abortLightbox: vi.fn(),
+		isOpen: vi.fn(() => true),
+		...overrides,
+	});
+
 	const mountComposable = (overrides = {}) => {
 		mockApollo = {
 			mutate: vi.fn().mockResolvedValue({ data: {} }),
@@ -102,7 +110,7 @@ describe('useExpressCheckoutModal', () => {
 		describe('empty basket → open modal', () => {
 			it('calls addToBasket and opens the modal on success', async () => {
 				basketItems.value = [];
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
 				const loan = { id: 999, name: 'Jacqueline' };
@@ -116,7 +124,7 @@ describe('useExpressCheckoutModal', () => {
 				expect(mockAddToBasket).toHaveBeenCalledTimes(1);
 				await vi.waitFor(() => {
 					expect(composable.expressCheckoutLoan.value).toEqual(loan);
-					expect(modalMock.openLightbox).toHaveBeenCalledTimes(1);
+					expect(modalMock.loadPaymentDetails).toHaveBeenCalledTimes(1);
 				});
 				expect(mockPush).not.toHaveBeenCalled();
 			});
@@ -124,7 +132,12 @@ describe('useExpressCheckoutModal', () => {
 			it('initializes checkout before opening the modal', async () => {
 				basketItems.value = [];
 				const order = [];
-				const modalMock = { openLightbox: vi.fn(() => order.push('open')) };
+				const modalMock = makeModalMock({
+					loadPaymentDetails: vi.fn(async () => {
+						order.push('open');
+						return true;
+					}),
+				});
 				composable.expressCheckoutModalRef.value = modalMock;
 				mockApollo.query.mockImplementationOnce(async () => {
 					order.push('initialize');
@@ -143,10 +156,9 @@ describe('useExpressCheckoutModal', () => {
 				}));
 			});
 
-			it('resolves the addToBasket onSuccess callback with the openLightbox result', async () => {
+			it('resolves the addToBasket onSuccess callback once payment details load', async () => {
 				basketItems.value = [];
-				const openLightboxPromise = Promise.resolve(true);
-				const modalMock = { openLightbox: vi.fn(() => openLightboxPromise) };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 				let addToBasketOnSuccess;
 				mockAddToBasket.mockImplementation(({ onSuccess }) => {
@@ -160,6 +172,7 @@ describe('useExpressCheckoutModal', () => {
 				});
 
 				await expect(addToBasketOnSuccess()).resolves.toBe(true);
+				expect(modalMock.loadPaymentDetails).toHaveBeenCalledTimes(1);
 				expect(mockPush).not.toHaveBeenCalled();
 			});
 
@@ -174,7 +187,7 @@ describe('useExpressCheckoutModal', () => {
 
 			it('sets expressCheckoutLoan to null when payload has no loan', async () => {
 				basketItems.value = [];
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
 
@@ -182,13 +195,13 @@ describe('useExpressCheckoutModal', () => {
 
 				await vi.waitFor(() => {
 					expect(composable.expressCheckoutLoan.value).toBeNull();
-					expect(modalMock.openLightbox).toHaveBeenCalledTimes(1);
+					expect(modalMock.loadPaymentDetails).toHaveBeenCalledTimes(1);
 				});
 			});
 
 			it('does not open the modal when checkout initialization fails', async () => {
 				basketItems.value = [];
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 				mockApollo.query.mockRejectedValueOnce(new Error('initialize failed'));
 				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
@@ -196,7 +209,8 @@ describe('useExpressCheckoutModal', () => {
 				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
 
 				await new Promise(resolve => { setTimeout(resolve, 0); });
-				expect(modalMock.openLightbox).not.toHaveBeenCalled();
+				expect(modalMock.loadPaymentDetails).not.toHaveBeenCalled();
+				expect(modalMock.abortLightbox).toHaveBeenCalled();
 				expect(mockKvTrackEvent).not.toHaveBeenCalled();
 			});
 		});
@@ -217,10 +231,10 @@ describe('useExpressCheckoutModal', () => {
 				expect(observedIsRedirecting).toBe(true);
 			});
 
-			it('redirects to /basket on addToBasket success', async () => {
+			it('redirects to /basket on addToBasket success and keeps the modal open', async () => {
 				basketItems.value = [loanItem({ id: 'other' })];
 				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 
 				await composable.handleAddRecommendedLoanToBasket({
@@ -229,7 +243,8 @@ describe('useExpressCheckoutModal', () => {
 				});
 
 				expect(mockPush).toHaveBeenCalledWith('/basket');
-				expect(modalMock.openLightbox).not.toHaveBeenCalled();
+				expect(modalMock.abortLightbox).not.toHaveBeenCalled();
+				expect(modalMock.loadPaymentDetails).not.toHaveBeenCalled();
 			});
 		});
 
@@ -292,12 +307,12 @@ describe('useExpressCheckoutModal', () => {
 			});
 
 			it('aborts the flow: the modal is not opened', async () => {
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 
 				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
 
-				expect(modalMock.openLightbox).not.toHaveBeenCalled();
+				expect(modalMock.loadPaymentDetails).not.toHaveBeenCalled();
 			});
 
 			it('does not refresh basket items a second time after the failed clear', async () => {
@@ -309,7 +324,7 @@ describe('useExpressCheckoutModal', () => {
 		describe('re-entry via Checkout now', () => {
 			it('reopens the modal without calling addToBasket when only the recommended loan remains', async () => {
 				basketItems.value = [loanItem({ id: 'recommended' })];
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 				const loan = { id: 'recommended', name: 'Jacqueline' };
 
@@ -321,7 +336,7 @@ describe('useExpressCheckoutModal', () => {
 				});
 
 				await vi.waitFor(() => {
-					expect(modalMock.openLightbox).toHaveBeenCalledTimes(1);
+					expect(modalMock.loadPaymentDetails).toHaveBeenCalledTimes(1);
 					expect(composable.expressCheckoutLoan.value).toEqual(loan);
 				});
 				expect(mockAddToBasket).not.toHaveBeenCalled();
@@ -346,7 +361,7 @@ describe('useExpressCheckoutModal', () => {
 
 			it('ignores recommendLoanIsInBasket when the basket is empty (falls back to add-and-open)', async () => {
 				basketItems.value = [];
-				const modalMock = { openLightbox: vi.fn() };
+				const modalMock = makeModalMock();
 				composable.expressCheckoutModalRef.value = modalMock;
 				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
 
@@ -358,7 +373,7 @@ describe('useExpressCheckoutModal', () => {
 
 				expect(mockAddToBasket).toHaveBeenCalledTimes(1);
 				await vi.waitFor(() => {
-					expect(modalMock.openLightbox).toHaveBeenCalledTimes(1);
+					expect(modalMock.loadPaymentDetails).toHaveBeenCalledTimes(1);
 				});
 			});
 		});
@@ -387,6 +402,166 @@ describe('useExpressCheckoutModal', () => {
 					composable.handleAddRecommendedLoanToBasket({ loanId: 999, lendAmount: '25' }),
 				).resolves.not.toThrow();
 				expect(composable.isRedirecting.value).toBe(false);
+			});
+		});
+
+		describe('instant loading modal', () => {
+			it('opens the loading modal synchronously before any basket work', async () => {
+				basketItems.value = [];
+				const order = [];
+				const modalMock = makeModalMock({
+					openLoading: vi.fn(() => order.push('openLoading')),
+				});
+				composable.expressCheckoutModalRef.value = modalMock;
+				mockLoadInitialBasketItems.mockImplementation(async () => {
+					order.push('loadBasket');
+				});
+				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
+
+				expect(order[0]).toBe('openLoading');
+				expect(order).toContain('loadBasket');
+			});
+
+			it('does not open the loading modal when the payload is missing loanId', async () => {
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+
+				await composable.handleAddRecommendedLoanToBasket({ lendAmount: '25' });
+
+				expect(modalMock.openLoading).not.toHaveBeenCalled();
+				expect(mockLoadInitialBasketItems).not.toHaveBeenCalled();
+				expect(mockAddToBasket).not.toHaveBeenCalled();
+			});
+
+			it('does not open the loading modal when the payload is missing lendAmount', async () => {
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 1 });
+
+				expect(modalMock.openLoading).not.toHaveBeenCalled();
+				expect(mockAddToBasket).not.toHaveBeenCalled();
+			});
+
+			it('does not open the loading modal when the feature flag is off', async () => {
+				app?.unmount();
+				mountComposable({ isExpressCheckoutEnabled: ref(false) });
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
+
+				expect(modalMock.openLoading).not.toHaveBeenCalled();
+			});
+
+			it('closes the loading modal when clearing the donation fails', async () => {
+				mockLoadInitialBasketItems.mockImplementationOnce(async () => {
+					basketItems.value = [donationItem()];
+				});
+				mockApollo.mutate.mockResolvedValueOnce({
+					errors: [{ message: 'cannot clear' }],
+				});
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
+
+				expect(modalMock.openLoading).toHaveBeenCalledTimes(1);
+				expect(modalMock.abortLightbox).toHaveBeenCalledTimes(1);
+				expect(mockAddToBasket).not.toHaveBeenCalled();
+			});
+
+			it('closes the loading modal when addToBasket fails', async () => {
+				basketItems.value = [];
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+				mockAddToBasket.mockImplementation(({ onError }) => onError?.());
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
+
+				expect(modalMock.abortLightbox).toHaveBeenCalled();
+				expect(modalMock.loadPaymentDetails).not.toHaveBeenCalled();
+			});
+
+			it('closes the loading modal when payment details fail to load', async () => {
+				basketItems.value = [];
+				const modalMock = makeModalMock({
+					loadPaymentDetails: vi.fn().mockResolvedValue(false),
+				});
+				composable.expressCheckoutModalRef.value = modalMock;
+				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' });
+
+				await vi.waitFor(() => {
+					expect(modalMock.abortLightbox).toHaveBeenCalled();
+				});
+			});
+
+			// The user can dismiss the skeleton while the basket chain is still in flight.
+			// addToBasket's onSuccess still fires — it must not initialize checkout, log a
+			// modal-open after the close event, or fetch payment details for a hidden modal.
+			it('skips checkout initialization when the skeleton was dismissed mid-load', async () => {
+				basketItems.value = [];
+				const modalMock = makeModalMock({ isOpen: vi.fn(() => false) });
+				composable.expressCheckoutModalRef.value = modalMock;
+				let addToBasketOnSuccess;
+				mockAddToBasket.mockImplementation(({ onSuccess }) => {
+					addToBasketOnSuccess = onSuccess;
+				});
+
+				await composable.handleAddRecommendedLoanToBasket({
+					loanId: 1,
+					lendAmount: '25',
+					loan: { id: 1 },
+				});
+
+				mockApollo.query.mockClear();
+				await expect(addToBasketOnSuccess()).resolves.toBe(false);
+
+				expect(mockApollo.query).not.toHaveBeenCalled();
+				expect(mockKvTrackEvent).not.toHaveBeenCalledWith(
+					'post-checkout',
+					'open',
+					'open-express-checkout',
+				);
+				expect(modalMock.loadPaymentDetails).not.toHaveBeenCalled();
+			});
+
+			it('closes the loading modal and shows a tip when addToBasket throws synchronously', async () => {
+				basketItems.value = [];
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+				mockAddToBasket.mockImplementation(() => {
+					throw new Error('addToBasket boom');
+				});
+
+				await expect(
+					composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' }),
+				).resolves.toBeUndefined();
+
+				expect(modalMock.abortLightbox).toHaveBeenCalledTimes(1);
+				expect(mockApollo.mutate).toHaveBeenCalledWith(expect.objectContaining({
+					variables: expect.objectContaining({
+						message: 'Something went wrong. Please, refresh the page and try again.',
+						type: 'error',
+					}),
+				}));
+			});
+
+			it('keeps the loading modal open while redirecting when the basket has other items', async () => {
+				basketItems.value = [loanItem({ id: 'other' })];
+				const modalMock = makeModalMock();
+				composable.expressCheckoutModalRef.value = modalMock;
+				mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
+
+				await composable.handleAddRecommendedLoanToBasket({ loanId: 999, lendAmount: '25' });
+
+				expect(modalMock.abortLightbox).not.toHaveBeenCalled();
+				expect(mockPush).toHaveBeenCalledWith('/basket');
 			});
 		});
 	});
@@ -447,7 +622,7 @@ describe('useExpressCheckoutModal', () => {
 
 		it('redirects to /basket on addToBasket success without opening the modal', async () => {
 			mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
-			const modalMock = { openLightbox: vi.fn() };
+			const modalMock = makeModalMock();
 			composable.expressCheckoutModalRef.value = modalMock;
 
 			await composable.handleAddRecommendedLoanToBasket({
@@ -457,7 +632,7 @@ describe('useExpressCheckoutModal', () => {
 			});
 
 			expect(mockPush).toHaveBeenCalledWith('/basket');
-			expect(modalMock.openLightbox).not.toHaveBeenCalled();
+			expect(modalMock.loadPaymentDetails).not.toHaveBeenCalled();
 			expect(composable.expressCheckoutLoan.value).toBeNull();
 		});
 
@@ -494,7 +669,7 @@ describe('useExpressCheckoutModal', () => {
 	describe('tracking events', () => {
 		it("fires 'post-checkout / open / open-express-checkout' when the modal opens on empty basket", async () => {
 			basketItems.value = [];
-			const modalMock = { openLightbox: vi.fn() };
+			const modalMock = makeModalMock();
 			composable.expressCheckoutModalRef.value = modalMock;
 			mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
 
@@ -515,7 +690,7 @@ describe('useExpressCheckoutModal', () => {
 
 		it("fires 'post-checkout / open / open-express-checkout' on Checkout now re-entry", async () => {
 			basketItems.value = [loanItem({ id: 'recommended' })];
-			const modalMock = { openLightbox: vi.fn() };
+			const modalMock = makeModalMock();
 			composable.expressCheckoutModalRef.value = modalMock;
 
 			await composable.handleAddRecommendedLoanToBasket({
@@ -559,7 +734,7 @@ describe('useExpressCheckoutModal', () => {
 			app?.unmount();
 			mountComposable({ kvTrackEvent: undefined });
 			basketItems.value = [];
-			const modalMock = { openLightbox: vi.fn() };
+			const modalMock = makeModalMock();
 			composable.expressCheckoutModalRef.value = modalMock;
 			mockAddToBasket.mockImplementation(({ onSuccess }) => onSuccess?.());
 
@@ -567,7 +742,7 @@ describe('useExpressCheckoutModal', () => {
 				composable.handleAddRecommendedLoanToBasket({ loanId: 1, lendAmount: '25' }),
 			).resolves.not.toThrow();
 			await vi.waitFor(() => {
-				expect(modalMock.openLightbox).toHaveBeenCalledTimes(1);
+				expect(modalMock.loadPaymentDetails).toHaveBeenCalledTimes(1);
 			});
 		});
 	});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3089

We noticed that users were dropping out during the express checkout that we present to users who create a goal on the thanks page. Here are the improvements included:

- Start token query query to reduce load time of modal
- Add a new loading state of the modal that shows right away on ATB click to make it feel faster
- Block closing the modal while the express modal is loading
- Cleaned up the redirect when loan already exists in basket so the modal doesn't pop in and out in that case