### PR TITLE
feat: [MP-3098] exclude admin-listed loan ids from the ads feed

### DIFF
--- a/server/util/live-loan/ads/ads-eligibility.js
+++ b/server/util/live-loan/ads/ads-eligibility.js
@@ -17,17 +17,24 @@ const THRESHOLDS = {
 	minDaysToExpiry: 3,
 };
 
+// Exclude-by-id filter fragment for the FLSS `none` operator. Returns an empty object (key omitted)
+// for an empty/absent list so we never send `{ none: [] }`. Generic by field so partner/sector
+// exclusion reuses it unchanged.
+const excludeIds = (field, ids) => (ids?.length ? { [field]: { none: ids } } : {});
+
 // FLSS filters that narrow fundraising loans down to the set eligible for the ad feed.
 // Attributes within a single FundraisingLoanSearchFilterInput object are AND-ed together,
 // while separate objects in the array are OR-ed -- so all five thresholds must live in one
-// merged object for a loan to be required to satisfy every criterion.
-export function buildAdFeedFilters() {
+// merged object for a loan to be required to satisfy every criterion. Admin-managed exclusions
+// (excludedLoanIds) are merged into the same object so excluded loans never enter the candidate set.
+export function buildAdFeedFilters({ excludedLoanIds = [] } = {}) {
 	return [{
 		partnerRiskRating: { range: { gte: THRESHOLDS.minRiskRating } },
 		lenderRepaymentTerm: { range: { lte: THRESHOLDS.maxRepaymentMonths } },
 		partnerDefaultRate: { range: { lte: THRESHOLDS.maxDefaultRate } },
 		amountLeft: { range: { gte: THRESHOLDS.minAmountLeft } },
 		daysUntilExpiration: { range: { gte: THRESHOLDS.minDaysToExpiry } },
+		...excludeIds('loanIds', excludedLoanIds),
 	}];
 }
 
@@ -58,7 +65,7 @@ const LOAN_FIELDS = `
 `;
 
 // Fetch fundraising loans that pass the FLSS ad-eligibility filters, then apply the code-side gate.
-export async function fetchAdEligibleLoans(count = AD_FEED_LOAN_COUNT) {
+export async function fetchAdEligibleLoans(count = AD_FEED_LOAN_COUNT, exclusions = {}) {
 	const data = await fetchGraphQL(
 		{
 			query: `query adEligibleLoans($filters: [FundraisingLoanSearchFilterInput!]) {
@@ -70,7 +77,7 @@ export async function fetchAdEligibleLoans(count = AD_FEED_LOAN_COUNT) {
 					values { ${LOAN_FIELDS} }
 				}
 			}`,
-			variables: { filters: buildAdFeedFilters() },
+			variables: { filters: buildAdFeedFilters(exclusions) },
 		},
 		'data.fundraisingLoans.values',
 	);

--- a/server/util/live-loan/ads/constants.js
+++ b/server/util/live-loan/ads/constants.js
@@ -12,3 +12,8 @@ export const KIVA_PROD_HOST = 'https://www.kiva.org';
 // max) — and never upscales a smaller source.
 export const CLOUDINARY_AD_IMAGE_BASE = 'https://res.cloudinary.com/kiva';
 export const CLOUDINARY_AD_IMAGE_TRANSFORM = 'c_limit,w_1200,h_1200,f_jpg,cs_srgb,fl_force_icc';
+
+// Settings Manager (uiConfigSetting) key holding the comma-separated loan ids to keep out of the ad
+// feed. Bare setting name -- `ui.` is the Settings Manager storage namespace, not part of the query
+// key. Empty or absent means no exclusions.
+export const EXCLUDED_LOAN_IDS_SETTING_KEY = 'live_loan_ads_excluded_loan_ids';

--- a/server/util/live-loan/ads/excluded-ids.js
+++ b/server/util/live-loan/ads/excluded-ids.js
@@ -1,0 +1,37 @@
+import fetchGraphQL from '../../fetchGraphQL.js';
+import { warn } from '../../log.js';
+
+// Parse a comma-separated uiConfigSetting value (loan/partner/sector ids) into a de-duplicated id list.
+// Matches strict digit runs only, not Number()/parseInt, so Number-coercible junk like "0x1A", "1e3",
+// "-7", or "5.5" can't slip a malformed id into the FLSS filter. A non-string value (absent setting)
+// yields an empty list -- i.e. "no exclusions".
+export function parseIdList(value) {
+	if (typeof value !== 'string') return [];
+	const ids = value
+		.split(',')
+		.map(part => part.trim())
+		.filter(part => /^\d+$/.test(part))
+		.map(Number);
+	return [...new Set(ids)];
+}
+
+// Read a Settings Manager denylist via the standard uiConfigSetting(key:) query and parse it into ids.
+// A missing setting or a failed read is treated as "no exclusions" (empty list) so the feed still
+// generates; the read failure is logged.
+export async function fetchExcludedIds(key) {
+	try {
+		const value = await fetchGraphQL(
+			{
+				query: `query liveLoanAdsUiConfigSetting($key: String!) {
+					general { uiConfigSetting(key: $key) { key value } }
+				}`,
+				variables: { key },
+			},
+			'data.general.uiConfigSetting.value',
+		);
+		return parseIdList(value);
+	} catch (err) {
+		warn(`Ad feed: failed to read uiConfigSetting "${key}"; treating as no exclusions`, { error: err });
+		return [];
+	}
+}

--- a/server/util/live-loan/ads/google-display/google-feed.js
+++ b/server/util/live-loan/ads/google-display/google-feed.js
@@ -1,6 +1,8 @@
 import { fetchAdEligibleLoans } from '../ads-eligibility.js';
+import { fetchExcludedIds } from '../excluded-ids.js';
+import { EXCLUDED_LOAN_IDS_SETTING_KEY } from '../constants.js';
 import { loanToFeedRow, isRowAdSafe, FEED_COLUMNS } from './feed-row.js';
-import { warn } from '../../../log.js';
+import { info, warn } from '../../../log.js';
 
 // Cache keys + TTLs for serving the feed. A fresh copy is served from cache between regenerations so
 // scrapers can't drive the FLSS/hydrate pipeline on every hit; the last-good copy is served if a
@@ -24,10 +26,15 @@ export function toTsv(rows, columns = FEED_COLUMNS) {
 }
 
 export async function generateGoogleFeed(count) {
+	// Admin-managed denylist (Settings Manager), read fresh each generation; excluded loans are pushed
+	// into the FLSS query so they never enter the candidate set. Absent/failed read => no exclusions.
+	const excludedLoanIds = await fetchExcludedIds(EXCLUDED_LOAN_IDS_SETTING_KEY);
+	info(`Ad feed: applying ${excludedLoanIds.length} excluded loan id(s)`, { excludedLoanIds });
+
 	// FLSS (updated via kafka events) is the freshest source of fundraising loans and already excludes
 	// funded/refunded/expired; the eligibility gate drops anonymized/no-name/no-image on the FLSS
 	// record. No re-check against a slower source is needed.
-	const eligible = await fetchAdEligibleLoans(count);
+	const eligible = await fetchAdEligibleLoans(count, { excludedLoanIds });
 
 	const rows = [];
 	eligible.forEach(loan => {

--- a/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
@@ -43,6 +43,17 @@ describe('ads-eligibility', () => {
 		it('caps the candidate count at the locked feed limit of 100', () => {
 			expect(AD_FEED_LOAN_COUNT).toEqual(100);
 		});
+
+		it('adds a loanIds none filter when excludedLoanIds are provided', () => {
+			expect(buildAdFeedFilters({ excludedLoanIds: [10, 20] })[0]).toMatchObject({
+				loanIds: { none: [10, 20] },
+			});
+		});
+
+		it('omits the loanIds key when the exclusion list is empty or absent', () => {
+			expect(buildAdFeedFilters({ excludedLoanIds: [] })[0]).not.toHaveProperty('loanIds');
+			expect(buildAdFeedFilters()[0]).not.toHaveProperty('loanIds');
+		});
 	});
 
 	describe('primaryFirstName', () => {
@@ -111,6 +122,15 @@ describe('ads-eligibility', () => {
 			expect(variables.filters).toEqual(buildAdFeedFilters());
 			expect(variables.sortBy).toBeUndefined();
 			expect(query).not.toMatch(/sortBy/);
+		});
+
+		it('threads excludedLoanIds into the query filters', async () => {
+			fetch.mockResolvedValue({ json: () => ({ data: { fundraisingLoans: { values: [] } } }) });
+
+			await fetchAdEligibleLoans(100, { excludedLoanIds: [7, 8] });
+
+			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);
+			expect(variables.filters).toEqual(buildAdFeedFilters({ excludedLoanIds: [7, 8] }));
 		});
 
 		it('threads a custom count into the fundraisingLoans limit', async () => {

--- a/test/unit/specs/server/util/live-loan/ads/excluded-ids.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/excluded-ids.spec.js
@@ -1,0 +1,74 @@
+// @vitest-environment node
+import fetch from '#server/util/fetch';
+import { warn } from '#server/util/log';
+import { parseIdList, fetchExcludedIds } from '#server/util/live-loan/ads/excluded-ids';
+
+// mock out the fetch module so that no real requests are made
+vi.mock('#server/util/fetch');
+
+// mock out the argv module to prevent command line arguments for jest from being read by the code under test
+vi.mock('#server/util/argv', () => ({ default: {} }));
+
+// mock out logging so warnings don't print during the test run
+vi.mock('#server/util/log', () => ({
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+}));
+
+const settingValue = value => ({
+	json: () => ({ data: { general: { uiConfigSetting: { key: 'k', value } } } }),
+});
+
+describe('excluded-ids', () => {
+	describe('parseIdList', () => {
+		it('parses a comma list into integers', () => {
+			expect(parseIdList('123,456,789')).toEqual([123, 456, 789]);
+		});
+
+		it('trims whitespace and ignores non-numeric entries', () => {
+			expect(parseIdList(' 12 , abc, 34 ,, 5.5, -7')).toEqual([12, 34]);
+		});
+
+		it('de-duplicates ids preserving first occurrence', () => {
+			expect(parseIdList('5,5,9,5')).toEqual([5, 9]);
+		});
+
+		it('returns [] for empty, undefined, null, or non-string', () => {
+			expect(parseIdList('')).toEqual([]);
+			expect(parseIdList(undefined)).toEqual([]);
+			expect(parseIdList(null)).toEqual([]);
+			expect(parseIdList(123)).toEqual([]);
+		});
+	});
+
+	describe('fetchExcludedIds', () => {
+		beforeEach(() => {
+			fetch.mockClear();
+			warn.mockClear();
+		});
+
+		it('passes the key and returns the parsed ids', async () => {
+			fetch.mockResolvedValue(settingValue('11, 22, 22'));
+
+			const result = await fetchExcludedIds('live_loan_ads_excluded_loan_ids');
+
+			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);
+			expect(variables.key).toEqual('live_loan_ads_excluded_loan_ids');
+			expect(result).toEqual([11, 22]);
+		});
+
+		it('returns [] when the setting is absent (null value)', async () => {
+			fetch.mockResolvedValue(settingValue(null));
+
+			expect(await fetchExcludedIds('k')).toEqual([]);
+		});
+
+		it('returns [] and warns when the read throws', async () => {
+			fetch.mockRejectedValue(new Error('boom'));
+
+			expect(await fetchExcludedIds('k')).toEqual([]);
+			expect(warn).toHaveBeenCalled();
+		});
+	});
+});

--- a/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
@@ -1,6 +1,9 @@
 // @vitest-environment node
 import { FEED_COLUMNS } from '#server/util/live-loan/ads/google-display/feed-row';
 import { fetchAdEligibleLoans } from '#server/util/live-loan/ads/ads-eligibility';
+import { fetchExcludedIds } from '#server/util/live-loan/ads/excluded-ids';
+import { EXCLUDED_LOAN_IDS_SETTING_KEY } from '#server/util/live-loan/ads/constants';
+import { info } from '#server/util/log';
 import { toTsv, generateGoogleFeed } from '#server/util/live-loan/ads/google-display/google-feed';
 
 // mock out the argv module to prevent command line arguments for jest from being read by the code under test
@@ -12,8 +15,12 @@ vi.mock('#server/util/live-loan/ads/ads-eligibility.js', async importOriginal =>
 	fetchAdEligibleLoans: vi.fn(),
 }));
 
+// stub the setting reader so no real request is made for the excluded-loan-ids denylist
+vi.mock('#server/util/live-loan/ads/excluded-ids.js', () => ({ fetchExcludedIds: vi.fn() }));
+
 // mock logging so the ad-safety drop warning doesn't print during the test run
 vi.mock('#server/util/log', () => ({
+	info: vi.fn(),
 	warn: vi.fn(),
 	error: vi.fn(),
 }));
@@ -80,6 +87,9 @@ describe('google-feed', () => {
 	describe('generateGoogleFeed', () => {
 		beforeEach(() => {
 			fetchAdEligibleLoans.mockClear();
+			fetchExcludedIds.mockClear();
+			info.mockClear();
+			fetchExcludedIds.mockResolvedValue([]);
 		});
 
 		it('produces a header line plus one data line per loan', async () => {
@@ -133,7 +143,26 @@ describe('google-feed', () => {
 
 			await generateGoogleFeed(50);
 
-			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(50);
+			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(50, { excludedLoanIds: [] });
+		});
+
+		it('reads the excluded-loan-ids setting and passes them to fetchAdEligibleLoans', async () => {
+			fetchExcludedIds.mockResolvedValue([456]);
+			fetchAdEligibleLoans.mockResolvedValue([]);
+
+			await generateGoogleFeed();
+
+			expect(fetchExcludedIds).toHaveBeenCalledWith(EXCLUDED_LOAN_IDS_SETTING_KEY);
+			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(undefined, { excludedLoanIds: [456] });
+		});
+
+		it('logs the applied excluded-id count on each generation', async () => {
+			fetchExcludedIds.mockResolvedValue([1, 2, 3]);
+			fetchAdEligibleLoans.mockResolvedValue([]);
+
+			await generateGoogleFeed();
+
+			expect(info).toHaveBeenCalledWith(expect.stringContaining('3'), { excludedLoanIds: [1, 2, 3] });
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Adds an admin-editable denylist that keeps specific loans out of the live-loan Google Ads feed. The excluded ids are read from a `uiConfigSetting` (`live_loan_ads_excluded_loan_ids`, edited in KivaAdmin → Settings Manager) each time the feed regenerates, and pushed **into the FLSS `fundraisingLoans` query** as `loanIds: { none: [...] }` — so excluded loans never enter the candidate set (no post-fetch filtering, no wasted slots against the 100-candidate cap).

## Approach / decisions to flag
- **In-query exclusion**, not a post-fetch gate — an excluded loan never returns from FLSS, so it's dropped even if it passes every other eligibility criterion.
- **Fail-open:** an empty, unset, or malformed setting → no exclusions; a failed read returns `[]` + a `warn` so the feed never errors or empties.
- **Parsing:** comma-delimited integers, whitespace-tolerant, non-numeric ignored, de-duplicated; strict `/^\d+$/` so `Number()`-coercible junk (`0x1A`, `1e3`, `-7`, `5.5`) can't slip a bad id into the filter.
- **No separate setting cache** — the feed's existing ~5-min fresh cache already bounds reads, and keeps "flush the one feed key = immediate" true.
- **Reusable seam for MP-3099:** `fetchExcludedIds(key)` + `excludeIds(field, ids)` + the options-object signature make partner/sector exclusion purely additive.
- **Setting key string** is bare `live_loan_ads_excluded_loan_ids` (the `ui.` prefix is the Settings Manager storage namespace), matching the `excluded_partners`/`excluded_sectors` precedent — ⚠️ pending an ops confirmation before launch.
- **Urgent "pull now"** is an ops-level flush of memjs key `google-ads-feed` (runbook item); no flush endpoint in this PR.

## Related
- Story: [MP-3098](https://kiva.atlassian.net/browse/MP-3098) · Epic: [MP-2908](https://kiva.atlassian.net/browse/MP-2908)
- Depends on: [MP-3013](https://kiva.atlassian.net/browse/MP-3013) — the feed itself (#7150)
- Related pattern: [MP-3099](https://kiva.atlassian.net/browse/MP-3099) — partner/sector exclusion (reuses this seam)

## Related tests (54 pass)
- `test/unit/specs/server/util/live-loan/ads/excluded-ids.spec.js` — `parseIdList` edge cases; `fetchExcludedIds` key wiring, absent setting, read failure
- `.../ads/ads-eligibility.spec.js` — `buildAdFeedFilters` adds/omits `loanIds:{none}`; `fetchAdEligibleLoans` threads exclusions into the query
- `.../ads/google-display/google-feed.spec.js` — `generateGoogleFeed` reads the setting, logs the applied count, passes ids through

## Dev verification
1. `npx vitest run test/unit/specs/server/util/live-loan/ads/` → 54 pass.
2. Set `ui.live_loan_ads_excluded_loan_ids` to a loan id currently in the feed; regenerate `/live-loan/ads/google-feed.tsv` (wait ≤5 min or flush `google-ads-feed`); confirm that id is gone from the TSV.
3. Blank the setting; confirm the feed returns to full (no `loanIds` filter sent).


[MP-3098]: https://kiva.atlassian.net/browse/MP-3098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ