### PR TITLE
fix: scope recap data to the goal's year

### DIFF
--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -143,6 +143,7 @@ export default function useGoalInReview({ apollo, cookieStore, goalData } = {}) 
 			const goalSummary = scopeToGoalYear(
 				mergeRecapExtras(summary, monolithSummary),
 				achievements,
+				year,
 			);
 
 			goalInReviewData.value = {
@@ -156,7 +157,7 @@ export default function useGoalInReview({ apollo, cookieStore, goalData } = {}) 
 					getCategories(),
 				),
 				loanStats: getLoanStats(goalSummary),
-				goalLoans: getGoalLoans(goalSummary, achievements),
+				goalLoans: getGoalLoans(goalSummary, achievements, year),
 				lifetimePercentile: lenderData?.my?.lendingStats?.amountLentPercentile ?? null,
 			};
 			return goalInReviewData.value;

--- a/src/util/goalInReview.js
+++ b/src/util/goalInReview.js
@@ -269,8 +269,8 @@ function getYearPurchases(goalSummary, tieredLendingAchievements, year) {
 	// mean pulling the whole year, and is not even reachable for lenders past the
 	// rolling window, which retains only the most recent loans.
 	return (getGoalAchievement(goalSummary, tieredLendingAchievements)?.loanPurchases ?? [])
-		.filter(purchase => purchase?.loan)
-		.filter(purchase => !Number.isFinite(year) || getPurchaseYear(purchase) === year);
+		.filter(purchase => purchase?.loan
+			&& (!Number.isFinite(year) || getPurchaseYear(purchase) === year));
 }
 
 function getYearLoans(goalSummary, tieredLendingAchievements, year) {
@@ -346,9 +346,11 @@ export function scopeToGoalYear(goalSummary, tieredLendingAchievements = [], yea
 
 	const yearPurchases = getYearPurchases(goalSummary, tieredLendingAchievements, year);
 	const achievement = getGoalAchievement(goalSummary, tieredLendingAchievements);
-	// progressForYear is authoritative: the rolling window can trim loanPurchases.
-	// Finite rather than truthy, so a real zero is not read as missing.
+	// yearPurchases can undercount a past year: the request asks for `target` purchases newest
+	// first, so later years are served before the recap year and can exhaust it. progressForYear
+	// is the service's own total for the year, subject to neither that request nor the window.
 	const progress = achievement?.progressForYear;
+	// Finite rather than truthy: a lender with no loans this year really did lend zero.
 	const lent = Number.isFinite(progress) ? progress : yearPurchases.length;
 	const target = Number(goalSummary.target) || 0;
 	const count = target > 0 ? Math.min(lent, target) : lent;

--- a/src/util/goalInReview.js
+++ b/src/util/goalInReview.js
@@ -256,16 +256,25 @@ function getGoalAchievement(goalSummary, tieredLendingAchievements) {
 	return (tieredLendingAchievements ?? []).find(entry => entry?.id === goalSummary?.category);
 }
 
-function getYearPurchases(goalSummary, tieredLendingAchievements) {
+// Read in UTC: locally, purchases either side of new year land in the wrong one.
+function getPurchaseYear(purchase) {
+	const purchasedAt = new Date(purchase.purchaseTime);
+	return Number.isNaN(purchasedAt.getTime()) ? null : purchasedAt.getUTCFullYear();
+}
+
+function getYearPurchases(goalSummary, tieredLendingAchievements, year) {
+	// The year the recap asks the service for scopes progressForYear, not this list, so it
+	// arrives carrying other years.
 	// Most recent first, as the service returns them. Selecting the oldest instead would
 	// mean pulling the whole year, and is not even reachable for lenders past the
 	// rolling window, which retains only the most recent loans.
 	return (getGoalAchievement(goalSummary, tieredLendingAchievements)?.loanPurchases ?? [])
-		.filter(purchase => purchase?.loan);
+		.filter(purchase => purchase?.loan)
+		.filter(purchase => !Number.isFinite(year) || getPurchaseYear(purchase) === year);
 }
 
-function getYearLoans(goalSummary, tieredLendingAchievements) {
-	return getYearPurchases(goalSummary, tieredLendingAchievements).map(purchase => purchase.loan);
+function getYearLoans(goalSummary, tieredLendingAchievements, year) {
+	return getYearPurchases(goalSummary, tieredLendingAchievements, year).map(purchase => purchase.loan);
 }
 
 /**
@@ -327,17 +336,20 @@ function getGoalSectors(loans) {
  *
  * @param {object} goalSummary The merged goal summary.
  * @param {Array} tieredLendingAchievements Achievements for the recap year.
+ * @param {number} year The goal's year. Purchases outside it are excluded.
  * @returns {object|null} The summary the slides read.
  */
-export function scopeToGoalYear(goalSummary, tieredLendingAchievements = []) {
+export function scopeToGoalYear(goalSummary, tieredLendingAchievements = [], year = undefined) {
 	if (!goalSummary || goalSummary.category === ID_SUPPORT_ALL) {
 		return goalSummary;
 	}
 
-	const yearPurchases = getYearPurchases(goalSummary, tieredLendingAchievements);
+	const yearPurchases = getYearPurchases(goalSummary, tieredLendingAchievements, year);
 	const achievement = getGoalAchievement(goalSummary, tieredLendingAchievements);
 	// progressForYear is authoritative: the rolling window can trim loanPurchases.
-	const lent = Number(achievement?.progressForYear) || yearPurchases.length;
+	// Finite rather than truthy, so a real zero is not read as missing.
+	const progress = achievement?.progressForYear;
+	const lent = Number.isFinite(progress) ? progress : yearPurchases.length;
 	const target = Number(goalSummary.target) || 0;
 	const count = target > 0 ? Math.min(lent, target) : lent;
 
@@ -364,14 +376,15 @@ export function scopeToGoalYear(goalSummary, tieredLendingAchievements = []) {
  *
  * @param {object} goalSummary The recap goal summary.
  * @param {Array} tieredLendingAchievements Achievements for the recap year.
+ * @param {number} year The goal's year. Loans outside it are excluded.
  * @returns {Array} Loans, each `{ id, name, image { hash } }`.
  */
-export function getGoalLoans(goalSummary, tieredLendingAchievements = []) {
+export function getGoalLoans(goalSummary, tieredLendingAchievements = [], year = undefined) {
 	if (goalSummary?.category === ID_SUPPORT_ALL) {
 		return goalSummary?.loans ?? [];
 	}
 
-	const loans = getYearLoans(goalSummary, tieredLendingAchievements);
+	const loans = getYearLoans(goalSummary, tieredLendingAchievements, year);
 	// scopeToGoalYear already capped `count`; the grid must not show more than it claims.
 	const count = Number(goalSummary?.count);
 

--- a/test/unit/specs/util/goalInReview.spec.js
+++ b/test/unit/specs/util/goalInReview.spec.js
@@ -496,6 +496,24 @@ describe('goalInReviewPayload.js', () => {
 			expect(getGoalLoans({ ...climateGoal, count: 1 }, newYearEve, 2027)).toEqual([]);
 		});
 
+		it('counts the year from progressForYear, not the purchases left after filtering', () => {
+			// A past year recap: 2027's purchase is served first and eats into the request, so
+			// only 2 of 2026's come back even though the lender made 100 that year.
+			const cappedByOtherYears = [{
+				...climateAchievements[0],
+				progressForYear: 100,
+				loanPurchases: [
+					{ purchaseTime: '2027-01-04T00:00:00Z', loan: { id: 9, name: 'Next year' } },
+					...climateAchievements[0].loanPurchases.slice(0, 2),
+				],
+			}];
+
+			const scoped = scopeToGoalYear({ ...climateGoal, target: 3 }, cappedByOtherYears, 2026);
+
+			expect(scoped.count).toBe(3);
+			expect(scoped.percent).toBe(100);
+		});
+
 		it('uses progressForYear over the retained purchases, which the window can trim', () => {
 			// progressForYear is 100 while only 3 loanPurchases came back
 			const scoped = scopeToGoalYear({ ...climateGoal, target: 200 }, climateAchievements);

--- a/test/unit/specs/util/goalInReview.spec.js
+++ b/test/unit/specs/util/goalInReview.spec.js
@@ -453,6 +453,49 @@ describe('goalInReviewPayload.js', () => {
 			expect(scoped.borrowerCount).toBe(3);
 		});
 
+		it('leaves out purchases from other years, which the service returns unfiltered', () => {
+			const acrossYears = [{
+				...climateAchievements[0],
+				progressForYear: 2,
+				loanPurchases: [
+					{ purchaseTime: '2027-01-04T00:00:00Z', loan: { id: 9, name: 'Next year' } },
+					...climateAchievements[0].loanPurchases.slice(0, 2),
+				],
+			}];
+
+			const scoped = scopeToGoalYear({ ...climateGoal, target: 10 }, acrossYears, 2026);
+
+			expect(scoped.count).toBe(2);
+			expect(getGoalLoans(scoped, acrossYears, 2026).map(loan => loan.name))
+				.toEqual(['Before the goal', 'Siti']);
+		});
+
+		it('shows nothing for a goal year the lender made no loans in', () => {
+			const noneThisYear = [{ ...climateAchievements[0], progressForYear: 0 }];
+
+			const scoped = scopeToGoalYear({ ...climateGoal, target: 63 }, noneThisYear, 2027);
+
+			expect(scoped.count).toBe(0);
+			expect(scoped.borrowerCount).toBe(0);
+			expect(scoped.percent).toBe(0);
+			expect(scoped.countries).toEqual([]);
+			expect(scoped.sectors).toEqual([]);
+			expect(getGoalLoans(scoped, noneThisYear, 2027)).toEqual([]);
+		});
+
+		it('reads purchase times in UTC, so new year purchases land in the right year', () => {
+			// 23:00 UTC on Dec 31 is still the previous year west of Greenwich.
+			const newYearEve = [{
+				...climateAchievements[0],
+				progressForYear: 1,
+				loanPurchases: [{ purchaseTime: '2026-12-31T23:00:00Z', loan: { id: 7, name: 'Eve' } }],
+			}];
+
+			expect(getGoalLoans({ ...climateGoal, count: 1 }, newYearEve, 2026).map(loan => loan.name))
+				.toEqual(['Eve']);
+			expect(getGoalLoans({ ...climateGoal, count: 1 }, newYearEve, 2027)).toEqual([]);
+		});
+
 		it('uses progressForYear over the retained purchases, which the window can trim', () => {
 			// progressForYear is 100 while only 3 loanPurchases came back
 			const scoped = scopeToGoalYear({ ...climateGoal, target: 200 }, climateAchievements);


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3135

Filter loan data from different year than the user goal