### PR TITLE
fix(useMyKivaHome): resolve the my kiva paths before first render AD-386

### DIFF
--- a/.storybook/stories/TheHeader.stories.js
+++ b/.storybook/stories/TheHeader.stories.js
@@ -6,6 +6,7 @@ import TheHeader from "#src/components/WwwFrame/TheHeader";
 
 const loggedIn = {
 	my: {
+		id: 1017469,
 		userAccount: {
 			id: 1017469,
 			balance: "0.00",

--- a/src/components/NotFound/NotFoundWrapper.vue
+++ b/src/components/NotFound/NotFoundWrapper.vue
@@ -33,13 +33,8 @@
 </template>
 
 <script setup>
-import {
-	inject,
-} from 'vue';
 import useMyKivaHome from '#src/composables/useMyKivaHome';
 
-const apollo = inject('apollo');
-
-const { homePagePath } = useMyKivaHome(apollo);
+const { homePagePath } = useMyKivaHome();
 
 </script>

--- a/src/components/Thanks/SingleVersion/JourneyGeneralPrompt.vue
+++ b/src/components/Thanks/SingleVersion/JourneyGeneralPrompt.vue
@@ -92,11 +92,10 @@ import JourneyDesktopImg from '#src/assets/images/thanks-page/journey-desktop.sv
 import BorrowerAvatarsContainer from '#src/components/Thanks/BorrowerAvatarsContainer';
 import useMyKivaHome from '#src/composables/useMyKivaHome';
 
-const apollo = inject('apollo');
 const $kvTrackEvent = inject('$kvTrackEvent');
 
 const router = useRouter();
-const { portfolioPath } = useMyKivaHome(apollo);
+const { portfolioPath } = useMyKivaHome();
 
 const emit = defineEmits(['continue-as-guest']);
 

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -569,7 +569,7 @@
 </template>
 
 <script>
-import { defineAsyncComponent, inject } from 'vue';
+import { defineAsyncComponent } from 'vue';
 import { getTransactorFlagsFromCookies } from '@kiva/kv-analytics';
 import {
 	userHasLentBefore,
@@ -692,8 +692,7 @@ export default {
 		},
 	},
 	setup() {
-		const apollo = inject('apollo');
-		const { homePagePath } = useMyKivaHome(apollo);
+		const { homePagePath } = useMyKivaHome();
 
 		return {
 			homePagePath,

--- a/src/composables/useMyKivaHome.js
+++ b/src/composables/useMyKivaHome.js
@@ -1,24 +1,16 @@
-import {
-	ref,
-	computed,
-	onMounted,
-} from 'vue';
-import logFormatter from '#src/util/logFormatter';
+import { computed } from 'vue';
 import userIdQuery from '#src/graphql/query/userId.graphql';
+import useApolloQuery from '#src/composables/useApolloQuery';
 
-export default function useMyKivaHome(apollo) {
-	const redirectToMyKivaHomepage = ref(false);
-	const userData = ref(false);
+const operation = { query: userIdQuery };
 
-	const fetchUserData = async () => {
-		await apollo.query({
-			query: userIdQuery,
-		}).then(({ data }) => {
-			userData.value = data?.my ?? null;
-		}).catch(e => {
-			logFormatter('Failed to fetch user ID for MyKiva home', 'error', { error: e });
-		});
-	};
+// Registered for prefetching by every component that imports this composable
+export const preFetchOperations = [operation];
+
+export default function useMyKivaHome() {
+	const { result } = useApolloQuery(operation);
+
+	const redirectToMyKivaHomepage = computed(() => !!result.value?.my?.id);
 
 	const homePagePath = computed(() => {
 		return redirectToMyKivaHomepage.value ? '/mykiva' : '/';
@@ -26,12 +18,6 @@ export default function useMyKivaHome(apollo) {
 
 	const portfolioPath = computed(() => {
 		return redirectToMyKivaHomepage.value ? '/mykiva' : '/portfolio';
-	});
-
-	onMounted(async () => {
-		await fetchUserData();
-
-		redirectToMyKivaHomepage.value = userData.value?.id || false;
 	});
 
 	return {

--- a/test/unit/fixtures/composables/UsesMultiMatching.vue
+++ b/test/unit/fixtures/composables/UsesMultiMatching.vue
@@ -1,0 +1,14 @@
+<template>
+	<div>
+		<span data-testid="enabled">{{ enableMultiMatching }}</span>
+		<span data-testid="resolved">{{ multiMatchingResolved }}</span>
+	</div>
+</template>
+
+<script setup>
+import useMultiMatching from '#src/composables/useMultiMatching';
+
+defineOptions({ name: 'UsesMultiMatching' });
+
+const { enableMultiMatching, multiMatchingResolved } = useMultiMatching();
+</script>

--- a/test/unit/fixtures/composables/UsesMyKivaHome.vue
+++ b/test/unit/fixtures/composables/UsesMyKivaHome.vue
@@ -1,0 +1,14 @@
+<template>
+	<div>
+		<span data-testid="home">{{ homePagePath }}</span>
+		<span data-testid="portfolio">{{ portfolioPath }}</span>
+	</div>
+</template>
+
+<script setup>
+import useMyKivaHome from '#src/composables/useMyKivaHome';
+
+defineOptions({ name: 'UsesMyKivaHome' });
+
+const { homePagePath, portfolioPath } = useMyKivaHome();
+</script>

--- a/test/unit/specs/composables/useMultiMatching.spec.js
+++ b/test/unit/specs/composables/useMultiMatching.spec.js
@@ -1,5 +1,8 @@
-import { createApp } from 'vue';
-import useMultiMatching, { preFetchOperations } from '#src/composables/useMultiMatching';
+import { nextTick } from 'vue';
+import { render } from '@testing-library/vue';
+import { globalOptions } from '#src/../test/unit/specUtils';
+import { preFetchOperations } from '#src/composables/useMultiMatching';
+import UsesMultiMatching from '#src/../test/unit/fixtures/composables/UsesMultiMatching';
 
 vi.mock('#src/graphql/query/multiMatchingEnabled.graphql', () => ({
 	default: { kind: 'Document', definitions: [{ name: { value: 'MultiMatchingEnabled' } }] },
@@ -13,80 +16,73 @@ function enabledData(value) {
 	};
 }
 
-describe('useMultiMatching', () => {
-	let mockApollo;
-	let emit;
-
-	const mountComposable = (apolloClient = mockApollo) => {
-		let result;
-		const TestComponent = {
-			name: 'TestComponent',
-			// The transform attaches the composable's operations to every real
-			// component that imports it
-			preFetchOperations,
-			setup() {
-				result = useMultiMatching();
-				return {};
+// Reads the prefetched value from cacheData, and captures the watch query
+// observer so a test can deliver a later result from the client
+function makeSettingApollo(cacheData = null) {
+	let observer = null;
+	const client = {
+		readQuery: () => cacheData,
+		watchQuery: () => ({
+			subscribe: o => {
+				observer = o;
+				return { unsubscribe: () => {} };
 			},
-			template: '<div></div>',
-		};
-		const app = createApp(TestComponent);
-		if (apolloClient) {
-			app.provide('apollo', apolloClient);
-		}
-		app.mount(document.createElement('div'));
-		return result;
+		}),
 	};
+	return {
+		client,
+		emitSetting: data => observer.next({ data }),
+		emitErrors: errors => observer.next({ data: undefined, errors }),
+		emitFailure: e => observer.error(e),
+	};
+}
 
-	beforeEach(() => {
-		emit = null;
-		mockApollo = {
-			readQuery: vi.fn(() => null),
-			watchQuery: vi.fn(() => ({
-				subscribe: observer => {
-					emit = observer;
-					return { unsubscribe: vi.fn() };
-				},
-			})),
-		};
+// The build step attaches the composable's operations to the fixture, the same
+// way it does for every component importing the composable
+function renderFixture(apollo) {
+	return render(UsesMultiMatching, {
+		global: { ...globalOptions, provide: { ...globalOptions.provide, apollo } },
 	});
+}
 
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
-
+describe('useMultiMatching', () => {
 	it('reports unresolved and disabled before the setting arrives', () => {
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable();
-		expect(enableMultiMatching.value).toBe(false);
-		expect(multiMatchingResolved.value).toBe(false);
+		const { getByTestId } = renderFixture(makeSettingApollo().client);
+		expect(getByTestId('enabled').textContent).toBe('false');
+		expect(getByTestId('resolved').textContent).toBe('false');
 	});
 
-	it('enables multi matching when the setting arrives enabled', () => {
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable();
-		emit.next({ data: enabledData('true') });
-		expect(enableMultiMatching.value).toBe(true);
-		expect(multiMatchingResolved.value).toBe(true);
+	it('enables multi matching when the setting arrives enabled', async () => {
+		const { client, emitSetting } = makeSettingApollo();
+		const { getByTestId } = renderFixture(client);
+		emitSetting(enabledData('true'));
+		await nextTick();
+		expect(getByTestId('enabled').textContent).toBe('true');
+		expect(getByTestId('resolved').textContent).toBe('true');
 	});
 
-	it('stays disabled but resolved when the setting arrives disabled', () => {
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable();
-		emit.next({ data: enabledData('false') });
-		expect(enableMultiMatching.value).toBe(false);
-		expect(multiMatchingResolved.value).toBe(true);
+	it('stays disabled but resolved when the setting arrives disabled', async () => {
+		const { client, emitSetting } = makeSettingApollo();
+		const { getByTestId } = renderFixture(client);
+		emitSetting(enabledData('false'));
+		await nextTick();
+		expect(getByTestId('enabled').textContent).toBe('false');
+		expect(getByTestId('resolved').textContent).toBe('true');
 	});
 
 	it('resolves synchronously from a prefetched cache value', () => {
-		mockApollo.readQuery = vi.fn(() => enabledData('true'));
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable();
-		expect(enableMultiMatching.value).toBe(true);
-		expect(multiMatchingResolved.value).toBe(true);
+		const { getByTestId } = renderFixture(makeSettingApollo(enabledData('true')).client);
+		expect(getByTestId('enabled').textContent).toBe('true');
+		expect(getByTestId('resolved').textContent).toBe('true');
 	});
 
-	it('resolves to the disabled default when the fetch fails', () => {
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable();
-		emit.error(new Error('Network error'));
-		expect(enableMultiMatching.value).toBe(false);
-		expect(multiMatchingResolved.value).toBe(true);
+	it('resolves to the disabled default when the fetch fails', async () => {
+		const { client, emitFailure } = makeSettingApollo();
+		const { getByTestId } = renderFixture(client);
+		emitFailure(new Error('Network error'));
+		await nextTick();
+		expect(getByTestId('enabled').textContent).toBe('false');
+		expect(getByTestId('resolved').textContent).toBe('true');
 	});
 
 	it('registers its operation for prefetching', () => {
@@ -94,16 +90,18 @@ describe('useMultiMatching', () => {
 		expect(preFetchOperations[0].query).toBeDefined();
 	});
 
-	it('resolves to the disabled default when graphql errors arrive instead of the setting', () => {
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable();
-		emit.next({ data: undefined, errors: [{ message: 'failed', code: 'api.error' }] });
-		expect(enableMultiMatching.value).toBe(false);
-		expect(multiMatchingResolved.value).toBe(true);
+	it('resolves to the disabled default when graphql errors arrive instead of the setting', async () => {
+		const { client, emitErrors } = makeSettingApollo();
+		const { getByTestId } = renderFixture(client);
+		emitErrors([{ message: 'failed', code: 'api.error' }]);
+		await nextTick();
+		expect(getByTestId('enabled').textContent).toBe('false');
+		expect(getByTestId('resolved').textContent).toBe('true');
 	});
 
 	it('stays unresolved and disabled when apollo is not provided', () => {
-		const { enableMultiMatching, multiMatchingResolved } = mountComposable(null);
-		expect(enableMultiMatching.value).toBe(false);
-		expect(multiMatchingResolved.value).toBe(false);
+		const { getByTestId } = renderFixture(null);
+		expect(getByTestId('enabled').textContent).toBe('false');
+		expect(getByTestId('resolved').textContent).toBe('false');
 	});
 });

--- a/test/unit/specs/composables/useMyKivaHome.spec.js
+++ b/test/unit/specs/composables/useMyKivaHome.spec.js
@@ -1,261 +1,119 @@
-import useMyKivaHome from '#src/composables/useMyKivaHome';
-import { render, waitFor } from '@testing-library/vue';
-
-// Mock the dependencies
-vi.mock('#src/util/logFormatter', () => ({
-	default: vi.fn()
-}));
+import { createApp } from 'vue';
+import useMyKivaHome, { preFetchOperations } from '#src/composables/useMyKivaHome';
 
 vi.mock('#src/graphql/query/userId.graphql', () => ({
-	default: 'userIdQuery'
+	default: { kind: 'Document', definitions: [{ name: { value: 'userId' } }] },
 }));
 
-describe('useMyKivaHome.js', () => {
-	let mockApollo;
+// Captures the watch query observer so a test can deliver the client result
+function makeApollo(cacheData = null) {
+	let observer = null;
+	const client = {
+		readQuery: () => cacheData,
+		watchQuery: () => ({
+			subscribe: o => {
+				observer = o;
+				return { unsubscribe: () => {} };
+			},
+		}),
+	};
+	return {
+		client,
+		emitUser: data => observer.next({ data }),
+		emitErrors: errors => observer.next({ data: undefined, errors }),
+		emitFailure: e => observer.error(e),
+	};
+}
 
-	beforeEach(() => {
-		mockApollo = {
-			query: vi.fn()
-		};
+function mountComposable(apollo) {
+	let paths;
+	const TestComponent = {
+		name: 'TestComponent',
+		// The transform attaches the composable's operations to every real
+		// component that imports it
+		preFetchOperations,
+		setup() {
+			paths = useMyKivaHome();
+			return {};
+		},
+		template: '<div></div>',
+	};
+	const app = createApp(TestComponent);
+	if (apollo) {
+		app.provide('apollo', apollo);
+	}
+	app.mount(document.createElement('div'));
+	return paths;
+}
+
+describe('useMyKivaHome', () => {
+	it('returns the homePagePath and portfolioPath computed properties', () => {
+		const { client } = makeApollo();
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		expect(homePagePath).toBeDefined();
+		expect(portfolioPath).toBeDefined();
 	});
 
-	afterEach(() => {
-		vi.clearAllMocks();
+	it('registers its operation for prefetching', () => {
+		expect(preFetchOperations).toHaveLength(1);
+		expect(preFetchOperations[0].query).toBeDefined();
 	});
 
-	it('should return homePagePath and portfolioPath computed properties', () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: { id: 123 }
-			}
-		});
-
-		let composable;
-		const TestComponent = {
-			template: '<div></div>',
-			setup() {
-				composable = useMyKivaHome(mockApollo);
-				return composable;
-			}
-		};
-
-		render(TestComponent);
-
-		expect(composable.homePagePath).toBeDefined();
-		expect(composable.portfolioPath).toBeDefined();
+	it('resolves both paths to my kiva from a prefetched cache value', () => {
+		const { client } = makeApollo({ my: { id: 456 } });
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		expect(homePagePath.value).toBe('/mykiva');
+		expect(portfolioPath.value).toBe('/mykiva');
 	});
 
-	it('should default homePagePath to "/" when redirectToMyKivaHomepage is false', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: null
-			}
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="home">{{ homePagePath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('home').textContent).toBe('/');
-		});
+	it('resolves to the logged-out destinations when the prefetched value has no user', () => {
+		const { client } = makeApollo({ my: null });
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		expect(homePagePath.value).toBe('/');
+		expect(portfolioPath.value).toBe('/portfolio');
 	});
 
-	it('should default portfolioPath to "/portfolio" when redirectToMyKivaHomepage is false', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: null
-			}
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="portfolio">{{ portfolioPath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('portfolio').textContent).toBe('/portfolio');
-		});
+	it('resolves to the logged-out destinations before the user arrives', () => {
+		const { client } = makeApollo();
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		expect(homePagePath.value).toBe('/');
+		expect(portfolioPath.value).toBe('/portfolio');
 	});
 
-	it('should set homePagePath to "/mykiva" when user has an id', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: { id: 456 }
-			}
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="home">{{ homePagePath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('home').textContent).toBe('/mykiva');
-		});
+	it('switches both paths to my kiva when the user arrives on the client', () => {
+		const { client, emitUser } = makeApollo();
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		emitUser({ my: { id: 789 } });
+		expect(homePagePath.value).toBe('/mykiva');
+		expect(portfolioPath.value).toBe('/mykiva');
 	});
 
-	it('should set portfolioPath to "/mykiva" when user has an id', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: { id: 456 }
-			}
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="portfolio">{{ portfolioPath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('portfolio').textContent).toBe('/mykiva');
-		});
+	it('keeps the logged-out destinations when the user arrives without an id', () => {
+		const { client, emitUser } = makeApollo();
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		emitUser({ my: { name: 'Test User' } });
+		expect(homePagePath.value).toBe('/');
+		expect(portfolioPath.value).toBe('/portfolio');
 	});
 
-	it('should call apollo.query with userIdQuery on mount', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: { id: 789 }
-			}
-		});
-
-		const TestComponent = {
-			template: '<div></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		render(TestComponent);
-
-		await waitFor(() => {
-			expect(mockApollo.query).toHaveBeenCalledWith({
-				query: 'userIdQuery'
-			});
-		});
+	it('keeps the logged-out destinations when the fetch fails', () => {
+		const { client, emitFailure } = makeApollo();
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		emitFailure(new Error('Network error'));
+		expect(homePagePath.value).toBe('/');
+		expect(portfolioPath.value).toBe('/portfolio');
 	});
 
-	it('should handle query errors gracefully', async () => {
-		mockApollo.query.mockRejectedValue(new Error('Network error'));
-
-		const TestComponent = {
-			template: '<div><span data-testid="home">{{ homePagePath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(mockApollo.query).toHaveBeenCalled();
-		});
-
-		// Should default to '/' on error
-		expect(getByTestId('home').textContent).toBe('/');
+	it('keeps the logged-out destinations when graphql errors arrive instead of the user', () => {
+		const { client, emitErrors } = makeApollo();
+		const { homePagePath, portfolioPath } = mountComposable(client);
+		emitErrors([{ message: 'failed', code: 'api.error' }]);
+		expect(homePagePath.value).toBe('/');
+		expect(portfolioPath.value).toBe('/portfolio');
 	});
 
-	it('should handle missing user data (my is null)', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: null
-			}
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="home">{{ homePagePath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('home').textContent).toBe('/');
-		});
-	});
-
-	it('should handle user data without id field', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: { name: 'Test User' }
-			}
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="home">{{ homePagePath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('home').textContent).toBe('/');
-		});
-	});
-
-	it('should handle query response with undefined data', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: undefined
-		});
-
-		const TestComponent = {
-			template: '<div><span data-testid="home">{{ homePagePath }}</span></div>',
-			setup() {
-				return useMyKivaHome(mockApollo);
-			}
-		};
-
-		const { getByTestId } = render(TestComponent);
-
-		await waitFor(() => {
-			expect(getByTestId('home').textContent).toBe('/');
-		});
-	});
-
-	it('should have reactive computed properties', async () => {
-		mockApollo.query.mockResolvedValue({
-			data: {
-				my: { id: 999 }
-			}
-		});
-
-		let homePagePath;
-		let portfolioPath;
-		const TestComponent = {
-			template: '<div></div>',
-			setup() {
-				const composable = useMyKivaHome(mockApollo);
-				({ homePagePath, portfolioPath } = composable);
-				return composable;
-			}
-		};
-
-		render(TestComponent);
-
-		// Asserted synchronously: onMounted has fired, but its apollo query
-		// resolves on a later microtask, so the paths are still at their
-		// pre-fetch defaults here.
+	it('keeps the logged-out destinations when apollo is not provided', () => {
+		const { homePagePath, portfolioPath } = mountComposable(null);
 		expect(homePagePath.value).toBe('/');
 		expect(portfolioPath.value).toBe('/portfolio');
 	});

--- a/test/unit/specs/composables/useMyKivaHome.spec.js
+++ b/test/unit/specs/composables/useMyKivaHome.spec.js
@@ -1,12 +1,16 @@
-import { createApp } from 'vue';
-import useMyKivaHome, { preFetchOperations } from '#src/composables/useMyKivaHome';
+import { nextTick } from 'vue';
+import { render } from '@testing-library/vue';
+import { globalOptions } from '#src/../test/unit/specUtils';
+import { preFetchOperations } from '#src/composables/useMyKivaHome';
+import UsesMyKivaHome from '#src/../test/unit/fixtures/composables/UsesMyKivaHome';
 
 vi.mock('#src/graphql/query/userId.graphql', () => ({
 	default: { kind: 'Document', definitions: [{ name: { value: 'userId' } }] },
 }));
 
-// Captures the watch query observer so a test can deliver the client result
-function makeApollo(cacheData = null) {
+// Reads the prefetched value from cacheData, and captures the watch query
+// observer so a test can deliver a later result from the client
+function makeUserIdApollo(cacheData = null) {
 	let observer = null;
 	const client = {
 		readQuery: () => cacheData,
@@ -25,33 +29,19 @@ function makeApollo(cacheData = null) {
 	};
 }
 
-function mountComposable(apollo) {
-	let paths;
-	const TestComponent = {
-		name: 'TestComponent',
-		// The transform attaches the composable's operations to every real
-		// component that imports it
-		preFetchOperations,
-		setup() {
-			paths = useMyKivaHome();
-			return {};
-		},
-		template: '<div></div>',
-	};
-	const app = createApp(TestComponent);
-	if (apollo) {
-		app.provide('apollo', apollo);
-	}
-	app.mount(document.createElement('div'));
-	return paths;
+// The build step attaches the composable's operations to the fixture, the same
+// way it does for every component importing the composable
+function renderFixture(apollo) {
+	return render(UsesMyKivaHome, {
+		global: { ...globalOptions, provide: { ...globalOptions.provide, apollo } },
+	});
 }
 
 describe('useMyKivaHome', () => {
 	it('returns the homePagePath and portfolioPath computed properties', () => {
-		const { client } = makeApollo();
-		const { homePagePath, portfolioPath } = mountComposable(client);
-		expect(homePagePath).toBeDefined();
-		expect(portfolioPath).toBeDefined();
+		const { getByTestId } = renderFixture(makeUserIdApollo().client);
+		expect(getByTestId('home')).toBeDefined();
+		expect(getByTestId('portfolio')).toBeDefined();
 	});
 
 	it('registers its operation for prefetching', () => {
@@ -60,61 +50,62 @@ describe('useMyKivaHome', () => {
 	});
 
 	it('resolves both paths to my kiva from a prefetched cache value', () => {
-		const { client } = makeApollo({ my: { id: 456 } });
-		const { homePagePath, portfolioPath } = mountComposable(client);
-		expect(homePagePath.value).toBe('/mykiva');
-		expect(portfolioPath.value).toBe('/mykiva');
+		const { getByTestId } = renderFixture(makeUserIdApollo({ my: { id: 456 } }).client);
+		expect(getByTestId('home').textContent).toBe('/mykiva');
+		expect(getByTestId('portfolio').textContent).toBe('/mykiva');
 	});
 
 	it('resolves to the logged-out destinations when the prefetched value has no user', () => {
-		const { client } = makeApollo({ my: null });
-		const { homePagePath, portfolioPath } = mountComposable(client);
-		expect(homePagePath.value).toBe('/');
-		expect(portfolioPath.value).toBe('/portfolio');
+		const { getByTestId } = renderFixture(makeUserIdApollo({ my: null }).client);
+		expect(getByTestId('home').textContent).toBe('/');
+		expect(getByTestId('portfolio').textContent).toBe('/portfolio');
 	});
 
 	it('resolves to the logged-out destinations before the user arrives', () => {
-		const { client } = makeApollo();
-		const { homePagePath, portfolioPath } = mountComposable(client);
-		expect(homePagePath.value).toBe('/');
-		expect(portfolioPath.value).toBe('/portfolio');
+		const { getByTestId } = renderFixture(makeUserIdApollo().client);
+		expect(getByTestId('home').textContent).toBe('/');
+		expect(getByTestId('portfolio').textContent).toBe('/portfolio');
 	});
 
-	it('switches both paths to my kiva when the user arrives on the client', () => {
-		const { client, emitUser } = makeApollo();
-		const { homePagePath, portfolioPath } = mountComposable(client);
+	it('switches both paths to my kiva when the user arrives on the client', async () => {
+		const { client, emitUser } = makeUserIdApollo();
+		const { getByTestId } = renderFixture(client);
 		emitUser({ my: { id: 789 } });
-		expect(homePagePath.value).toBe('/mykiva');
-		expect(portfolioPath.value).toBe('/mykiva');
+		await nextTick();
+		expect(getByTestId('home').textContent).toBe('/mykiva');
+		expect(getByTestId('portfolio').textContent).toBe('/mykiva');
 	});
 
-	it('keeps the logged-out destinations when the user arrives without an id', () => {
-		const { client, emitUser } = makeApollo();
-		const { homePagePath, portfolioPath } = mountComposable(client);
+	it('keeps the logged-out destinations when the user arrives without an id', async () => {
+		const { client, emitUser } = makeUserIdApollo();
+		const { getByTestId } = renderFixture(client);
 		emitUser({ my: { name: 'Test User' } });
-		expect(homePagePath.value).toBe('/');
-		expect(portfolioPath.value).toBe('/portfolio');
+		await nextTick();
+		expect(getByTestId('home').textContent).toBe('/');
+		expect(getByTestId('portfolio').textContent).toBe('/portfolio');
 	});
 
-	it('keeps the logged-out destinations when the fetch fails', () => {
-		const { client, emitFailure } = makeApollo();
-		const { homePagePath, portfolioPath } = mountComposable(client);
+	it('keeps the logged-out destinations when the fetch fails', async () => {
+		const { client, emitFailure } = makeUserIdApollo();
+		const { getByTestId } = renderFixture(client);
 		emitFailure(new Error('Network error'));
-		expect(homePagePath.value).toBe('/');
-		expect(portfolioPath.value).toBe('/portfolio');
+		await nextTick();
+		expect(getByTestId('home').textContent).toBe('/');
+		expect(getByTestId('portfolio').textContent).toBe('/portfolio');
 	});
 
-	it('keeps the logged-out destinations when graphql errors arrive instead of the user', () => {
-		const { client, emitErrors } = makeApollo();
-		const { homePagePath, portfolioPath } = mountComposable(client);
+	it('keeps the logged-out destinations when graphql errors arrive instead of the user', async () => {
+		const { client, emitErrors } = makeUserIdApollo();
+		const { getByTestId } = renderFixture(client);
 		emitErrors([{ message: 'failed', code: 'api.error' }]);
-		expect(homePagePath.value).toBe('/');
-		expect(portfolioPath.value).toBe('/portfolio');
+		await nextTick();
+		expect(getByTestId('home').textContent).toBe('/');
+		expect(getByTestId('portfolio').textContent).toBe('/portfolio');
 	});
 
 	it('keeps the logged-out destinations when apollo is not provided', () => {
-		const { homePagePath, portfolioPath } = mountComposable(null);
-		expect(homePagePath.value).toBe('/');
-		expect(portfolioPath.value).toBe('/portfolio');
+		const { getByTestId } = renderFixture(null);
+		expect(getByTestId('home').textContent).toBe('/');
+		expect(getByTestId('portfolio').textContent).toBe('/portfolio');
 	});
 });


### PR DESCRIPTION
This changes useMyKivaHome to use prefetching so that the correct paths are known during navigation, improving initial page load times and preventing the logged-out page from initially being loaded for logged-in users.