### PR TITLE
fix: host estimated repayments page

### DIFF
--- a/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
+++ b/src/util/estimatedRepayments/estimatedRepaymentsConstants.js
@@ -1,11 +1,11 @@
-// Route path, chart palette, and legacy copy for the estimated-repayments beta page.
+// Route path, chart palette, and legacy copy for the estimated-repayments page.
 // Colours mirror the legacy stacked chart's two series and were validated (dataviz
 // skill) for colour-blind separation and surface contrast in light and dark modes.
 import kvTokensPrimitives from '@kiva/kv-tokens';
 
 const { colors } = kvTokensPrimitives;
 
-export const ESTIMATED_REPAYMENTS_ROUTE = '/portfolio/estimated-repayments-beta';
+export const ESTIMATED_REPAYMENTS_ROUTE = '/portfolio/estimated-repayments';
 
 // The legacy detail query caps the per-month loan list; surface a truncation notice
 // when the returned list reaches this size. Mirrors the resolver's default limit.


### PR DESCRIPTION
Number parsing issue fixed and tested on dev, now `ui` can host this file again, here's the first step.