### PR TITLE
fix: make KvWwwHeaderBasic the default global header

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -4,7 +4,7 @@
 		:class="isInExperimentPages ? 'tw-sticky tw-top-0 tw-z-sticky' : ''"
 	>
 		<KvWwwHeaderBasic
-			v-if="isNavUpdateExp"
+			v-if="showBasicHeader"
 			class="tw-bg-primary tw-border-b tw-border-tertiary tw-relative"
 			ref="newExpHeader"
 			:logged-in="!isVisitor"
@@ -104,7 +104,12 @@
 					</div>
 				</template>
 
-				<!-- Default Header -->
+				<!--
+					Default Header — UNREACHABLE as of the stage 1 header default flip.
+					The enclosing <nav> only renders when `minimal` or `corporate` is set,
+					so this `v-else` can never match. Retained for stage 2 deletion; see
+					docs/ui-docs/specs/2026-08-20-global-header-experiment-cleanup-design.md
+				-->
 				<template v-else>
 					<div
 						class="header
@@ -711,6 +716,12 @@ export default {
 				'--user-avatar': 'var(--ui-data-user-avatar)',
 			};
 		},
+		// The basic header is the default. The legacy <nav> now renders only for the
+		// minimal and corporate pathways — note this inverts the previous precedence,
+		// where the home_page experiment won over both.
+		showBasicHeader() {
+			return !this.minimal && !this.corporate;
+		},
 		isVisitor() {
 			return !this.userId && !this.$renderConfig?.cdnNotedLoggedIn;
 		},
@@ -856,8 +867,8 @@ export default {
 		this.determineIfMobile();
 		window.addEventListener('resize', this.throttledDetermineIfMobile);
 
-		// Prefetch the new header's search suggestions on mount, only when the experiment is active.
-		if (this.isNavUpdateExp) {
+		// Prefetch the basic header's search suggestions on mount.
+		if (this.showBasicHeader) {
 			this.loadSearchData();
 		}
 	},

--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -601,15 +601,22 @@ import addToBasketMixin from '#src/plugins/add-to-basket-mixin';
 import {
 	KvButton, KvLoadingPlaceholder, KvMaterialIcon, KvPageContainer, KvWwwHeaderBasic
 } from '@kiva/kv-components';
-import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
-import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
+// import experimentAssignmentQuery from '#src/graphql/query/experimentAssignment.graphql';
+// import { trackExperimentVersion } from '#src/util/experiment/experimentUtils';
 import useMyKivaHome from '#src/composables/useMyKivaHome';
 import { COUNTRIES_NOT_LENT_TO_URL } from '#src/util/headerUtils';
 import SearchBar from './SearchBar';
 import PromoCreditBanner from './PromotionalBanner/Banners/PromoCreditBanner';
 
 const COMMS_OPT_IN_EXP_KEY = 'opt_in_comms';
-const NAV_UPDATE_EXP_KEY = 'home_page'; // Key aligns with key used in Fastly experimentation for cached CPS pages
+
+// The `home_page` global header experiment (EXP-CIT-4367-June2026) is retired — KvWwwHeaderBasic is
+// now the unconditional default. The config below is kept commented, not deleted, because this
+// wiring gets reused for future header experiments. It lives in five places that must be
+// uncommented together: these two imports and this constant, the `isNavUpdateExp` data field, the
+// experimentAssignmentQuery entry in the `apollo` array, and the trackExperimentVersion block in
+// `created()`. See docs/ui-docs/specs/2026-08-20-global-header-experiment-cleanup-design.md
+// const NAV_UPDATE_EXP_KEY = 'home_page'; // Key aligns with the Fastly experimentation key for cached CPS pages
 
 export default {
 	name: 'TheHeader',
@@ -662,7 +669,7 @@ export default {
 			teamsMenuEnabled: false,
 			trusteeId: null,
 			userId: null,
-			isNavUpdateExp: false,
+			// isNavUpdateExp: false,
 			throttledDetermineIfMobile: null,
 			COUNTRIES_NOT_LENT_TO_URL,
 		};
@@ -809,30 +816,30 @@ export default {
 				fireNewUserHotJarEvent(this.hasEverLoggedIn);
 			},
 		},
-		{
-			query: experimentAssignmentQuery,
-			preFetch(_, client) {
-				return client.query({
-					query: experimentAssignmentQuery,
-					variables: {
-						id: NAV_UPDATE_EXP_KEY,
-					},
-				});
-			},
-		},
+		// {
+		// 	query: experimentAssignmentQuery,
+		// 	preFetch(_, client) {
+		// 		return client.query({
+		// 			query: experimentAssignmentQuery,
+		// 			variables: {
+		// 				id: NAV_UPDATE_EXP_KEY,
+		// 			},
+		// 		});
+		// 	},
+		// },
 	],
 	created() {
 		this.isBasketLoading = this.$renderConfig?.useCDNCaching ?? false;
 		this.isUserDataLoading = this.$renderConfig?.useCDNCaching && this.$renderConfig?.cdnNotedLoggedIn;
 
-		const navExperiment = trackExperimentVersion(
-			this.apollo,
-			this.$kvTrackEvent,
-			'event-tracking',
-			NAV_UPDATE_EXP_KEY,
-			'EXP-CIT-4367-June2026'
-		);
-		this.isNavUpdateExp = navExperiment?.version === 'b';
+		// const navExperiment = trackExperimentVersion(
+		// 	this.apollo,
+		// 	this.$kvTrackEvent,
+		// 	'event-tracking',
+		// 	NAV_UPDATE_EXP_KEY,
+		// 	'EXP-CIT-4367-June2026'
+		// );
+		// this.isNavUpdateExp = navExperiment?.version === 'b';
 	},
 	mounted() {
 		const { version } = this.apollo.readFragment({

--- a/test/unit/specs/components/WwwFrame/TheHeader.spec.js
+++ b/test/unit/specs/components/WwwFrame/TheHeader.spec.js
@@ -1,38 +1,67 @@
 import { render } from '@testing-library/vue';
-import userEvent from '@testing-library/user-event';
 import TheHeader from '#src/components/WwwFrame/TheHeader';
 
 import { emptyComponent, globalOptions } from '../../../specUtils';
 
-describe('TheHeader', () => {
-	it('should display a search area', async () => {
-		const user = userEvent.setup();
-		const { queryByPlaceholderText } = render(
-			TheHeader,
-			{
-				global: {
-					...globalOptions,
-					// Stubbing out child components not used in this test
-					stubs: {
-						MonthlyGoodExpMenuWrapper: { ...emptyComponent },
-						PromoBannerLarge: { ...emptyComponent },
-						PromoBannerSmall: { ...emptyComponent },
-						TheLendMenu: { ...emptyComponent },
-						RouterLink: { ...emptyComponent },
-					},
-					mocks: {
-						...globalOptions.mocks,
-						$route: {
-							path: '/'
-						},
-					}
+// Stand-in for the external @kiva/kv-components header. It is stubbed rather than
+// rendered so the spec asserts *which* header the component chose, not the
+// internals of a released library component. The two methods exist because
+// TheHeader's `loadMenu()` / `loadSearchData()` call them through `$refs`, and
+// `loadSearchData()` fires on mount whenever the basic header is shown.
+const KvWwwHeaderBasicStub = {
+	name: 'KvWwwHeaderBasic',
+	template: '<div data-testid="basic-header"></div>',
+	methods: {
+		loadMenuData() {},
+		loadSearchSuggestions() {},
+	},
+};
+
+const renderHeader = (props = {}) => render(
+	TheHeader,
+	{
+		props,
+		global: {
+			...globalOptions,
+			stubs: {
+				KvWwwHeaderBasic: KvWwwHeaderBasicStub,
+				MonthlyGoodExpMenuWrapper: { ...emptyComponent },
+				PromoBannerLarge: { ...emptyComponent },
+				PromoBannerSmall: { ...emptyComponent },
+				TheLendMenu: { ...emptyComponent },
+				RouterLink: { ...emptyComponent },
+			},
+			mocks: {
+				...globalOptions.mocks,
+				$route: {
+					path: '/',
 				},
 			},
-		);
+		},
+	},
+);
 
-		// Expect the search bar to exist and be focused on click
-		const searchBar = queryByPlaceholderText('Search all loans');
-		await user.click(searchBar);
-		expect(searchBar).toBe(document.activeElement);
+describe('TheHeader', () => {
+	it('should render the basic header by default', () => {
+		const { queryByTestId, container } = renderHeader();
+
+		expect(queryByTestId('basic-header')).not.toBeNull();
+		expect(container.querySelector('nav[aria-label="Primary navigation"]')).toBeNull();
+	});
+
+	it('should render the minimal header instead of the basic header when minimal', () => {
+		const { queryByTestId, container } = renderHeader({ minimal: true });
+
+		expect(queryByTestId('basic-header')).toBeNull();
+		expect(container.querySelector('nav[aria-label="Primary navigation"]')).not.toBeNull();
+		expect(queryByTestId('header-home')).not.toBeNull();
+	});
+
+	it('should render the corporate header instead of the basic header when corporate', () => {
+		const { queryByTestId, container } = renderHeader({ corporate: true });
+
+		expect(queryByTestId('basic-header')).toBeNull();
+		expect(container.querySelector('nav[aria-label="Primary navigation"]')).not.toBeNull();
+		expect(queryByTestId('header-basket')).not.toBeNull();
 	});
 });


### PR DESCRIPTION
Stage 1 of the global header experiment cleanup.

## What changed

`TheHeader.vue` no longer reads the `home_page` experiment. A new `showBasicHeader` computed (`!minimal && !corporate`) picks the header, making `KvWwwHeaderBasic` the default.

**Precedence is inverted.** The experiment gate previously sat above the minimal and corporate branches, so a variant-`b` user got the basic header even on `/cc/*` pages. Those pathways now win over the basic header, which is the intended behavior.

The experiment's Apollo operation, `trackExperimentVersion` call, key constant, imports, and data flag are **commented out rather than deleted** — this wiring gets reused for future header experiments. An anchor comment above the constant names all five sites so they can be restored together.

The legacy default header markup stays in the file but is now unreachable, marked for stage 2 deletion. Removing it, and removing the Fastly `forceHeader` plumbing, are follow-up PRs.

## Testing

`TheHeader.spec.js` is rewritten as three pathway tests (default / minimal / corporate) with `KvWwwHeaderBasic` stubbed. The old test asserted on the legacy `SearchBar`, which no longer renders on the default path.

Full suite: 328 files, 5114 tests passing. `npm run lint`: 0 errors.

Manually verified on `/`, `/lend`, a `/cc/*` corporate route, logged-in and logged-out, and the `WwwPageMinimal` Storybook story (no route reaches the minimal pathway).

## Note for reviewers

The `home_page` experiment stays active server-side; this only stops `ui` from reading it. Until `cms-page-server` makes the same flip, a variant-`a` user could see the new header on `ui` routes and the legacy one on CPS routes in the same session. Ramping `home_page` to 100% `b` before this merges would close that window.

Spec: `~/kiva/docs/ui-docs/specs/2026-08-20-global-header-experiment-cleanup-design.md`
Plan: `~/kiva/docs/ui-docs/plans/2026-08-20-global-header-default-stage-1.md`