### PR TITLE
fix: user has goal validation was thought to check null value instead…

### DIFF
--- a/src/components/MyKiva/JourneyCardCarousel.vue
+++ b/src/components/MyKiva/JourneyCardCarousel.vue
@@ -267,6 +267,8 @@ const showSurveyCard = computed(() => props.showSurveySlide && checkShowSurveyCa
 
 const nonBadgesSlides = computed(() => filterNonBadgesSlides(props.slides));
 
+const userHasGoal = computed(() => !!props.userGoal && Object.keys(props.userGoal).length > 0);
+
 const hideGoalSignup = computed(() => shouldHideGoalSignup({
 	recapStartDate: props.goalInReviewInProgressStart,
 	now: getGoalInReviewNow(),
@@ -275,7 +277,7 @@ const hideGoalSignup = computed(() => shouldHideGoalSignup({
 const shouldShowGoalCard = computed(() => {
 	if (!props.inLendingStats) return false;
 	// With no goal, this card is only the sign up ask.
-	if (!props.userGoal && hideGoalSignup.value) return false;
+	if (!userHasGoal.value && hideGoalSignup.value) return false;
 
 	return (!props.userGoal || !props.userGoalAchieved || props.userGoalAchieved) && !props.hideGoalCard;
 });

--- a/src/components/MyKiva/JourneyCardCarousel.vue
+++ b/src/components/MyKiva/JourneyCardCarousel.vue
@@ -98,7 +98,7 @@ import { KvCarousel } from '@kiva/kv-components';
 import MyKivaSharingModal from '#src/components/MyKiva/MyKivaSharingModal';
 import MyKivaCard from '#src/components/MyKiva/MyKivaCard';
 import NextYearGoalCard from '#src/components/MyKiva/NextYearGoalCard';
-import useGoalData from '#src/composables/useGoalData';
+import useGoalData, { hasGoal } from '#src/composables/useGoalData';
 import MyKivaEmailUpdatesTransition from '#src/components/MyKiva/MyKivaEmailUpdatesTransition';
 import MyKivaLatestLoanCard from '#src/components/MyKiva/MyKivaLatestLoanCard';
 import MyKivaSurveyCard from '#src/components/MyKiva/MyKivaSurveyCard';
@@ -267,8 +267,6 @@ const showSurveyCard = computed(() => props.showSurveySlide && checkShowSurveyCa
 
 const nonBadgesSlides = computed(() => filterNonBadgesSlides(props.slides));
 
-const userHasGoal = computed(() => !!props.userGoal && Object.keys(props.userGoal).length > 0);
-
 const hideGoalSignup = computed(() => shouldHideGoalSignup({
 	recapStartDate: props.goalInReviewInProgressStart,
 	now: getGoalInReviewNow(),
@@ -277,7 +275,7 @@ const hideGoalSignup = computed(() => shouldHideGoalSignup({
 const shouldShowGoalCard = computed(() => {
 	if (!props.inLendingStats) return false;
 	// With no goal, this card is only the sign up ask.
-	if (!userHasGoal.value && hideGoalSignup.value) return false;
+	if (!hasGoal(props.userGoal) && hideGoalSignup.value) return false;
 
 	return (!props.userGoal || !props.userGoalAchieved || props.userGoalAchieved) && !props.hideGoalCard;
 });

--- a/src/components/MyKiva/JourneyCardCarousel.vue
+++ b/src/components/MyKiva/JourneyCardCarousel.vue
@@ -98,7 +98,7 @@ import { KvCarousel } from '@kiva/kv-components';
 import MyKivaSharingModal from '#src/components/MyKiva/MyKivaSharingModal';
 import MyKivaCard from '#src/components/MyKiva/MyKivaCard';
 import NextYearGoalCard from '#src/components/MyKiva/NextYearGoalCard';
-import useGoalData, { hasGoal } from '#src/composables/useGoalData';
+import useGoalData from '#src/composables/useGoalData';
 import MyKivaEmailUpdatesTransition from '#src/components/MyKiva/MyKivaEmailUpdatesTransition';
 import MyKivaLatestLoanCard from '#src/components/MyKiva/MyKivaLatestLoanCard';
 import MyKivaSurveyCard from '#src/components/MyKiva/MyKivaSurveyCard';
@@ -134,7 +134,7 @@ const {
 	isTieredAchievementComplete,
 } = useBadgeData(apollo);
 
-const { getCategoryLoansLastYear } = useGoalData();
+const { getCategoryLoansLastYear, hasGoal } = useGoalData();
 
 const emit = defineEmits(['update-journey', 'open-goal-modal', 'open-impact-insight-modal']);
 

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -76,6 +76,17 @@ export const HALF_GOAL_THRESHOLD = 50;
 const MIN_CATEGORY_LOANS_AMOUNT = 100;
 const RECOMMENDED_LOANS_LIMIT = 4;
 
+/**
+ * A lender with no goal gets `{}` rather than null, since setGoalState spreads an
+ * absent goal. Truthiness is therefore never enough to tell whether a goal exists.
+ *
+ * @param {object} goal The lender's goal.
+ * @returns {boolean} Whether the lender has a goal.
+ */
+export function hasGoal(goal) {
+	return !!goal && Object.keys(goal).length > 0;
+}
+
 function getGoalDisplayName(target, category) {
 	if (!target || target > 1) return GOAL_DISPLAY_MAP[category] || 'loans';
 	return GOAL_1_DISPLAY_MAP[category] || 'loan';
@@ -117,6 +128,8 @@ export default function useGoalData({ apollo } = {}) {
 		const categoryProgress = progress?.find(n => n.id === goal?.category);
 		return categoryProgress?.progressForYear || 0;
 	});
+
+	const userHasGoal = computed(() => hasGoal(userGoal.value));
 
 	const userGoalAchieved = computed(() => goalProgress.value >= userGoal.value?.target);
 
@@ -1272,6 +1285,7 @@ export default function useGoalData({ apollo } = {}) {
 		storeGoalPreferences,
 		userGoal,
 		userGoalAchieved,
+		userHasGoal,
 		userGoalAchievedNow,
 		suppressAchievementNudges,
 		userPreferences,

--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -83,7 +83,7 @@ const RECOMMENDED_LOANS_LIMIT = 4;
  * @param {object} goal The lender's goal.
  * @returns {boolean} Whether the lender has a goal.
  */
-export function hasGoal(goal) {
+function hasGoal(goal) {
 	return !!goal && Object.keys(goal).length > 0;
 }
 
@@ -1273,6 +1273,7 @@ export default function useGoalData({ apollo } = {}) {
 		getCategoryLoansLastYear,
 		getCtaHref,
 		getGoalDisplayName,
+		hasGoal,
 		getGoalSummary,
 		getLoanStatsByYear,
 		getPostCheckoutProgressByLoans,

--- a/test/unit/specs/components/MyKiva/JourneyCardCarousel.spec.js
+++ b/test/unit/specs/components/MyKiva/JourneyCardCarousel.spec.js
@@ -23,6 +23,7 @@ vi.mock('#src/composables/useGoalData', () => ({
 		getCategoryLoansLastYear: () => 0,
 	}),
 	GOALS_CURRENT_YEAR: new Date().getFullYear(),
+	hasGoal: goal => !!goal && Object.keys(goal).length > 0,
 }));
 
 vi.mock('#src/util/imageUtils', () => ({

--- a/test/unit/specs/components/MyKiva/JourneyCardCarousel.spec.js
+++ b/test/unit/specs/components/MyKiva/JourneyCardCarousel.spec.js
@@ -21,9 +21,9 @@ vi.mock('#src/composables/useBreakpoints', () => ({
 vi.mock('#src/composables/useGoalData', () => ({
 	default: () => ({
 		getCategoryLoansLastYear: () => 0,
+		hasGoal: goal => !!goal && Object.keys(goal).length > 0,
 	}),
 	GOALS_CURRENT_YEAR: new Date().getFullYear(),
-	hasGoal: goal => !!goal && Object.keys(goal).length > 0,
 }));
 
 vi.mock('#src/util/imageUtils', () => ({


### PR DESCRIPTION
… of empty object

Goal Card was still present days before releasing goal recap because the check was failing to recognize an empty goal (`{}`). 

## Testing

In a no goal account go to `https://kiva-ui.local/mykiva?recapDate=2027-01-01`, you should not see the goal card in next steps row since `goal_in_review_in_progress_start` is set to `2026-11-15` in Settings manager