### PR TITLE
chore: automatically install node modules in new worktrees AD-397

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,1 @@
+pre-start = "npm ci && npx husky install"


### PR DESCRIPTION
When using worktrunk with this repo, I often run into the initial build or the pre-commit hook failing because node modules haven't been installed yet and/or the husky hooks haven't been applied. This fixes that by adding a worktrunk config file for this repo that [runs a hook](https://worktrunk.dev/config/#hooks-1) that calls `npm ci && npx husky install` every time a new worktree is created.