### PR TITLE
fix: release loans and bonus history migrations

### DIFF
--- a/src/pages/Deposit/DepositPage.vue
+++ b/src/pages/Deposit/DepositPage.vue
@@ -136,6 +136,11 @@ import {
 
 export default {
 	name: 'DepositPage',
+	head() {
+		return {
+			title: 'Add credit',
+		};
+	},
 	components: {
 		PortfolioShell,
 		KvButton,

--- a/src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.vue
+++ b/src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage.vue
@@ -131,7 +131,7 @@ export default {
 	inject: ['apollo'],
 	head() {
 		return {
-			title: 'Free Credit History',
+			title: 'Free credit history',
 		};
 	},
 	components: {

--- a/src/pages/Portfolio/Donations/DonationsPage.vue
+++ b/src/pages/Portfolio/Donations/DonationsPage.vue
@@ -290,6 +290,11 @@ const LIMIT = 10;
 
 export default {
 	name: 'DonationsPage',
+	head() {
+		return {
+			title: 'My donations',
+		};
+	},
 	inject: ['apollo'],
 	components: {
 		WwwPage,

--- a/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
+++ b/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
@@ -131,7 +131,7 @@ export default {
 	name: 'EstimatedRepaymentsPage',
 	head() {
 		return {
-			title: 'Estimated Repayments',
+			title: 'Estimated repayments',
 		};
 	},
 	components: {

--- a/src/pages/Portfolio/KivaCards/KivaCardsPage.vue
+++ b/src/pages/Portfolio/KivaCards/KivaCardsPage.vue
@@ -167,6 +167,11 @@ const SORT_OPTIONS = [
 
 export default {
 	name: 'KivaCardsPage',
+	head() {
+		return {
+			title: 'Kiva Cards',
+		};
+	},
 	inject: ['apollo'],
 	components: {
 		WwwPage,

--- a/src/pages/Portfolio/Loans/LoansPage.vue
+++ b/src/pages/Portfolio/Loans/LoansPage.vue
@@ -107,6 +107,11 @@ const sortByName = values => [...(values || [])].sort((a, b) => (a.name || '').l
 
 export default {
 	name: 'LoansPage',
+	head() {
+		return {
+			title: 'My loans',
+		};
+	},
 	inject: ['apollo', 'cookieStore'],
 	components: {
 		WwwPage,

--- a/src/pages/Withdraw/WithdrawAuthorizePage.vue
+++ b/src/pages/Withdraw/WithdrawAuthorizePage.vue
@@ -58,6 +58,11 @@ const DEFAULT_ERROR = 'Your authorization link is invalid or has expired. '
 
 export default {
 	name: 'WithdrawAuthorizePage',
+	head() {
+		return {
+			title: 'Withdraw credit',
+		};
+	},
 	components: {
 		PortfolioShell,
 		KvButton,

--- a/src/pages/Withdraw/WithdrawCheckInboxPage.vue
+++ b/src/pages/Withdraw/WithdrawCheckInboxPage.vue
@@ -41,6 +41,11 @@ import { WITHDRAW_STATE_KEY } from '#src/util/withdraw/withdrawConstants';
 
 export default {
 	name: 'WithdrawCheckInboxPage',
+	head() {
+		return {
+			title: 'Withdraw credit',
+		};
+	},
 	components: {
 		PortfolioShell,
 		KvButton,

--- a/src/pages/Withdraw/WithdrawConfirmPage.vue
+++ b/src/pages/Withdraw/WithdrawConfirmPage.vue
@@ -137,6 +137,11 @@ import { WITHDRAWAL_STATUS, WITHDRAW_ROUTE, WITHDRAW_STATE_KEY } from '#src/util
 
 export default {
 	name: 'WithdrawConfirmPage',
+	head() {
+		return {
+			title: 'Withdraw credit',
+		};
+	},
 	components: {
 		PortfolioShell,
 		KvButton,

--- a/src/pages/Withdraw/WithdrawPage.vue
+++ b/src/pages/Withdraw/WithdrawPage.vue
@@ -228,6 +228,11 @@ const MIN_WITHDRAWAL_AMOUNT = 0.01;
 
 export default {
 	name: 'WithdrawPage',
+	head() {
+		return {
+			title: 'Withdraw credit',
+		};
+	},
 	components: {
 		PortfolioShell,
 		KvButton,

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -357,7 +357,7 @@ export default [
 		path: '/portfolio/loans',
 		component: () => import('#src/pages/Portfolio/Loans/LoansPage'),
 		meta: {
-			authenticationRequired: true,
+			activeLoginRequired: true,
 			excludeFromStaticSitemap: true,
 		}
 	},

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -354,7 +354,7 @@ export default [
 		}
 	},
 	{
-		path: '/portfolio/loans-beta',
+		path: '/portfolio/loans',
 		component: () => import('#src/pages/Portfolio/Loans/LoansPage'),
 		meta: {
 			authenticationRequired: true,
@@ -370,7 +370,7 @@ export default [
 		}
 	},
 	{
-		path: '/portfolio/credit/bonus-history-beta',
+		path: '/portfolio/credit/bonus-history',
 		component: () => import('#src/pages/Portfolio/BonusCreditHistory/BonusCreditHistoryPage'),
 		meta: {
 			authenticationRequired: true,


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2976
https://kiva.atlassian.net/browse/MP-2754

Release `/portfolio/loans` and `/portfolio/credit/bonus-history` on newstack.

Also:
- Increased auth guard on loans page
- Added missing page titles