### PR TITLE
fix(SummaryCard): show the borrower's city for lending partner loans AD-440

### DIFF
--- a/.storybook/stories/BorrowerProfile/SummaryCard.stories.js
+++ b/.storybook/stories/BorrowerProfile/SummaryCard.stories.js
@@ -7,6 +7,7 @@ import {
 	createQueryResult,
 	loggedInUser,
 	fundraisingPartnerLoan,
+	longLocationPartnerLoan,
 	fullyFundedLoan,
 	payingBackLoan,
 	overpaidPayingBackLoan,
@@ -40,6 +41,9 @@ export default {
 };
 
 export const Fundraising = summaryCardStory(fundraisingPartnerLoan, loggedInUser);
+
+export const LongLocation = summaryCardStory(longLocationPartnerLoan, loggedInUser);
+LongLocation.storyName = 'Long location';
 
 export const FullyFunded = summaryCardStory(fullyFundedLoan);
 

--- a/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
+++ b/.storybook/stories/BorrowerProfile/mockLoanFixtures.js
@@ -402,6 +402,15 @@ export const longTeamNameCommentsLoan = createMockLoan({
 	},
 });
 
+/** Partner loan whose city is long enough to wrap inside the location pill. */
+export const longLocationPartnerLoan = createMockLoan({
+	geocode: {
+		city: 'Sralab, Sralab, Tboung Khmum, Tboung Khmum Cambodian District Tboung Khmum',
+		country: { name: 'Cambodia', isoCode: 'KH', __typename: 'Country' },
+		__typename: 'Geocode',
+	},
+});
+
 /**
  * A partner loan's repayment periods, covering every way a period can present:
  * received, delinquent with an attribution, delinquent with currency loss, and upcoming.

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -61,7 +61,13 @@
 					<a
 						v-if="totalComments > 0"
 						href="#bp-comments-jump-link"
-						class="tw-inline-block tw-text-black hover:tw-text-black"
+						class="
+							tw-inline-flex tw-items-center
+							tw-rounded tw-p-1
+							tw-text-upper tw-no-underline hover:tw-no-underline
+							tw-text-black hover:tw-text-black
+							tw-bg-brand-100 hover:tw-bg-brand-200
+						"
 						v-kv-track-event="[
 							'borrower-profile',
 							'click',
@@ -69,12 +75,10 @@
 							'comments-pill'
 						]"
 					>
-						<summary-tag class="hover:tw-bg-brand-200 tw-mr-0" background-color="tw-bg-brand-100">
-							<heart-comment class="tw-h-3 tw-w-3 tw-mr-0.5 heart-svg" />
-							<span class="tw-flex-1">
-								{{ totalComments }} Comment{{ totalComments > 1 ? 's' : '' }}
-							</span>
-						</summary-tag>
+						<heart-comment class="tw-h-3 tw-w-3 tw-mr-0.5 heart-svg" />
+						<span class="tw-flex-1">
+							{{ totalComments }} Comment{{ totalComments > 1 ? 's' : '' }}
+						</span>
 					</a>
 					<loan-progress
 						data-testid="bp-summary-progress"
@@ -109,7 +113,7 @@
 				Learn more
 			</kv-text-link>
 		</p>
-		<div class="tw-flex-auto tw-inline-flex tw-w-full">
+		<div class="tw-flex-auto tw-inline-flex tw-flex-wrap tw-gap-2 tw-w-full">
 			<template v-if="isLoading">
 				<kv-loading-placeholder class="tw-h-4" :style="{width: '50%'}" />
 			</template>
@@ -321,6 +325,9 @@ export default {
 			if (this.countryName === 'Puerto Rico') {
 				const formattedString = `${this.city}, PR`;
 				return formattedString;
+			}
+			if (this.city) {
+				return `${this.city}, ${this.countryName}`;
 			}
 			return this.countryName;
 		}

--- a/src/components/BorrowerProfile/SummaryTag.vue
+++ b/src/components/BorrowerProfile/SummaryTag.vue
@@ -1,7 +1,10 @@
 <template>
 	<p
-		:class="`${backgroundColor}`"
-		class="tw-rounded tw-p-1 tw-mb-0 tw-mr-2 tw-text-upper tw-inline-flex tw-items-center"
+		class="
+			tw-rounded tw-p-1 tw-mb-0
+			tw-bg-secondary tw-text-upper
+			tw-inline-flex tw-items-center
+		"
 	>
 		<slot></slot>
 	</p>
@@ -10,11 +13,5 @@
 <script>
 export default {
 	name: 'SummaryTag',
-	props: {
-		backgroundColor: {
-			type: String,
-			default: 'tw-bg-secondary',
-		},
-	}
 };
 </script>

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -44,9 +44,6 @@
 				<div v-if="countryName">
 					<summary-tag
 						class="tw-absolute tw-bottom-2 tw-left-1 tw-text-primary"
-						:city="city"
-						:state="state"
-						:country-name="countryName"
 					>
 						<kv-material-icon
 							class="tw-h-2.5 tw-w-2.5 tw-mr-0.5"

--- a/src/components/LoanCards/NewHomePageLoanCard.vue
+++ b/src/components/LoanCards/NewHomePageLoanCard.vue
@@ -42,7 +42,6 @@
 				<div v-if="countryName">
 					<summary-tag
 						class="tw-absolute tw-bottom-2 tw-left-1 tw-text-primary"
-						:country-name="countryName"
 					>
 						<kv-material-icon
 							class="tw-h-2.5 tw-w-2.5 tw-mr-0.5"

--- a/src/pages/InstantActions/ProcessInstantLending.vue
+++ b/src/pages/InstantActions/ProcessInstantLending.vue
@@ -75,9 +75,6 @@
 						<div v-if="countryName">
 							<summary-tag
 								class="tw-absolute tw-bottom-1 tw-left-1 tw-text-primary"
-								:city="city"
-								:state="state"
-								:country-name="countryName"
 							>
 								<kv-material-icon
 									class="tw-h-2.5 tw-w-2.5 tw-mr-0.5"

--- a/test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js
+++ b/test/unit/specs/components/BorrowerProfile/SummaryCard.spec.js
@@ -3,7 +3,7 @@ import { mount } from '@vue/test-utils';
 import SummaryCard from '#src/components/BorrowerProfile/SummaryCard';
 import { globalOptions, routerLinkStub } from '../../../specUtils';
 
-function mountSummaryCard({ anonymizationLevel } = {}) {
+function mountSummaryCard({ anonymizationLevel, distributionModel, geocode } = {}) {
 	const openDefinition = vi.fn();
 	const wrapper = mount(SummaryCard, {
 		props: {
@@ -12,6 +12,8 @@ function mountSummaryCard({ anonymizationLevel } = {}) {
 				name: 'Test Borrower',
 				fullLoanUse: 'A loan of $600 helps...',
 				anonymizationLevel,
+				distributionModel,
+				geocode,
 			},
 		},
 		global: {
@@ -65,5 +67,38 @@ describe('SummaryCard anonymization affordances', () => {
 
 		expect(wrapper.find('[data-testid="bp-summary-pii-info"]').exists()).toBe(false);
 		expect(wrapper.find('[data-testid="bp-summary-anonymous-learn-more"]').exists()).toBe(true);
+	});
+});
+
+describe('SummaryCard location line', () => {
+	it.each([
+		{
+			case: 'partner loan with a city',
+			distributionModel: 'partner',
+			geocode: { city: 'Nyamira', state: '', country: { name: 'Kenya' } },
+			expected: 'Nyamira, Kenya',
+		},
+		{
+			case: 'partner loan with no city',
+			distributionModel: 'partner',
+			geocode: { city: '', state: '', country: { name: 'Kenya' } },
+			expected: 'Kenya',
+		},
+		{
+			case: 'direct loan',
+			distributionModel: 'direct',
+			geocode: { city: 'Portland', state: 'Oregon', country: { name: 'United States' } },
+			expected: 'Portland, Oregon, United States',
+		},
+		{
+			case: 'Puerto Rico partner loan',
+			distributionModel: 'partner',
+			geocode: { city: 'San Juan', state: 'PR', country: { name: 'Puerto Rico' } },
+			expected: 'San Juan, PR',
+		},
+	])('formats the location of a $case as $expected', ({ distributionModel, geocode, expected }) => {
+		const { wrapper } = mountSummaryCard({ distributionModel, geocode });
+
+		expect(wrapper.find('[data-testid="bp-summary-country-tag"]').text()).toBe(expected);
 	});
 });


### PR DESCRIPTION
The classic loan view includes the loan's city regardless of loan type, but the current borrower profile only shows the city for direct loans and Puerto Rico. Product says this info should continue to be available, so this PR adds the city back for all loans. The design direction has been approved for now, but the internal wrapping that occurs with long city names and small screens is not ideal, so it may be redesigned in the future.

<img width="1110" height="513" alt="Screenshot 2026-08-19 at 5 01 41 PM" src="https://github.com/user-attachments/assets/cb6a1322-e2e2-496c-b60a-638854a5902c" />
<img width="662" height="430" alt="Screenshot 2026-08-19 at 5 05 37 PM" src="https://github.com/user-attachments/assets/3b563a27-7a58-464f-895c-ea7fd811a7a4" />

I cleaned up the usage of SummaryTag, as it was being passed properties it didn't have anymore, and there was one spot where the usage of it was causing incorrect `<p>` inside `<a>` markup.