### PR TITLE
fix: temp view changes for disaster relief giving fund on mykiva and portfolio

### DIFF
--- a/src/components/GivingFunds/MyGivingFundsCard.vue
+++ b/src/components/GivingFunds/MyGivingFundsCard.vue
@@ -1,6 +1,5 @@
 <template>
 	<div
-		v-if="showCard"
 		class="giving-fund-card tw-rounded tw-bg-white tw-p-2 tw-w-full tw-flex tw-flex-col tw-gap-2 tw-items-stretch
 			md:tw-flex-row md:tw-items-center md:tw-justify-between md:tw-gap-3 md:tw-p-2.5"
 	>
@@ -15,7 +14,6 @@
 			</transition>
 		</div>
 		<KvButton
-			:key="`giving-funds-cta-${isDisasterReliefOnly}`"
 			class="tw-w-full md:tw-w-auto md:tw-ml-auto"
 			variant="primary"
 			:to="ctaTo"
@@ -43,7 +41,6 @@ import {
 	computed,
 	inject,
 	ref,
-	watch,
 	onMounted,
 } from 'vue';
 
@@ -57,10 +54,10 @@ const props = defineProps({
 		default: null,
 	},
 	/**
-	 * When true (MyKiva), the card is not rendered at all for lenders whose only
-	 * giving fund activity is supporting the disaster relief fund
+	 * Whether the lender's only giving fund activity is supporting the disaster
+	 * relief fund; renders the fund-specific variant of the card
 	 */
-	hideDisasterReliefOnly: {
+	isDisasterReliefOnly: {
 		type: Boolean,
 		default: false,
 	},
@@ -72,47 +69,24 @@ const {
 } = useGivingFund(apollo);
 
 const myFundsCount = ref(0);
-const contributedFundIds = ref([]);
-const fundsCountLoaded = ref(false);
-const contributedFundsLoaded = ref(false);
+const contributedFundsCount = ref(0);
 
-const contributedFundsCount = computed(() => contributedFundIds.value.length);
-
-const dataLoaded = computed(() => fundsCountLoaded.value && contributedFundsLoaded.value);
-
-// Lender supports the disaster relief fund and no other giving funds
-const isDisasterReliefOnly = computed(() => dataLoaded.value
-	&& myFundsCount.value === 0
-	&& contributedFundIds.value.length === 1
-	&& contributedFundIds.value[0] === givingFundIds.COLOMBIA_DISASTER_RELIEF);
-
-const showCard = computed(() => {
-	if (!props.hideDisasterReliefOnly) {
-		return true;
-	}
-	// Wait for fund data so the card never flashes in before being hidden
-	return dataLoaded.value && !isDisasterReliefOnly.value;
-});
-
-const titleCopy = computed(() => (isDisasterReliefOnly.value
+const titleCopy = computed(() => (props.isDisasterReliefOnly
 	? 'Check in on the Colombia earthquake recovery fund'
 	: 'Check in on your giving funds'));
 
-const ctaCopy = computed(() => (isDisasterReliefOnly.value ? 'View fund' : 'See your giving funds'));
+const ctaCopy = computed(() => (props.isDisasterReliefOnly ? 'View fund' : 'See your giving funds'));
 
 const ctaTo = computed(() => (
-	isDisasterReliefOnly.value ? `/gf/${givingFundIds.COLOMBIA_DISASTER_RELIEF}` : '/gfm'
+	props.isDisasterReliefOnly ? `/gf/${givingFundIds.COLOMBIA_DISASTER_RELIEF}` : '/gfm'
 ));
 
-const clickTrackEventProps = computed(() => (isDisasterReliefOnly.value
+const clickTrackEventProps = computed(() => (props.isDisasterReliefOnly
 	? ['portfolio', 'click', 'see-your-giving-funds', 'disaster-relief']
 	: ['portfolio', 'click', 'see-your-giving-funds']));
 
 const textCopy = computed(() => {
 	let copy = '';
-	if (isDisasterReliefOnly.value) {
-		return copy;
-	}
 	if (myFundsCount.value > 0 && contributedFundsCount.value > 0) {
 		copy = `You have ${myFundsCount.value} ${
 			myFundsCount.value === 1 ? 'fund' : 'funds'
@@ -131,32 +105,21 @@ const textCopy = computed(() => {
 	return copy;
 });
 
-let viewEventTracked = false;
-
-watch(isDisasterReliefOnly, value => {
-	// Track views of the disaster relief variant, which only renders when not hidden
-	if (value && !props.hideDisasterReliefOnly && !viewEventTracked) {
-		viewEventTracked = true;
-		$kvTrackEvent?.('portfolio', 'view', 'see-your-giving-funds', 'disaster-relief');
-	}
-});
-
 onMounted(() => {
+	if (props.isDisasterReliefOnly) {
+		$kvTrackEvent?.('portfolio', 'view', 'see-your-giving-funds', 'disaster-relief');
+		return;
+	}
+
 	// Fetch giving fund data
 	fetchMyGivingFundsCount()
 		.then(response => {
 			myFundsCount.value = response?.givingFunds?.totalCount ?? 0;
-		})
-		.finally(() => {
-			fundsCountLoaded.value = true;
 		});
 
 	getFundsContributedToIds(parseInt(props?.userId, 10) || null)
 		.then(fundIds => {
-			contributedFundIds.value = fundIds ?? [];
-		})
-		.finally(() => {
-			contributedFundsLoaded.value = true;
+			contributedFundsCount.value = fundIds?.length ?? 0;
 		});
 });
 </script>

--- a/src/components/GivingFunds/MyGivingFundsCard.vue
+++ b/src/components/GivingFunds/MyGivingFundsCard.vue
@@ -1,10 +1,11 @@
 <template>
 	<div
+		v-if="showCard"
 		class="giving-fund-card tw-rounded tw-bg-white tw-p-2 tw-w-full tw-flex tw-flex-col tw-gap-2 tw-items-stretch
 			md:tw-flex-row md:tw-items-center md:tw-justify-between md:tw-gap-3 md:tw-p-2.5"
 	>
 		<h2 class="tw-text-center md:tw-text-left md:tw-flex-1 !tw-text-title">
-			Check in on your giving funds
+			{{ titleCopy }}
 		</h2>
 		<div class="tw-text-center md:tw-text-left md:tw-flex-1">
 			<transition name="kvfade">
@@ -14,14 +15,15 @@
 			</transition>
 		</div>
 		<KvButton
+			:key="`giving-funds-cta-${isDisasterReliefOnly}`"
 			class="tw-w-full md:tw-w-auto md:tw-ml-auto"
 			variant="primary"
-			to="/gfm"
-			aria-label="See your giving funds"
-			v-kv-track-event="['portfolio', 'click', 'see-your-giving-funds']"
+			:to="ctaTo"
+			:aria-label="ctaCopy"
+			v-kv-track-event="clickTrackEventProps"
 		>
 			<div class="tw-flex tw-items-center tw-w-full tw-gap-1 md:tw-w-auto">
-				<span>See your giving funds</span>
+				<span>{{ ctaCopy }}</span>
 				<KvMaterialIcon
 					class="tw-w-3 tw-h-3"
 					:icon="mdiArrowTopRight"
@@ -35,21 +37,32 @@
 import { KvButton, KvMaterialIcon } from '@kiva/kv-components';
 import { mdiArrowTopRight } from '@mdi/js';
 import useGivingFund from '#src/composables/useGivingFund';
+import { givingFundIds } from '#src/util/givingFundUtils';
 
 import {
 	computed,
 	inject,
 	ref,
+	watch,
 	onMounted,
 } from 'vue';
 
 const apollo = inject('apollo');
+const $kvTrackEvent = inject('$kvTrackEvent');
 
 const props = defineProps({
 	userId: {
 		type: [String, Number],
 		required: false,
 		default: null,
+	},
+	/**
+	 * When true (MyKiva), the card is not rendered at all for lenders whose only
+	 * giving fund activity is supporting the disaster relief fund
+	 */
+	hideDisasterReliefOnly: {
+		type: Boolean,
+		default: false,
 	},
 });
 
@@ -59,10 +72,47 @@ const {
 } = useGivingFund(apollo);
 
 const myFundsCount = ref(0);
-const contributedFundsCount = ref(0);
+const contributedFundIds = ref([]);
+const fundsCountLoaded = ref(false);
+const contributedFundsLoaded = ref(false);
+
+const contributedFundsCount = computed(() => contributedFundIds.value.length);
+
+const dataLoaded = computed(() => fundsCountLoaded.value && contributedFundsLoaded.value);
+
+// Lender supports the disaster relief fund and no other giving funds
+const isDisasterReliefOnly = computed(() => dataLoaded.value
+	&& myFundsCount.value === 0
+	&& contributedFundIds.value.length === 1
+	&& contributedFundIds.value[0] === givingFundIds.COLOMBIA_DISASTER_RELIEF);
+
+const showCard = computed(() => {
+	if (!props.hideDisasterReliefOnly) {
+		return true;
+	}
+	// Wait for fund data so the card never flashes in before being hidden
+	return dataLoaded.value && !isDisasterReliefOnly.value;
+});
+
+const titleCopy = computed(() => (isDisasterReliefOnly.value
+	? 'Check in on the Colombia earthquake recovery fund'
+	: 'Check in on your giving funds'));
+
+const ctaCopy = computed(() => (isDisasterReliefOnly.value ? 'View fund' : 'See your giving funds'));
+
+const ctaTo = computed(() => (
+	isDisasterReliefOnly.value ? `/gf/${givingFundIds.COLOMBIA_DISASTER_RELIEF}` : '/gfm'
+));
+
+const clickTrackEventProps = computed(() => (isDisasterReliefOnly.value
+	? ['portfolio', 'click', 'see-your-giving-funds', 'disaster-relief']
+	: ['portfolio', 'click', 'see-your-giving-funds']));
 
 const textCopy = computed(() => {
 	let copy = '';
+	if (isDisasterReliefOnly.value) {
+		return copy;
+	}
 	if (myFundsCount.value > 0 && contributedFundsCount.value > 0) {
 		copy = `You have ${myFundsCount.value} ${
 			myFundsCount.value === 1 ? 'fund' : 'funds'
@@ -81,16 +131,32 @@ const textCopy = computed(() => {
 	return copy;
 });
 
+let viewEventTracked = false;
+
+watch(isDisasterReliefOnly, value => {
+	// Track views of the disaster relief variant, which only renders when not hidden (MP-3121)
+	if (value && !props.hideDisasterReliefOnly && !viewEventTracked) {
+		viewEventTracked = true;
+		$kvTrackEvent?.('portfolio', 'view', 'see-your-giving-funds', 'disaster-relief');
+	}
+});
+
 onMounted(() => {
 	// Fetch giving fund data
 	fetchMyGivingFundsCount()
 		.then(response => {
-			myFundsCount.value = response.givingFunds.totalCount;
+			myFundsCount.value = response?.givingFunds?.totalCount ?? 0;
+		})
+		.finally(() => {
+			fundsCountLoaded.value = true;
 		});
 
 	getFundsContributedToIds(parseInt(props?.userId, 10) || null)
 		.then(fundIds => {
-			contributedFundsCount.value = fundIds.length;
+			contributedFundIds.value = fundIds ?? [];
+		})
+		.finally(() => {
+			contributedFundsLoaded.value = true;
 		});
 });
 </script>

--- a/src/components/GivingFunds/MyGivingFundsCard.vue
+++ b/src/components/GivingFunds/MyGivingFundsCard.vue
@@ -134,7 +134,7 @@ const textCopy = computed(() => {
 let viewEventTracked = false;
 
 watch(isDisasterReliefOnly, value => {
-	// Track views of the disaster relief variant, which only renders when not hidden (MP-3121)
+	// Track views of the disaster relief variant, which only renders when not hidden
 	if (value && !props.hideDisasterReliefOnly && !viewEventTracked) {
 		viewEventTracked = true;
 		$kvTrackEvent?.('portfolio', 'view', 'see-your-giving-funds', 'disaster-relief');

--- a/src/graphql/query/myKiva.graphql
+++ b/src/graphql/query/myKiva.graphql
@@ -6,6 +6,15 @@ query myKivaQuery {
       totalAmount
       totalCount
     }
+    # Fund ID must match COLOMBIA_DISASTER_RELIEF
+    reliefFundParticipation: givingFundParticipation(
+      filter: { fundIds: ["238fe077-033e-4a59-8d11-e571e6e4ed31"] }
+    ) {
+      totalCount
+    }
+    givingFunds {
+      totalCount
+    }
     loans {
       totalCount
       values {

--- a/src/graphql/query/portfolioQuery.graphql
+++ b/src/graphql/query/portfolioQuery.graphql
@@ -5,6 +5,15 @@ query portfolioQuery {
 			totalAmount
 			totalCount
 		}
+		# Fund ID must match COLOMBIA_DISASTER_RELIEF
+		reliefFundParticipation: givingFundParticipation(
+			filter: { fundIds: ["238fe077-033e-4a59-8d11-e571e6e4ed31"] }
+		) {
+			totalCount
+		}
+		givingFunds {
+			totalCount
+		}
 		loans(limit: 50) {
 			totalCount
 			values {

--- a/src/pages/MyKiva/MyKivaPage.vue
+++ b/src/pages/MyKiva/MyKivaPage.vue
@@ -59,6 +59,7 @@ import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.g
 import { initializeExperiment } from '#src/util/experiment/experimentUtils';
 import { readBoolSetting, readDateSetting } from '#src/util/settingsUtils';
 import useGoalData, { LAST_YEAR_KEY } from '#src/composables/useGoalData';
+import { isDisasterReliefFundOnlySupporter } from '#src/util/givingFundUtils';
 import useBadgeData, {
 	applyFreshProgressToAchievements,
 	FRESH_PROGRESS_LOAN_PURCHASE_LIMIT,
@@ -289,10 +290,12 @@ export default {
 					inviterName: this.userInfo.userAccount?.inviterName ?? null,
 				};
 				// show giving funds card if user has any giving fund participation
-				this.showMyGivingFundsCard = (
-					(this.userInfo?.givingFundParticipation?.totalCount ?? 0) > 0
-					|| (this.userInfo?.givingFundParticipation?.totalAmount ?? 0) > 0
-				);
+				const participation = this.userInfo?.givingFundParticipation ?? {};
+				const hasGivingFundParticipation = (participation.totalCount ?? 0) > 0
+					|| (participation.totalAmount ?? 0) > 0;
+				// Hide the card when the lender's only activity is supporting the disaster relief fund
+				this.showMyGivingFundsCard = hasGivingFundParticipation
+					&& !isDisasterReliefFundOnlySupporter(this.userInfo);
 				this.loans = myKivaQueryResult.my?.loans?.values ?? [];
 				this.sidesheetLoan = bpSidesheetLoan?.lend?.loan ?? { id: 0 };
 				const isSideSheetLoanInLoans = this.loans.some(loan => loan?.id === this.sidesheetLoan.id);

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -16,7 +16,6 @@
 		<section v-if="showMyGivingFundsCard" class="tw-mt-4">
 			<MyGivingFundsCard
 				:user-id="userInfo?.id"
-				hide-disaster-relief-only
 			/>
 		</section>
 		<MyKivaFeaturedSlot

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -16,6 +16,7 @@
 		<section v-if="showMyGivingFundsCard" class="tw-mt-4">
 			<MyGivingFundsCard
 				:user-id="userInfo?.id"
+				hide-disaster-relief-only
 			/>
 		</section>
 		<MyKivaFeaturedSlot

--- a/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
+++ b/src/pages/Portfolio/ImpactDashboard/ImpactDashboardPage.vue
@@ -22,6 +22,7 @@
 					<my-giving-funds-card
 						v-if="showMyGivingFundsCard"
 						:user-id="userId"
+						:is-disaster-relief-only="isDisasterReliefOnly"
 						class="tw-my-2 tw-mx-0 md:tw-mx-0 tw-rounded-none md:tw-rounded"
 					/>
 					<your-donations />
@@ -70,6 +71,7 @@ import GoalInReviewModal from '#src/components/MyKiva/GoalInReview/GoalInReviewM
 import portfolioQuery from '#src/graphql/query/portfolioQuery.graphql';
 import badgeGoalMixin from '#src/plugins/badge-goal-mixin';
 import { hasLoanFunFactFootnote } from '#src/util/myKivaUtils';
+import { isDisasterReliefFundOnlySupporter } from '#src/util/givingFundUtils';
 import { KvGrid, KvPageContainer } from '@kiva/kv-components';
 import MyGivingFundsCard from '#src/components/GivingFunds/MyGivingFundsCard';
 
@@ -150,6 +152,7 @@ export default {
 			goalsEntrypointEnable: false,
 			isEmptyGoal: true,
 			showMyGivingFundsCard: false,
+			isDisasterReliefOnly: false,
 			userId: null,
 		};
 	},
@@ -222,6 +225,8 @@ export default {
 			(userData?.givingFundParticipation?.totalCount ?? 0) > 0
 			|| (userData?.givingFundParticipation?.totalAmount ?? 0) > 0
 		);
+		// Render the card's disaster relief variant when that fund is the lender's only activity
+		this.isDisasterReliefOnly = isDisasterReliefFundOnlySupporter(userData);
 
 		const teamsChallengeEnable = readBoolSetting(portfolioQueryData, 'general.team_challenge_enable.value');
 		const userTeams = portfolioQueryData?.my?.teams?.values ?? [];

--- a/src/util/givingFundUtils.js
+++ b/src/util/givingFundUtils.js
@@ -2,7 +2,7 @@
  * Well-known giving fund IDs, keyed by fund identity.
  */
 export const givingFundIds = {
-	// Colombia earthquake recovery (disaster relief) fund, MP-3121
+	// Colombia earthquake recovery (disaster relief) fund
 	// https://www.kiva.org/gf/238fe077-033e-4a59-8d11-e571e6e4ed31
 	COLOMBIA_DISASTER_RELIEF: '238fe077-033e-4a59-8d11-e571e6e4ed31',
 };

--- a/src/util/givingFundUtils.js
+++ b/src/util/givingFundUtils.js
@@ -1,4 +1,13 @@
 /**
+ * Well-known giving fund IDs, keyed by fund identity.
+ */
+export const givingFundIds = {
+	// Colombia earthquake recovery (disaster relief) fund, MP-3121
+	// https://www.kiva.org/gf/238fe077-033e-4a59-8d11-e571e6e4ed31
+	COLOMBIA_DISASTER_RELIEF: '238fe077-033e-4a59-8d11-e571e6e4ed31',
+};
+
+/**
  * Utility method for parsing newly created giving fund cookie data
  * This cookie is generated when guests create a giving fund
  * Cookie format: gfid|uiv|action

--- a/src/util/givingFundUtils.js
+++ b/src/util/givingFundUtils.js
@@ -8,6 +8,21 @@ export const givingFundIds = {
 };
 
 /**
+ * Whether a lender's only giving fund activity is supporting the disaster relief fund:
+ * they own no giving funds and every donation they've made went to the relief fund
+ *
+ * @param {Object} my Query data with givingFunds and givingFundParticipation counts,
+ * including the relief-fund-filtered reliefFundParticipation alias
+ * @returns {boolean}
+ */
+export function isDisasterReliefFundOnlySupporter(my) {
+	const reliefFundDonationCount = my?.reliefFundParticipation?.totalCount ?? 0;
+	return (my?.givingFunds?.totalCount ?? 0) === 0
+		&& reliefFundDonationCount > 0
+		&& reliefFundDonationCount === (my?.givingFundParticipation?.totalCount ?? 0);
+}
+
+/**
  * Utility method for parsing newly created giving fund cookie data
  * This cookie is generated when guests create a giving fund
  * Cookie format: gfid|uiv|action

--- a/test/unit/specs/components/GivingFunds/MyGivingFundsCard.spec.js
+++ b/test/unit/specs/components/GivingFunds/MyGivingFundsCard.spec.js
@@ -1,0 +1,132 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { render, screen, waitFor } from '@testing-library/vue';
+import { flushPromises } from '@vue/test-utils';
+import MyGivingFundsCard from '#src/components/GivingFunds/MyGivingFundsCard';
+import useGivingFund from '#src/composables/useGivingFund';
+import { givingFundIds } from '#src/util/givingFundUtils';
+
+vi.mock('#src/composables/useGivingFund', () => ({
+	default: vi.fn(),
+}));
+
+vi.mock('@kiva/kv-components', () => ({
+	KvButton: {
+		name: 'KvButton',
+		props: ['to'],
+		template: '<a :href="to"><slot /></a>',
+	},
+	KvMaterialIcon: {
+		name: 'KvMaterialIcon',
+		template: '<span />',
+	},
+}));
+
+describe('MyGivingFundsCard', () => {
+	const mockUseGivingFund = ({ myFundsCount = 0, contributedFundIds = [] } = {}) => {
+		useGivingFund.mockReturnValue({
+			fetchMyGivingFundsCount: vi.fn().mockResolvedValue({ givingFunds: { totalCount: myFundsCount } }),
+			getFundsContributedToIds: vi.fn().mockResolvedValue(contributedFundIds),
+		});
+	};
+
+	const mountCard = ({ props = {}, $kvTrackEvent = vi.fn() } = {}) => {
+		const wrapper = render(MyGivingFundsCard, {
+			props,
+			global: {
+				provide: {
+					apollo: {},
+					$kvTrackEvent,
+				},
+				directives: {
+					kvTrackEvent: () => {},
+				},
+			},
+		});
+		return { ...wrapper, $kvTrackEvent };
+	};
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders the default card immediately and shows the funds copy once data resolves', async () => {
+		mockUseGivingFund({ myFundsCount: 2, contributedFundIds: ['fund-1', 'fund-2'] });
+
+		mountCard();
+
+		expect(screen.getByText('Check in on your giving funds')).toBeTruthy();
+		const link = screen.getByText('See your giving funds').closest('a');
+		expect(link.getAttribute('href')).toBe('/gfm');
+
+		await flushPromises();
+
+		expect(screen.getByText(
+			'You have 2 funds making an impact and have contributed to 2 funds.'
+		)).toBeTruthy();
+	});
+
+	it('shows the disaster-relief-only variant and fires a single view event', async () => {
+		const $kvTrackEvent = vi.fn();
+		mockUseGivingFund({ myFundsCount: 0, contributedFundIds: [givingFundIds.COLOMBIA_DISASTER_RELIEF] });
+
+		mountCard({ $kvTrackEvent });
+
+		await flushPromises();
+
+		await waitFor(() => {
+			expect(screen.getByText('Check in on the Colombia earthquake recovery fund')).toBeTruthy();
+		});
+
+		const link = screen.getByText('View fund').closest('a');
+		expect(link.getAttribute('href')).toBe(`/gf/${givingFundIds.COLOMBIA_DISASTER_RELIEF}`);
+		expect(screen.queryByText(/You have/)).toBeFalsy();
+
+		expect($kvTrackEvent).toHaveBeenCalledTimes(1);
+		expect($kvTrackEvent).toHaveBeenCalledWith('portfolio', 'view', 'see-your-giving-funds', 'disaster-relief');
+	});
+
+	it('keeps the normal card for mixed participation and does not fire a view event', async () => {
+		const $kvTrackEvent = vi.fn();
+		mockUseGivingFund({
+			myFundsCount: 0,
+			contributedFundIds: [givingFundIds.COLOMBIA_DISASTER_RELIEF, 'other-id'],
+		});
+
+		mountCard({ $kvTrackEvent });
+
+		await flushPromises();
+
+		expect(screen.getByText('Check in on your giving funds')).toBeTruthy();
+		const link = screen.getByText('See your giving funds').closest('a');
+		expect(link.getAttribute('href')).toBe('/gfm');
+
+		expect($kvTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('renders nothing when hideDisasterReliefOnly is true and the lender is disaster-relief-only', async () => {
+		const $kvTrackEvent = vi.fn();
+		mockUseGivingFund({ myFundsCount: 0, contributedFundIds: [givingFundIds.COLOMBIA_DISASTER_RELIEF] });
+
+		const { container } = mountCard({ props: { hideDisasterReliefOnly: true }, $kvTrackEvent });
+
+		await flushPromises();
+
+		expect(container.querySelector('.giving-fund-card')).toBeFalsy();
+		expect($kvTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('renders the card when hideDisasterReliefOnly is true but the lender has normal fund activity', async () => {
+		mockUseGivingFund({ myFundsCount: 1, contributedFundIds: [] });
+
+		const { container } = mountCard({ props: { hideDisasterReliefOnly: true } });
+
+		expect(container.querySelector('.giving-fund-card')).toBeFalsy();
+
+		await flushPromises();
+
+		await waitFor(() => {
+			expect(container.querySelector('.giving-fund-card')).toBeTruthy();
+		});
+		expect(screen.getByText('Check in on your giving funds')).toBeTruthy();
+	});
+});

--- a/test/unit/specs/components/GivingFunds/MyGivingFundsCard.spec.js
+++ b/test/unit/specs/components/GivingFunds/MyGivingFundsCard.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { render, screen, waitFor } from '@testing-library/vue';
+import { render, screen } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
 import MyGivingFundsCard from '#src/components/GivingFunds/MyGivingFundsCard';
 import useGivingFund from '#src/composables/useGivingFund';
@@ -23,10 +23,12 @@ vi.mock('@kiva/kv-components', () => ({
 
 describe('MyGivingFundsCard', () => {
 	const mockUseGivingFund = ({ myFundsCount = 0, contributedFundIds = [] } = {}) => {
-		useGivingFund.mockReturnValue({
+		const mocks = {
 			fetchMyGivingFundsCount: vi.fn().mockResolvedValue({ givingFunds: { totalCount: myFundsCount } }),
 			getFundsContributedToIds: vi.fn().mockResolvedValue(contributedFundIds),
-		});
+		};
+		useGivingFund.mockReturnValue(mocks);
+		return mocks;
 	};
 
 	const mountCard = ({ props = {}, $kvTrackEvent = vi.fn() } = {}) => {
@@ -65,68 +67,33 @@ describe('MyGivingFundsCard', () => {
 		)).toBeTruthy();
 	});
 
-	it('shows the disaster-relief-only variant and fires a single view event', async () => {
+	it('renders the disaster-relief variant from the prop, fetching nothing, firing the view event once', async () => {
 		const $kvTrackEvent = vi.fn();
-		mockUseGivingFund({ myFundsCount: 0, contributedFundIds: [givingFundIds.COLOMBIA_DISASTER_RELIEF] });
+		const mocks = mockUseGivingFund();
 
-		mountCard({ $kvTrackEvent });
+		mountCard({ props: { isDisasterReliefOnly: true }, $kvTrackEvent });
 
-		await flushPromises();
-
-		await waitFor(() => {
-			expect(screen.getByText('Check in on the Colombia earthquake recovery fund')).toBeTruthy();
-		});
-
+		expect(screen.getByText('Check in on the Colombia earthquake recovery fund')).toBeTruthy();
 		const link = screen.getByText('View fund').closest('a');
 		expect(link.getAttribute('href')).toBe(`/gf/${givingFundIds.COLOMBIA_DISASTER_RELIEF}`);
 		expect(screen.queryByText(/You have/)).toBeFalsy();
 
+		await flushPromises();
+
 		expect($kvTrackEvent).toHaveBeenCalledTimes(1);
 		expect($kvTrackEvent).toHaveBeenCalledWith('portfolio', 'view', 'see-your-giving-funds', 'disaster-relief');
+		expect(mocks.fetchMyGivingFundsCount).not.toHaveBeenCalled();
+		expect(mocks.getFundsContributedToIds).not.toHaveBeenCalled();
 	});
 
-	it('keeps the normal card for mixed participation and does not fire a view event', async () => {
+	it('never fires the view event when isDisasterReliefOnly is not set', async () => {
 		const $kvTrackEvent = vi.fn();
-		mockUseGivingFund({
-			myFundsCount: 0,
-			contributedFundIds: [givingFundIds.COLOMBIA_DISASTER_RELIEF, 'other-id'],
-		});
+		mockUseGivingFund({ myFundsCount: 1, contributedFundIds: ['fund-1'] });
 
 		mountCard({ $kvTrackEvent });
 
 		await flushPromises();
 
-		expect(screen.getByText('Check in on your giving funds')).toBeTruthy();
-		const link = screen.getByText('See your giving funds').closest('a');
-		expect(link.getAttribute('href')).toBe('/gfm');
-
 		expect($kvTrackEvent).not.toHaveBeenCalled();
-	});
-
-	it('renders nothing when hideDisasterReliefOnly is true and the lender is disaster-relief-only', async () => {
-		const $kvTrackEvent = vi.fn();
-		mockUseGivingFund({ myFundsCount: 0, contributedFundIds: [givingFundIds.COLOMBIA_DISASTER_RELIEF] });
-
-		const { container } = mountCard({ props: { hideDisasterReliefOnly: true }, $kvTrackEvent });
-
-		await flushPromises();
-
-		expect(container.querySelector('.giving-fund-card')).toBeFalsy();
-		expect($kvTrackEvent).not.toHaveBeenCalled();
-	});
-
-	it('renders the card when hideDisasterReliefOnly is true but the lender has normal fund activity', async () => {
-		mockUseGivingFund({ myFundsCount: 1, contributedFundIds: [] });
-
-		const { container } = mountCard({ props: { hideDisasterReliefOnly: true } });
-
-		expect(container.querySelector('.giving-fund-card')).toBeFalsy();
-
-		await flushPromises();
-
-		await waitFor(() => {
-			expect(container.querySelector('.giving-fund-card')).toBeTruthy();
-		});
-		expect(screen.getByText('Check in on your giving funds')).toBeTruthy();
 	});
 });

--- a/test/unit/specs/util/givingFundUtils.spec.js
+++ b/test/unit/specs/util/givingFundUtils.spec.js
@@ -1,4 +1,54 @@
-import parseGivingFundCookie from '#src/util/givingFundUtils';
+import parseGivingFundCookie, { isDisasterReliefFundOnlySupporter } from '#src/util/givingFundUtils';
+
+describe('isDisasterReliefFundOnlySupporter', () => {
+	it('should return true when the lender owns no funds and every donation went to the relief fund', () => {
+		const my = {
+			givingFunds: { totalCount: 0 },
+			givingFundParticipation: { totalCount: 3 },
+			reliefFundParticipation: { totalCount: 3 },
+		};
+
+		expect(isDisasterReliefFundOnlySupporter(my)).toBe(true);
+	});
+
+	it('should return false when the lender owns giving funds', () => {
+		const my = {
+			givingFunds: { totalCount: 1 },
+			givingFundParticipation: { totalCount: 3 },
+			reliefFundParticipation: { totalCount: 3 },
+		};
+
+		expect(isDisasterReliefFundOnlySupporter(my)).toBe(false);
+	});
+
+	it('should return false when the relief fund donation count is 0', () => {
+		const my = {
+			givingFunds: { totalCount: 0 },
+			givingFundParticipation: { totalCount: 0 },
+			reliefFundParticipation: { totalCount: 0 },
+		};
+
+		expect(isDisasterReliefFundOnlySupporter(my)).toBe(false);
+	});
+
+	it('should return false when the relief fund count is less than the total donation count', () => {
+		const my = {
+			givingFunds: { totalCount: 0 },
+			givingFundParticipation: { totalCount: 3 },
+			reliefFundParticipation: { totalCount: 2 },
+		};
+
+		expect(isDisasterReliefFundOnlySupporter(my)).toBe(false);
+	});
+
+	it('should return false for an undefined my object', () => {
+		expect(isDisasterReliefFundOnlySupporter(undefined)).toBe(false);
+	});
+
+	it('should return false for an empty my object', () => {
+		expect(isDisasterReliefFundOnlySupporter({})).toBe(false);
+	});
+});
 
 describe('parseGivingFundCookie', () => {
 	it('should parse a full cookie string with fundId, uiv, and action', () => {


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3121

- Hide Giving Funds MyKiva card if user only participated in relief fund
- Update Portfolio card to be custom for relief fund if user only participated in that fund

General idea is to reduce confusion for users who only contributed to the Colombia relief fund.