### PR TITLE
fix(borrower-profile): show the full loan view to volunteers CIT-4820

### DIFF
--- a/src/pages/BorrowerProfile/BorrowerProfile.vue
+++ b/src/pages/BorrowerProfile/BorrowerProfile.vue
@@ -39,7 +39,7 @@ import FullBorrowerProfile, { fullProfileQuery } from '#src/components/BorrowerP
 import { shareButtonFragment } from '#src/components/BorrowerProfile/ShareButton';
 import { fireHotJarEvent } from '#src/util/hotJarUtils';
 import { readAccountRailPreference, resolveRailPreference } from '#src/util/loanDetailsRailPreference';
-import { isPublicLoanStatus } from '#src/util/loanUtils';
+import { isPublicLoanStatus, showFullView } from '#src/util/loanUtils';
 import { getKivaImageUrl } from '@kiva/kv-components';
 
 const getPublicId = route => route?.query?.utm_content ?? route?.query?.name ?? route?.query?.lender ?? '';
@@ -123,6 +123,13 @@ const routingQuery = gql`
 			lender(publicId: $publicId) {
 				id
 				name
+			}
+		}
+		my {
+			id
+			userAccount {
+				id
+				volunteerId
 			}
 		}
 		shop(basketId: $basketId) {
@@ -241,6 +248,7 @@ export default {
 			loan: {},
 			routingLoan: {},
 			lender: {},
+			isVolunteer: false,
 			// SSR-resolved rail preference (logged-in only); reconciled client-side in the component.
 			initialShowDetailsInRail: false,
 			inviterName: '',
@@ -284,11 +292,11 @@ export default {
 
 					// Routing decision
 					const unreservedAmount = Number(loan.unreservedAmount ?? 0);
-					const minimalOverride = route.query?.minimal === 'false';
 					const isPrivileged = loan.userProperties?.isPrivileged ?? false;
+					const isVolunteer = !!data?.my?.userAccount?.volunteerId;
 
 					// Anon goes to login (so a lender/trustee can authenticate in); logged-in non-priv goes to /lend.
-					if (!isPublicLoanStatus(loan.status) && !isPrivileged) {
+					if (!isPublicLoanStatus(loan.status) && !isPrivileged && !isVolunteer) {
 						if (!kvAuth0?.getKivaId()) {
 							return Promise.reject({
 								path: '/ui-login',
@@ -298,11 +306,13 @@ export default {
 						return Promise.reject({ path: '/lend', query: route.query });
 					}
 
-					const showFullView = (unreservedAmount > 0 && loan.status === 'fundraising')
-						|| isPrivileged
-						|| minimalOverride;
-
-					const childQuery = showFullView ? fullProfileQuery : minimalProfileQuery;
+					const childQuery = showFullView(
+						loan.status,
+						unreservedAmount,
+						isPrivileged,
+						isVolunteer,
+						route.query,
+					) ? fullProfileQuery : minimalProfileQuery;
 
 					return Promise.all([
 						client.query({
@@ -357,6 +367,7 @@ export default {
 			}
 			this.loan = fullLoan ?? routingLoan;
 			this.routingLoan = routingLoan;
+			this.isVolunteer = !!result?.data?.my?.userAccount?.volunteerId;
 			this.inviterName = this.inviterIsGuestOrAnonymous
 				? '' : result?.data?.community?.lender?.name ?? '';
 			this.itemsInBasket = result?.data?.shop?.basket?.items?.values ?? [];
@@ -411,11 +422,13 @@ export default {
 			return this.loan?.userProperties?.isPrivileged ?? false;
 		},
 		showFullView() {
-			// Fully-reserved fundraising loans (unreservedAmount === 0) show the minimal view
-			// for non-privileged users since there's nothing left to lend.
-			return (this.unreservedAmount > 0 && this.loan?.status === 'fundraising')
-				|| this.isPrivileged
-				|| this.$route.query.minimal === 'false';
+			return showFullView(
+				this.loan?.status,
+				this.unreservedAmount,
+				this.isPrivileged,
+				this.isVolunteer,
+				this.$route.query,
+			);
 		},
 		loanType() {
 			// eslint-disable-next-line no-underscore-dangle

--- a/src/util/loanUtils.js
+++ b/src/util/loanUtils.js
@@ -61,6 +61,25 @@ export function isPublicLoanStatus(status) {
 }
 
 /**
+ * Returns true if the borrower profile should render the full view instead of the minimal view.
+ * Fully-reserved fundraising loans (unreservedAmount === 0) show the minimal view
+ * for non-privileged, non-volunteer users since there's nothing left to lend.
+ *
+ * @param {string} status loan status
+ * @param {number} unreservedAmount amount of the loan not yet funded or reserved
+ * @param {boolean} isPrivileged viewer has privileged access to the loan
+ * @param {boolean} isVolunteer viewer is a Kiva volunteer
+ * @param {object} routeQuery current route query params
+ * @returns {boolean}
+ */
+export function showFullView(status, unreservedAmount, isPrivileged, isVolunteer, routeQuery) {
+	return (unreservedAmount > 0 && status === FUNDRAISING)
+		|| isPrivileged
+		|| isVolunteer
+		|| routeQuery?.minimal === 'false';
+}
+
+/**
  * Returns the why special string for the loan if it is defined
  *
  * @param {string} whySpecial from LoanBasic.whySpecial

--- a/test/unit/specs/pages/BorrowerProfile/BorrowerProfile.spec.js
+++ b/test/unit/specs/pages/BorrowerProfile/BorrowerProfile.spec.js
@@ -16,8 +16,13 @@ describe('BorrowerProfile.apollo.preFetch', () => {
 		userProperties: { isPrivileged },
 	});
 
-	const makeClient = loan => ({
-		query: vi.fn().mockResolvedValue({ data: { lend: { loan } } }),
+	const makeClient = (loan, my = null) => ({
+		query: vi.fn().mockResolvedValue({ data: { lend: { loan }, my } }),
+	});
+
+	const makeMy = ({ volunteerId = null } = {}) => ({
+		id: 1,
+		userAccount: { id: 2, volunteerId },
 	});
 
 	const makeContext = ({ kivaId } = {}) => ({
@@ -97,4 +102,38 @@ describe('BorrowerProfile.apollo.preFetch', () => {
 			expect(getChildProfileOperationName(client)).toBe(expectedOperation);
 		}
 	);
+
+	it.each(RESTRICTED_STATUSES)(
+		'allows volunteer viewers to load restricted status %s (CIT-4820)',
+		async status => {
+			const client = makeClient(makeLoan(status), makeMy({ volunteerId: 987 }));
+			const context = makeContext({ kivaId: 'auth0|abc' });
+
+			await expect(BorrowerProfile.apollo.preFetch({}, client, context)).resolves.toBeDefined();
+		}
+	);
+
+	it.each([
+		'funded',
+		'fundraising',
+	])(
+		'routes volunteer viewers to the full profile for a fully-reserved %s loan (CIT-4820)',
+		async status => {
+			const client = makeClient(makeLoan(status, { unreservedAmount: '0' }), makeMy({ volunteerId: 987 }));
+			const context = makeContext({ kivaId: 'auth0|abc' });
+
+			await BorrowerProfile.apollo.preFetch({}, client, context);
+
+			expect(getChildProfileOperationName(client)).toBe('fullBorrowerProfileData');
+		}
+	);
+
+	it('routes logged-in non-volunteer viewers to the minimal profile for a fully-reserved funded loan', async () => {
+		const client = makeClient(makeLoan('funded', { unreservedAmount: '0' }), makeMy());
+		const context = makeContext({ kivaId: 'auth0|abc' });
+
+		await BorrowerProfile.apollo.preFetch({}, client, context);
+
+		expect(getChildProfileOperationName(client)).toBe('minimalBorrowerProfileData');
+	});
 });

--- a/test/unit/specs/util/loanUtils.spec.js
+++ b/test/unit/specs/util/loanUtils.spec.js
@@ -20,6 +20,7 @@ import {
 	isBetween25And500,
 	isActivelyInPfp,
 	isPublicLoanStatus,
+	showFullView,
 } from '#src/util/loanUtils';
 
 describe('loanUtils.js', () => {
@@ -996,6 +997,42 @@ describe('loanUtils.js', () => {
 			'reviewed', 'deleted', 'issue', 'inactive', 'inactiveExpired',
 		])('should return false for restricted status %s', status => {
 			expect(isPublicLoanStatus(status)).toBe(false);
+		});
+	});
+
+	describe('showFullView', () => {
+		it('should return true for a fundraising loan with unreserved amount remaining', () => {
+			expect(showFullView('fundraising', 400, false, false, {})).toBe(true);
+		});
+
+		it('should return false for a fully-reserved fundraising loan', () => {
+			expect(showFullView('fundraising', 0, false, false, {})).toBe(false);
+		});
+
+		it.each([
+			'funded', 'raised', 'expired', 'payingBack', 'refunded', 'ended', 'defaulted',
+		])('should return false for non-fundraising status %s', status => {
+			expect(showFullView(status, 400, false, false, {})).toBe(false);
+		});
+
+		it('should return true for privileged viewers regardless of status and amount', () => {
+			expect(showFullView('funded', 0, true, false, {})).toBe(true);
+		});
+
+		it('should return true for volunteer viewers regardless of status and amount', () => {
+			expect(showFullView('funded', 0, false, true, {})).toBe(true);
+		});
+
+		it('should return true when the minimal=false query override is set', () => {
+			expect(showFullView('funded', 0, false, false, { minimal: 'false' })).toBe(true);
+		});
+
+		it.each([
+			['minimal=true', { minimal: 'true' }],
+			['no minimal param', {}],
+			['an undefined query', undefined],
+		])('should return false with %s and no other full-view condition', (label, routeQuery) => {
+			expect(showFullView('funded', 0, false, false, routeQuery)).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
Volunteers have access to loan data in all states, so they should get the full borrower profile view by default for all statuses. The user's volunteer status is not being checked, so volunteers are mistakenly being shown the minimal view first, putting an extra click between them and the full profile. This PR fixes that by getting the volunteer ID for the current user (which is null if they are not a volunteer) and checking that when deciding to show the full or minimal view. I also extracted the logic for that decision to a testable utility method so that there aren't divergences between the prefetch and mounted view behavior (AD-320).