### PR TITLE
feat: make the goal sign up hiding respect the recapDate param override

### DIFF
--- a/src/components/MyKiva/JourneyCardCarousel.vue
+++ b/src/components/MyKiva/JourneyCardCarousel.vue
@@ -103,6 +103,7 @@ import MyKivaEmailUpdatesTransition from '#src/components/MyKiva/MyKivaEmailUpda
 import MyKivaLatestLoanCard from '#src/components/MyKiva/MyKivaLatestLoanCard';
 import MyKivaSurveyCard from '#src/components/MyKiva/MyKivaSurveyCard';
 import { shouldHideGoalSignup } from '#src/util/goalInReview';
+import { getGoalInReviewNow } from '#src/composables/useGoalInReview';
 import AlmostFundedNextStep from '#src/components/MyKiva/AlmostFundedNextStep';
 import {
 	getSlideTitle,
@@ -268,6 +269,7 @@ const nonBadgesSlides = computed(() => filterNonBadgesSlides(props.slides));
 
 const hideGoalSignup = computed(() => shouldHideGoalSignup({
 	recapStartDate: props.goalInReviewInProgressStart,
+	now: getGoalInReviewNow(),
 }));
 
 const shouldShowGoalCard = computed(() => {

--- a/src/components/MyKiva/MyKivaFeaturedSlot.vue
+++ b/src/components/MyKiva/MyKivaFeaturedSlot.vue
@@ -101,6 +101,7 @@ const alreadyViewedSnapshot = ref(null);
 
 const hideGoalSignup = computed(() => shouldHideGoalSignup({
 	recapStartDate: props.goalInReviewInProgressStart,
+	now: getGoalInReviewNow(),
 }));
 
 const slotState = computed(() => {

--- a/src/components/Thanks/ThanksPageSingleVersion.vue
+++ b/src/components/Thanks/ThanksPageSingleVersion.vue
@@ -209,6 +209,7 @@ import GoalInProgress from '#src/components/Thanks/SingleVersion/GoalInProgress'
 import ExpressCheckoutModal from '#src/components/Thanks/ExpressCheckout/ExpressCheckoutModal';
 import useGoalData, { GOAL_STATUS } from '#src/composables/useGoalData';
 import { shouldHideGoalSignup } from '#src/util/goalInReview';
+import { getGoalInReviewNow } from '#src/composables/useGoalInReview';
 import useGoalSettingRecommendedLoan, {
 	GOAL_RECOMMENDED_LOAN_ENTRYPOINT_POST_CHECKOUT,
 } from '#src/composables/useGoalSettingRecommendedLoan';
@@ -461,6 +462,7 @@ const showJourneyModule = computed(() => {
 const showLoanComment = computed(() => hasPfpLoan.value || hasTeamAttributedPartnerLoan.value);
 const hideGoalSignup = computed(() => shouldHideGoalSignup({
 	recapStartDate: props.goalInReviewInProgressStart,
+	now: getGoalInReviewNow(),
 }));
 
 const showGoalEntrypoint = computed(() => {

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -65,7 +65,7 @@ import { gql } from 'graphql-tag';
 import { readBoolSetting, readDateSetting } from '#src/util/settingsUtils';
 import { shouldHideGoalSignup } from '#src/util/goalInReview';
 import { GOAL_STATUS, GOALS_CURRENT_YEAR } from '#src/composables/useGoalData';
-import useGoalInReview from '#src/composables/useGoalInReview';
+import useGoalInReview, { getGoalInReviewNow } from '#src/composables/useGoalInReview';
 import GoalInReviewModal from '#src/components/MyKiva/GoalInReview/GoalInReviewModal';
 import portfolioQuery from '#src/graphql/query/portfolioQuery.graphql';
 import badgeGoalMixin from '#src/plugins/badge-goal-mixin';
@@ -161,7 +161,10 @@ export default {
 	},
 	computed: {
 		hideGoalSignup() {
-			return shouldHideGoalSignup({ recapStartDate: this.goalInReviewInProgressStart });
+			return shouldHideGoalSignup({
+				recapStartDate: this.goalInReviewInProgressStart,
+				now: getGoalInReviewNow(),
+			});
 		},
 	},
 	methods: {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3120

Realized that `recapDate` was not being involved in the goal sign up hiding feature, so I added it just as a **testing tool** to validate in VQA