### PR TITLE
feat(live-loan-ads): align the google feed with the merchant center product spec

### DIFF
--- a/server/util/live-loan/ads/ads-eligibility.js
+++ b/server/util/live-loan/ads/ads-eligibility.js
@@ -1,13 +1,18 @@
 import fetchGraphQL from '../../fetchGraphQL.js';
 import { warn } from '../../log.js';
 
-// Locked candidate cap for the curated feed: request at most this many fundraising loans per
-// generation and do not paginate. The feed is deliberately conservative, so a single page is enough.
-export const AD_FEED_LOAN_COUNT = 100;
+// Pull the FLSS single-page maximum (200) per generation without paginating -- the eligibility and
+// ad-safety gates drop a chunk of candidates (small images, banned copy), so requesting the max leaves
+// headroom to fill the feed.
+export const AD_FEED_LOAN_COUNT = 200;
 
 // Not-anonymized value of AnonymizationLevelEnum (none | public | full | pii). Any other value
 // hides borrower identity/photo, which makes the loan unsuitable for a public ad feed.
 const NOT_ANONYMIZED = 'none';
+
+// Google Merchant Center requires an image_link of at least 500x500 px. We don't upscale, so a loan
+// whose photo is smaller than this on either side is dropped rather than shipped small.
+const MIN_IMAGE_DIMENSION = 500;
 
 const THRESHOLDS = {
 	minRiskRating: 3.5,
@@ -56,14 +61,16 @@ export function isEligibleLoan(loan) {
 	if (loan.anonymizationLevel !== NOT_ANONYMIZED) return false;
 	if (!primaryFirstName(loan)) return false;
 	if (!loan?.image?.hash) return false;
+	if (!(loan.image.width >= MIN_IMAGE_DIMENSION && loan.image.height >= MIN_IMAGE_DIMENSION)) return false;
 	return true;
 }
 
 const LOAN_FIELDS = `
 	id
 	anonymizationLevel
+	use
 	borrowers { id firstName isPrimary }
-	image { id hash }
+	image { id hash width height }
 	geocode { country { id name } }
 	sector { id name }
 `;

--- a/server/util/live-loan/ads/constants.js
+++ b/server/util/live-loan/ads/constants.js
@@ -1,17 +1,7 @@
-// The public prod host for the ad Final URL (the lend link Google serves to real lenders). Deliberately
+// The public prod host for the ad `link` (the lend URL Google serves to real lenders). Deliberately
 // hardcoded and NOT derived from config.app.host / BASE_URL: Google serves this URL to real lenders, so
 // it must always point at the live prod site even when the feed is generated in a non-prod environment.
 export const KIVA_PROD_HOST = 'https://www.kiva.org';
-
-// Ad images are delivered by Cloudinary, which fetches the loan's stored original through Kiva's
-// pre-configured `remote/` mapping and transforms it on the fly. The transform pins JPEG (f_jpg — never
-// f_auto, since Google Ads allows only PNG/JPG/GIF and f_auto can deliver webp), converts to sRGB, and
-// force-embeds an sRGB ICC profile (fl_force_icc): Google's image spec calls for JPG ads in RGB with an
-// embedded ICC profile, and Kiva's originals are RGB but untagged. c_limit,w_1200,h_1200 caps the longest
-// edge at 1200px — our bound (Google requires no specific size; this stays well under its 6 MP / 11.4 MB
-// max) — and never upscales a smaller source.
-export const CLOUDINARY_AD_IMAGE_BASE = 'https://res.cloudinary.com/kiva';
-export const CLOUDINARY_AD_IMAGE_TRANSFORM = 'c_limit,w_1200,h_1200,f_jpg,cs_srgb,fl_force_icc';
 
 // Settings Manager (uiConfigSetting) keys holding the comma-separated loan, partner, and sector ids
 // to keep out of the ad feed. Bare setting names -- `ui.` is the Settings Manager storage namespace,

--- a/server/util/live-loan/ads/google-display/feed-row.js
+++ b/server/util/live-loan/ads/google-display/feed-row.js
@@ -1,12 +1,23 @@
 import { primaryFirstName } from '../ads-eligibility.js';
-import { KIVA_PROD_HOST, CLOUDINARY_AD_IMAGE_BASE, CLOUDINARY_AD_IMAGE_TRANSFORM } from '../constants.js';
+import { KIVA_PROD_HOST } from '../constants.js';
 
 const UTM_QUERY = 'utm_medium=paid&utm_source=google&utm_campaign=liveloans';
 const KIVA_LEND_BASE = `${KIVA_PROD_HOST}/lend`;
-// Cloudinary's `remote/` mapping fetches the loan's stored original at <hash>.jpg to transform on the fly.
-const AD_IMAGE_BASE = `${CLOUDINARY_AD_IMAGE_BASE}/${CLOUDINARY_AD_IMAGE_TRANSFORM}/remote`;
-// Google caps Item title / subtitle / description at 25 characters.
-const CAP = 25;
+// Ad image: Kiva's own image CDN in WebP at a fixed size. WebP is a Google-Merchant-accepted format and
+// the `.webp` extension matches the served bytes, so no image-conversion step is needed. The prod host is
+// hardcoded (not env-derived) so Google is always served the live image, even from a non-prod feed run.
+const AD_IMAGE_SIZE = 'w1200h1200';
+const KIVA_IMAGE_BASE = `${KIVA_PROD_HOST}/img/${AD_IMAGE_SIZE}`;
+// Google Merchant Center max lengths for the title and description fields.
+const TITLE_MAX = 150;
+const DESCRIPTION_MAX = 5000;
+
+// Static Google Merchant attributes every row carries. A Kiva loan is not a purchasable good, so price
+// and availability are fixed placeholders, and identifier_exists=no tells Google the item intentionally
+// has no brand/GTIN/MPN (which it otherwise requires on new products).
+const DEFAULT_PRICE = '25.00 USD';
+const DEFAULT_AVAILABILITY = 'in_stock';
+const IDENTIFIER_EXISTS = 'no';
 
 // Words barred from ad copy: financial-services / ecommerce framing that risks Google reclassifying
 // the ads out of the nonprofit lane.
@@ -15,36 +26,43 @@ const BANNED_WORDS_RE = new RegExp(`\\b(${BANNED_WORDS.join('|')})\\b`, 'iu');
 // A run of 4+ uppercase letters reads as ALL-CAPS "shouting", which Google disapproves.
 const ALL_CAPS_RE = /\p{Lu}{4,}/u;
 
+// Lead-in that turns a bare loan-use fragment into a sentence for the description.
+const LOAN_USE_PREFIX = 'This loan is special because';
+
 export const FEED_COLUMNS = [
-	'ID', 'Item title', 'Item description', 'Item subtitle', 'Item category', 'Image URL', 'Final URL',
+	'id', 'title', 'description', 'google_product_category', 'image_link', 'link',
+	'price', 'availability', 'identifier_exists',
 ];
 
 export function sanitizeText(s) {
 	return (s ?? '').replace(/[\t\n\r\p{Cc}]/gu, ' ').replace(/\s+/g, ' ').trim();
 }
 
-// Hard-cap short text at Google's per-field limit, code-point-safe so a multi-byte character
+// Hard-cap text at `max` code points, code-point-safe so a multi-byte character
 // (emoji, astral CJK) is never split into invalid UTF-8.
-export function truncate(s) {
-	return [...sanitizeText(s)].slice(0, CAP).join('');
+export function truncate(s, max) {
+	return [...sanitizeText(s)].slice(0, max).join('');
 }
 
 export function buildTitle(loan) {
-	return truncate(`Support ${primaryFirstName(loan)}`);
+	return truncate(`Support ${primaryFirstName(loan)}`, TITLE_MAX);
 }
 
 export function buildCategory(loan) {
 	return sanitizeText(loan?.sector?.name);
 }
 
-// Item description shows the same value as Item category -- the loan's sector name -- capped to the
-// 25-char limit Google applies to the description field.
+// Present the borrower's loan-use text as a sentence, used only when it fits the 5000-char limit;
+// over the limit (or with no use text) we fall back to the whole sector name rather than truncate
+// the sentence mid-word.
 export function buildDescription(loan) {
-	return truncate(buildCategory(loan));
-}
-
-export function buildSubtitle(loan) {
-	return truncate(loan?.geocode?.country?.name);
+	const use = sanitizeText(loan?.use);
+	if (use) {
+		const lowerFirst = use.charAt(0).toLowerCase() + use.slice(1);
+		const sentence = `${LOAN_USE_PREFIX} ${lowerFirst}`;
+		if ([...sentence].length <= DESCRIPTION_MAX) return sentence;
+	}
+	return buildCategory(loan);
 }
 
 export function buildFinalUrl(id) {
@@ -52,24 +70,28 @@ export function buildFinalUrl(id) {
 }
 
 export function buildImageUrl(hash) {
-	return `${AD_IMAGE_BASE}/${hash}.jpg`;
+	return `${KIVA_IMAGE_BASE}/${hash}.webp`;
 }
 
-// Whether a row's visible copy is safe to publish as an ad: rejects ALL-CAPS shouting and banned
-// financial/ecommerce words in the title/description. Unsafe rows are dropped from the feed.
-export function isRowAdSafe(row) {
-	const copy = `${row['Item title']} ${row['Item description']}`;
+// Whether a loan is safe to publish as an ad: rejects ALL-CAPS shouting and banned financial/ecommerce
+// words in the borrower's own text (first name, loan-use, sector). Only borrower-authored copy is
+// scanned -- the fixed template wording (the "Support ..." title, the "This loan is special because ..."
+// lead-in) is safe by construction. Unsafe loans are dropped from the feed.
+export function isLoanAdSafe(loan) {
+	const copy = [primaryFirstName(loan), sanitizeText(loan?.use), buildCategory(loan)].join(' ');
 	return !ALL_CAPS_RE.test(copy) && !BANNED_WORDS_RE.test(copy);
 }
 
 export function loanToFeedRow(loan) {
 	return {
-		ID: String(loan.id),
-		'Item title': buildTitle(loan),
-		'Item description': buildDescription(loan),
-		'Item subtitle': buildSubtitle(loan),
-		'Item category': buildCategory(loan),
-		'Image URL': buildImageUrl(loan.image.hash),
-		'Final URL': buildFinalUrl(loan.id),
+		id: String(loan.id),
+		title: buildTitle(loan),
+		description: buildDescription(loan),
+		google_product_category: buildCategory(loan),
+		image_link: buildImageUrl(loan.image.hash),
+		link: buildFinalUrl(loan.id),
+		price: DEFAULT_PRICE,
+		availability: DEFAULT_AVAILABILITY,
+		identifier_exists: IDENTIFIER_EXISTS,
 	};
 }

--- a/server/util/live-loan/ads/google-display/google-feed.js
+++ b/server/util/live-loan/ads/google-display/google-feed.js
@@ -5,7 +5,7 @@ import {
 	EXCLUDED_PARTNER_IDS_SETTING_KEY,
 	EXCLUDED_SECTOR_IDS_SETTING_KEY,
 } from '../constants.js';
-import { loanToFeedRow, isRowAdSafe, FEED_COLUMNS } from './feed-row.js';
+import { loanToFeedRow, isLoanAdSafe, FEED_COLUMNS } from './feed-row.js';
 import { info, warn } from '../../../log.js';
 
 // Cache keys + TTLs for serving the feed. A fresh copy is served from cache between regenerations so
@@ -53,13 +53,12 @@ export async function generateGoogleFeed(count) {
 
 	const rows = [];
 	eligible.forEach(loan => {
-		const row = loanToFeedRow(loan);
-		// Drop rows whose copy isn't ad-safe (banned words / ALL-CAPS) rather than emit a policy risk.
-		if (!isRowAdSafe(row)) {
-			warn(`Ad feed: dropping loan ${row.ID} whose copy is not ad-safe`);
+		// Drop loans whose borrower copy isn't ad-safe (banned words / ALL-CAPS) rather than emit a policy risk.
+		if (!isLoanAdSafe(loan)) {
+			warn(`Ad feed: dropping loan ${loan.id} whose copy is not ad-safe`);
 			return;
 		}
-		rows.push(row);
+		rows.push(loanToFeedRow(loan));
 	});
 	return toTsv(rows);
 }

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -546,7 +546,7 @@ describe('live-loan-router ads feed route', () => {
 		cache = createMockCache();
 		memJsUtils.getFromCache.mockResolvedValue(null);
 		memJsUtils.setToCache.mockResolvedValue(undefined);
-		generateGoogleFeed.mockResolvedValue('ID\tItem title\n1\tSupport Maria');
+		generateGoogleFeed.mockResolvedValue('id\ttitle\n1\tSupport Maria');
 	});
 
 	it('generates, caches (fresh + last-good), and serves the feed on a cache miss', async () => {

--- a/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/ads-eligibility.spec.js
@@ -25,7 +25,9 @@ const completeLoan = {
 	id: 1,
 	anonymizationLevel: 'none',
 	borrowers: [{ id: 1, firstName: 'Maria', isPrimary: true }],
-	image: { id: 'img-1', hash: 'abcimagehash01' },
+	image: {
+		id: 'img-1', hash: 'abcimagehash01', width: 800, height: 800
+	},
 };
 
 describe('ads-eligibility', () => {
@@ -40,8 +42,8 @@ describe('ads-eligibility', () => {
 			}]);
 		});
 
-		it('caps the candidate count at the locked feed limit of 100', () => {
-			expect(AD_FEED_LOAN_COUNT).toEqual(100);
+		it('requests the FLSS single-page maximum of 200 candidates', () => {
+			expect(AD_FEED_LOAN_COUNT).toEqual(200);
 		});
 
 		it('adds a loanIds none filter when a loan-id exclusion list is provided', () => {
@@ -135,6 +137,20 @@ describe('ads-eligibility', () => {
 			expect(isEligibleLoan({ ...completeLoan, image: null })).toEqual(false);
 		});
 
+		it('accepts an image exactly at the 500x500 minimum', () => {
+			expect(isEligibleLoan({ ...completeLoan, image: { ...completeLoan.image, width: 500, height: 500 } }))
+				.toEqual(true);
+		});
+
+		it('returns false when the image is under 500px on either side', () => {
+			expect(isEligibleLoan({ ...completeLoan, image: { ...completeLoan.image, width: 499 } })).toEqual(false);
+			expect(isEligibleLoan({ ...completeLoan, image: { ...completeLoan.image, height: 320 } })).toEqual(false);
+		});
+
+		it('returns false when the image has no width/height', () => {
+			expect(isEligibleLoan({ ...completeLoan, image: { id: 'img-1', hash: 'abcimagehash01' } })).toEqual(false);
+		});
+
 		it('returns false when the loan has no id', () => {
 			expect(isEligibleLoan({ ...completeLoan, id: undefined })).toEqual(false);
 			expect(isEligibleLoan(null)).toEqual(false);
@@ -174,6 +190,25 @@ describe('ads-eligibility', () => {
 
 			const { variables } = JSON.parse(fetch.mock.calls[0][1].body);
 			expect(variables.filters).toEqual(buildAdFeedFilters(exclusions));
+		});
+
+		it('requests the borrower loan-use text in the query fields', async () => {
+			fetch.mockResolvedValue({ json: () => ({ data: { fundraisingLoans: { values: [] } } }) });
+
+			await fetchAdEligibleLoans();
+
+			const { query } = JSON.parse(fetch.mock.calls[0][1].body);
+			expect(query).toMatch(/\buse\b/);
+		});
+
+		it('requests the image dimensions in the query fields', async () => {
+			fetch.mockResolvedValue({ json: () => ({ data: { fundraisingLoans: { values: [] } } }) });
+
+			await fetchAdEligibleLoans();
+
+			const { query } = JSON.parse(fetch.mock.calls[0][1].body);
+			expect(query).toMatch(/\bwidth\b/);
+			expect(query).toMatch(/\bheight\b/);
 		});
 
 		it('threads a custom count into the fundraisingLoans limit', async () => {

--- a/test/unit/specs/server/util/live-loan/ads/google-display/feed-row.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/google-display/feed-row.spec.js
@@ -5,11 +5,10 @@ import {
 	truncate,
 	buildTitle,
 	buildDescription,
-	buildSubtitle,
 	buildCategory,
 	buildFinalUrl,
 	buildImageUrl,
-	isRowAdSafe,
+	isLoanAdSafe,
 	loanToFeedRow,
 } from '#server/util/live-loan/ads/google-display/feed-row';
 
@@ -22,11 +21,11 @@ const loan = {
 	sector: { id: 1, name: 'Retail' },
 	geocode: { country: { id: 1, name: 'Tajikistan' } },
 	image: { id: 1, hash: 'abc123def456' },
+	use: 'To buy a cow',
 };
 
-// The hash 'abc123def456' rendered through the Cloudinary ad-image transform.
-const EXPECTED_IMAGE_URL = 'https://res.cloudinary.com/kiva/'
-	+ 'c_limit,w_1200,h_1200,f_jpg,cs_srgb,fl_force_icc/remote/abc123def456.jpg';
+// The hash 'abc123def456' as a Kiva image-CDN WebP URL at the ad size, on the hardcoded prod host.
+const EXPECTED_IMAGE_URL = 'https://www.kiva.org/img/w1200h1200/abc123def456.webp';
 
 describe('feed-row', () => {
 	describe('sanitizeText', () => {
@@ -41,18 +40,18 @@ describe('feed-row', () => {
 	});
 
 	describe('truncate', () => {
-		it('caps text at 25 characters', () => {
-			expect(truncate('a'.repeat(40))).toEqual('a'.repeat(25));
+		it('caps text at the given length', () => {
+			expect(truncate('a'.repeat(200), 150)).toEqual('a'.repeat(150));
 		});
 
 		it('leaves text within the cap unchanged', () => {
-			expect(truncate('Short country')).toEqual('Short country');
+			expect(truncate('Short use text', 5000)).toEqual('Short use text');
 		});
 
 		it('is code-point-safe: never splits a multi-byte character', () => {
 			// 24 ASCII + an astral emoji lands exactly at the 25th code point; a UTF-16 slice would
 			// cut the emoji mid-surrogate and emit invalid UTF-8.
-			const result = truncate(`${'a'.repeat(24)}\u{1F600}bcd`);
+			const result = truncate(`${'a'.repeat(24)}\u{1F600}bcd`, 25);
 			expect(result).toEqual(`${'a'.repeat(24)}\u{1F600}`);
 			expect([...result]).toHaveLength(25);
 		});
@@ -62,28 +61,31 @@ describe('feed-row', () => {
 		it('builds "Support {firstName}" from the primary borrower', () => {
 			expect(buildTitle(loan)).toEqual('Support Mukumoy');
 		});
+
+		it('caps a very long title at 150 characters', () => {
+			const longName = { borrowers: [{ id: 1, firstName: 'x'.repeat(200), isPrimary: true }] };
+			expect([...buildTitle(longName)]).toHaveLength(150);
+		});
 	});
 
 	describe('buildDescription', () => {
-		it('is the sector name, mirroring Item category', () => {
-			expect(buildDescription(loan)).toEqual('Retail');
-			expect(buildDescription(loan)).toEqual(buildCategory(loan));
+		it('wraps the borrower loan-use text in the "special because" sentence', () => {
+			expect(buildDescription(loan)).toEqual('This loan is special because to buy a cow');
 		});
 
-		it('caps a long sector name at 25 characters', () => {
-			const longSector = { sector: { name: 'Wholesale and Retail Distribution' } };
-			expect(buildDescription(longSector)).toEqual('Wholesale and Retail Dist');
-		});
-	});
-
-	describe('buildSubtitle', () => {
-		it('is the borrower country', () => {
-			expect(buildSubtitle(loan)).toEqual('Tajikistan');
+		it('falls back to the sector name, unformatted, when use is empty or missing', () => {
+			expect(buildDescription({ use: '', sector: { name: 'Retail' } })).toEqual('Retail');
+			expect(buildDescription({ sector: { name: 'Agriculture' } })).toEqual('Agriculture');
 		});
 
-		it('caps a long country name at 25 characters', () => {
-			const longCountry = { geocode: { country: { name: 'The Democratic Republic of the Congo' } } };
-			expect(buildSubtitle(longCountry)).toEqual('The Democratic Republic o');
+		it('keeps the formatted sentence when it is within the 5000-character limit', () => {
+			const result = buildDescription({ use: 'a'.repeat(4000), sector: { name: 'Retail' } });
+			expect(result.startsWith('This loan is special because ')).toBe(true);
+			expect([...result].length).toBeLessThanOrEqual(5000);
+		});
+
+		it('falls back to the sector name when the formatted sentence would exceed 5000 characters', () => {
+			expect(buildDescription({ use: 'x'.repeat(6000), sector: { name: 'Retail' } })).toEqual('Retail');
 		});
 	});
 
@@ -102,37 +104,50 @@ describe('feed-row', () => {
 	});
 
 	describe('buildImageUrl', () => {
-		it('builds the Cloudinary sRGB+ICC image URL from the hash', () => {
+		it('builds the Kiva image-CDN WebP URL from the hash', () => {
 			expect(buildImageUrl('abc123def456')).toEqual(EXPECTED_IMAGE_URL);
 		});
 	});
 
-	describe('isRowAdSafe', () => {
-		it('accepts clean nonprofit copy', () => {
-			expect(isRowAdSafe({ 'Item title': 'Help Maria', 'Item description': 'Support Maria' })).toBe(true);
+	describe('isLoanAdSafe', () => {
+		const cleanLoan = {
+			borrowers: [{ id: 1, firstName: 'Maria', isPrimary: true }],
+			use: 'Groceries for her family',
+			sector: { id: 1, name: 'Retail' },
+		};
+
+		it('accepts a loan with clean borrower copy', () => {
+			expect(isLoanAdSafe(cleanLoan)).toBe(true);
 		});
 
-		it('rejects a banned financial/ecommerce word', () => {
-			expect(isRowAdSafe({ 'Item title': 'Help Invest', 'Item description': 'Support Invest' })).toBe(false);
+		it('rejects a banned word in the borrower loan-use text', () => {
+			expect(isLoanAdSafe({ ...cleanLoan, use: 'To buy a cow' })).toBe(false);
 		});
 
-		it('rejects an ALL-CAPS run of 4+ letters', () => {
-			expect(isRowAdSafe({ 'Item title': 'Help MARIA', 'Item description': 'Support MARIA' })).toBe(false);
+		it('rejects a banned word in the sector name', () => {
+			expect(isLoanAdSafe({ ...cleanLoan, sector: { id: 1, name: 'Loan services' } })).toBe(false);
+		});
+
+		it('rejects an ALL-CAPS borrower first name', () => {
+			expect(isLoanAdSafe({ ...cleanLoan, borrowers: [{ id: 1, firstName: 'MARIA', isPrimary: true }] }))
+				.toBe(false);
 		});
 	});
 
 	describe('loanToFeedRow', () => {
-		it('maps a loan to the 7 monolith-aligned columns in order', () => {
+		it('maps a loan to the Google Merchant product columns in order', () => {
 			const row = loanToFeedRow(loan);
 			expect(Object.keys(row)).toEqual(FEED_COLUMNS);
 			expect(row).toEqual({
-				ID: '456',
-				'Item title': 'Support Mukumoy',
-				'Item description': 'Retail',
-				'Item subtitle': 'Tajikistan',
-				'Item category': 'Retail',
-				'Image URL': EXPECTED_IMAGE_URL,
-				'Final URL': 'https://www.kiva.org/lend/456?utm_medium=paid&utm_source=google&utm_campaign=liveloans',
+				id: '456',
+				title: 'Support Mukumoy',
+				description: 'This loan is special because to buy a cow',
+				google_product_category: 'Retail',
+				image_link: EXPECTED_IMAGE_URL,
+				link: 'https://www.kiva.org/lend/456?utm_medium=paid&utm_source=google&utm_campaign=liveloans',
+				price: '25.00 USD',
+				availability: 'in_stock',
+				identifier_exists: 'no',
 			});
 		});
 	});

--- a/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
+++ b/test/unit/specs/server/util/live-loan/ads/google-display/google-feed.spec.js
@@ -7,7 +7,7 @@ import {
 	EXCLUDED_PARTNER_IDS_SETTING_KEY,
 	EXCLUDED_SECTOR_IDS_SETTING_KEY,
 } from '#server/util/live-loan/ads/constants';
-import { info } from '#server/util/log';
+import { info, warn } from '#server/util/log';
 import { toTsv, generateGoogleFeed } from '#server/util/live-loan/ads/google-display/google-feed';
 
 // mock out the argv module to prevent command line arguments for jest from being read by the code under test
@@ -36,6 +36,7 @@ const loanOne = {
 	geocode: { country: { id: 1, name: 'Tajikistan' } },
 	activity: { id: 1, name: 'Food Production/Sales' },
 	image: { id: 1, hash: 'hash456' },
+	use: 'To support her family shop',
 };
 
 const loanTwo = {
@@ -45,6 +46,7 @@ const loanTwo = {
 	geocode: { country: { id: 2, name: 'Kenya' } },
 	activity: { id: 2, name: 'Farming' },
 	image: { id: 2, hash: 'hash789' },
+	use: 'To grow her small farm',
 };
 
 describe('google-feed', () => {
@@ -93,6 +95,7 @@ describe('google-feed', () => {
 			fetchAdEligibleLoans.mockClear();
 			fetchExcludedIds.mockClear();
 			info.mockClear();
+			warn.mockClear();
 			fetchExcludedIds.mockResolvedValue([]);
 		});
 
@@ -105,6 +108,9 @@ describe('google-feed', () => {
 			expect(lines).toHaveLength(3);
 			expect(lines[0]).toEqual(FEED_COLUMNS.join('\t'));
 			expect(lines[1]).toContain('Support Mukumoy');
+			// The composed description carries the "This loan is special because ..." lead-in; the row
+			// survives ad-safety, proving the template word "loan" is not scanned (only raw borrower text is).
+			expect(lines[1]).toContain('This loan is special because to support her family shop');
 			expect(lines[1]).toContain(
 				'https://www.kiva.org/lend/456?utm_medium=paid&utm_source=google&utm_campaign=liveloans',
 			);
@@ -123,6 +129,19 @@ describe('google-feed', () => {
 
 			expect(lines).toHaveLength(2); // header + loanOne only
 			expect(result).not.toContain('MARIA');
+		});
+
+		it('drops a loan whose loan-use description contains a banned word', async () => {
+			const buyLoan = { ...loanOne, id: 111, use: 'To buy a cow' };
+			fetchAdEligibleLoans.mockResolvedValue([loanTwo, buyLoan]);
+
+			const result = await generateGoogleFeed();
+			const lines = result.split('\n');
+
+			expect(lines).toHaveLength(2); // header + loanTwo only
+			expect(result).not.toContain('cow');
+			// The drop warning names the real loan id, not undefined (guards the id-vs-ID key regression).
+			expect(warn).toHaveBeenCalledWith(expect.stringContaining('111'));
 		});
 
 		it('returns exactly the header line when there are no eligible loans', async () => {


### PR DESCRIPTION
## What & why
MP-3136 — adjusts the live-loan Google ads feed to conform to the [Google Merchant Center product data spec](https://support.google.com/merchants/answer/7052112) (the previous TSV used Google Ads dynamic-display attribute names Merchant Center doesn't recognize).

### Feed shape
- **Columns renamed** to Merchant product attributes: `id, title, description, google_product_category, image_link, link` (dropped `Item subtitle`).
- **Added** `price` (`25.00 USD`), `availability` (`in_stock`), `identifier_exists` (`no`). All 7 always-required attributes are now present; `identifier_exists=no` covers the brand/GTIN/MPN requirement (loans have no product identifiers).

### Copy
- **`description`** is now the borrower's own loan-use text, formatted into a sentence (`This loan is special because …`, mirroring `formatWhySpecial`), falling back to the sector name when the use text is absent or would exceed the 5000-char limit.
- **Ad-safety** now scans the **raw borrower inputs** (first name, loan-use, sector) rather than the composed row, so authored template words (e.g. "loan" in the lead-in) don't drop every row.

### Images
- **Served from Kiva's own WebP CDN** (`…/img/w1200h1200/<hash>.webp`), dropping the Cloudinary transform — WebP is Merchant-accepted and needs no ICC step. Prod host is hardcoded (like `link`) so Google always gets the live image; `w1200h1200` caps large originals without upscaling.
- **500x500 eligibility gate** — loans whose image is smaller on either side are dropped (Merchant minimum; we don't upscale).

### Volume
- **Candidate pull raised 100 -> 200** (the FLSS single-page maximum) to backfill after the eligibility/ad-safety drops.

## Testing
- All live-loan-ads unit specs green (109) + live-loan-router (35); full suite shows only the pre-existing `possibleTypesCacheIntegrity` flake.
- Verified against the dev gateway and Fastly: WebP delivery + extension match, the size gate drops ~12% (88 kept), and FLSS honors `limit:200` (errors at 201).

## Known / out of scope
- `google_product_category` currently carries the free-text sector name (Google expects its taxonomy; likely ignored, harmless).
- The banned-word ad-safety list may over-drop loan-use text containing `buy`/`invest`/`earn` — accepted for now.
