### PR TITLE
perf(externals): load the OneTrust consent stub without blocking render AD-252

### DIFF
--- a/src/rendering/externals.js
+++ b/src/rendering/externals.js
@@ -9,8 +9,17 @@ export function renderExternals(config) {
 		// add OneTrust loader
 		if (config.oneTrust && config.oneTrust.enable) {
 			const key = `${config.oneTrust.key}${config.oneTrust.domainSuffix}`;
-			const src = `https://cdn.cookielaw.org/consent/${key}/otSDKStub.js`;
-			renderedExternals += `<script type="text/javascript" data-domain-script="${key}" src="${src}"></script>`;
+			const domain = 'https://cdn.cookielaw.org';
+			const src = `${domain}/consent/${key}/otSDKStub.js`;
+			const options = [
+				'type="text/javascript"',
+				`data-domain-script="${key}"`,
+				`src="${src}"`,
+				'async',
+			].join(' ');
+			renderedExternals += `<link rel="preconnect" href="${domain}">`;
+			renderedExternals += `<link rel="dns-prefetch" href="${domain}">`;
+			renderedExternals += `<script ${options}></script>`;
 		}
 		// add primary head script
 		const renderedHeadScript = serialize(headScript);

--- a/test/unit/specs/rendering/externals.spec.js
+++ b/test/unit/specs/rendering/externals.spec.js
@@ -26,10 +26,33 @@ describe('rendering/externals.js', () => {
 		expect(result).toContain('SERIALIZED(headScript)');
 	});
 
+	it('renders the OneTrust script as async', () => {
+		const config = { oneTrust: { enable: true, key: 'abc', domainSuffix: 'def' } };
+		const result = renderExternals(config);
+		const [oneTrustTag] = result.match(/<script[^>]*otSDKStub\.js[^>]*>/) ?? [];
+		expect(oneTrustTag).toMatch(/\basync\b/);
+	});
+
+	it('renders the OneTrust script before the head script that defines OptanonWrapper', () => {
+		const config = { oneTrust: { enable: true, key: 'abc', domainSuffix: 'def' } };
+		const result = renderExternals(config);
+		expect(result.indexOf('otSDKStub.js')).toBeLessThan(result.indexOf('SERIALIZED(headScript)'));
+	});
+
+	it('opens a connection to the OneTrust domain ahead of the script that uses it', () => {
+		const config = { oneTrust: { enable: true, key: 'abc', domainSuffix: 'def' } };
+		const result = renderExternals(config);
+		expect(result).toContain('<link rel="preconnect" href="https://cdn.cookielaw.org">');
+		expect(result).toContain('<link rel="dns-prefetch" href="https://cdn.cookielaw.org">');
+		expect(result.indexOf('rel="preconnect"')).toBeLessThan(result.indexOf('otSDKStub.js'));
+		expect(result.indexOf('rel="dns-prefetch"')).toBeLessThan(result.indexOf('otSDKStub.js'));
+	});
+
 	it('renders only head script if OneTrust is not enabled', () => {
 		const config = { oneTrust: { enable: false } };
 		const result = renderExternals(config);
 		expect(result).not.toContain('otSDKStub.js');
+		expect(result).not.toContain('cdn.cookielaw.org');
 		expect(result).toContain('SERIALIZED(headScript)');
 	});
 


### PR DESCRIPTION
The `otSDKStub.js` tag carried no async attribute, so the browser stops parsing to fetch and execute it from `cdn.cookielaw.org` before painting, leaving the user with a blank screen until it completes. This addresses that by adding the `async` attribute so that parsing is not paused and the page is displayed while the OneTrust library continues to load in the background. This also adds `preconnect` and `dns-prefetch` links to the OneTrust origin, which don't block the page rendering, to reduce the load time for the library once it starts. This matches the settings CPS uses for loading OneTrust.