### PR TITLE
fix: resolve issue with super lender data on estimated repayments newstack page

### DIFF
--- a/src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.vue
+++ b/src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.vue
@@ -91,6 +91,7 @@ import {
 	SETTLEMENT_NOTE,
 	DETAIL_LIMIT,
 } from '#src/util/estimatedRepayments/estimatedRepaymentsConstants';
+import { parseMoney } from '#src/util/numberUtils';
 
 export default {
 	name: 'RepaymentsMonthDetail',
@@ -146,7 +147,7 @@ export default {
 			return row.totalRepayments != null && row.pastRepayments === row.totalRepayments;
 		},
 		promoText(row) {
-			if (!row.promoAmount || Number(row.promoAmount) <= 0) {
+			if (parseMoney(row.promoAmount) <= 0) {
 				return '';
 			}
 			const type = PROMO_TYPE_LABELS[row.promoType] || PROMO_CREDIT_FALLBACK_LABEL;

--- a/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
+++ b/src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.vue
@@ -102,6 +102,7 @@ import RepaymentsSummaryTable from '#src/components/Portfolio/EstimatedRepayment
 import RepaymentsMonthDetail from '#src/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail';
 import RepaymentsDisclaimer from '#src/components/Portfolio/EstimatedRepayments/RepaymentsDisclaimer';
 import logFormatter from '#src/util/logFormatter';
+import { parseMoney } from '#src/util/numberUtils';
 import expectedRepaymentsQuery from '#src/graphql/query/portfolio/estimatedRepayments.graphql';
 import expectedRepaymentsDetailQuery from '#src/graphql/query/portfolio/estimatedRepaymentsDetail.graphql';
 import {
@@ -230,8 +231,8 @@ export default {
 					if (!parts) {
 						return null;
 					}
-					const userRepayments = Number(item.userRepayments) || 0;
-					const promoRepayments = Number(item.promoRepayments) || 0;
+					const userRepayments = parseMoney(item.userRepayments);
+					const promoRepayments = parseMoney(item.promoRepayments);
 					// Build the Date from the already-parsed integer parts (local constructor,
 					// day 1) so formatting can't reintroduce the UTC-parse timezone shift that
 					// parseRepaymentDate avoids.

--- a/src/util/numberUtils.js
+++ b/src/util/numberUtils.js
@@ -1,3 +1,5 @@
+import numeral from 'numeral';
+
 /**
  * Returns whether the provided value is a number
  *
@@ -13,17 +15,19 @@ export function isNumber(value) {
 /**
  * Parses a GraphQL `Money` value into a JS number.
  *
- * The gateway serializes `Money` as a display-formatted string with thousands
- * separators (e.g. `'11,621.53'`), so a bare `Number()` returns `NaN` for any
- * value of 1,000 or more. Strip the separators before coercing.
+ * `Money` arrives as a display-formatted string (`'11,621.53'`), so plain
+ * coercion mangles it: `Number()` gives `NaN` at 1,000 and up, `parseFloat()`
+ * truncates at the comma. Uses `numeral` to match how the rest of the app
+ * parses Money.
  *
  * @param {string|number|null|undefined} value The `Money` value to parse
- * @returns {number} The parsed amount, or 0 when it isn't numeric
+ * @returns {number} The parsed amount, or 0 when it isn't a finite number
  */
 export function parseMoney(value) {
-	if (value === null || value === undefined || typeof value === 'boolean') return 0;
+	// numeral reads booleans as 1 and passes Infinity through; Money is neither.
+	if (typeof value === 'boolean') return 0;
 
-	const parsed = Number(String(value).replace(/,/g, ''));
+	const parsed = numeral(value).value();
 
 	return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/src/util/numberUtils.js
+++ b/src/util/numberUtils.js
@@ -1,5 +1,3 @@
-// TODO: remove eslint-disable when more exports are added
-
 /**
  * Returns whether the provided value is a number
  *
@@ -10,4 +8,22 @@ export function isNumber(value) {
 	if (value === '' || ['object', 'boolean'].includes(typeof value)) return false;
 
 	return !Number.isNaN(Number(value));
+}
+
+/**
+ * Parses a GraphQL `Money` value into a JS number.
+ *
+ * The gateway serializes `Money` as a display-formatted string with thousands
+ * separators (e.g. `'11,621.53'`), so a bare `Number()` returns `NaN` for any
+ * value of 1,000 or more. Strip the separators before coercing.
+ *
+ * @param {string|number|null|undefined} value The `Money` value to parse
+ * @returns {number} The parsed amount, or 0 when it isn't numeric
+ */
+export function parseMoney(value) {
+	if (value === null || value === undefined || typeof value === 'boolean') return 0;
+
+	const parsed = Number(String(value).replace(/,/g, ''));
+
+	return Number.isFinite(parsed) ? parsed : 0;
 }

--- a/test/unit/specs/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.spec.js
+++ b/test/unit/specs/components/Portfolio/EstimatedRepayments/RepaymentsMonthDetail.spec.js
@@ -17,10 +17,12 @@ const renderDetail = (props = {}) => render(RepaymentsMonthDetail, {
 	},
 });
 
+// Money fields are the display-formatted strings the gateway actually returns,
+// separators included, not plain JS numbers (MP-3138).
 const row = overrides => ({
-	amount: 50,
-	userAmount: 40,
-	promoAmount: 0,
+	amount: '50.00',
+	userAmount: '40.00',
+	promoAmount: '0.00',
 	promoType: null,
 	isDelinquent: false,
 	pastRepayments: 3,
@@ -42,23 +44,37 @@ describe('RepaymentsMonthDetail', () => {
 
 	it('maps the raw promoType enum to its human-readable label (legacy parity)', () => {
 		const { getByText } = renderDetail({
-			rows: [row({ promoAmount: 10, promoType: 'reward_credit' })],
+			rows: [row({ promoAmount: '10.00', promoType: 'reward_credit' })],
 		});
 		expect(getByText(/Includes \$10\.00 of bonus credit \(repaid to Kiva or sponsor\)/)).toBeTruthy();
 	});
 
 	it('maps the free_trial promoType to "free trial credit"', () => {
 		const { getByText } = renderDetail({
-			rows: [row({ promoAmount: 7.5, promoType: 'free_trial' })],
+			rows: [row({ promoAmount: '7.50', promoType: 'free_trial' })],
 		});
 		expect(getByText(/Includes \$7\.50 of free trial credit \(repaid to Kiva or sponsor\)/)).toBeTruthy();
 	});
 
 	it('falls back to a generic promo label for an unknown or missing promoType', () => {
 		const { getByText } = renderDetail({
-			rows: [row({ promoAmount: 5, promoType: 'something_new' })],
+			rows: [row({ promoAmount: '5.00', promoType: 'something_new' })],
 		});
 		expect(getByText(/of promotional credit/)).toBeTruthy();
+	});
+
+	it('shows the promo note for a comma-formatted promo amount', () => {
+		// Number('1,250.75') is NaN, and `NaN <= 0` is false, so a bare Number()
+		// check let this through but the amount itself rendered as NaN.
+		const { getByText } = renderDetail({
+			rows: [row({ amount: '2,000.00', promoAmount: '1,250.75', promoType: 'reward_credit' })],
+		});
+		expect(getByText(/Includes \$1,250\.75 of bonus credit \(repaid to Kiva or sponsor\)/)).toBeTruthy();
+	});
+
+	it('omits the promo note when the promo amount is zero', () => {
+		const { queryByText } = renderDetail({ rows: [row({ promoAmount: '0.00' })] });
+		expect(queryByText(/repaid to Kiva or sponsor/)).toBeNull();
 	});
 
 	it('flags delinquent and final repayments', () => {

--- a/test/unit/specs/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.spec.js
+++ b/test/unit/specs/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage.spec.js
@@ -4,12 +4,22 @@ import { flushPromises } from '@vue/test-utils';
 import numeral from 'numeral';
 import EstimatedRepaymentsPage from '#src/pages/Portfolio/EstimatedRepayments/EstimatedRepaymentsPage';
 
+// Mocks mirror what the gateway actually returns: `Date` as a full ISO datetime
+// and `Money` as a display-formatted string (thousands separators included), not
+// as plain JS numbers. See MP-3138 — mocking Money as a number hid a bug where
+// every month over $999.99 rendered as $0.00.
 const listResponse = (expectedRepayments = [
 	{
-		repaymentDate: '2026-07-01', userRepayments: 300, promoRepayments: 100, loansMakingRepayments: 6
+		repaymentDate: '2026-07-01T07:00:00Z',
+		userRepayments: '300.00',
+		promoRepayments: '100.00',
+		loansMakingRepayments: 6,
 	},
 	{
-		repaymentDate: '2026-08-01', userRepayments: 200, promoRepayments: 0, loansMakingRepayments: 4
+		repaymentDate: '2026-08-01T07:00:00Z',
+		userRepayments: '200.00',
+		promoRepayments: '0.00',
+		loansMakingRepayments: 4,
 	},
 ]) => ({
 	my: { id: 'my-1', userAccount: { id: 'ua-1', expectedRepayments } },
@@ -17,10 +27,10 @@ const listResponse = (expectedRepayments = [
 
 const julyDetail = [
 	{
-		repaymentDate: '2026-07-01',
-		amount: 50,
-		userAmount: 40,
-		promoAmount: 10,
+		repaymentDate: '2026-07-01T07:00:00Z',
+		amount: '50.00',
+		userAmount: '40.00',
+		promoAmount: '10.00',
 		promoType: 'reward_credit',
 		isDelinquent: false,
 		pastRepayments: 3,
@@ -28,10 +38,10 @@ const julyDetail = [
 		loan: { id: '123', name: 'Maria' },
 	},
 	{
-		repaymentDate: '2026-07-01',
-		amount: 25,
-		userAmount: 25,
-		promoAmount: 0,
+		repaymentDate: '2026-07-01T07:00:00Z',
+		amount: '25.00',
+		userAmount: '25.00',
+		promoAmount: '0.00',
 		promoType: null,
 		isDelinquent: true,
 		pastRepayments: 8,
@@ -42,10 +52,10 @@ const julyDetail = [
 
 const augustDetail = [
 	{
-		repaymentDate: '2026-08-01',
-		amount: 200,
-		userAmount: 200,
-		promoAmount: 0,
+		repaymentDate: '2026-08-01T07:00:00Z',
+		amount: '200.00',
+		userAmount: '200.00',
+		promoAmount: '0.00',
 		promoType: null,
 		isDelinquent: false,
 		pastRepayments: 1,
@@ -104,6 +114,36 @@ describe('EstimatedRepaymentsPage', () => {
 		// first (July) month detail auto-loaded
 		expect(getByText('Maria')).toBeTruthy();
 		expect(getByText('Estimated repayments due by Jul 1, 2026')).toBeTruthy();
+	});
+
+	it('sums comma-formatted Money amounts for large months', async () => {
+		// The gateway returns Money as a display-formatted string, so a super
+		// lender's months come back as e.g. '11,621.53'. Number() is NaN on those,
+		// which used to zero out every month over $999.99 while leaving smaller
+		// months correct — the "only some months are accurate" symptom. Real
+		// payload for lender 70846.
+		const { getByTestId, getAllByTestId } = renderPage({
+			expectedRepayments: [
+				{
+					repaymentDate: '2026-09-01T07:00:00Z',
+					userRepayments: '11,621.53',
+					promoRepayments: '0.55',
+					loansMakingRepayments: 2460,
+				},
+				{
+					repaymentDate: '2027-03-01T08:00:00Z',
+					userRepayments: '843.57',
+					promoRepayments: '0.55',
+					loansMakingRepayments: 248,
+				},
+			],
+		});
+		await waitFor(() => expect(getByTestId('repayments-summary-table')).toBeTruthy());
+		const rows = getAllByTestId(/^repayments-month-row-/);
+		// Above the separator: must be the real total, not $0.55.
+		expect(rows[0].textContent).toContain('$11,622.08');
+		// Below it: unchanged, so the fix can't be a no-op that only moves the bug.
+		expect(rows[1].textContent).toContain('$844.12');
 	});
 
 	it('renders the promo, delinquent, and final note flags (legacy parity)', async () => {
@@ -181,9 +221,9 @@ describe('EstimatedRepaymentsPage', () => {
 				const year = 2026 + Math.floor((7 + i) / 12);
 				const month = ((7 + i) % 12) + 1;
 				return {
-					repaymentDate: `${year}-${String(month).padStart(2, '0')}-01`,
-					userRepayments: 100 + i,
-					promoRepayments: 10,
+					repaymentDate: `${year}-${String(month).padStart(2, '0')}-01T07:00:00Z`,
+					userRepayments: `${100 + i}.00`,
+					promoRepayments: '10.00',
 					loansMakingRepayments: 2,
 				};
 			});
@@ -202,10 +242,10 @@ describe('EstimatedRepaymentsPage', () => {
 	it('flags truncation with the true total only when the server cap is actually hit', async () => {
 		// July summary reports 1200 loans; the capped detail returns exactly 500 rows.
 		const capped = Array.from({ length: 500 }, (unused, i) => ({
-			repaymentDate: '2026-07-01',
-			amount: 10,
-			userAmount: 10,
-			promoAmount: 0,
+			repaymentDate: '2026-07-01T07:00:00Z',
+			amount: '10.00',
+			userAmount: '10.00',
+			promoAmount: '0.00',
 			promoType: null,
 			isDelinquent: false,
 			pastRepayments: 1,
@@ -218,7 +258,10 @@ describe('EstimatedRepaymentsPage', () => {
 			}
 			return Promise.resolve({
 				data: listResponse([{
-					repaymentDate: '2026-07-01', userRepayments: 1, promoRepayments: 0, loansMakingRepayments: 1200,
+					repaymentDate: '2026-07-01T07:00:00Z',
+					userRepayments: '1.00',
+					promoRepayments: '0.00',
+					loansMakingRepayments: 1200,
 				}]),
 			});
 		});

--- a/test/unit/specs/util/numberUtils.spec.js
+++ b/test/unit/specs/util/numberUtils.spec.js
@@ -64,13 +64,23 @@ describe('numberUtils.js', () => {
 			expect(parseMoney(0)).toBe(0);
 		});
 
+		it('should parse the other formats numeral accepts', () => {
+			// parseMoney delegates to numeral, so these come for free — worth pinning
+			// so a future reimplementation can't silently drop them.
+			expect(parseMoney('$1,234.56')).toBe(1234.56);
+			expect(parseMoney('(1,234.56)')).toBe(-1234.56);
+		});
+
 		it('should fall back to 0 for non-numeric and absent values', () => {
 			expect(parseMoney(null)).toBe(0);
 			expect(parseMoney(undefined)).toBe(0);
 			expect(parseMoney('')).toBe(0);
 			expect(parseMoney('n/a')).toBe(0);
 			expect(parseMoney(NaN)).toBe(0);
+			// numeral passes these straight through; a Money value is never infinite,
+			// and letting one escape would poison every downstream total.
 			expect(parseMoney(Infinity)).toBe(0);
+			expect(parseMoney(-Infinity)).toBe(0);
 			expect(parseMoney(true)).toBe(0);
 			expect(parseMoney({})).toBe(0);
 		});

--- a/test/unit/specs/util/numberUtils.spec.js
+++ b/test/unit/specs/util/numberUtils.spec.js
@@ -1,4 +1,4 @@
-import { isNumber } from '#src/util/numberUtils';
+import { isNumber, parseMoney } from '#src/util/numberUtils';
 
 describe('numberUtils.js', () => {
 	describe('isNumber', () => {
@@ -45,6 +45,34 @@ describe('numberUtils.js', () => {
 		it('should handle scientific notation', () => {
 			expect(isNumber('1e5')).toBe(true);
 			expect(isNumber('1e-5')).toBe(true);
+		});
+	});
+
+	describe('parseMoney', () => {
+		it('should parse the formatted strings the gateway returns for Money', () => {
+			// A bare Number() is NaN on any of these (MP-3138).
+			expect(parseMoney('11,621.53')).toBe(11621.53);
+			expect(parseMoney('1,000')).toBe(1000);
+			expect(parseMoney('10,745,000.04')).toBe(10745000.04);
+		});
+
+		it('should parse unseparated strings and plain numbers', () => {
+			expect(parseMoney('843.57')).toBe(843.57);
+			expect(parseMoney('0.00')).toBe(0);
+			expect(parseMoney('-12.50')).toBe(-12.5);
+			expect(parseMoney(300)).toBe(300);
+			expect(parseMoney(0)).toBe(0);
+		});
+
+		it('should fall back to 0 for non-numeric and absent values', () => {
+			expect(parseMoney(null)).toBe(0);
+			expect(parseMoney(undefined)).toBe(0);
+			expect(parseMoney('')).toBe(0);
+			expect(parseMoney('n/a')).toBe(0);
+			expect(parseMoney(NaN)).toBe(0);
+			expect(parseMoney(Infinity)).toBe(0);
+			expect(parseMoney(true)).toBe(0);
+			expect(parseMoney({})).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-3138

Turns out a didn't test the migrated page with a user with large enough lending history... Simple money parsing fix.