### PR TITLE
fix: release a couple beta migration pages

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -386,7 +386,7 @@ export default [
 		}
 	},
 	{
-		path: '/portfolio/transactions-beta',
+		path: '/portfolio/transactions',
 		component: () => import('#src/pages/Portfolio/Transactions/TransactionsPage'),
 		meta: {
 			activeLoginRequired: true,

--- a/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
+++ b/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
@@ -1,11 +1,11 @@
-// Route path, chart palette, and legacy copy for the estimated-repayments beta page.
+// Route path, chart palette, and legacy copy for the estimated-repayments page.
 // Colours mirror the legacy stacked chart's two series and were validated (dataviz
 // skill) for colour-blind separation and surface contrast in light and dark modes.
 import kvTokensPrimitives from '@kiva/kv-tokens';
 
 const { colors } = kvTokensPrimitives;
 
-export const ESTIMATED_REPAYMENTS_ROUTE = '/portfolio/estimated-repayments-beta';
+export const ESTIMATED_REPAYMENTS_ROUTE = '/portfolio/estimated-repayments';
 
 // The legacy detail query caps the per-month loan list; surface a truncation notice
 // when the returned list reaches this size. Mirrors the resolver's default limit.


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2980
https://kiva.atlassian.net/browse/MP-2977

Releasing `/porfolio/transactions` and `/portfolio/estimated-repayments` on newstack.