### PR TITLE
fix: change logic to show goal in review after next session or login

### DIFF
--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -590,7 +590,7 @@ onMounted(async () => {
 	});
 	hasContributingLoans.value = contributingLoans;
 	// Thanks can mark the goal complete, but MyKiva owns hiding the completed card after showing it once.
-	await checkCompletedGoal({ currentGoalProgress: totalProgress, persistHideGoalCard: false });
+	await checkCompletedGoal({ currentGoalProgress: totalProgress, persistHideGoalCard: false, cookieStore });
 	goalDataInitialized.value = true;
 	isEmptyGoal.value = Object.keys(userGoal.value || {}).length === 0;
 	goalSignupThanksViewCapped.value = !props.isGuest

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -14,6 +14,7 @@ import { getTransactionTimestamp } from '#src/util/myKivaUtils';
 import { createUserPreferences, updateUserPreferences, setMyKivaGoal } from '#src/util/userPreferenceUtils';
 import { runLoansQuery } from '#src/util/loanSearch/dataUtils';
 import { FLSS_ORIGIN_GOAL_RECOMMENDED_LOAN } from '#src/util/flssUtils';
+import { markGoalCompletedThisSession } from '#src/util/goalRecapSession';
 
 import useBadgeData, {
 	calculateFreshProgressAdjustments,
@@ -855,7 +856,6 @@ export default function useGoalData({ apollo } = {}) {
 
 	const viewedGoalComplete = yearKeyedPreference('viewedGoalComplete');
 	const goalRecapViewed = yearKeyedPreference('goalRecapViewed');
-	const goalRecapPending = yearKeyedPreference('goalRecapPending');
 	const goalFeedbackSubmitted = yearKeyedPreference('goalFeedbackSubmitted');
 
 	/**
@@ -872,6 +872,7 @@ export default function useGoalData({ apollo } = {}) {
 		category = 'post-checkout',
 		eventLabel = 'annual-goal-complete',
 		persistHideGoalCard = false,
+		cookieStore = null,
 	} = {}) {
 		const goal = userGoal.value;
 		if (!goal || goal.status === GOAL_STATUS.EXPIRED) {
@@ -898,6 +899,9 @@ export default function useGoalData({ apollo } = {}) {
 		}
 
 		if (isGoalComplete) {
+			// Marked as soon as the goal looks complete, even if the achievement service has
+			// not confirmed it yet, so the recap cannot appear later in this same session.
+			markGoalCompletedThisSession(cookieStore, GOALS_CURRENT_YEAR);
 			// Capture goal data before storeGoalPreferences (which may filter out the goal via setGoalState)
 			const goalCategory = goal.category;
 			const goalTarget = goal.target;
@@ -1285,10 +1289,6 @@ export default function useGoalData({ apollo } = {}) {
 		goalRecapViewedByYear: goalRecapViewed.byYear,
 		hasViewedGoalRecapForYear: goalRecapViewed.hasForYear,
 		setGoalRecapViewedPreference: goalRecapViewed.setForYear,
-		// Armed the first time a completed goal is seen, so the recap opens on the visit after it.
-		goalRecapPendingByYear: goalRecapPending.byYear,
-		hasGoalRecapPendingForYear: goalRecapPending.hasForYear,
-		setGoalRecapPendingPreference: goalRecapPending.setForYear,
 		setGoalFeedbackSubmittedPreference: goalFeedbackSubmitted.setForYear,
 		getSupportAllLoanCountByYear,
 		setGoalState,

--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -7,9 +7,10 @@ import {
 import goalInReviewAchievementsQuery from '#src/graphql/query/goalInReviewAchievements.graphql';
 import goalInReviewLenderQuery from '#src/graphql/query/goalInReviewLender.graphql';
 import contentfulEntriesQuery from '#src/graphql/query/contentfulEntries.graphql';
-import useGoalData, { GOALS_CURRENT_YEAR, GOAL_STATUS } from '#src/composables/useGoalData';
+import useGoalData, { GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
 import { ID_SUPPORT_ALL } from '#src/composables/useBadgeData';
 import { shouldAutoOpenRecap } from '#src/util/goalInReviewTrigger';
+import { completedGoalThisSession } from '#src/util/goalRecapSession';
 import logFormatter from '#src/util/logFormatter';
 import {
 	getCategoryName,
@@ -68,19 +69,19 @@ export function getGoalInReviewCurrentYear() {
  *
  * @param {object} options Composable options.
  * @param {object} [options.apollo] Apollo client; injected when omitted.
+ * @param {object} [options.cookieStore] Cookie store; injected when omitted.
  * @param {object} [options.goalData] An existing useGoalData instance. Pass the page's
  *   own so the recap reads and writes the same preferences it does — each call to
  *   useGoalData owns a separate `userPreferences` ref.
  * @returns {object} Goal In Review state, eligibility, and loading function.
  */
-export default function useGoalInReview({ apollo, goalData } = {}) {
+export default function useGoalInReview({ apollo, cookieStore, goalData } = {}) {
 	const apolloClient = apollo || inject('apollo');
+	const cookies = cookieStore || inject('cookieStore', null);
 	const {
 		getGoalSummary,
-		hasGoalRecapPendingForYear,
 		hasViewedGoalRecapForYear,
 		loadPreferences,
-		setGoalRecapPendingPreference,
 		setGoalRecapViewedPreference,
 		hasSubmittedGoalFeedbackForYear,
 		setGoalFeedbackSubmittedPreference,
@@ -176,7 +177,6 @@ export default function useGoalInReview({ apollo, goalData } = {}) {
 		const now = getGoalInReviewNow();
 		const year = getGoalInReviewTargetYear(now);
 		const hasViewedRecap = hasViewedGoalRecapForYear(year);
-		const hasCompletionPending = hasGoalRecapPendingForYear(year);
 		if (hasViewedRecap) {
 			return null;
 		}
@@ -191,16 +191,12 @@ export default function useGoalInReview({ apollo, goalData } = {}) {
 			goalYear,
 			currentGoalYear: GOALS_CURRENT_YEAR,
 			hasViewedRecap,
-			hasCompletionPending,
+			completedThisSession: completedGoalThisSession(cookies, year),
 			inProgressStartDate,
 			now,
 		});
 
 		if (!shouldOpen) {
-			// First sighting of a completed goal arms the recap for the next session.
-			if (data?.isEligible && data?.goalSummary?.status === GOAL_STATUS.COMPLETED && !hasCompletionPending) {
-				await setGoalRecapPendingPreference(year);
-			}
 			return null;
 		}
 

--- a/src/pages/MyKiva/MyKivaNextStepsContent.vue
+++ b/src/pages/MyKiva/MyKivaNextStepsContent.vue
@@ -690,7 +690,7 @@ watch(() => props.goalRefreshKey, async (newVal, oldVal) => {
 });
 
 onMounted(async () => {
-	await checkCompletedGoal({ category: 'portfolio', persistHideGoalCard: true });
+	await checkCompletedGoal({ category: 'portfolio', persistHideGoalCard: true, cookieStore });
 	if (shouldShowPostLendingNextStepsCards) {
 		removePostLendingCardCookie(cookieStore);
 	}

--- a/src/util/goalInReviewTrigger.js
+++ b/src/util/goalInReviewTrigger.js
@@ -29,8 +29,8 @@ function hasInProgressReleaseStarted(startDate, now) {
  * @param {number|string} options.goalYear The year the goal belongs to.
  * @param {number|string} options.currentGoalYear The goal year in progress now.
  * @param {boolean} options.hasViewedRecap Whether the recap has already been seen.
- * @param {boolean} options.hasCompletionPending Whether a completed goal was already
- *   seen on an earlier visit, which makes this the session after completion.
+ * @param {boolean} options.completedThisSession Whether the goal completed during this
+ *   browsing session, which means the recap waits for the next one.
  * @param {Date|string|null} options.inProgressStartDate The goal_in_review_in_progress_start
  *   setting, the date in-progress goal setters become eligible.
  * @param {Date} options.now The effective current date.
@@ -43,7 +43,7 @@ export function shouldAutoOpenRecap({
 	goalYear = null,
 	currentGoalYear = null,
 	hasViewedRecap = false,
-	hasCompletionPending = false,
+	completedThisSession = false,
 	inProgressStartDate = null,
 	now = new Date(),
 } = {}) {
@@ -57,9 +57,10 @@ export function shouldAutoOpenRecap({
 		return false;
 	}
 
+	// If the user arrives at MyKiva from the thanks page, the recap is not shown yet.
+	// It waits for their next session.
 	if (goalStatus === GOAL_STATUS.COMPLETED) {
-		// The session after completion: the completed goal was already seen on an earlier visit.
-		return hasCompletionPending;
+		return !completedThisSession;
 	}
 
 	// Completed goal setters see the recap as soon as the feature is live; in-progress

--- a/src/util/goalRecapSession.js
+++ b/src/util/goalRecapSession.js
@@ -1,0 +1,29 @@
+// Session cookie — no expiry, so it lives until the browser session ends. The recap is
+// meant to arrive on the session *after* the one the goal was completed in, and a
+// server-side preference cannot express that: it has no idea where one visit ends and
+// the next begins.
+const COMPLETION_SESSION_COOKIE = 'kvgrcs';
+
+/**
+ * Records that the goal was completed during this browsing session, so the recap holds
+ * off until the next one.
+ *
+ * @param {object} cookieStore The injected cookie store.
+ * @param {number|string} year The year of the goal that completed.
+ */
+export function markGoalCompletedThisSession(cookieStore, year) {
+	if (!cookieStore || !year) return;
+	cookieStore.set(COMPLETION_SESSION_COOKIE, String(year), { path: '/' });
+}
+
+/**
+ * Whether the goal for this year completed during the current browsing session.
+ *
+ * @param {object} cookieStore The injected cookie store.
+ * @param {number|string} year The recap year.
+ * @returns {boolean} True while still in the session the goal was completed in.
+ */
+export function completedGoalThisSession(cookieStore, year) {
+	if (!cookieStore || !year) return false;
+	return cookieStore.get(COMPLETION_SESSION_COOKIE) === String(year);
+}

--- a/src/util/goalRecapSession.js
+++ b/src/util/goalRecapSession.js
@@ -1,8 +1,6 @@
-// Session cookie — no expiry, so it lives until the browser session ends. The recap is
-// meant to arrive on the session *after* the one the goal was completed in, and a
-// server-side preference cannot express that: it has no idea where one visit ends and
-// the next begins.
-const COMPLETION_SESSION_COOKIE = 'kvgrcs';
+// No expiry, so it clears when the browser session ends. A stored preference cannot do
+// this: it has no idea where one visit ends and the next begins.
+const COMPLETION_SESSION_COOKIE = 'kv_goal_completed_this_session';
 
 /**
  * Records that the goal was completed during this browsing session, so the recap holds

--- a/test/unit/specs/components/Thanks/ThanksPageSingleVersion.spec.js
+++ b/test/unit/specs/components/Thanks/ThanksPageSingleVersion.spec.js
@@ -257,6 +257,7 @@ describe('ThanksPageSingleVersion', () => {
 			expect(mockCheckCompletedGoal).toHaveBeenCalledWith({
 				currentGoalProgress: 5,
 				persistHideGoalCard: false,
+				cookieStore: expect.anything(),
 			});
 		});
 	});

--- a/test/unit/specs/util/goalInReviewTrigger.spec.js
+++ b/test/unit/specs/util/goalInReviewTrigger.spec.js
@@ -7,7 +7,6 @@ const completed = {
 	goalYear: 2026,
 	currentGoalYear: 2026,
 	hasViewedRecap: false,
-	hasCompletionPending: true,
 };
 
 const IN_PROGRESS_RELEASE = new Date('2026-11-15T00:00:00Z');
@@ -15,24 +14,16 @@ const IN_PROGRESS_RELEASE = new Date('2026-11-15T00:00:00Z');
 const inProgress = {
 	...completed,
 	goalStatus: 'in-progress',
-	hasCompletionPending: false,
 	inProgressStartDate: IN_PROGRESS_RELEASE,
 	now: IN_PROGRESS_RELEASE,
 };
 
 describe('goalInReviewTrigger.js', () => {
 	describe('completed goals', () => {
-		it('opens in the session after completion', () => {
+		// Goals complete at checkout, so the first visit to MyKiva or Portfolio is already
+		// a later session and there is nothing to wait for.
+		it('opens on the first visit after completion', () => {
 			expect(shouldAutoOpenRecap(completed)).toBe(true);
-		});
-
-		it('waits on the visit where the completed goal is first seen', () => {
-			expect(shouldAutoOpenRecap({ ...completed, hasCompletionPending: false })).toBe(false);
-		});
-
-		it('opens for someone who completed before release, on their second visit', () => {
-			// back-fill: the first post-release visit arms it, the next one opens it
-			expect(shouldAutoOpenRecap({ ...completed, hasCompletionPending: true })).toBe(true);
 		});
 	});
 
@@ -47,10 +38,6 @@ describe('goalInReviewTrigger.js', () => {
 
 		it('stays shut before the release date, even with the flag on', () => {
 			expect(shouldAutoOpenRecap({ ...inProgress, now: new Date('2026-11-14T23:59:59Z') })).toBe(false);
-		});
-
-		it('does not require a pending completion', () => {
-			expect(shouldAutoOpenRecap({ ...inProgress, hasCompletionPending: false })).toBe(true);
 		});
 
 		it('accepts the date as a string, since settings come back serialized', () => {

--- a/test/unit/specs/util/goalRecapSession.spec.js
+++ b/test/unit/specs/util/goalRecapSession.spec.js
@@ -1,0 +1,53 @@
+import { completedGoalThisSession, markGoalCompletedThisSession } from '#src/util/goalRecapSession';
+
+const makeCookieStore = (initial = {}) => {
+	const jar = { ...initial };
+	return {
+		get: name => jar[name],
+		set: (name, value) => { jar[name] = value; },
+		jar,
+	};
+};
+
+describe('goalRecapSession.js', () => {
+	it('reports the completion session once it has been marked', () => {
+		const cookieStore = makeCookieStore();
+
+		markGoalCompletedThisSession(cookieStore, 2026);
+
+		expect(completedGoalThisSession(cookieStore, 2026)).toBe(true);
+	});
+
+	it('sets no expiry, so the mark dies with the browser session', () => {
+		const cookieStore = { get: vi.fn(), set: vi.fn() };
+
+		markGoalCompletedThisSession(cookieStore, 2026);
+
+		expect(cookieStore.set).toHaveBeenCalledWith('kvgrcs', '2026', { path: '/' });
+	});
+
+	it('does not carry a mark from one goal year to another', () => {
+		const cookieStore = makeCookieStore();
+
+		markGoalCompletedThisSession(cookieStore, 2026);
+
+		expect(completedGoalThisSession(cookieStore, 2027)).toBe(false);
+	});
+
+	it('reports nothing for a session that never marked a completion', () => {
+		expect(completedGoalThisSession(makeCookieStore(), 2026)).toBe(false);
+	});
+
+	it('survives a missing cookie store', () => {
+		expect(completedGoalThisSession(null, 2026)).toBe(false);
+		expect(() => markGoalCompletedThisSession(null, 2026)).not.toThrow();
+	});
+
+	it('ignores a missing year rather than marking a bare cookie', () => {
+		const cookieStore = { get: vi.fn(), set: vi.fn() };
+
+		markGoalCompletedThisSession(cookieStore, null);
+
+		expect(cookieStore.set).not.toHaveBeenCalled();
+	});
+});

--- a/test/unit/specs/util/goalRecapSession.spec.js
+++ b/test/unit/specs/util/goalRecapSession.spec.js
@@ -23,7 +23,7 @@ describe('goalRecapSession.js', () => {
 
 		markGoalCompletedThisSession(cookieStore, 2026);
 
-		expect(cookieStore.set).toHaveBeenCalledWith('kvgrcs', '2026', { path: '/' });
+		expect(cookieStore.set).toHaveBeenCalledWith('kv_goal_completed_this_session', '2026', { path: '/' });
 	});
 
 	it('does not carry a mark from one goal year to another', () => {


### PR DESCRIPTION
Pending work for `next session / login` missing logic called out in the ticket.

https://kiva.atlassian.net/browse/MP-3063