### PR TITLE
fix(LoanProgress): distinguish ended loans that carry currency loss AD-434

### DIFF
--- a/.storybook/stories/BorrowerProfile/LoanProgress.stories.js
+++ b/.storybook/stories/BorrowerProfile/LoanProgress.stories.js
@@ -124,6 +124,21 @@ export const Ended = () => ({
 	`,
 });
 
+export const EndedWithCurrencyLoss = () => ({
+	components: { LoanProgress },
+	template: `
+		<loan-progress
+			loan-status="ended"
+			:has-currency-exchange-loss="true"
+			:progress-percent="1"
+			money-left="0.00"
+			:loading="false"
+			:loan-id="123"
+		/>
+	`,
+});
+EndedWithCurrencyLoss.storyName = 'Ended / Currency Loss';
+
 export const Defaulted = () => ({
 	components: { LoanProgress },
 	template: `

--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -196,6 +196,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		hasCurrencyExchangeLoss: {
+			type: Boolean,
+			default: false,
+		},
 		numberOfLenders: {
 			type: Number,
 			default: 0,
@@ -234,6 +238,9 @@ export default {
 			return this.loanId ? this.loanId : this.$route.params.id;
 		},
 		statusLabel() {
+			if (this.loanStatus === 'ended' && this.hasCurrencyExchangeLoss) {
+				return 'Repaid with currency loss';
+			}
 			const labels = {
 				ended: 'Repaid',
 				defaulted: 'Defaulted',

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -84,6 +84,7 @@
 						:time-left="timeLeft"
 						:loan-status="inPfp ? 'pfp' : status"
 						:is-delinquent="delinquent"
+						:has-currency-exchange-loss="hasCurrencyExchangeLoss"
 						:number-of-lenders="numLenders"
 						:pfp-min-lenders="pfpMinLenders"
 						:loading="isLoading"
@@ -163,6 +164,7 @@ export const summaryCardFragment = gql`fragment summaryCardFields on LoanBasic {
 	name
 	status
 	delinquent
+	hasCurrencyExchangeLossLenders
 	use
 	anonymizationLevel
 	borrowerCount
@@ -282,6 +284,9 @@ export default {
 		},
 		delinquent() {
 			return this.loan?.delinquent ?? false;
+		},
+		hasCurrencyExchangeLoss() {
+			return this.loan?.hasCurrencyExchangeLossLenders ?? false;
 		},
 		use() {
 			return this.loan?.fullLoanUse ?? '';


### PR DESCRIPTION
An ended loan with currency exchange loss to lenders now reads "Repaid with currency loss" rather than a plain "Repaid", matching what the monolith used to display.