### PR TITLE
fix(live-loan-ads): use "Support" title copy and show sector in Item description

### DIFF
--- a/server/util/live-loan/ads/google-display/feed-row.js
+++ b/server/util/live-loan/ads/google-display/feed-row.js
@@ -30,19 +30,21 @@ export function truncate(s) {
 }
 
 export function buildTitle(loan) {
-	return truncate(`Help ${primaryFirstName(loan)}`);
-}
-
-export function buildDescription(loan) {
 	return truncate(`Support ${primaryFirstName(loan)}`);
-}
-
-export function buildSubtitle(loan) {
-	return truncate(loan?.geocode?.country?.name);
 }
 
 export function buildCategory(loan) {
 	return sanitizeText(loan?.sector?.name);
+}
+
+// Item description shows the same value as Item category -- the loan's sector name -- capped to the
+// 25-char limit Google applies to the description field.
+export function buildDescription(loan) {
+	return truncate(buildCategory(loan));
+}
+
+export function buildSubtitle(loan) {
+	return truncate(loan?.geocode?.country?.name);
 }
 
 export function buildFinalUrl(id) {

--- a/test/unit/specs/server/util/live-loan/ads/google-display/feed-row.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/google-display/feed-row.spec.js
@@ -59,14 +59,20 @@ describe('feed-row', () => {
 	});
 
 	describe('buildTitle', () => {
-		it('builds "Help {firstName}" from the primary borrower', () => {
-			expect(buildTitle(loan)).toEqual('Help Mukumoy');
+		it('builds "Support {firstName}" from the primary borrower', () => {
+			expect(buildTitle(loan)).toEqual('Support Mukumoy');
 		});
 	});
 
 	describe('buildDescription', () => {
-		it('builds "Support {firstName}" from the primary borrower', () => {
-			expect(buildDescription(loan)).toEqual('Support Mukumoy');
+		it('is the sector name, mirroring Item category', () => {
+			expect(buildDescription(loan)).toEqual('Retail');
+			expect(buildDescription(loan)).toEqual(buildCategory(loan));
+		});
+
+		it('caps a long sector name at 25 characters', () => {
+			const longSector = { sector: { name: 'Wholesale and Retail Distribution' } };
+			expect(buildDescription(longSector)).toEqual('Wholesale and Retail Dist');
 		});
 	});
 
@@ -121,8 +127,8 @@ describe('feed-row', () => {
 			expect(Object.keys(row)).toEqual(FEED_COLUMNS);
 			expect(row).toEqual({
 				ID: '456',
-				'Item title': 'Help Mukumoy',
-				'Item description': 'Support Mukumoy',
+				'Item title': 'Support Mukumoy',
+				'Item description': 'Retail',
 				'Item subtitle': 'Tajikistan',
 				'Item category': 'Retail',
 				'Image URL': EXPECTED_IMAGE_URL,


### PR DESCRIPTION
## Summary

Two copy changes to the live-loan Google Ads feed (`/live-loan/ads/google-feed.tsv`), per product request on MP-3013:

- **Item title**: `Help {firstName}` → `Support {firstName}`
- **Item description**: `Support {firstName}` → the loan's **sector name** — the same value shown in **Item category** — capped to Google's 25-char description limit.

## Why

- Shifts the ad title to the requested "Support" framing.
- Surfaces the sector in the description field.

> Note: Item description and Item category are now identical on every row (both the sector). That's the intended behavior of this request; flagging it in case product later wants the description to carry something distinct.

## Testing

- Updated `feed-row.spec.js`: title now asserts `Support {firstName}`; description asserts it mirrors Item category (sector) and is capped at 25 chars; `loanToFeedRow` mapping updated.
- Unit specs `feed-row`, `google-feed`, `live-loan-router` — **65 passing**. eslint clean.
- Regenerated a 100-row TSV against the dev gateway: every title starts with `Support ` (0 exceptions), and `Item description == Item category` on all rows (0 mismatches).

Sample row:

```
3208854	Support Maria Liduvina	Clothing	Paraguay	Clothing	https://res.cloudinary.com/kiva/c_limit,w_1200,h_1200,f_jpg,cs_srgb,fl_force_icc/remote/5c258e1d730889cdb1af37be1196ba00.jpg	https://www.kiva.org/lend/3208854?utm_medium=paid&utm_source=google&utm_campaign=liveloans
```
