### PR TITLE
feat(checkout): self-describing event for bandit upsell recommendation

### DIFF
--- a/src/graphql/query/checkout/getCheckoutAlmostFundedRecommendation.graphql
+++ b/src/graphql/query/checkout/getCheckoutAlmostFundedRecommendation.graphql
@@ -1,5 +1,6 @@
-query getCheckoutAlmostFundedRecommendation($loginId: Int,$balance: Float) {
-    getCheckoutAlmostFundedRecommendation(loginId: $loginId, balance: $balance) {
+query getCheckoutAlmostFundedRecommendation($loginId: Int, $balance: Float, $basketAmount: Float) {
+    getCheckoutAlmostFundedRecommendation(loginId: $loginId, balance: $balance, basketAmount: $basketAmount) {
+        modelVersion
         recommendedRanges {
             end
             start

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -1196,15 +1196,20 @@ export default {
 						logReadQueryError(e, 'getLoansByExpiringSoon');
 					});
 			} else if (this.isBanditUpsellExpEnabled) {
-				const balance = parseFloat(this.myBalance);
+				// Money fields are formatted strings (numeral parses them); balance is nullable when logged out
+				const balance = this.myBalance == null ? null : numeral(this.myBalance).value();
+				const basketAmount = numeral(this.totals?.itemTotal).value();
 				this.apollo.query({
 					query: getCheckoutAlmostFundedRecommendationQuery,
 					variables: {
 						loginId: this.myId,
 						balance,
+						basketAmount,
 					},
 				}).then(({ data }) => {
-					const ranges = data?.getCheckoutAlmostFundedRecommendation?.recommendedRanges ?? [];
+					const recommendation = data?.getCheckoutAlmostFundedRecommendation;
+					const ranges = recommendation?.recommendedRanges ?? [];
+					const modelVersion = recommendation?.modelVersion;
 					const promiseArray = ranges.map(range => this.getLoansByAmountLeftRange(range.start, range.end));
 					// Adding general query as fallback in case the ranges don't return any loans
 					promiseArray.push(this.getLoansByAmountLeft());
@@ -1218,12 +1223,13 @@ export default {
 
 						const arrayLength = loansArray.length;
 						if (loansIndex >= 0 && loansIndex !== arrayLength - 1) {
-							this.$kvTrackEvent(
-								'basket',
-								'view',
-								'recommended-checkout-upsell',
-								`${ranges[loansIndex].start} - ${ranges[loansIndex].end}`,
-							);
+							this.trackUpsellRecommendation({
+								balance,
+								basketTotal: basketAmount,
+								modelVersion,
+								// send only { start, end }; Apollo attaches __typename to each range
+								recommendedRanges: ranges.map(({ start, end }) => ({ start, end })),
+							});
 						}
 					});
 				}).catch(e => {
@@ -1238,6 +1244,21 @@ export default {
 						this.upsellLoan = loans.filter(loan => !this.addedUpsellLoans.includes(loan.id))[0] || {};
 					});
 			}
+		},
+		trackUpsellRecommendation({
+			balance, basketTotal, modelVersion, recommendedRanges
+		}) {
+			// eslint-disable-next-line max-len
+			const schema = 'https://raw.githubusercontent.com/kiva/snowplow/master/conf/snowplow_checkout_upsell_recommendation_event_schema_1_0_0.json#';
+			this.$kvTrackSelfDescribingEvent({
+				schema,
+				data: {
+					balance,
+					basketTotal,
+					modelVersion,
+					recommendedRanges,
+				},
+			});
 		},
 		verificationComplete() {
 			this.verificationSubmitted = true;

--- a/test/unit/specs/pages/Checkout/CheckoutPageUpsell.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPageUpsell.spec.js
@@ -67,10 +67,13 @@ describe('CheckoutPage upsell - expiring soon', () => {
 				isExpiringSoonExpEnabled: false,
 				myId: 123,
 				myBalance: '50.00',
+				totals: { itemTotal: '75.00' },
 				$kvTrackEvent: vi.fn(),
+				$kvTrackSelfDescribingEvent: vi.fn(),
 				getLoansByAmountLeft: CheckoutPage.methods.getLoansByAmountLeft,
 				getLoansByAmountLeftRange: CheckoutPage.methods.getLoansByAmountLeftRange,
 				getLoansByExpiringSoon: CheckoutPage.methods.getLoansByExpiringSoon,
+				trackUpsellRecommendation: CheckoutPage.methods.trackUpsellRecommendation,
 			};
 		});
 
@@ -182,6 +185,84 @@ describe('CheckoutPage upsell - expiring soon', () => {
 			await vi.waitFor(() => {
 				expect(context.upsellLoan).toEqual({ id: 2, name: 'New Loan' });
 			});
+		});
+
+		it.each([
+			{ myBalance: '50.00', itemTotal: '75.00', expected: { balance: 50, basketAmount: 75 } },
+			{ myBalance: undefined, itemTotal: '75.00', expected: { balance: null, basketAmount: 75 } },
+			{ myBalance: '1,234.56', itemTotal: '1,075.00', expected: { balance: 1234.56, basketAmount: 1075 } },
+		])('maps money fields to query variables (balance=$myBalance)', ({ myBalance, itemTotal, expected }) => {
+			context.isBanditUpsellExpEnabled = true;
+			context.myBalance = myBalance;
+			context.totals = { itemTotal };
+			runRecommendationsQuery.mockResolvedValue({ loans: [], totalCount: 0 });
+
+			CheckoutPage.methods.getUpsellModuleData.call(context, 0);
+
+			expect(context.apollo.query).toHaveBeenCalledWith(
+				expect.objectContaining({
+					variables: { loginId: 123, ...expected },
+				})
+			);
+		});
+
+		it('fires the self-describing event when a recommended range produces the upsell loan', async () => {
+			context.isBanditUpsellExpEnabled = true;
+			context.apollo.query = vi.fn().mockResolvedValue({
+				data: {
+					getCheckoutAlmostFundedRecommendation: {
+						modelVersion: 'v1',
+						// Apollo attaches __typename; the event must send only { start, end }
+						recommendedRanges: [{ start: 25, end: 50, __typename: 'CheckoutRecommendedRange' }],
+					},
+				},
+			});
+			runRecommendationsQuery.mockResolvedValue({ loans: [{ id: 99, name: 'Recommended' }], totalCount: 1 });
+
+			CheckoutPage.methods.getUpsellModuleData.call(context, 0);
+
+			await vi.waitFor(() => {
+				expect(context.$kvTrackSelfDescribingEvent).toHaveBeenCalledWith(
+					expect.objectContaining({
+						schema: expect.stringContaining('kiva/snowplow'),
+						data: {
+							balance: 50,
+							basketTotal: 75,
+							modelVersion: 'v1',
+							recommendedRanges: [{ start: 25, end: 50 }],
+						},
+					})
+				);
+			});
+			expect(context.$kvTrackEvent).not.toHaveBeenCalledWith(
+				'basket',
+				'view',
+				'recommended-checkout-upsell',
+				expect.anything(),
+			);
+		});
+
+		it('does not fire the self-describing event when only the fallback returns loans', async () => {
+			context.isBanditUpsellExpEnabled = true;
+			context.apollo.query = vi.fn().mockResolvedValue({
+				data: {
+					getCheckoutAlmostFundedRecommendation: {
+						modelVersion: 'v1',
+						recommendedRanges: [{ start: 25, end: 50 }],
+					},
+				},
+			});
+			// range promise (first call) returns nothing; fallback (last call) returns a loan
+			runRecommendationsQuery
+				.mockResolvedValueOnce({ loans: [], totalCount: 0 })
+				.mockResolvedValue({ loans: [{ id: 99, name: 'Fallback' }], totalCount: 1 });
+
+			CheckoutPage.methods.getUpsellModuleData.call(context, 0);
+
+			await vi.waitFor(() => {
+				expect(context.upsellLoan).toEqual({ id: 99, name: 'Fallback' });
+			});
+			expect(context.$kvTrackSelfDescribingEvent).not.toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
## MP-3004 — Support bandit for upsell (instrumentation)

Adds analytics for the checkout upsell **bandit** experiment.

### What changed
- Fires a **Snowplow self-describing event** (`trackUpsellRecommendation`) when a model-recommended upsell loan is shown, carrying `balance`, `basketTotal`, `modelVersion`, and the full ordered `recommendedRanges` (`{start,end}`). This **replaces** the old `recommended-checkout-upsell` GA event, at the same gate (a non-fallback recommended range produced the shown loan).
- Passes `basketAmount` to `getCheckoutAlmostFundedRecommendation` and selects `modelVersion` from the response.
- Money fields (`balance`, `itemTotal`) parsed with `numeral(...).value()` — they're formatted strings; `balance` is `null` for logged-out users, `basketTotal` is always numeric (the event only fires for a non-empty basket).
- The `view-checkout-upsell` event in `UpsellModule.vue` is **unchanged** (the ticket's "ensure it stays" event).
- Gated by the existing `checkout_bandit_upsell_enable` experiment flag.

### Dependencies
- **Snowplow Iglu schema:** merged — kiva/snowplow #28 (`checkout_upsell_recommendation_event` v1-0-0).
- ⚠️ **Blocked on prod API:** `modelVersion` + `basketAmount` are live on the **dev** GraphQL gateway but **not yet prod**. CI `lint` re-fetches the prod schema, so the GraphQL lint check will fail until the API ships those fields to prod. **Do not merge until then.**

### Testing
- Unit tests in `CheckoutPageUpsell.spec.js`: query-variable mapping (incl. logged-out `null` and comma-formatted money via `it.each`), the self-describing event payload (with `__typename` stripping), the fallback no-event case, and the old-GA-event removal assertion. Full unit suite green.

Ticket: MP-3004
