### PR TITLE
feat: [MP-3095] funded-state ad-landing event and funded fallback headline

### DIFF
--- a/src/components/BorrowerProfile/LoanProgress.vue
+++ b/src/components/BorrowerProfile/LoanProgress.vue
@@ -35,7 +35,7 @@
 				</div>
 				<div v-else>
 					<p class="tw-text-title tw-m-0" data-testid="bp-summary-amount-to-go">
-						This loan is fully funded!
+						{{ fundedHeadline }}
 					</p>
 					<div class="md:tw-flex tw-gap-2">
 						<p class="tw-text-upper tw-text-secondary tw-block">
@@ -215,9 +215,18 @@ export default {
 		hideViewProfileLinks: {
 			type: Boolean,
 			default: false
+		},
+		isLiveLoanAd: {
+			type: Boolean,
+			default: false
 		}
 	},
 	computed: {
+		fundedHeadline() {
+			return this.isLiveLoanAd
+				? 'This loan was just funded! Find another loan'
+				: 'This loan is fully funded!';
+		},
 		pfpProgressPercent() {
 			if (this.pfpMinLenders === 0) {
 				return 0;

--- a/src/components/BorrowerProfile/MinimalBorrowerProfile.vue
+++ b/src/components/BorrowerProfile/MinimalBorrowerProfile.vue
@@ -48,6 +48,7 @@
 											:progress-percent="progressPercent"
 											:loading="isSummaryLoading"
 											:loan-status="loanStatus"
+											:is-live-loan-ad="isLiveLoanAd"
 										/>
 									</div>
 								</div>
@@ -262,6 +263,9 @@ export default {
 			// eslint-disable-next-line max-len
 			return 'Kiva is a loan, not a donation. With Kiva you can lend as little as $25 and make a big change in someone\'s life.';
 		},
+		isLiveLoanAd() {
+			return this.$route?.query?.utm_campaign === 'liveloans';
+		},
 		loanStatus() {
 			// Loan may still be fundraising, but all shares are reserved
 			if (this.loanData?.status === 'fundraising') {
@@ -295,8 +299,15 @@ export default {
 	},
 	mounted() {
 		this.initRecommendations();
+		this.trackAdFundedLanding();
 	},
 	methods: {
+		trackAdFundedLanding() {
+			if (!this.isLiveLoanAd || !this.loanData?.status) {
+				return;
+			}
+			this.$kvTrackEvent('borrower-profile', 'funded-state landing', this.loanData.id, this.loanData.status);
+		},
 		initRecommendations() {
 			// Build the rows only once the loan's own query has populated loanData
 			// (loanData.sector); building from an empty loan yields "undefined" headings.

--- a/test/unit/specs/components/BorrowerProfile/LoanProgress.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/LoanProgress.spec.js
@@ -1,0 +1,32 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
+import LoanProgress from '#src/components/BorrowerProfile/LoanProgress';
+import { globalOptions, routerLinkStub } from '../../../specUtils';
+
+function mountLoanProgress(props) {
+	return mount(LoanProgress, {
+		props: { loading: false, loanStatus: 'funded', ...props },
+		global: {
+			...globalOptions,
+			stubs: { RouterLink: routerLinkStub },
+			mocks: {
+				...globalOptions.mocks,
+				$route: { params: { id: '88' } },
+			},
+		},
+	});
+}
+
+describe('LoanProgress funded headline', () => {
+	it('shows the standard funded headline by default', () => {
+		const wrapper = mountLoanProgress();
+		expect(wrapper.get('[data-testid="bp-summary-amount-to-go"]').text())
+			.toBe('This loan is fully funded!');
+	});
+
+	it('shows the live-loan ad fallback headline when isLiveLoanAd is set', () => {
+		const wrapper = mountLoanProgress({ isLiveLoanAd: true });
+		expect(wrapper.get('[data-testid="bp-summary-amount-to-go"]').text())
+			.toBe('This loan was just funded! Find another loan');
+	});
+});

--- a/test/unit/specs/components/BorrowerProfile/MinimalBorrowerProfile.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/MinimalBorrowerProfile.spec.js
@@ -1,4 +1,50 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { mount } from '@vue/test-utils';
 import MinimalBorrowerProfile from '#src/components/BorrowerProfile/MinimalBorrowerProfile';
+import LoanProgress from '#src/components/BorrowerProfile/LoanProgress';
+import { globalOptions, routerLinkStub } from '../../../specUtils';
+
+function mountMinimal({ utmCampaign } = {}) {
+	return mount(MinimalBorrowerProfile, {
+		props: {
+			loan: {
+				id: 88,
+				name: 'Eunice',
+				status: 'funded',
+				geocode: { country: { name: 'Uganda' } },
+			},
+		},
+		global: {
+			...globalOptions,
+			stubs: {
+				RouterLink: routerLinkStub,
+				HeroBackground: true,
+				BorrowerImage: true,
+				KivaClassicLoanCarousel: true,
+				LoanCardController: true,
+			},
+			mocks: {
+				...globalOptions.mocks,
+				$route: {
+					params: { id: '88' },
+					query: utmCampaign ? { utm_campaign: utmCampaign } : {},
+				},
+			},
+		},
+	});
+}
+
+describe('MinimalBorrowerProfile live-loan ad funded messaging', () => {
+	it('flags LoanProgress to show the ad fallback headline for ad landings', () => {
+		const wrapper = mountMinimal({ utmCampaign: 'liveloans' });
+		expect(wrapper.findComponent(LoanProgress).props('isLiveLoanAd')).toBe(true);
+	});
+
+	it('does not flag LoanProgress for non-ad traffic', () => {
+		const wrapper = mountMinimal();
+		expect(wrapper.findComponent(LoanProgress).props('isLiveLoanAd')).toBe(false);
+	});
+});
 
 describe('MinimalBorrowerProfile.apollo.result', () => {
 	const invokeResult = (ctx, data) => {
@@ -44,6 +90,56 @@ describe('MinimalBorrowerProfile.apollo.result isSummaryLoading', () => {
 		const ctx = { loanData: { id: 123, name: 'Maria' }, isSummaryLoading: true };
 		invokeResult(ctx, { lend: { loan: null } });
 		expect(ctx.isSummaryLoading).toBe(false);
+	});
+});
+
+describe('MinimalBorrowerProfile.computed.isLiveLoanAd', () => {
+	const invoke = ctx => MinimalBorrowerProfile.computed.isLiveLoanAd.call(ctx);
+
+	it('is true when the landing query is the live-loan ads campaign', () => {
+		expect(invoke({ $route: { query: { utm_campaign: 'liveloans' } } })).toBe(true);
+	});
+
+	it('is false for a different campaign', () => {
+		expect(invoke({ $route: { query: { utm_campaign: 'scle' } } })).toBe(false);
+	});
+
+	it('is false when no campaign is present', () => {
+		expect(invoke({ $route: { query: {} } })).toBe(false);
+	});
+});
+
+describe('MinimalBorrowerProfile.methods.trackAdFundedLanding', () => {
+	const invoke = ctx => MinimalBorrowerProfile.methods.trackAdFundedLanding.call(ctx);
+
+	const adCtx = overrides => ({
+		isLiveLoanAd: true,
+		loanData: { id: 123, status: 'expired' },
+		$kvTrackEvent: vi.fn(),
+		...overrides,
+	});
+
+	it('fires the funded-state landing event with the raw status in the property arg', () => {
+		const ctx = adCtx();
+		invoke(ctx);
+		expect(ctx.$kvTrackEvent).toHaveBeenCalledWith(
+			'borrower-profile',
+			'funded-state landing',
+			123,
+			'expired',
+		);
+	});
+
+	it('does not fire for non-ad traffic', () => {
+		const ctx = adCtx({ isLiveLoanAd: false });
+		invoke(ctx);
+		expect(ctx.$kvTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('does not fire without a loaded status', () => {
+		const ctx = adCtx({ loanData: { id: 123 } });
+		invoke(ctx);
+		expect(ctx.$kvTrackEvent).not.toHaveBeenCalled();
 	});
 });
 


### PR DESCRIPTION
## Summary
Adds the **funded-click fallback** for the live-loan Google Ads campaign: when a `liveloans`
ad click lands on a **funded / no-longer-lendable** borrower profile (the minimal `/lend/{id}`
view that anonymous ad traffic hits), the page now

1. fires a dedicated **`borrower-profile` / `funded-state landing`** analytics event (label = loan id,
   `property` = the loan's raw status), and
2. shows the **"This loan was just funded! Find another loan"** headline instead of the generic
   "This loan is fully funded!".

This gives a clean, first-class count of ad clicks that hit a loan which funded before the feed
dropped it — independent of session/attribution stitching.

> **Scope:** this is the kiva-ui slice of MP-3095. The end-to-end funnel, Google Ads conversion
> upload, first-time-lender attribution, and the Looker pipeline are **not** in this PR — they're
> config/data-team work (see *Follow-ups*).

## Approach / decisions to flag
- **Gate:** landing route query `utm_campaign === 'liveloans'` (the ad Final URL carries it) **and**
  the minimal view. Real ad traffic is anonymous → always the minimal view; privileged/admin sessions
  see the full view and are intentionally out of scope.
- **Event:** fires once in `mounted` (client-only). Raw loan status rides in the `property` arg so the
  data team can segment "just funded" from "already repaying / expired" — the event fires for **any**
  non-lendable ad landing, even though the headline only reads "just funded" for funded/raised.
- **Headline:** new `isLiveLoanAd` prop on the shared `LoanProgress` (**default `false` → every other
  consumer unchanged**). Funded / raised / fully-reserved render the message; expired / refunded /
  paying-back render their **honest** state (and still fire the event).

## Related
- Story: [MP-3095](https://kiva.atlassian.net/browse/MP-3095) · Epic: [MP-2908](https://kiva.atlassian.net/browse/MP-2908)
- Depends on: [MP-3013](https://kiva.atlassian.net/browse/MP-3013) — the feed itself (#7150)
- Blocked: end-to-end validation is gated on the feed going live ([MP-3115](https://kiva.atlassian.net/browse/MP-3115))

## Follow-ups (not in this PR)
- Funnel conversion events + UTM/GCLID verification on the `liveloans` path (mostly existing analytics)
- Google Ads conversion upload + first-time-lender attribution + minimal-data-to-Google
- Looker pipeline: reporting fields + warehouse `origin: "google:live-loan-ads"` recognition

## Related tests
Two specs changed (17 pass); full BorrowerProfile suite (161) green.
- `LoanProgress.spec.js` (new) — funded headline is the standard copy by default, the ad copy when
  `isLiveLoanAd`.
- `MinimalBorrowerProfile.spec.js` — `isLiveLoanAd` campaign detection; `trackAdFundedLanding` fires
  with the raw status in `property`, not for non-ad traffic, not without a loaded status; and the
  mounted component passes `isLiveLoanAd` through to `LoanProgress`.

## Dev verification
Verified on `--config=dev-custom-host` (dev gateway):
1. Funded loan (id 88) via the `liveloans` URL → headline reads **"This loan was just funded! Find
   another loan"** and the `borrower-profile` / `funded-state landing` event fires with the loan id +
   status. Confirmed logged-in (non-privileged) and logged-out.
2. Group loan (id 3153211) in an **incognito** window → same minimal-view behavior. (Privileged/admin
   sessions render the full view, which this feature intentionally doesn't touch.)

[MP-3095]: https://kiva.atlassian.net/browse/MP-3095
