### PR TITLE
feat: [MP-3099] exclude admin-listed partner and sector ids from the ads feed

### DIFF
--- a/server/util/live-loan/ads/ads-eligibility.js
+++ b/server/util/live-loan/ads/ads-eligibility.js
@@ -26,8 +26,9 @@ const excludeIds = (field, ids) => (ids?.length ? { [field]: { none: ids } } : {
 // Attributes within a single FundraisingLoanSearchFilterInput object are AND-ed together,
 // while separate objects in the array are OR-ed -- so all five thresholds must live in one
 // merged object for a loan to be required to satisfy every criterion. Admin-managed exclusions
-// (excludedLoanIds) are merged into the same object so excluded loans never enter the candidate set.
-export function buildAdFeedFilters({ excludedLoanIds = [] } = {}) {
+// (loan, partner, and sector ids) are merged into the same object so excluded loans never enter
+// the candidate set.
+export function buildAdFeedFilters({ excludedLoanIds = [], excludedPartnerIds = [], excludedSectorIds = [] } = {}) {
 	return [{
 		partnerRiskRating: { range: { gte: THRESHOLDS.minRiskRating } },
 		lenderRepaymentTerm: { range: { lte: THRESHOLDS.maxRepaymentMonths } },
@@ -35,6 +36,8 @@ export function buildAdFeedFilters({ excludedLoanIds = [] } = {}) {
 		amountLeft: { range: { gte: THRESHOLDS.minAmountLeft } },
 		daysUntilExpiration: { range: { gte: THRESHOLDS.minDaysToExpiry } },
 		...excludeIds('loanIds', excludedLoanIds),
+		...excludeIds('partnerId', excludedPartnerIds),
+		...excludeIds('sectorId', excludedSectorIds),
 	}];
 }
 

--- a/server/util/live-loan/ads/ads-eligibility.js
+++ b/server/util/live-loan/ads/ads-eligibility.js
@@ -18,26 +18,27 @@ const THRESHOLDS = {
 };
 
 // Exclude-by-id filter fragment for the FLSS `none` operator. Returns an empty object (key omitted)
-// for an empty/absent list so we never send `{ none: [] }`. Generic by field so partner/sector
-// exclusion reuses it unchanged.
+// for an empty/absent list so we never send `{ none: [] }`.
 const excludeIds = (field, ids) => (ids?.length ? { [field]: { none: ids } } : {});
 
 // FLSS filters that narrow fundraising loans down to the set eligible for the ad feed.
 // Attributes within a single FundraisingLoanSearchFilterInput object are AND-ed together,
 // while separate objects in the array are OR-ed -- so all five thresholds must live in one
 // merged object for a loan to be required to satisfy every criterion. Admin-managed exclusions
-// (loan, partner, and sector ids) are merged into the same object so excluded loans never enter
-// the candidate set.
-export function buildAdFeedFilters({ excludedLoanIds = [], excludedPartnerIds = [], excludedSectorIds = [] } = {}) {
+// arrive as a map of FLSS filter field -> ids (e.g. { loanIds, partnerId, sectorId }) and are merged
+// into the same object as `none` fragments -- so a new exclusion dimension is one more map entry at
+// the call site, not a change to this signature.
+export function buildAdFeedFilters(exclusions = {}) {
 	return [{
 		partnerRiskRating: { range: { gte: THRESHOLDS.minRiskRating } },
 		lenderRepaymentTerm: { range: { lte: THRESHOLDS.maxRepaymentMonths } },
 		partnerDefaultRate: { range: { lte: THRESHOLDS.maxDefaultRate } },
 		amountLeft: { range: { gte: THRESHOLDS.minAmountLeft } },
 		daysUntilExpiration: { range: { gte: THRESHOLDS.minDaysToExpiry } },
-		...excludeIds('loanIds', excludedLoanIds),
-		...excludeIds('partnerId', excludedPartnerIds),
-		...excludeIds('sectorId', excludedSectorIds),
+		...Object.entries(exclusions).reduce(
+			(filters, [field, ids]) => ({ ...filters, ...excludeIds(field, ids) }),
+			{},
+		),
 	}];
 }
 

--- a/server/util/live-loan/ads/constants.js
+++ b/server/util/live-loan/ads/constants.js
@@ -13,7 +13,9 @@ export const KIVA_PROD_HOST = 'https://www.kiva.org';
 export const CLOUDINARY_AD_IMAGE_BASE = 'https://res.cloudinary.com/kiva';
 export const CLOUDINARY_AD_IMAGE_TRANSFORM = 'c_limit,w_1200,h_1200,f_jpg,cs_srgb,fl_force_icc';
 
-// Settings Manager (uiConfigSetting) key holding the comma-separated loan ids to keep out of the ad
-// feed. Bare setting name -- `ui.` is the Settings Manager storage namespace, not part of the query
-// key. Empty or absent means no exclusions.
+// Settings Manager (uiConfigSetting) keys holding the comma-separated loan, partner, and sector ids
+// to keep out of the ad feed. Bare setting names -- `ui.` is the Settings Manager storage namespace,
+// not part of the query key. Empty or absent means no exclusions.
 export const EXCLUDED_LOAN_IDS_SETTING_KEY = 'live_loan_ads_excluded_loan_ids';
+export const EXCLUDED_PARTNER_IDS_SETTING_KEY = 'live_loan_ads_excluded_partner_ids';
+export const EXCLUDED_SECTOR_IDS_SETTING_KEY = 'live_loan_ads_excluded_sector_ids';

--- a/server/util/live-loan/ads/excluded-ids.js
+++ b/server/util/live-loan/ads/excluded-ids.js
@@ -7,7 +7,11 @@ import { warn } from '../../log.js';
 // yields an empty list -- i.e. "no exclusions".
 export function parseIdList(value) {
 	if (typeof value !== 'string') return [];
+	// Settings Manager may JSON-encode the value (string type -> `"6,16"`, array -> `["6","16"]`).
+	// Strip the JSON wrapper chars up front: the strict per-id digit filter below is the real gate, so
+	// quotes/brackets can be dropped blindly while junk like "abc"/"5.5"/"-7" is still rejected.
 	const ids = value
+		.replace(/["[\]]/g, '')
 		.split(',')
 		.map(part => part.trim())
 		.filter(part => /^\d+$/.test(part))

--- a/server/util/live-loan/ads/google-display/google-feed.js
+++ b/server/util/live-loan/ads/google-display/google-feed.js
@@ -1,6 +1,10 @@
 import { fetchAdEligibleLoans } from '../ads-eligibility.js';
 import { fetchExcludedIds } from '../excluded-ids.js';
-import { EXCLUDED_LOAN_IDS_SETTING_KEY } from '../constants.js';
+import {
+	EXCLUDED_LOAN_IDS_SETTING_KEY,
+	EXCLUDED_PARTNER_IDS_SETTING_KEY,
+	EXCLUDED_SECTOR_IDS_SETTING_KEY,
+} from '../constants.js';
 import { loanToFeedRow, isRowAdSafe, FEED_COLUMNS } from './feed-row.js';
 import { info, warn } from '../../../log.js';
 
@@ -26,15 +30,24 @@ export function toTsv(rows, columns = FEED_COLUMNS) {
 }
 
 export async function generateGoogleFeed(count) {
-	// Admin-managed denylist (Settings Manager), read fresh each generation; excluded loans are pushed
-	// into the FLSS query so they never enter the candidate set. Absent/failed read => no exclusions.
-	const excludedLoanIds = await fetchExcludedIds(EXCLUDED_LOAN_IDS_SETTING_KEY);
-	info(`Ad feed: applying ${excludedLoanIds.length} excluded loan id(s)`, { excludedLoanIds });
+	// Admin-managed denylists (Settings Manager), read fresh each generation; excluded loans, partners,
+	// and sectors are pushed into the FLSS query so they never enter the candidate set. The three reads
+	// are independent, so they run in parallel. Absent/failed read => no exclusions for that dimension.
+	const [excludedLoanIds, excludedPartnerIds, excludedSectorIds] = await Promise.all([
+		fetchExcludedIds(EXCLUDED_LOAN_IDS_SETTING_KEY),
+		fetchExcludedIds(EXCLUDED_PARTNER_IDS_SETTING_KEY),
+		fetchExcludedIds(EXCLUDED_SECTOR_IDS_SETTING_KEY),
+	]);
+	info(
+		`Ad feed: applying ${excludedLoanIds.length} excluded loan id(s), `
+		+ `${excludedPartnerIds.length} partner id(s), ${excludedSectorIds.length} sector id(s)`,
+		{ excludedLoanIds, excludedPartnerIds, excludedSectorIds },
+	);
 
 	// FLSS (updated via kafka events) is the freshest source of fundraising loans and already excludes
 	// funded/refunded/expired; the eligibility gate drops anonymized/no-name/no-image on the FLSS
 	// record. No re-check against a slower source is needed.
-	const eligible = await fetchAdEligibleLoans(count, { excludedLoanIds });
+	const eligible = await fetchAdEligibleLoans(count, { excludedLoanIds, excludedPartnerIds, excludedSectorIds });
 
 	const rows = [];
 	eligible.forEach(loan => {

--- a/server/util/live-loan/ads/google-display/google-feed.js
+++ b/server/util/live-loan/ads/google-display/google-feed.js
@@ -38,16 +38,18 @@ export async function generateGoogleFeed(count) {
 		fetchExcludedIds(EXCLUDED_PARTNER_IDS_SETTING_KEY),
 		fetchExcludedIds(EXCLUDED_SECTOR_IDS_SETTING_KEY),
 	]);
+	// Keyed by FLSS filter field so buildAdFeedFilters can merge each dimension without knowing them.
+	const exclusions = { loanIds: excludedLoanIds, partnerId: excludedPartnerIds, sectorId: excludedSectorIds };
 	info(
 		`Ad feed: applying ${excludedLoanIds.length} excluded loan id(s), `
 		+ `${excludedPartnerIds.length} partner id(s), ${excludedSectorIds.length} sector id(s)`,
-		{ excludedLoanIds, excludedPartnerIds, excludedSectorIds },
+		exclusions,
 	);
 
 	// FLSS (updated via kafka events) is the freshest source of fundraising loans and already excludes
 	// funded/refunded/expired; the eligibility gate drops anonymized/no-name/no-image on the FLSS
 	// record. No re-check against a slower source is needed.
-	const eligible = await fetchAdEligibleLoans(count, { excludedLoanIds, excludedPartnerIds, excludedSectorIds });
+	const eligible = await fetchAdEligibleLoans(count, exclusions);
 
 	const rows = [];
 	eligible.forEach(loan => {

--- a/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
@@ -54,6 +54,39 @@ describe('ads-eligibility', () => {
 			expect(buildAdFeedFilters({ excludedLoanIds: [] })[0]).not.toHaveProperty('loanIds');
 			expect(buildAdFeedFilters()[0]).not.toHaveProperty('loanIds');
 		});
+
+		it('adds a partnerId none filter when excludedPartnerIds are provided', () => {
+			expect(buildAdFeedFilters({ excludedPartnerIds: [11, 12] })[0]).toMatchObject({
+				partnerId: { none: [11, 12] },
+			});
+		});
+
+		it('adds a sectorId none filter when excludedSectorIds are provided', () => {
+			expect(buildAdFeedFilters({ excludedSectorIds: [2, 3] })[0]).toMatchObject({
+				sectorId: { none: [2, 3] },
+			});
+		});
+
+		it('omits the partnerId and sectorId keys when those exclusion lists are empty or absent', () => {
+			const [filter] = buildAdFeedFilters({ excludedPartnerIds: [], excludedSectorIds: [] });
+			expect(filter).not.toHaveProperty('partnerId');
+			expect(filter).not.toHaveProperty('sectorId');
+			expect(buildAdFeedFilters()[0]).not.toHaveProperty('partnerId');
+			expect(buildAdFeedFilters()[0]).not.toHaveProperty('sectorId');
+		});
+
+		it('merges loan, partner, and sector exclusions into the single AND-ed filter object', () => {
+			const [filter] = buildAdFeedFilters({
+				excludedLoanIds: [1],
+				excludedPartnerIds: [2],
+				excludedSectorIds: [3],
+			});
+			expect(filter).toMatchObject({
+				loanIds: { none: [1] },
+				partnerId: { none: [2] },
+				sectorId: { none: [3] },
+			});
+		});
 	});
 
 	describe('primaryFirstName', () => {
@@ -131,6 +164,16 @@ describe('ads-eligibility', () => {
 
 			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);
 			expect(variables.filters).toEqual(buildAdFeedFilters({ excludedLoanIds: [7, 8] }));
+		});
+
+		it('threads excludedPartnerIds and excludedSectorIds into the query filters', async () => {
+			fetch.mockResolvedValue({ json: () => ({ data: { fundraisingLoans: { values: [] } } }) });
+
+			const exclusions = { excludedPartnerIds: [7, 8], excludedSectorIds: [6, 16] };
+			await fetchAdEligibleLoans(100, exclusions);
+
+			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);
+			expect(variables.filters).toEqual(buildAdFeedFilters(exclusions));
 		});
 
 		it('threads a custom count into the fundraisingLoans limit', async () => {

--- a/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
@@ -44,48 +44,48 @@ describe('ads-eligibility', () => {
 			expect(AD_FEED_LOAN_COUNT).toEqual(100);
 		});
 
-		it('adds a loanIds none filter when excludedLoanIds are provided', () => {
-			expect(buildAdFeedFilters({ excludedLoanIds: [10, 20] })[0]).toMatchObject({
+		it('adds a loanIds none filter when a loan-id exclusion list is provided', () => {
+			expect(buildAdFeedFilters({ loanIds: [10, 20] })[0]).toMatchObject({
 				loanIds: { none: [10, 20] },
 			});
 		});
 
 		it('omits the loanIds key when the exclusion list is empty or absent', () => {
-			expect(buildAdFeedFilters({ excludedLoanIds: [] })[0]).not.toHaveProperty('loanIds');
+			expect(buildAdFeedFilters({ loanIds: [] })[0]).not.toHaveProperty('loanIds');
 			expect(buildAdFeedFilters()[0]).not.toHaveProperty('loanIds');
 		});
 
-		it('adds a partnerId none filter when excludedPartnerIds are provided', () => {
-			expect(buildAdFeedFilters({ excludedPartnerIds: [11, 12] })[0]).toMatchObject({
+		it('adds a partnerId none filter when a partner-id exclusion list is provided', () => {
+			expect(buildAdFeedFilters({ partnerId: [11, 12] })[0]).toMatchObject({
 				partnerId: { none: [11, 12] },
 			});
 		});
 
-		it('adds a sectorId none filter when excludedSectorIds are provided', () => {
-			expect(buildAdFeedFilters({ excludedSectorIds: [2, 3] })[0]).toMatchObject({
+		it('adds a sectorId none filter when a sector-id exclusion list is provided', () => {
+			expect(buildAdFeedFilters({ sectorId: [2, 3] })[0]).toMatchObject({
 				sectorId: { none: [2, 3] },
 			});
 		});
 
 		it('omits the partnerId and sectorId keys when those exclusion lists are empty or absent', () => {
-			const [filter] = buildAdFeedFilters({ excludedPartnerIds: [], excludedSectorIds: [] });
+			const [filter] = buildAdFeedFilters({ partnerId: [], sectorId: [] });
 			expect(filter).not.toHaveProperty('partnerId');
 			expect(filter).not.toHaveProperty('sectorId');
 			expect(buildAdFeedFilters()[0]).not.toHaveProperty('partnerId');
 			expect(buildAdFeedFilters()[0]).not.toHaveProperty('sectorId');
 		});
 
-		it('merges loan, partner, and sector exclusions into the single AND-ed filter object', () => {
-			const [filter] = buildAdFeedFilters({
-				excludedLoanIds: [1],
-				excludedPartnerIds: [2],
-				excludedSectorIds: [3],
-			});
+		it('merges every exclusion field into the single AND-ed filter object', () => {
+			const [filter] = buildAdFeedFilters({ loanIds: [1], partnerId: [2], sectorId: [3] });
 			expect(filter).toMatchObject({
 				loanIds: { none: [1] },
 				partnerId: { none: [2] },
 				sectorId: { none: [3] },
 			});
+		});
+
+		it('ignores an unknown exclusion field with no ids rather than emitting an empty none', () => {
+			expect(buildAdFeedFilters({ loanIds: [], partnerId: [] })[0]).toEqual(buildAdFeedFilters()[0]);
 		});
 	});
 
@@ -157,19 +157,19 @@ describe('ads-eligibility', () => {
 			expect(query).not.toMatch(/sortBy/);
 		});
 
-		it('threads excludedLoanIds into the query filters', async () => {
+		it('threads a loan-id exclusion into the query filters', async () => {
 			fetch.mockResolvedValue({ json: () => ({ data: { fundraisingLoans: { values: [] } } }) });
 
-			await fetchAdEligibleLoans(100, { excludedLoanIds: [7, 8] });
+			await fetchAdEligibleLoans(100, { loanIds: [7, 8] });
 
 			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);
-			expect(variables.filters).toEqual(buildAdFeedFilters({ excludedLoanIds: [7, 8] }));
+			expect(variables.filters).toEqual(buildAdFeedFilters({ loanIds: [7, 8] }));
 		});
 
-		it('threads excludedPartnerIds and excludedSectorIds into the query filters', async () => {
+		it('threads partner and sector exclusions into the query filters', async () => {
 			fetch.mockResolvedValue({ json: () => ({ data: { fundraisingLoans: { values: [] } } }) });
 
-			const exclusions = { excludedPartnerIds: [7, 8], excludedSectorIds: [6, 16] };
+			const exclusions = { partnerId: [7, 8], sectorId: [6, 16] };
 			await fetchAdEligibleLoans(100, exclusions);
 
 			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);

--- a/test/unit/specs/server/util/live-loan/ads/excluded-ids.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/excluded-ids.spec.js
@@ -40,6 +40,26 @@ describe('excluded-ids', () => {
 			expect(parseIdList(null)).toEqual([]);
 			expect(parseIdList(123)).toEqual([]);
 		});
+
+		it('unwraps a JSON-encoded string value (Settings Manager string type)', () => {
+			expect(parseIdList('"3220492"')).toEqual([3220492]);
+		});
+
+		it('unwraps a JSON-encoded comma list', () => {
+			expect(parseIdList('"123,456"')).toEqual([123, 456]);
+		});
+
+		it('unwraps a JSON array of ids, filtering non-numeric entries', () => {
+			expect(parseIdList('["123","abc",456]')).toEqual([123, 456]);
+		});
+
+		it('recovers ids from a value with unbalanced JSON wrapper chars', () => {
+			expect(parseIdList('["3220492"')).toEqual([3220492]);
+		});
+
+		it('yields no exclusions for a value with no valid ids', () => {
+			expect(parseIdList('["abc","5.5"]')).toEqual([]);
+		});
 	});
 
 	describe('fetchExcludedIds', () => {

--- a/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
@@ -148,9 +148,9 @@ describe('google-feed', () => {
 			await generateGoogleFeed(50);
 
 			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(50, {
-				excludedLoanIds: [],
-				excludedPartnerIds: [],
-				excludedSectorIds: [],
+				loanIds: [],
+				partnerId: [],
+				sectorId: [],
 			});
 		});
 
@@ -169,9 +169,9 @@ describe('google-feed', () => {
 			expect(fetchExcludedIds).toHaveBeenCalledWith(EXCLUDED_PARTNER_IDS_SETTING_KEY);
 			expect(fetchExcludedIds).toHaveBeenCalledWith(EXCLUDED_SECTOR_IDS_SETTING_KEY);
 			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(undefined, {
-				excludedLoanIds: [456],
-				excludedPartnerIds: [11, 12],
-				excludedSectorIds: [2],
+				loanIds: [456],
+				partnerId: [11, 12],
+				sectorId: [2],
 			});
 		});
 
@@ -186,9 +186,9 @@ describe('google-feed', () => {
 			await generateGoogleFeed();
 
 			expect(info).toHaveBeenCalledWith(expect.any(String), {
-				excludedLoanIds: [1, 2, 3],
-				excludedPartnerIds: [9],
-				excludedSectorIds: [],
+				loanIds: [1, 2, 3],
+				partnerId: [9],
+				sectorId: [],
 			});
 		});
 	});

--- a/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
@@ -2,7 +2,11 @@
 import { FEED_COLUMNS } from '#server/util/live-loan/ads/google-display/feed-row';
 import { fetchAdEligibleLoans } from '#server/util/live-loan/ads/ads-eligibility';
 import { fetchExcludedIds } from '#server/util/live-loan/ads/excluded-ids';
-import { EXCLUDED_LOAN_IDS_SETTING_KEY } from '#server/util/live-loan/ads/constants';
+import {
+	EXCLUDED_LOAN_IDS_SETTING_KEY,
+	EXCLUDED_PARTNER_IDS_SETTING_KEY,
+	EXCLUDED_SECTOR_IDS_SETTING_KEY,
+} from '#server/util/live-loan/ads/constants';
 import { info } from '#server/util/log';
 import { toTsv, generateGoogleFeed } from '#server/util/live-loan/ads/google-display/google-feed';
 
@@ -143,26 +147,49 @@ describe('google-feed', () => {
 
 			await generateGoogleFeed(50);
 
-			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(50, { excludedLoanIds: [] });
+			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(50, {
+				excludedLoanIds: [],
+				excludedPartnerIds: [],
+				excludedSectorIds: [],
+			});
 		});
 
-		it('reads the excluded-loan-ids setting and passes them to fetchAdEligibleLoans', async () => {
-			fetchExcludedIds.mockResolvedValue([456]);
+		it('reads all three denylist settings and routes each to its own exclusion field', async () => {
+			fetchExcludedIds.mockImplementation(key => {
+				if (key === EXCLUDED_LOAN_IDS_SETTING_KEY) return Promise.resolve([456]);
+				if (key === EXCLUDED_PARTNER_IDS_SETTING_KEY) return Promise.resolve([11, 12]);
+				if (key === EXCLUDED_SECTOR_IDS_SETTING_KEY) return Promise.resolve([2]);
+				return Promise.resolve([]);
+			});
 			fetchAdEligibleLoans.mockResolvedValue([]);
 
 			await generateGoogleFeed();
 
 			expect(fetchExcludedIds).toHaveBeenCalledWith(EXCLUDED_LOAN_IDS_SETTING_KEY);
-			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(undefined, { excludedLoanIds: [456] });
+			expect(fetchExcludedIds).toHaveBeenCalledWith(EXCLUDED_PARTNER_IDS_SETTING_KEY);
+			expect(fetchExcludedIds).toHaveBeenCalledWith(EXCLUDED_SECTOR_IDS_SETTING_KEY);
+			expect(fetchAdEligibleLoans).toHaveBeenCalledWith(undefined, {
+				excludedLoanIds: [456],
+				excludedPartnerIds: [11, 12],
+				excludedSectorIds: [2],
+			});
 		});
 
-		it('logs the applied excluded-id count on each generation', async () => {
-			fetchExcludedIds.mockResolvedValue([1, 2, 3]);
+		it('logs the applied excluded-id counts for loans, partners, and sectors', async () => {
+			fetchExcludedIds.mockImplementation(key => {
+				if (key === EXCLUDED_LOAN_IDS_SETTING_KEY) return Promise.resolve([1, 2, 3]);
+				if (key === EXCLUDED_PARTNER_IDS_SETTING_KEY) return Promise.resolve([9]);
+				return Promise.resolve([]);
+			});
 			fetchAdEligibleLoans.mockResolvedValue([]);
 
 			await generateGoogleFeed();
 
-			expect(info).toHaveBeenCalledWith(expect.stringContaining('3'), { excludedLoanIds: [1, 2, 3] });
+			expect(info).toHaveBeenCalledWith(expect.any(String), {
+				excludedLoanIds: [1, 2, 3],
+				excludedPartnerIds: [9],
+				excludedSectorIds: [],
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary
Extends the live-loan Google Ads feed with two admin-editable denylists — **partner ids** and
**sector ids** — alongside the existing loan-id exclusion (MP-3098). Both are read from
`uiConfigSetting` (`live_loan_ads_excluded_partner_ids` / `live_loan_ads_excluded_sector_ids`, edited
in KivaAdmin → Settings Manager) each time the feed regenerates, and pushed **into the FLSS
`fundraisingLoans` query** as `partnerId: { none: [...] }` / `sectorId: { none: [...] }` — so excluded
loans never enter the candidate set (no post-fetch filtering, no wasted slots against the
100-candidate cap).

## Approach / decisions to flag
- **Purely additive on the MP-3098 seam** — reuses the generic `excludeIds(field, ids)` helper and
  `fetchExcludedIds(key)` reader; `buildAdFeedFilters` gains two params, `generateGoogleFeed` reads
  the three denylists in parallel.
- **In-query exclusion**, not a post-fetch gate — `partnerId`/`sectorId` are `IntKeyFilterModifierInput`
  (same type as `loanIds`), which supports `none: [Int!]`; verified against the live schema.
- **Exclude by id, not name** — ids are stable across partner/sector renames and match how the rest of
  the codebase filters; no case/whitespace normalization.
- **Fail-open per dimension:** empty / unset / malformed setting → that filter key is omitted; a failed
  read returns `[]` + a `warn`, so the feed never errors.
- **Parsing (also hardens MP-3098):** `parseIdList` strips JSON wrapper chars before the strict
  `/^\d+$/` digit filter, because Settings Manager returns string-typed values JSON-encoded (e.g.
  `"6,16"`). Per-id strictness is unchanged — `Number()`-coercible junk (`0x1A`/`1e3`/`-7`/`5.5`)
  still can't slip in.
- **Logging:** applied id counts per lever logged each generation (excluded loans never return, so
  there's no per-loan dropped count).
- **v1 sector denylist** seeded to `6,16` (Health, Personal Use) per the spike — config not code; the
  final list is a Product/Legal/Risk call, adjustable in Settings Manager without a deploy.

## Related
- Story: [MP-3099](https://kiva.atlassian.net/browse/MP-3099) · Epic: [MP-2908](https://kiva.atlassian.net/browse/MP-2908)
- Depends on: [MP-3013](https://kiva.atlassian.net/browse/MP-3013) — the feed itself (#7150)
- Extends: [MP-3098](https://kiva.atlassian.net/browse/MP-3098) — loan-level exclusion (#7155); this PR
  also folds in a fix to that ticket's `parseIdList` (JSON-encoded / quoted value handling)

## Related tests (64 pass)
- `.../ads/excluded-ids.spec.js` — `parseIdList` incl. JSON-encoded / quoted / array values,
  wrapper-char recovery, garbage → `[]`; `fetchExcludedIds` key wiring, absent setting, read failure
- `.../ads/ads-eligibility.spec.js` — `buildAdFeedFilters` adds/omits `partnerId`/`sectorId` `{none}`
  and merges all three; `fetchAdEligibleLoans` threads partner/sector into the query
- `.../ads/google-display/google-feed.spec.js` — `generateGoogleFeed` reads all three settings, routes
  each to its own field, logs the counts

## Dev verification
1. `npx vitest run test/unit/specs/server/util/live-loan/ads/` → 64 pass.
2. Verified live on dev FLSS: with `sectorId: { none: [6,16] }` (the configured value), the Health(6)
   loan present in the baseline candidate pool was removed and the slot backfilled; also spot-checked
   `none: [12,7]`, which erased all Food + Retail loans. `partnerId` rides the identical
   `IntKeyFilterModifierInput`/`none` path.
3. Set `ui.live_loan_ads_excluded_sector_ids` / `..._partner_ids`; regenerate
   `/live-loan/ads/google-feed.tsv` (wait ≤5 min or flush `google-ads-feed`); confirm listed
   sectors/partners are gone. Blank the settings → feed returns to full (no `sectorId`/`partnerId`
   filter sent).


[MP-3099]: https://kiva.atlassian.net/browse/MP-3099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ