### PR TITLE
fix: [MP-3148] - set a new `updatedAt` field in MyKivaGoal setting

### DIFF
--- a/src/composables/useGoalData.js
+++ b/src/composables/useGoalData.js
@@ -714,7 +714,14 @@ export default function useGoalData({ apollo } = {}) {
 		const goals = parsedPrefs.goals || [];
 		const goalIndex = goals.findIndex(g => g.goalName === previousGoal.goalName);
 		if (goalIndex !== -1) {
-			goals[goalIndex] = { ...updatedGoal };
+			// Editing a goal must not reset its start date. `dateStarted` is the goal's
+			// created date — the recap and the past-goals list key off it — so
+			// preserve the stored value and record the edit moment separately in `updatedAt`.
+			goals[goalIndex] = {
+				...updatedGoal,
+				dateStarted: goals[goalIndex].dateStarted ?? updatedGoal.dateStarted,
+				updatedAt: new Date().toISOString(),
+			};
 		}
 
 		// If the updated category is support-all, we need to load the latest yearly loan count to set accurate progress

--- a/test/unit/specs/composables/useGoalData.spec.js
+++ b/test/unit/specs/composables/useGoalData.spec.js
@@ -1439,6 +1439,53 @@ describe('useGoalData', () => {
 			// Validate the new progress is user total loans
 			expect(composable.goalProgress.value).toBe(yearlyLoanCount);
 		});
+
+		it('preserves the original dateStarted and records updatedAt on edit (MP-3148)', async () => {
+			const mockPrefs = {
+				goals: [
+					{
+						goalName: 'goal-to-edit',
+						category: ID_WOMENS_EQUALITY,
+						target: 5,
+						status: GOAL_STATUS.IN_PROGRESS,
+						dateStarted: '2026-01-01T00:00:00.000Z',
+					},
+				],
+			};
+
+			mockApollo.query = vi.fn()
+				.mockResolvedValueOnce({
+					data: {
+						my: {
+							userPreferences: { id: '1', preferences: JSON.stringify(mockPrefs) },
+							loans: { totalCount: 0 },
+						},
+					},
+				})
+				.mockResolvedValueOnce({
+					data: { userAchievementProgress: { tieredLendingAchievements: [] } },
+				});
+
+			await composable.loadGoalData();
+
+			const previousGoal = { ...mockPrefs.goals[0] };
+			// The goal-setting modal always sends a fresh dateStarted (= "now") on save;
+			// on an edit that later date must be ignored in favor of the created one.
+			const updatedGoal = {
+				...mockPrefs.goals[0],
+				target: 20,
+				dateStarted: '2026-07-15T00:00:00.000Z',
+			};
+
+			await composable.updateCurrentGoal(previousGoal, updatedGoal);
+
+			expect(composable.userGoal.value.target).toBe(20);
+			// dateStarted stays the original created date, not the edit date
+			expect(composable.userGoal.value.dateStarted).toBe('2026-01-01T00:00:00.000Z');
+			// updatedAt captures the edit as a valid ISO timestamp
+			expect(composable.userGoal.value.updatedAt).toEqual(expect.any(String));
+			expect(Number.isNaN(Date.parse(composable.userGoal.value.updatedAt))).toBe(false);
+		});
 	});
 
 	describe('checkCompletedGoal', () => {


### PR DESCRIPTION
# MP-3148

## Summary

add a new `updatedAt` field in MyKivaGoal setting to fix bug https://kiva.atlassian.net/browse/MP-3148

## Evidences

https://github.com/user-attachments/assets/59db6870-e84d-47bd-b352-6ab13b2ba216

