### PR TITLE
feat: [MP-3131] auto-open badge claim modal from marketing email link

### DIFF
--- a/src/pages/Portfolio/LendingStats/BadgesList.vue
+++ b/src/pages/Portfolio/LendingStats/BadgesList.vue
@@ -103,6 +103,14 @@ export default {
 			getLoanFindingUrl,
 		};
 	},
+	watch: {
+		completedAchievements: {
+			immediate: true,
+			handler() {
+				this.autoOpenBadgeFromEmail();
+			},
+		},
+	},
 	computed: {
 		sortedTieredBadges() {
 			const tieredBadges = [];
@@ -137,6 +145,19 @@ export default {
 		},
 	},
 	methods: {
+		autoOpenBadgeFromEmail() {
+			const campaign = this.$route?.query?.utm_campaign ?? '';
+			if (!campaign.startsWith('badge_')) {
+				return;
+			}
+			const badgeId = campaign.slice('badge_'.length);
+			const badge = this.completedAchievements.find(b => b.id === badgeId);
+			if (!badge) {
+				return;
+			}
+			this.selectedBadgeData = badge;
+			this.showBadgeModal = true;
+		},
 		navigateToLoanFindingUrl(id) {
 			const loanFindingUrl = this.getLoanFindingUrl(id, this.$router.currentRoute.value);
 			if (loanFindingUrl) {

--- a/test/unit/specs/pages/Portfolio/LendingStats/BadgesList.spec.js
+++ b/test/unit/specs/pages/Portfolio/LendingStats/BadgesList.spec.js
@@ -1,0 +1,113 @@
+import { render, waitFor } from '@testing-library/vue';
+import BadgesList from '#src/pages/Portfolio/LendingStats/BadgesList';
+import { STATE_EARNED } from '#src/composables/useBadgeModal';
+
+const flushPromises = () => new Promise(resolve => { setTimeout(resolve); });
+
+const eventBadge = (id = 'stewardship-2026') => ({
+	id,
+	level: 0,
+	earnedAtDate: '2026-08-21',
+	challengeName: 'Stewardship',
+	achievementData: { tiers: [] },
+});
+
+// Only completedAchievements varies between rerenders; the other props stay put.
+const rerenderWith = (rerender, completedAchievements) => rerender({
+	completedAchievements,
+	isLoading: false,
+	loans: [],
+	badgesData: [],
+});
+
+const renderBadgesList = ({ completedAchievements = [], query = {} } = {}) => {
+	return render(BadgesList, {
+		props: {
+			completedAchievements,
+			isLoading: false,
+			loans: [],
+			badgesData: [],
+		},
+		global: {
+			provide: {
+				apollo: { query: () => Promise.resolve({}) },
+			},
+			directives: { kvTrackEvent: () => {} },
+			mocks: {
+				$kvTrackEvent: () => {},
+				$router: { push: () => {}, currentRoute: { value: { query } } },
+				$route: { query },
+			},
+			stubs: {
+				BadgeCard: { name: 'BadgeCard', props: ['badge'], template: '<div />' },
+				JourneySideSheet: { name: 'JourneySideSheet', template: '<div />' },
+				KvLoadingPlaceholder: { name: 'KvLoadingPlaceholder', template: '<div />' },
+				BadgeModal: {
+					name: 'BadgeModal',
+					props: ['show', 'badge', 'state', 'tier', 'isEarnedSection'],
+					template: `<div
+						data-testid="badge-modal"
+						:data-badge-id="badge && badge.id"
+						:data-state="state"
+					/>`,
+				},
+			},
+		},
+	});
+};
+
+describe('BadgesList email-link auto-open', () => {
+	it('auto-opens the earned badge modal when arriving via the badge email link', async () => {
+		const { queryByTestId } = renderBadgesList({
+			completedAchievements: [eventBadge('stewardship-2026')],
+			query: { utm_campaign: 'badge_stewardship-2026' },
+		});
+
+		await waitFor(() => expect(queryByTestId('badge-modal')).toBeTruthy());
+		expect(queryByTestId('badge-modal').getAttribute('data-badge-id')).toBe('stewardship-2026');
+		expect(queryByTestId('badge-modal').getAttribute('data-state')).toBe(STATE_EARNED);
+	});
+
+	it('does not auto-open on an ordinary visit without the email param', async () => {
+		const { queryByTestId } = renderBadgesList({
+			completedAchievements: [eventBadge('stewardship-2026')],
+			query: {},
+		});
+
+		await flushPromises();
+		expect(queryByTestId('badge-modal')).toBeNull();
+	});
+
+	it('does not auto-open when the user does not own the linked badge', async () => {
+		const { queryByTestId } = renderBadgesList({
+			completedAchievements: [eventBadge('some-other-badge')],
+			query: { utm_campaign: 'badge_stewardship-2026' },
+		});
+
+		await flushPromises();
+		expect(queryByTestId('badge-modal')).toBeNull();
+	});
+
+	it('does not auto-open for a share campaign that merely contains "badge_"', async () => {
+		const { queryByTestId } = renderBadgesList({
+			completedAchievements: [eventBadge('equity')],
+			query: { utm_campaign: 'social_share_portfolio_badge_equity' },
+		});
+
+		await flushPromises();
+		expect(queryByTestId('badge-modal')).toBeNull();
+	});
+
+	it('auto-opens once the badges finish loading after mount', async () => {
+		const { queryByTestId, rerender } = renderBadgesList({
+			completedAchievements: [],
+			query: { utm_campaign: 'badge_stewardship-2026' },
+		});
+
+		expect(queryByTestId('badge-modal')).toBeNull();
+
+		await rerenderWith(rerender, [eventBadge('stewardship-2026')]);
+
+		await waitFor(() => expect(queryByTestId('badge-modal')).toBeTruthy());
+	});
+});


### PR DESCRIPTION
## Summary

On the portfolio **Lending stats** page, auto-open the existing celebratory badge modal when a user arrives from the marketing "claim" email. Marketing links to `/portfolio/lending-stats?utm_campaign=badge_<id>`; on arrival the badge is resolved by ownership and the existing `BadgeModal` → `BadgeCompleted` (badge art, confetti, share CTA) opens automatically. There is no real "claim" — the modal is celebratory only, and the badge continues to render normally in the Achievements section.

The whole change lives in `BadgesList.vue`, which already hosts `BadgeModal` and its open state — a `watch` on `completedAchievements` plus a small `autoOpenBadgeFromEmail()` method.

## Approach / decisions

- **Ownership self-guard.** The modal opens only if the `<id>` from the link resolves to a badge the user actually owns (`completedAchievements.find`). Ordinary visits (no param) and users without the badge are unaffected. The watcher is `immediate` and fires again when the async badge data lands, so a link that arrives before the data is ready still opens once the badge loads.
- **Prefix match, not substring.** `utm_campaign.startsWith('badge_')` (then `slice`) is used instead of a `split('badge_')` substring, so the share-button campaign `social_share_portfolio_badge_<id>` (which embeds `badge_` mid-string and targets `/lender/...`) is correctly excluded.
- **Non-tiered event badge.** Manual badges (MP-3127) are non-tiered, so the modal opens in the earned/celebratory state via the component's existing `data()` defaults (`state: STATE_EARNED`, `tier: null`) — no extra assignment needed.
- **No click analytics on auto-open.** The auto-open sets the modal state directly rather than reusing `handleBadgeClicked` (which fires a `click` event). The `badge-claim-modal` **view** event is scoped to MP-3132.

## Out of scope (separate tickets)

- **MP-3132** — `portfolio / view / badge-claim-modal / {badge_name}` analytics view event (blocked on this PR).
- **MP-3133** — end-to-end Playwright tests for the flow (blocked on this PR).

## Related

- Jira story: **MP-3131**
- Epic: **MP-2999** (Stewardship experiment)
- Depends on: **MP-3127** — bulk manual grant (`bulkGrantManualAchievement`), merged & in QA. A manually-granted badge reads back identically to an auto-earned one (COMPLETE, earned date set).

## Related tests

`test/unit/specs/pages/Portfolio/LendingStats/BadgesList.spec.js` (5 cases):
1. Auto-opens the earned badge modal when arriving via the badge email link.
2. Does not auto-open on an ordinary visit without the email param.
3. Does not auto-open when the user does not own the linked badge.
4. Does not auto-open for a share campaign that merely contains `badge_` (prefix guard).
5. Auto-opens once the badges finish loading after mount.

## Dev verification

1. Log in as a user who has been granted the `equity` badge (via MP-3127) and has a matching Contentful `challenge` entry.
2. Visit: `https://kiva-ui.local/portfolio/lending-stats?utm_campaign=badge_equity`
   - The celebratory badge modal should auto-open (badge image, confetti, Share button).
3. Visit `https://kiva-ui.local/portfolio/lending-stats` (no query string) — the modal should **not** auto-open, and the badge should still appear in the "My Achievements" section.

_If the modal does not open, it is almost always a data precondition (badge not granted to that user, or no matching Contentful entry), not the wiring — the ownership guard intentionally stays silent in those cases._
