### PR TITLE
feat: deploy seen-once logic for goal in review modal in my kiva and …

### DIFF
--- a/src/components/MyKiva/GoalInReview/GoalInReviewSlide7.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewSlide7.vue
@@ -1,6 +1,6 @@
 <template>
 	<section
-		class="tw-w-full tw-bg-eco-green-4 tw-px-2 tw-py-4 tw-text-center"
+		class="tw-w-full tw-bg-eco-green-4 tw-px-2 tw-pt-4 tw-pb-16 tw-text-center"
 		data-testid="goal-in-review-slide-7"
 	>
 		<div class="tw-mx-auto tw-max-w-lg">

--- a/src/components/MyKiva/GoalInReview/GoalInReviewSlide7.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewSlide7.vue
@@ -1,6 +1,6 @@
 <template>
 	<section
-		class="tw-w-full tw-bg-eco-green-4 tw-px-2 tw-pt-4 tw-pb-16 tw-text-center"
+		class="tw-w-full tw-bg-eco-green-4 tw-px-2 tw-pt-4 tw-pb-6.5 tw-text-center"
 		data-testid="goal-in-review-slide-7"
 	>
 		<div class="tw-mx-auto tw-max-w-lg">

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -852,6 +852,55 @@ export default function useGoalData({ apollo } = {}) {
 		);
 	}
 
+	const goalRecapViewedByYear = computed(() => {
+		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
+		return parsedPrefs.goalRecapViewed || {};
+	});
+
+	function hasViewedGoalRecapForYear(year) {
+		return Boolean(goalRecapViewedByYear.value?.[year]);
+	}
+
+	async function setGoalRecapViewedPreference(year = GOALS_CURRENT_YEAR) {
+		if (!year) return;
+		const parsedPrefs = await loadPreferences('network-only');
+		const prev = parsedPrefs?.goalRecapViewed || {};
+		// Year-keyed flag so seeing this year's recap does not suppress next year's.
+		if (prev[year]) return;
+		const updatedPreference = { goalRecapViewed: { ...prev, [year]: true } };
+		await updateUserPreferences(
+			apolloClient,
+			userPreferences.value,
+			parsedPrefs,
+			updatedPreference
+		);
+	}
+
+	const goalRecapPendingByYear = computed(() => {
+		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
+		return parsedPrefs.goalRecapPending || {};
+	});
+
+	function hasGoalRecapPendingForYear(year) {
+		return Boolean(goalRecapPendingByYear.value?.[year]);
+	}
+
+	// Set the first time a completed goal is seen, so the recap can open on the session
+	// after completion without depending on the goal card's own celebration flag.
+	async function setGoalRecapPendingPreference(year = GOALS_CURRENT_YEAR) {
+		if (!year) return;
+		const parsedPrefs = await loadPreferences('network-only');
+		const prev = parsedPrefs?.goalRecapPending || {};
+		if (prev[year]) return;
+		const updatedPreference = { goalRecapPending: { ...prev, [year]: true } };
+		await updateUserPreferences(
+			apolloClient,
+			userPreferences.value,
+			parsedPrefs,
+			updatedPreference
+		);
+	}
+
 	const goalFeedbackSubmittedByYear = computed(() => {
 		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
 		return parsedPrefs.goalFeedbackSubmitted || {};
@@ -1291,6 +1340,12 @@ export default function useGoalData({ apollo } = {}) {
 		setViewedGoalCompletePreference,
 		goalFeedbackSubmittedByYear,
 		hasSubmittedGoalFeedbackForYear,
+		goalRecapViewedByYear,
+		hasViewedGoalRecapForYear,
+		setGoalRecapViewedPreference,
+		goalRecapPendingByYear,
+		hasGoalRecapPendingForYear,
+		setGoalRecapPendingPreference,
 		setGoalFeedbackSubmittedPreference,
 		getSupportAllLoanCountByYear,
 		setGoalState,

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -819,14 +819,44 @@ export default function useGoalData({ apollo } = {}) {
 		// MyKiva renders the completed card once, then hides it on the next page load.
 	}
 
-	const viewedGoalCompleteByYear = computed(() => {
-		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
-		return parsedPrefs.viewedGoalComplete || {};
-	});
+	/**
+	 * Builds the reader/writer pair for a preference stored as `{ [year]: true }`,
+	 * so a flag set for one year never applies to another.
+	 *
+	 * @param {string} preferenceKey Key this flag is stored under in user preferences
+	 * @returns {object} The by-year map, a per-year reader, and a per-year setter
+	 */
+	function yearKeyedPreference(preferenceKey) {
+		const byYear = computed(() => {
+			const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
+			return parsedPrefs[preferenceKey] || {};
+		});
 
-	function hasViewedCompletedGoalForYear(year) {
-		return Boolean(viewedGoalCompleteByYear.value?.[year]);
+		function hasForYear(year) {
+			return Boolean(byYear.value?.[year]);
+		}
+
+		async function setForYear(year = GOALS_CURRENT_YEAR) {
+			if (!year) return;
+			const parsedPrefs = await loadPreferences('network-only');
+			const prev = parsedPrefs?.[preferenceKey] || {};
+			if (prev[year]) return;
+			const updatedPreference = { [preferenceKey]: { ...prev, [year]: true } };
+			await updateUserPreferences(
+				apolloClient,
+				userPreferences.value,
+				parsedPrefs,
+				updatedPreference
+			);
+		}
+
+		return { byYear, hasForYear, setForYear };
 	}
+
+	const viewedGoalComplete = yearKeyedPreference('viewedGoalComplete');
+	const goalRecapViewed = yearKeyedPreference('goalRecapViewed');
+	const goalRecapPending = yearKeyedPreference('goalRecapPending');
+	const goalFeedbackSubmitted = yearKeyedPreference('goalFeedbackSubmitted');
 
 	/**
 	 * Drives the basket / ATB-modal achievement nudges so they stay out of the
@@ -836,94 +866,6 @@ export default function useGoalData({ apollo } = {}) {
 	const suppressAchievementNudges = computed(() => (
 		userGoal.value?.status === GOAL_STATUS.IN_PROGRESS
 	));
-
-	async function setViewedGoalCompletePreference(year = GOALS_CURRENT_YEAR) {
-		if (!year) return;
-		const parsedPrefs = await loadPreferences('network-only');
-		const prev = parsedPrefs?.viewedGoalComplete || {};
-		// Year-keyed flag so next year's celebration is not suppressed by a prior year's view.
-		if (prev[year]) return;
-		const updatedPreference = { viewedGoalComplete: { ...prev, [year]: true } };
-		await updateUserPreferences(
-			apolloClient,
-			userPreferences.value,
-			parsedPrefs,
-			updatedPreference
-		);
-	}
-
-	const goalRecapViewedByYear = computed(() => {
-		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
-		return parsedPrefs.goalRecapViewed || {};
-	});
-
-	function hasViewedGoalRecapForYear(year) {
-		return Boolean(goalRecapViewedByYear.value?.[year]);
-	}
-
-	async function setGoalRecapViewedPreference(year = GOALS_CURRENT_YEAR) {
-		if (!year) return;
-		const parsedPrefs = await loadPreferences('network-only');
-		const prev = parsedPrefs?.goalRecapViewed || {};
-		// Year-keyed flag so seeing this year's recap does not suppress next year's.
-		if (prev[year]) return;
-		const updatedPreference = { goalRecapViewed: { ...prev, [year]: true } };
-		await updateUserPreferences(
-			apolloClient,
-			userPreferences.value,
-			parsedPrefs,
-			updatedPreference
-		);
-	}
-
-	const goalRecapPendingByYear = computed(() => {
-		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
-		return parsedPrefs.goalRecapPending || {};
-	});
-
-	function hasGoalRecapPendingForYear(year) {
-		return Boolean(goalRecapPendingByYear.value?.[year]);
-	}
-
-	// Set the first time a completed goal is seen, so the recap can open on the session
-	// after completion without depending on the goal card's own celebration flag.
-	async function setGoalRecapPendingPreference(year = GOALS_CURRENT_YEAR) {
-		if (!year) return;
-		const parsedPrefs = await loadPreferences('network-only');
-		const prev = parsedPrefs?.goalRecapPending || {};
-		if (prev[year]) return;
-		const updatedPreference = { goalRecapPending: { ...prev, [year]: true } };
-		await updateUserPreferences(
-			apolloClient,
-			userPreferences.value,
-			parsedPrefs,
-			updatedPreference
-		);
-	}
-
-	const goalFeedbackSubmittedByYear = computed(() => {
-		const parsedPrefs = JSON.parse(userPreferences.value?.preferences || '{}');
-		return parsedPrefs.goalFeedbackSubmitted || {};
-	});
-
-	function hasSubmittedGoalFeedbackForYear(year) {
-		return Boolean(goalFeedbackSubmittedByYear.value?.[year]);
-	}
-
-	async function setGoalFeedbackSubmittedPreference(year = GOALS_CURRENT_YEAR) {
-		if (!year) return;
-		const parsedPrefs = await loadPreferences('network-only');
-		const prev = parsedPrefs?.goalFeedbackSubmitted || {};
-		// Year-keyed flag so a prior year's feedback does not gate the next recap's survey.
-		if (prev[year]) return;
-		const updatedPreference = { goalFeedbackSubmitted: { ...prev, [year]: true } };
-		await updateUserPreferences(
-			apolloClient,
-			userPreferences.value,
-			parsedPrefs,
-			updatedPreference
-		);
-	}
 
 	async function checkCompletedGoal({
 		currentGoalProgress = 0,
@@ -1335,18 +1277,19 @@ export default function useGoalData({ apollo } = {}) {
 		renewAnnualGoal,
 		hideGoalCard,
 		setHideGoalCardPreference,
-		viewedGoalCompleteByYear,
-		hasViewedCompletedGoalForYear,
-		setViewedGoalCompletePreference,
-		goalFeedbackSubmittedByYear,
-		hasSubmittedGoalFeedbackForYear,
-		goalRecapViewedByYear,
-		hasViewedGoalRecapForYear,
-		setGoalRecapViewedPreference,
-		goalRecapPendingByYear,
-		hasGoalRecapPendingForYear,
-		setGoalRecapPendingPreference,
-		setGoalFeedbackSubmittedPreference,
+		viewedGoalCompleteByYear: viewedGoalComplete.byYear,
+		hasViewedCompletedGoalForYear: viewedGoalComplete.hasForYear,
+		setViewedGoalCompletePreference: viewedGoalComplete.setForYear,
+		goalFeedbackSubmittedByYear: goalFeedbackSubmitted.byYear,
+		hasSubmittedGoalFeedbackForYear: goalFeedbackSubmitted.hasForYear,
+		goalRecapViewedByYear: goalRecapViewed.byYear,
+		hasViewedGoalRecapForYear: goalRecapViewed.hasForYear,
+		setGoalRecapViewedPreference: goalRecapViewed.setForYear,
+		// Armed the first time a completed goal is seen, so the recap opens on the visit after it.
+		goalRecapPendingByYear: goalRecapPending.byYear,
+		hasGoalRecapPendingForYear: goalRecapPending.hasForYear,
+		setGoalRecapPendingPreference: goalRecapPending.setForYear,
+		setGoalFeedbackSubmittedPreference: goalFeedbackSubmitted.setForYear,
 		getSupportAllLoanCountByYear,
 		setGoalState,
 		removeGoalFromPreferences,

--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -68,9 +68,12 @@ export function getGoalInReviewCurrentYear() {
  *
  * @param {object} options Composable options.
  * @param {object} [options.apollo] Apollo client; injected when omitted.
+ * @param {object} [options.goalData] An existing useGoalData instance. Pass the page's
+ *   own so the recap reads and writes the same preferences it does — each call to
+ *   useGoalData owns a separate `userPreferences` ref.
  * @returns {object} Goal In Review state, eligibility, and loading function.
  */
-export default function useGoalInReview({ apollo } = {}) {
+export default function useGoalInReview({ apollo, goalData } = {}) {
 	const apolloClient = apollo || inject('apollo');
 	const {
 		getGoalSummary,
@@ -79,7 +82,9 @@ export default function useGoalInReview({ apollo } = {}) {
 		loadPreferences,
 		setGoalRecapPendingPreference,
 		setGoalRecapViewedPreference,
-	} = useGoalData({ apollo: apolloClient });
+		hasSubmittedGoalFeedbackForYear,
+		setGoalFeedbackSubmittedPreference,
+	} = goalData || useGoalData({ apollo: apolloClient });
 	const loading = ref(false);
 	const goalInReviewData = ref(null);
 
@@ -206,5 +211,10 @@ export default function useGoalInReview({ apollo } = {}) {
 		loadAutoOpenRecap,
 		loadGoalInReview,
 		loading,
+		// Re-exposed from the same useGoalData instance the recap writes through, so
+		// callers without their own do not end up reading a second store.
+		hasSubmittedGoalFeedbackForYear,
+		loadGoalPreferences: loadPreferences,
+		setGoalFeedbackSubmittedPreference,
 	};
 }

--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -211,8 +211,6 @@ export default function useGoalInReview({ apollo, goalData } = {}) {
 		loadAutoOpenRecap,
 		loadGoalInReview,
 		loading,
-		// Re-exposed from the same useGoalData instance the recap writes through, so
-		// callers without their own do not end up reading a second store.
 		hasSubmittedGoalFeedbackForYear,
 		loadGoalPreferences: loadPreferences,
 		setGoalFeedbackSubmittedPreference,

--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -7,8 +7,9 @@ import {
 import goalInReviewAchievementsQuery from '#src/graphql/query/goalInReviewAchievements.graphql';
 import goalInReviewLenderQuery from '#src/graphql/query/goalInReviewLender.graphql';
 import contentfulEntriesQuery from '#src/graphql/query/contentfulEntries.graphql';
-import useGoalData from '#src/composables/useGoalData';
+import useGoalData, { GOALS_CURRENT_YEAR, GOAL_STATUS } from '#src/composables/useGoalData';
 import { ID_SUPPORT_ALL } from '#src/composables/useBadgeData';
+import { shouldAutoOpenRecap } from '#src/util/goalInReviewTrigger';
 import logFormatter from '#src/util/logFormatter';
 import {
 	getCategoryName,
@@ -71,7 +72,14 @@ export function getGoalInReviewCurrentYear() {
  */
 export default function useGoalInReview({ apollo } = {}) {
 	const apolloClient = apollo || inject('apollo');
-	const { getGoalSummary } = useGoalData({ apollo: apolloClient });
+	const {
+		getGoalSummary,
+		hasGoalRecapPendingForYear,
+		hasViewedGoalRecapForYear,
+		loadPreferences,
+		setGoalRecapPendingPreference,
+		setGoalRecapViewedPreference,
+	} = useGoalData({ apollo: apolloClient });
 	const loading = ref(false);
 	const goalInReviewData = ref(null);
 
@@ -143,10 +151,59 @@ export default function useGoalInReview({ apollo } = {}) {
 		}
 	}
 
+	/**
+	 * Loads the recap only when it should open by itself. MyKiva and Portfolio both
+	 * call this, so the pop-up happens once per user rather than once per page.
+	 *
+	 * @param {object} options Trigger options.
+	 * @param {boolean} options.enabled The goal_in_review_enable setting.
+	 * @returns {Promise<object|null>} The recap payload to show, or null to stay shut.
+	 */
+	async function loadAutoOpenRecap({ enabled = false } = {}) {
+		if (!enabled) {
+			return null;
+		}
+
+		await loadPreferences('network-only');
+		const year = getGoalInReviewTargetYear();
+		const hasViewedRecap = hasViewedGoalRecapForYear(year);
+		const hasCompletionPending = hasGoalRecapPendingForYear(year);
+		if (hasViewedRecap) {
+			return null;
+		}
+
+		const data = await loadGoalInReview({ year });
+		const goalYear = new Date(data?.goalSummary?.dateStarted).getFullYear();
+
+		const shouldOpen = shouldAutoOpenRecap({
+			enabled,
+			isEligible: Boolean(data?.isEligible),
+			goalStatus: data?.goalSummary?.status,
+			goalYear,
+			currentGoalYear: GOALS_CURRENT_YEAR,
+			hasViewedRecap,
+			hasCompletionPending,
+		});
+
+		if (!shouldOpen) {
+			// First sighting of a completed goal arms the recap for the next session.
+			if (data?.isEligible && data?.goalSummary?.status === GOAL_STATUS.COMPLETED && !hasCompletionPending) {
+				await setGoalRecapPendingPreference(year);
+			}
+			return null;
+		}
+
+		// Opening is what counts as seen, so dismissing without reading still stops it
+		// coming back on the other page or in a later session.
+		await setGoalRecapViewedPreference(year);
+		return data;
+	}
+
 	return {
 		GOAL_RECAP_DEEP_LINK,
 		goalInReviewData,
 		isEligible,
+		loadAutoOpenRecap,
 		loadGoalInReview,
 		loading,
 	};

--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -162,15 +162,19 @@ export default function useGoalInReview({ apollo, goalData } = {}) {
 	 *
 	 * @param {object} options Trigger options.
 	 * @param {boolean} options.enabled The goal_in_review_enable setting.
+	 * @param {Date|string|null} [options.inProgressStartDate] The
+	 *   goal_in_review_in_progress_start setting, the date in-progress goal setters
+	 *   become eligible. Completed goal setters are not gated by it.
 	 * @returns {Promise<object|null>} The recap payload to show, or null to stay shut.
 	 */
-	async function loadAutoOpenRecap({ enabled = false } = {}) {
+	async function loadAutoOpenRecap({ enabled = false, inProgressStartDate = null } = {}) {
 		if (!enabled) {
 			return null;
 		}
 
 		await loadPreferences('network-only');
-		const year = getGoalInReviewTargetYear();
+		const now = getGoalInReviewNow();
+		const year = getGoalInReviewTargetYear(now);
 		const hasViewedRecap = hasViewedGoalRecapForYear(year);
 		const hasCompletionPending = hasGoalRecapPendingForYear(year);
 		if (hasViewedRecap) {
@@ -188,6 +192,8 @@ export default function useGoalInReview({ apollo, goalData } = {}) {
 			currentGoalYear: GOALS_CURRENT_YEAR,
 			hasViewedRecap,
 			hasCompletionPending,
+			inProgressStartDate,
+			now,
 		});
 
 		if (!shouldOpen) {

--- a/src/graphql/query/myKiva.graphql
+++ b/src/graphql/query/myKiva.graphql
@@ -184,5 +184,9 @@ query myKivaQuery {
       key
       value
     }
+    goal_in_review_in_progress_start: uiConfigSetting(key: "goal_in_review_in_progress_start") {
+      key
+      value
+    }
   }
 }

--- a/src/graphql/query/portfolioQuery.graphql
+++ b/src/graphql/query/portfolioQuery.graphql
@@ -49,5 +49,9 @@ query portfolioQuery {
 			key
 			value
 		}
+		goal_in_review_in_progress_start: uiConfigSetting(key: "goal_in_review_in_progress_start") {
+			key
+			value
+		}
 	}
 }

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -34,6 +34,7 @@
 			:show-my-giving-funds-card="showMyGivingFundsCard"
 			:goal-recommended-loan-enable="goalRecommendedLoanEnable"
 			:goal-in-review-enable="goalInReviewEnable"
+			:goal-in-review-in-progress-start="goalInReviewInProgressStart"
 			:goals-row-enabled="goalsRowEnabled"
 			:should-render-featured-slot="shouldRenderFeaturedSlot"
 		/>
@@ -55,7 +56,7 @@ import { gql } from 'graphql-tag';
 import borrowerProfileSideSheetQuery from '#src/graphql/query/borrowerProfileSideSheet.graphql';
 import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
 import { initializeExperiment } from '#src/util/experiment/experimentUtils';
-import { readBoolSetting } from '#src/util/settingsUtils';
+import { readBoolSetting, readDateSetting } from '#src/util/settingsUtils';
 import useGoalData, { LAST_YEAR_KEY } from '#src/composables/useGoalData';
 import useBadgeData, {
 	applyFreshProgressToAchievements,
@@ -116,6 +117,7 @@ export default {
 			recentTransactionLoans: [],
 			goalRecommendedLoanEnable: false,
 			goalInReviewEnable: false,
+			goalInReviewInProgressStart: null,
 			goalsRowEnabled: false,
 			shouldRenderFeaturedSlot: true,
 		};
@@ -342,6 +344,7 @@ export default {
 
 				const goalInReviewFlag = readBoolSetting(myKivaQueryResult, 'general.goal_in_review_enable.value') ?? false; // eslint-disable-line max-len
 				this.goalInReviewEnable = goalInReviewFlag;
+				this.goalInReviewInProgressStart = readDateSetting(myKivaQueryResult, 'general.goal_in_review_in_progress_start.value'); // eslint-disable-line max-len
 
 				this.latestLoan = myKivaQueryResult.my?.latestLoan?.values?.[0]?.loan ? {
 					...myKivaQueryResult.my.latestLoan.values[0].loan,

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -722,8 +722,8 @@ export default {
 		toggleTooltip() {
 			this.tooltipVisible = !this.tooltipVisible;
 		},
-		// Client-side only: /portfolio is CDN cached and MyKiva server renders, so the
-		// pop-up must not be decided during SSR.
+		// Called from mounted: the decision reads user preferences and writes one back,
+		// so it must not run during server render.
 		async openGoalRecapIfDue() {
 			const goalInReview = await this.loadAutoOpenRecap({ enabled: this.goalInReviewEnable });
 			if (!goalInReview) {

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -345,15 +345,14 @@ export default {
 	},
 	setup() {
 		const apollo = inject('apollo');
+		const goalData = inject('goalData');
 		const { getMostRecentBlogPost } = useContentful(apollo);
 		const { isMobile } = useBreakpoints();
 		const {
 			goalInReviewData,
 			loadAutoOpenRecap,
 			loadGoalInReview,
-		} = useGoalInReview();
-
-		const goalData = inject('goalData');
+		} = useGoalInReview({ goalData });
 
 		const {
 			getLoanFindingUrl,

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -349,6 +349,7 @@ export default {
 		const { isMobile } = useBreakpoints();
 		const {
 			goalInReviewData,
+			loadAutoOpenRecap,
 			loadGoalInReview,
 		} = useGoalInReview();
 
@@ -365,6 +366,7 @@ export default {
 			getMostRecentBlogPost,
 			goalInReviewData,
 			isMobile,
+			loadAutoOpenRecap,
 			loadGoalInReview,
 			hasSubmittedGoalFeedbackForYear: goalData.hasSubmittedGoalFeedbackForYear,
 			setGoalFeedbackSubmittedPreference: goalData.setGoalFeedbackSubmittedPreference,
@@ -720,6 +722,17 @@ export default {
 		toggleTooltip() {
 			this.tooltipVisible = !this.tooltipVisible;
 		},
+		// Client-side only: /portfolio is CDN cached and MyKiva server renders, so the
+		// pop-up must not be decided during SSR.
+		async openGoalRecapIfDue() {
+			const goalInReview = await this.loadAutoOpenRecap({ enabled: this.goalInReviewEnable });
+			if (!goalInReview) {
+				return;
+			}
+			await this.loadGoalPreferences('network-only');
+			this.goalInReviewFeedbackSubmitted = this.hasSubmittedGoalFeedbackForYear(goalInReview.year);
+			this.showGoalInReviewModal = true;
+		},
 		async handleGoToDeepLink(sectionId) {
 			if (sectionId === GOAL_RECAP_DEEP_LINK) {
 				if (!this.goalInReviewEnable) {
@@ -761,7 +774,9 @@ export default {
 			const sectionId = this.$route?.query?.goTo || '';
 			if (sectionId) {
 				this.handleGoToDeepLink(sectionId);
+				return;
 			}
+			this.openGoalRecapIfDue();
 		});
 
 		this.$kvTrackEvent('portfolio', 'view', 'New My Kiva');

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -333,6 +333,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		goalInReviewInProgressStart: {
+			type: Date,
+			default: null,
+		},
 		goalsRowEnabled: {
 			type: Boolean,
 			default: false,
@@ -724,7 +728,10 @@ export default {
 		// Called from mounted: the decision reads user preferences and writes one back,
 		// so it must not run during server render.
 		async openGoalRecapIfDue() {
-			const goalInReview = await this.loadAutoOpenRecap({ enabled: this.goalInReviewEnable });
+			const goalInReview = await this.loadAutoOpenRecap({
+				enabled: this.goalInReviewEnable,
+				inProgressStartDate: this.goalInReviewInProgressStart,
+			});
 			if (!goalInReview) {
 				return;
 			}

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -728,7 +728,6 @@ export default {
 			if (!goalInReview) {
 				return;
 			}
-			await this.loadGoalPreferences('network-only');
 			this.goalInReviewFeedbackSubmitted = this.hasSubmittedGoalFeedbackForYear(goalInReview.year);
 			this.showGoalInReviewModal = true;
 		},

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -46,6 +46,14 @@
 				</section>
 			</kv-page-container>
 		</div>
+		<GoalInReviewModal
+			v-if="goalInReviewEnable && showGoalInReviewModal"
+			:show="showGoalInReviewModal"
+			:data="goalInReviewData"
+			:feedback-submitted="goalInReviewFeedbackSubmitted"
+			@close="showGoalInReviewModal = false"
+			@feedback-submitted="handleGoalInReviewFeedbackSubmitted"
+		/>
 	</www-page>
 </template>
 
@@ -55,7 +63,10 @@ import TheMyKivaSecondaryMenu from '#src/components/WwwFrame/Menus/TheMyKivaSeco
 import ThePortfolioTertiaryMenu from '#src/components/WwwFrame/Menus/ThePortfolioTertiaryMenu';
 import { gql } from 'graphql-tag';
 import { readBoolSetting } from '#src/util/settingsUtils';
-import { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
+import { inject } from 'vue';
+import useGoalData, { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
+import useGoalInReview from '#src/composables/useGoalInReview';
+import GoalInReviewModal from '#src/components/MyKiva/GoalInReview/GoalInReviewModal';
 import portfolioQuery from '#src/graphql/query/portfolioQuery.graphql';
 import badgeGoalMixin from '#src/plugins/badge-goal-mixin';
 import { hasLoanFunFactFootnote } from '#src/util/myKivaUtils';
@@ -86,6 +97,7 @@ export default {
 	inject: ['apollo', 'cookieStore'],
 	components: {
 		AccountOverview,
+		GoalInReviewModal,
 		AccountUpdates,
 		DistributionGraphs,
 		EducationModule,
@@ -103,6 +115,19 @@ export default {
 		LoanCards,
 		GoalEntrypoint
 	},
+	setup() {
+		const apollo = inject('apollo');
+		const { goalInReviewData, loadAutoOpenRecap } = useGoalInReview({ apollo });
+		const goalData = useGoalData({ apollo });
+
+		return {
+			goalInReviewData,
+			loadAutoOpenRecap,
+			hasSubmittedGoalFeedbackForYear: goalData.hasSubmittedGoalFeedbackForYear,
+			loadGoalPreferences: goalData.loadPreferences,
+			setGoalFeedbackSubmittedPreference: goalData.setGoalFeedbackSubmittedPreference,
+		};
+	},
 	data() {
 		return {
 			allowedTeams: [],
@@ -116,6 +141,8 @@ export default {
 			showTeamChallenge: false,
 			teamsChallengeEnable: false,
 			goalInReviewEnable: false,
+			showGoalInReviewModal: false,
+			goalInReviewFeedbackSubmitted: false,
 			userPreferences: null,
 			goalsEntrypointEnable: false,
 			isEmptyGoal: true,
@@ -130,6 +157,20 @@ export default {
 		},
 	},
 	methods: {
+		// Client-side only: /portfolio is CDN cached, so the pop-up must not be
+		// decided during server render.
+		async openGoalRecapIfDue() {
+			const goalInReview = await this.loadAutoOpenRecap({ enabled: this.goalInReviewEnable });
+			if (!goalInReview) {
+				return;
+			}
+			await this.loadGoalPreferences('network-only');
+			this.goalInReviewFeedbackSubmitted = this.hasSubmittedGoalFeedbackForYear(goalInReview.year);
+			this.showGoalInReviewModal = true;
+		},
+		async handleGoalInReviewFeedbackSubmitted() {
+			await this.setGoalFeedbackSubmittedPreference(this.goalInReviewData?.year);
+		},
 		loadEducationPost() {
 			// Donation Education Module Experiment MARS-497
 			this.apollo.query({
@@ -194,6 +235,7 @@ export default {
 	},
 	async mounted() {
 		this.loadEducationPost();
+		this.openGoalRecapIfDue();
 
 		if (this.$route?.query?.goal_saved) {
 			const badgeName = this.$route?.query?.goal_saved ?? '';

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -63,8 +63,7 @@ import TheMyKivaSecondaryMenu from '#src/components/WwwFrame/Menus/TheMyKivaSeco
 import ThePortfolioTertiaryMenu from '#src/components/WwwFrame/Menus/ThePortfolioTertiaryMenu';
 import { gql } from 'graphql-tag';
 import { readBoolSetting } from '#src/util/settingsUtils';
-import { inject } from 'vue';
-import useGoalData, { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
+import { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
 import useGoalInReview from '#src/composables/useGoalInReview';
 import GoalInReviewModal from '#src/components/MyKiva/GoalInReview/GoalInReviewModal';
 import portfolioQuery from '#src/graphql/query/portfolioQuery.graphql';
@@ -116,16 +115,20 @@ export default {
 		GoalEntrypoint
 	},
 	setup() {
-		const apollo = inject('apollo');
-		const { goalInReviewData, loadAutoOpenRecap } = useGoalInReview({ apollo });
-		const goalData = useGoalData({ apollo });
+		const {
+			goalInReviewData,
+			loadAutoOpenRecap,
+			hasSubmittedGoalFeedbackForYear,
+			loadGoalPreferences,
+			setGoalFeedbackSubmittedPreference,
+		} = useGoalInReview();
 
 		return {
 			goalInReviewData,
 			loadAutoOpenRecap,
-			hasSubmittedGoalFeedbackForYear: goalData.hasSubmittedGoalFeedbackForYear,
-			loadGoalPreferences: goalData.loadPreferences,
-			setGoalFeedbackSubmittedPreference: goalData.setGoalFeedbackSubmittedPreference,
+			hasSubmittedGoalFeedbackForYear,
+			loadGoalPreferences,
+			setGoalFeedbackSubmittedPreference,
 		};
 	},
 	data() {

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -62,7 +62,7 @@ import WwwPage from '#src/components/WwwFrame/WwwPage';
 import TheMyKivaSecondaryMenu from '#src/components/WwwFrame/Menus/TheMyKivaSecondaryMenu';
 import ThePortfolioTertiaryMenu from '#src/components/WwwFrame/Menus/ThePortfolioTertiaryMenu';
 import { gql } from 'graphql-tag';
-import { readBoolSetting } from '#src/util/settingsUtils';
+import { readBoolSetting, readDateSetting } from '#src/util/settingsUtils';
 import { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
 import useGoalInReview from '#src/composables/useGoalInReview';
 import GoalInReviewModal from '#src/components/MyKiva/GoalInReview/GoalInReviewModal';
@@ -142,6 +142,7 @@ export default {
 			showTeamChallenge: false,
 			teamsChallengeEnable: false,
 			goalInReviewEnable: false,
+			goalInReviewInProgressStart: null,
 			showGoalInReviewModal: false,
 			goalInReviewFeedbackSubmitted: false,
 			userPreferences: null,
@@ -161,7 +162,10 @@ export default {
 		// Called from mounted: the decision reads user preferences and writes one back,
 		// so it must not run during server render.
 		async openGoalRecapIfDue() {
-			const goalInReview = await this.loadAutoOpenRecap({ enabled: this.goalInReviewEnable });
+			const goalInReview = await this.loadAutoOpenRecap({
+				enabled: this.goalInReviewEnable,
+				inProgressStartDate: this.goalInReviewInProgressStart,
+			});
 			if (!goalInReview) {
 				return;
 			}
@@ -221,6 +225,7 @@ export default {
 		this.showTeamChallenge = teamsChallengeEnable && this.allowedTeams.length > 0;
 
 		this.goalInReviewEnable = readBoolSetting(portfolioQueryData, 'general.goal_in_review_enable.value') ?? false;
+		this.goalInReviewInProgressStart = readDateSetting(portfolioQueryData, 'general.goal_in_review_in_progress_start.value'); // eslint-disable-line max-len
 
 		this.userPreferences = portfolioQueryData?.my?.userPreferences ?? null;
 

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -119,7 +119,6 @@ export default {
 			goalInReviewData,
 			loadAutoOpenRecap,
 			hasSubmittedGoalFeedbackForYear,
-			loadGoalPreferences,
 			setGoalFeedbackSubmittedPreference,
 		} = useGoalInReview();
 
@@ -127,7 +126,6 @@ export default {
 			goalInReviewData,
 			loadAutoOpenRecap,
 			hasSubmittedGoalFeedbackForYear,
-			loadGoalPreferences,
 			setGoalFeedbackSubmittedPreference,
 		};
 	},
@@ -167,7 +165,6 @@ export default {
 			if (!goalInReview) {
 				return;
 			}
-			await this.loadGoalPreferences('network-only');
 			this.goalInReviewFeedbackSubmitted = this.hasSubmittedGoalFeedbackForYear(goalInReview.year);
 			this.showGoalInReviewModal = true;
 		},

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -157,8 +157,8 @@ export default {
 		},
 	},
 	methods: {
-		// Client-side only: /portfolio is CDN cached, so the pop-up must not be
-		// decided during server render.
+		// Called from mounted: the decision reads user preferences and writes one back,
+		// so it must not run during server render.
 		async openGoalRecapIfDue() {
 			const goalInReview = await this.loadAutoOpenRecap({ enabled: this.goalInReviewEnable });
 			if (!goalInReview) {

--- a/src/util/goalInReviewTrigger.js
+++ b/src/util/goalInReviewTrigger.js
@@ -1,6 +1,23 @@
 import { GOAL_STATUS } from '#src/composables/useGoalData';
 
 /**
+ * Whether the in-progress release date has arrived. Missing or unparseable dates
+ * read as "not yet", so an unset setting holds the pop-up back rather than
+ * releasing it to every in-progress goal setter at once.
+ *
+ * @param {Date|string|null} startDate The configured release date.
+ * @param {Date} now The effective current date.
+ * @returns {boolean} Whether in-progress goal setters are eligible yet.
+ */
+function hasInProgressReleaseStarted(startDate, now) {
+	const start = startDate instanceof Date ? startDate : new Date(startDate ?? NaN);
+	if (Number.isNaN(start.getTime())) {
+		return false;
+	}
+	return now.getTime() >= start.getTime();
+}
+
+/**
  * Decides whether the recap should open by itself, for MyKiva and Portfolio alike.
  * Both pages call this so the pop-up happens once per user across the two, rather
  * than once per page.
@@ -14,6 +31,9 @@ import { GOAL_STATUS } from '#src/composables/useGoalData';
  * @param {boolean} options.hasViewedRecap Whether the recap has already been seen.
  * @param {boolean} options.hasCompletionPending Whether a completed goal was already
  *   seen on an earlier visit, which makes this the session after completion.
+ * @param {Date|string|null} options.inProgressStartDate The goal_in_review_in_progress_start
+ *   setting, the date in-progress goal setters become eligible.
+ * @param {Date} options.now The effective current date.
  * @returns {boolean} Whether to open the recap automatically.
  */
 export function shouldAutoOpenRecap({
@@ -24,6 +44,8 @@ export function shouldAutoOpenRecap({
 	currentGoalYear = null,
 	hasViewedRecap = false,
 	hasCompletionPending = false,
+	inProgressStartDate = null,
+	now = new Date(),
 } = {}) {
 	if (!enabled || !isEligible || hasViewedRecap) {
 		return false;
@@ -40,10 +62,10 @@ export function shouldAutoOpenRecap({
 		return hasCompletionPending;
 	}
 
-	// In progress goal setters are reached when the feature itself goes live, so the
-	// flag is the only gate.
+	// Completed goal setters see the recap as soon as the feature is live; in-progress
+	// ones wait for the configured release date so their goal has run most of its course.
 	if (goalStatus === GOAL_STATUS.IN_PROGRESS) {
-		return true;
+		return hasInProgressReleaseStarted(inProgressStartDate, now);
 	}
 
 	return false;

--- a/src/util/goalInReviewTrigger.js
+++ b/src/util/goalInReviewTrigger.js
@@ -1,0 +1,50 @@
+import { GOAL_STATUS } from '#src/composables/useGoalData';
+
+/**
+ * Decides whether the recap should open by itself, for MyKiva and Portfolio alike.
+ * Both pages call this so the pop-up happens once per user across the two, rather
+ * than once per page.
+ *
+ * @param {object} options Trigger inputs.
+ * @param {boolean} options.enabled The goal_in_review_enable setting.
+ * @param {boolean} options.isEligible Whether the recap has a goal with progress.
+ * @param {string} options.goalStatus The goal's status.
+ * @param {number|string} options.goalYear The year the goal belongs to.
+ * @param {number|string} options.currentGoalYear The goal year in progress now.
+ * @param {boolean} options.hasViewedRecap Whether the recap has already been seen.
+ * @param {boolean} options.hasCompletionPending Whether a completed goal was already
+ *   seen on an earlier visit, which makes this the session after completion.
+ * @returns {boolean} Whether to open the recap automatically.
+ */
+export function shouldAutoOpenRecap({
+	enabled = false,
+	isEligible = false,
+	goalStatus = '',
+	goalYear = null,
+	currentGoalYear = null,
+	hasViewedRecap = false,
+	hasCompletionPending = false,
+} = {}) {
+	if (!enabled || !isEligible || hasViewedRecap) {
+		return false;
+	}
+
+	// The pop-up is for this year's goal setters. A goal from a previous year is only
+	// reachable through the goal card entry point.
+	if (Number(goalYear) !== Number(currentGoalYear)) {
+		return false;
+	}
+
+	if (goalStatus === GOAL_STATUS.COMPLETED) {
+		// The session after completion: the completed goal was already seen on an earlier visit.
+		return hasCompletionPending;
+	}
+
+	// In progress goal setters are reached when the feature itself goes live, so the
+	// flag is the only gate.
+	if (goalStatus === GOAL_STATUS.IN_PROGRESS) {
+		return true;
+	}
+
+	return false;
+}

--- a/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
@@ -24,6 +24,8 @@ const makeBadge = (id, totalProgress, tierTargets) => ({
 	level: tierTargets.reduce((lvl, t, i) => (totalProgress >= t ? i + 1 : lvl), 0),
 });
 
+const IN_PROGRESS_RELEASE = new Date('2026-11-15T00:00:00Z');
+
 describe('MyKivaPageContent', () => {
 	describe('allBadgesCompleted', () => {
 		const callComputed = heroBadgeData => {
@@ -171,6 +173,7 @@ describe('MyKivaPageContent', () => {
 	describe('openGoalRecapIfDue', () => {
 		const makeContext = overrides => ({
 			goalInReviewEnable: true,
+			goalInReviewInProgressStart: IN_PROGRESS_RELEASE,
 			loadAutoOpenRecap: vi.fn().mockResolvedValue({ year: 2026 }),
 			loadGoalPreferences: vi.fn().mockResolvedValue({}),
 			hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(false),
@@ -184,7 +187,10 @@ describe('MyKivaPageContent', () => {
 
 			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
 
-			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: true });
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({
+				enabled: true,
+				inProgressStartDate: IN_PROGRESS_RELEASE,
+			});
 			expect(context.showGoalInReviewModal).toBe(true);
 		});
 
@@ -204,7 +210,10 @@ describe('MyKivaPageContent', () => {
 
 			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
 
-			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: false });
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({
+				enabled: false,
+				inProgressStartDate: IN_PROGRESS_RELEASE,
+			});
 			expect(context.showGoalInReviewModal).toBe(false);
 		});
 

--- a/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
@@ -208,12 +208,12 @@ describe('MyKivaPageContent', () => {
 			expect(context.showGoalInReviewModal).toBe(false);
 		});
 
-		it('snapshots the already-submitted feedback flag before opening', async () => {
+		it('snapshots the already-submitted feedback flag, without a second preferences fetch', async () => {
 			const context = makeContext({ hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(true) });
 
 			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
 
-			expect(context.loadGoalPreferences).toHaveBeenCalledWith('network-only');
+			expect(context.loadGoalPreferences).not.toHaveBeenCalled();
 			expect(context.goalInReviewFeedbackSubmitted).toBe(true);
 		});
 	});

--- a/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
+++ b/test/unit/specs/pages/MyKiva/MyKivaPageContent.spec.js
@@ -168,6 +168,56 @@ describe('MyKivaPageContent', () => {
 		});
 	});
 
+	describe('openGoalRecapIfDue', () => {
+		const makeContext = overrides => ({
+			goalInReviewEnable: true,
+			loadAutoOpenRecap: vi.fn().mockResolvedValue({ year: 2026 }),
+			loadGoalPreferences: vi.fn().mockResolvedValue({}),
+			hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(false),
+			showGoalInReviewModal: false,
+			goalInReviewFeedbackSubmitted: false,
+			...overrides,
+		});
+
+		it('opens the recap when the composable says it is due', async () => {
+			const context = makeContext();
+
+			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: true });
+			expect(context.showGoalInReviewModal).toBe(true);
+		});
+
+		it('stays shut when the composable declines', async () => {
+			const context = makeContext({ loadAutoOpenRecap: vi.fn().mockResolvedValue(null) });
+
+			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.showGoalInReviewModal).toBe(false);
+		});
+
+		it('passes the flag through, so the composable can decline before fetching', async () => {
+			const context = makeContext({
+				goalInReviewEnable: false,
+				loadAutoOpenRecap: vi.fn().mockResolvedValue(null),
+			});
+
+			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: false });
+			expect(context.showGoalInReviewModal).toBe(false);
+		});
+
+		it('snapshots the already-submitted feedback flag before opening', async () => {
+			const context = makeContext({ hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(true) });
+
+			await MyKivaPageContent.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.loadGoalPreferences).toHaveBeenCalledWith('network-only');
+			expect(context.goalInReviewFeedbackSubmitted).toBe(true);
+		});
+	});
+
 	describe('handleGoalInReviewFeedbackSubmitted', () => {
 		it('persists the feedback-submitted preference for the recap year', async () => {
 			const setGoalFeedbackSubmittedPreference = vi.fn().mockResolvedValue();

--- a/test/unit/specs/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.spec.js
@@ -1,9 +1,12 @@
 import ImpactDashboardPage from '#src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage';
 
+const IN_PROGRESS_RELEASE = new Date('2026-11-15T00:00:00Z');
+
 describe('ImpactDashboardPage', () => {
 	describe('openGoalRecapIfDue', () => {
 		const makeContext = overrides => ({
 			goalInReviewEnable: true,
+			goalInReviewInProgressStart: IN_PROGRESS_RELEASE,
 			loadAutoOpenRecap: vi.fn().mockResolvedValue({ year: 2026 }),
 			loadGoalPreferences: vi.fn().mockResolvedValue({}),
 			hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(false),
@@ -17,7 +20,10 @@ describe('ImpactDashboardPage', () => {
 
 			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
 
-			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: true });
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({
+				enabled: true,
+				inProgressStartDate: IN_PROGRESS_RELEASE,
+			});
 			expect(context.showGoalInReviewModal).toBe(true);
 		});
 
@@ -37,7 +43,10 @@ describe('ImpactDashboardPage', () => {
 
 			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
 
-			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: false });
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({
+				enabled: false,
+				inProgressStartDate: IN_PROGRESS_RELEASE,
+			});
 			expect(context.showGoalInReviewModal).toBe(false);
 		});
 

--- a/test/unit/specs/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.spec.js
@@ -41,12 +41,12 @@ describe('ImpactDashboardPage', () => {
 			expect(context.showGoalInReviewModal).toBe(false);
 		});
 
-		it('snapshots the already-submitted feedback flag before opening', async () => {
+		it('snapshots the already-submitted feedback flag, without a second preferences fetch', async () => {
 			const context = makeContext({ hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(true) });
 
 			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
 
-			expect(context.loadGoalPreferences).toHaveBeenCalledWith('network-only');
+			expect(context.loadGoalPreferences).not.toHaveBeenCalled();
 			expect(context.goalInReviewFeedbackSubmitted).toBe(true);
 		});
 	});

--- a/test/unit/specs/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.spec.js
@@ -1,0 +1,67 @@
+import ImpactDashboardPage from '#src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage';
+
+describe('ImpactDashboardPage', () => {
+	describe('openGoalRecapIfDue', () => {
+		const makeContext = overrides => ({
+			goalInReviewEnable: true,
+			loadAutoOpenRecap: vi.fn().mockResolvedValue({ year: 2026 }),
+			loadGoalPreferences: vi.fn().mockResolvedValue({}),
+			hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(false),
+			showGoalInReviewModal: false,
+			goalInReviewFeedbackSubmitted: false,
+			...overrides,
+		});
+
+		it('opens the recap on Portfolio when it is due', async () => {
+			const context = makeContext();
+
+			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: true });
+			expect(context.showGoalInReviewModal).toBe(true);
+		});
+
+		it('stays shut when the composable declines, so it cannot pop on both pages', async () => {
+			const context = makeContext({ loadAutoOpenRecap: vi.fn().mockResolvedValue(null) });
+
+			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.showGoalInReviewModal).toBe(false);
+		});
+
+		it('passes the flag through', async () => {
+			const context = makeContext({
+				goalInReviewEnable: false,
+				loadAutoOpenRecap: vi.fn().mockResolvedValue(null),
+			});
+
+			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.loadAutoOpenRecap).toHaveBeenCalledWith({ enabled: false });
+			expect(context.showGoalInReviewModal).toBe(false);
+		});
+
+		it('snapshots the already-submitted feedback flag before opening', async () => {
+			const context = makeContext({ hasSubmittedGoalFeedbackForYear: vi.fn().mockReturnValue(true) });
+
+			await ImpactDashboardPage.methods.openGoalRecapIfDue.call(context);
+
+			expect(context.loadGoalPreferences).toHaveBeenCalledWith('network-only');
+			expect(context.goalInReviewFeedbackSubmitted).toBe(true);
+		});
+	});
+
+	describe('handleGoalInReviewFeedbackSubmitted', () => {
+		it('persists the feedback-submitted preference for the recap year', async () => {
+			const setGoalFeedbackSubmittedPreference = vi.fn().mockResolvedValue();
+			const context = {
+				goalInReviewData: { year: 2026 },
+				setGoalFeedbackSubmittedPreference,
+			};
+
+			await ImpactDashboardPage.methods.handleGoalInReviewFeedbackSubmitted.call(context);
+
+			expect(setGoalFeedbackSubmittedPreference).toHaveBeenCalledWith(2026);
+		});
+	});
+});

--- a/test/unit/specs/util/goalInReviewTrigger.spec.js
+++ b/test/unit/specs/util/goalInReviewTrigger.spec.js
@@ -1,0 +1,80 @@
+import { shouldAutoOpenRecap } from '#src/util/goalInReviewTrigger';
+
+const completed = {
+	enabled: true,
+	isEligible: true,
+	goalStatus: 'completed',
+	goalYear: 2026,
+	currentGoalYear: 2026,
+	hasViewedRecap: false,
+	hasCompletionPending: true,
+};
+
+const inProgress = {
+	...completed,
+	goalStatus: 'in-progress',
+	hasCompletionPending: false,
+};
+
+describe('goalInReviewTrigger.js', () => {
+	describe('completed goals', () => {
+		it('opens in the session after completion', () => {
+			expect(shouldAutoOpenRecap(completed)).toBe(true);
+		});
+
+		it('waits on the visit where the completed goal is first seen', () => {
+			expect(shouldAutoOpenRecap({ ...completed, hasCompletionPending: false })).toBe(false);
+		});
+
+		it('opens for someone who completed before release, on their second visit', () => {
+			// back-fill: the first post-release visit arms it, the next one opens it
+			expect(shouldAutoOpenRecap({ ...completed, hasCompletionPending: true })).toBe(true);
+		});
+	});
+
+	describe('in-progress goals', () => {
+		it('opens once the feature is live, with no separate date gate', () => {
+			expect(shouldAutoOpenRecap(inProgress)).toBe(true);
+		});
+
+		it('does not require a pending completion', () => {
+			expect(shouldAutoOpenRecap({ ...inProgress, hasCompletionPending: false })).toBe(true);
+		});
+	});
+
+	describe('opens only once', () => {
+		it('never reopens after the recap has been seen', () => {
+			expect(shouldAutoOpenRecap({ ...completed, hasViewedRecap: true })).toBe(false);
+			expect(shouldAutoOpenRecap({ ...inProgress, hasViewedRecap: true })).toBe(false);
+		});
+	});
+
+	describe('goals it must never open for', () => {
+		it('a goal from a previous year', () => {
+			expect(shouldAutoOpenRecap({ ...completed, goalYear: 2025 })).toBe(false);
+			expect(shouldAutoOpenRecap({ ...inProgress, goalYear: 2025 })).toBe(false);
+		});
+
+		it('an expired goal', () => {
+			expect(shouldAutoOpenRecap({ ...completed, goalStatus: 'expired' })).toBe(false);
+		});
+
+		it('a lender with no goal or no loans toward it', () => {
+			expect(shouldAutoOpenRecap({ ...completed, isEligible: false })).toBe(false);
+			expect(shouldAutoOpenRecap({ ...inProgress, isEligible: false })).toBe(false);
+		});
+
+		it('anyone, when the feature flag is off', () => {
+			expect(shouldAutoOpenRecap({ ...completed, enabled: false })).toBe(false);
+			expect(shouldAutoOpenRecap({ ...inProgress, enabled: false })).toBe(false);
+		});
+
+		it('a call with nothing passed at all', () => {
+			expect(shouldAutoOpenRecap()).toBe(false);
+		});
+	});
+
+	it('compares goal years loosely, since preferences store them as strings', () => {
+		expect(shouldAutoOpenRecap({ ...completed, goalYear: '2026', currentGoalYear: 2026 })).toBe(true);
+	});
+});

--- a/test/unit/specs/util/goalInReviewTrigger.spec.js
+++ b/test/unit/specs/util/goalInReviewTrigger.spec.js
@@ -10,10 +10,14 @@ const completed = {
 	hasCompletionPending: true,
 };
 
+const IN_PROGRESS_RELEASE = new Date('2026-11-15T00:00:00Z');
+
 const inProgress = {
 	...completed,
 	goalStatus: 'in-progress',
 	hasCompletionPending: false,
+	inProgressStartDate: IN_PROGRESS_RELEASE,
+	now: IN_PROGRESS_RELEASE,
 };
 
 describe('goalInReviewTrigger.js', () => {
@@ -33,12 +37,46 @@ describe('goalInReviewTrigger.js', () => {
 	});
 
 	describe('in-progress goals', () => {
-		it('opens once the feature is live, with no separate date gate', () => {
+		it('opens on the configured release date', () => {
 			expect(shouldAutoOpenRecap(inProgress)).toBe(true);
+		});
+
+		it('opens after the release date', () => {
+			expect(shouldAutoOpenRecap({ ...inProgress, now: new Date('2026-12-01T00:00:00Z') })).toBe(true);
+		});
+
+		it('stays shut before the release date, even with the flag on', () => {
+			expect(shouldAutoOpenRecap({ ...inProgress, now: new Date('2026-11-14T23:59:59Z') })).toBe(false);
 		});
 
 		it('does not require a pending completion', () => {
 			expect(shouldAutoOpenRecap({ ...inProgress, hasCompletionPending: false })).toBe(true);
+		});
+
+		it('accepts the date as a string, since settings come back serialized', () => {
+			expect(shouldAutoOpenRecap({ ...inProgress, inProgressStartDate: '2026-11-15T00:00:00Z' })).toBe(true);
+		});
+
+		it('stays shut when the release date is unset', () => {
+			expect(shouldAutoOpenRecap({ ...inProgress, inProgressStartDate: null })).toBe(false);
+		});
+
+		it('stays shut when the release date cannot be parsed', () => {
+			expect(shouldAutoOpenRecap({ ...inProgress, inProgressStartDate: 'not-a-date' })).toBe(false);
+		});
+	});
+
+	describe('completed goals are not held back by the in-progress date', () => {
+		it('opens before the in-progress release date', () => {
+			expect(shouldAutoOpenRecap({
+				...completed,
+				inProgressStartDate: IN_PROGRESS_RELEASE,
+				now: new Date('2026-11-01T00:00:00Z'),
+			})).toBe(true);
+		});
+
+		it('opens with no in-progress release date configured at all', () => {
+			expect(shouldAutoOpenRecap({ ...completed, inProgressStartDate: null })).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
…portfolio pages

Opens the Goal in Review modal, once per user in total across both My Kiva and Portfolio pages.

## What changed

1. **A seen-once flag the feature owns.** `goalRecapViewed[year]` is written to user preferences when the recap opens, so opening and dismissing both count as seen. It is server side, so it holds across pages, sessions and devices (a cookie would not).

2. **A pending marker for the "session after completion" rule.** `goalRecapPending[year]` is set the first time a completed goal is seen, and the recap opens on the visit after that.

3. ** Both pages ask the same question.** Every rule about when the recap should appear lives in one place, `shouldAutoOpenRecap`. It takes the things it needs as arguments and answers yes or no, so each rule can be tested on its own without standing up a page.

4. **Portfolio now renders the modal.** It computed `goalInReviewEnable` but never had `GoalInReviewModal` mounted.

## Trigger rules

| Goal state | Behaviour |
|---|---|
| Completed, first sighting | nothing shown, arms `goalRecapPending[year]` |
| Completed, already pending | opens, marks `goalRecapViewed[year]` |
| In progress | opens on the first visit once the flag is on |
| Already seen | never again, on either page |
| Previous year or expired | never |
| No goal, or no loans toward it | never |
| Feature flag off | never |

On MyKiva a `?goTo=goal-recap` deep link returns early and skips the auto-open, so an explicit link does not silently consume the once-only flag. The deep link also does not set the flag, so a link in an email keeps working however many times it is clicked.

---

# Test instructions - VQA

You need:

* `goal_in_review_enable` switched on.
* A logged in lender with a goal for the current year and at least one loan toward it.

Use `/mykiva` or `/portfolio` with **no query parameters**. A `?goTo=goal-recap` parameter skips the auto-open path deliberately.

## Check your starting state

Run this in the gateway while logged in as the test account:

```graphql
query { my { id userPreferences { id preferences } } }
```

Look inside the `preferences` JSON for `goalRecapViewed` and `goalRecapPending`. They determine what happens next, and they are stored on the account (clearing cookies or changing browser will not reset them).

## Scenarios

### In progress goal

Needs `goal_in_review_in_progress_start` in the past, or use `?recapDate` to jump past it.

1. No flags set. Visit `/mykiva`. The recap opens.
2. Reload. Nothing. `goalRecapViewed[year]` is now set.
3. Visit `/portfolio`. Nothing. This is the "once in total, not once per page" criterion.
4. Move the setting into the future instead. Nothing, on either page. That is the mid-November gate.

### Completed goal, the session rule

This is the one worth walking end to end, because it spans checkout.

1. With a goal one loan short, check out the loan that completes it. The thanks page shows the completion.
2. Go straight to `/mykiva`. **Nothing.** You are still in the session you completed in. Check that the `kvgrcs` cookie is set to the goal year.
3. Reload, then visit `/portfolio`. Still nothing, for the same reason.
4. End the session, using one of the methods below, and return to `/mykiva`. The recap opens.
5. Dismiss it and reload. Nothing. `goalRecapViewed[year]` is now set.

### How to end the session properly

Closing the tab does **not** work. `kvgrcs` is a session cookie, and a browser session means the whole browser, not one tab. It survives as long as any window of that browser is open.

Quitting the browser usually works, but not always. Chrome's "Continue where you left off" startup setting and Firefox's session restore both bring session cookies back across a full quit. If you have either one enabled, quitting will make the feature look broken.

Two reliable options:

1. **Delete the cookie by hand.** DevTools, then Application, then Cookies, then delete `kvgrcs`. Reload the page. This is the fastest and the one to use for most passes.
2. **Use a private window.** Close every private window to end that session for real.

Worth knowing beyond testing: a lender who never quits their browser stays in the completion session indefinitely and will not get the pop-up. If that is a concern, the alternative is a cookie with a short expiry of a few hours instead of a session cookie. That is looser than "next session", but it always clears itself. Only the way `completedThisSession` is calculated would change.

### Completed goal, already completed in an earlier session

A lender who completed before the feature shipped has no `kvgrcs` cookie, so their first visit opens the recap straight away. Test this by clearing the cookie with a completed goal and no `goalRecapViewed` set.

### Portfolio on its own, without visiting MyKiva

Worth running as its own pass, since a lender who never opens MyKiva must still get the recap.

1. Completed goal, no `goalRecapViewed`, no `kvgrcs` cookie. Visit `/portfolio`. The recap opens.
2. Visit `/mykiva`. Nothing.

### Dismissal counts as seen

Open the recap, then close it with the X or by clicking outside it. Reload. It does not come back. The flag is written when it opens, not when it is read.

### Cases that must never pop

* A goal from a previous year, or an expired goal.
* A lender with no goal, or a goal with no loans toward it.
* Anyone, with `goal_in_review_enable` off.

## Resetting between runs

The flags are written to the account, so each scenario is one-shot. To run them again, clear `goalRecapViewed` and `goalRecapPending` from that user's preferences.