### PR TITLE
fix: [MP-3143] - hide goal recap CTA in BadgesV2 after March 01

### DIFF
--- a/src/composables/useGoalInReview.js
+++ b/src/composables/useGoalInReview.js
@@ -36,7 +36,14 @@ export function getGoalInReviewNow() {
 	if (typeof window !== 'undefined') {
 		const param = new URLSearchParams(window.location.search).get('recapDate');
 		if (param) {
-			const override = new Date(param);
+			// Parse a bare YYYY-MM-DD as LOCAL midnight, not UTC. `new Date('2027-04-01')` is
+			// UTC per spec, which in a negative-offset zone (e.g. America/Los_Angeles) lands on
+			// the previous evening — pushing the effective "now" a day back and breaking the
+			// March-31 recap cutoff and the year-boundary checks in QA. Anything with
+			// an explicit time is left as-is.
+			const override = /^\d{4}-\d{2}-\d{2}$/.test(param)
+				? new Date(`${param}T00:00:00`)
+				: new Date(param);
 			if (!Number.isNaN(override.getTime())) {
 				return override;
 			}

--- a/test/unit/specs/composables/useGoalInReview.spec.js
+++ b/test/unit/specs/composables/useGoalInReview.spec.js
@@ -1,4 +1,5 @@
 import useGoalInReview, {
+	getGoalInReviewNow,
 	getGoalInReviewTargetYear,
 } from '#src/composables/useGoalInReview';
 
@@ -67,6 +68,30 @@ describe('useGoalInReview', () => {
 
 	it('defaults the target year from the provided date', () => {
 		expect(getGoalInReviewTargetYear(new Date('2028-03-01T00:00:00Z'))).toBe(2028);
+	});
+
+	describe('recapDate override (getGoalInReviewNow)', () => {
+		afterEach(() => {
+			// Clear the recapDate so it never leaks into the other tests' "now".
+			window.history.pushState({}, '', '/');
+		});
+
+		it('parses a bare recapDate as a local calendar day, not UTC (MP-3143)', () => {
+			window.history.pushState({}, '', '/?recapDate=2027-04-01');
+			// Local April 1 midnight. A UTC parse would land on Mar 31 evening in a
+			// negative-offset zone and slip past the March-31 recap cutoff a day late.
+			expect(getGoalInReviewNow().getTime()).toBe(new Date(2027, 3, 1).getTime());
+		});
+
+		it('keeps the year on a Jan 1 recapDate in any timezone (MP-3143)', () => {
+			window.history.pushState({}, '', '/?recapDate=2027-01-01');
+			expect(getGoalInReviewTargetYear()).toBe(2027);
+		});
+
+		it('leaves a recapDate with an explicit time unchanged', () => {
+			window.history.pushState({}, '', '/?recapDate=2027-04-01T12:00:00Z');
+			expect(getGoalInReviewNow().getTime()).toBe(new Date('2027-04-01T12:00:00Z').getTime());
+		});
 	});
 
 	it('loads the recap payload for the requested year', async () => {


### PR DESCRIPTION
# MP-3143 — Goal recap button doesn't hide after March of the next year

## Summary

Bug: The ?recapDate=YYYY-MM-DD QA override was parsed with new Date('2027-04-01'), which JS reads as UTC midnight. The recap-entry cutoff (March 31) is built in local time, so in a negative-offset zone (e.g. LA) the override landed on March 31 evening — a day behind — and the "View goal recap" CTA stayed past the cutoff. QA-only; production uses the real local new Date() and was unaffected.

Fix: In getGoalInReviewNow(), parse a bare YYYY-MM-DD recapDate as local midnight (new Date('${param}T00:00:00')) so it matches the local cutoff and the real clock. Also fixes the year-rollover on recapDate=2027-01-01. Added tests. No backend/schema changes.

https://kiva.atlassian.net/browse/MP-3143

## Evidences

### before March

<img width="1366" height="770" alt="Captura de pantalla 2026-08-25 a la(s) 21 03 41" src="https://github.com/user-attachments/assets/31c92640-0cd1-4598-a260-efd7d8ee2341" />

### after March

<img width="1320" height="770" alt="Captura de pantalla 2026-08-25 a la(s) 21 04 16" src="https://github.com/user-attachments/assets/ad23c6cb-11b8-49c3-885e-a712a46855ef" />
