### PR TITLE
fix: show goal recap cta from the completed goal card

### DIFF
--- a/src/components/MyKiva/GoalProgressRing.vue
+++ b/src/components/MyKiva/GoalProgressRing.vue
@@ -69,7 +69,8 @@
 
 		<KvButton
 			class="tw-w-full goal-button"
-			v-kv-track-event="['portfolio', 'click', 'continue-towards-goal']"
+			:key="`goal-cta-${showRecapCta}`"
+			v-kv-track-event="showRecapCta ? null : ['portfolio', 'click', 'continue-towards-goal']"
 			@click="handleButtonClick"
 		>
 			{{ buttonText }}
@@ -97,6 +98,7 @@ import { useRouter } from 'vue-router';
 import { KvButton, KvProgressCircle, KvMaterialIcon } from '@kiva/kv-components';
 import { COMPLETED_GOAL_THRESHOLD, HALF_GOAL_THRESHOLD } from '#src/composables/useGoalData';
 import goalCopy from '#src/util/goalCopy';
+import { RECAP_CTA_LABEL } from '#src/util/goalInReview';
 import {
 	ID_SUPPORT_ALL,
 	ID_US_ECONOMIC_EQUALITY,
@@ -176,6 +178,13 @@ const props = defineProps({
 	 * Flag to indicate if the goal has been completed
 	 */
 	isGoalCompleted: {
+		type: Boolean,
+		default: false,
+	},
+	/**
+	 * Card variant: offer the goal recap instead of the continue-toward-goal CTA
+	 */
+	showRecapCta: {
 		type: Boolean,
 		default: false,
 	},
@@ -285,6 +294,9 @@ const buttonText = computed(() => {
 	}
 
 	// Card variant
+	if (props.showRecapCta) {
+		return RECAP_CTA_LABEL;
+	}
 	if (props.goalProgressPercentage === COMPLETED_GOAL_THRESHOLD) {
 		return goalCopy.RING_BUTTON_CARD_GOAL_COMPLETED;
 	}

--- a/src/components/MyKiva/JourneyCardCarousel.vue
+++ b/src/components/MyKiva/JourneyCardCarousel.vue
@@ -21,7 +21,9 @@
 					:user-goal="userGoal"
 					:prev-year-loans="womenLoansLastYear"
 					:hide-goal-card="hideGoalCard"
+					:show-recap-cta="showRecapCta"
 					@open-goal-modal="$emit('open-goal-modal', $event)"
+					@view-goal-recap="$emit('view-goal-recap', $event)"
 				/>
 				<MyKivaSurveyCard
 					v-else-if="slide?.isSurveyCard"
@@ -102,8 +104,8 @@ import useGoalData from '#src/composables/useGoalData';
 import MyKivaEmailUpdatesTransition from '#src/components/MyKiva/MyKivaEmailUpdatesTransition';
 import MyKivaLatestLoanCard from '#src/components/MyKiva/MyKivaLatestLoanCard';
 import MyKivaSurveyCard from '#src/components/MyKiva/MyKivaSurveyCard';
-import { shouldHideGoalSignup } from '#src/util/goalInReview';
-import { getGoalInReviewNow } from '#src/composables/useGoalInReview';
+import { getGoalYear, shouldHideGoalSignup, shouldShowRecapEntryPoint } from '#src/util/goalInReview';
+import { getGoalInReviewCurrentYear, getGoalInReviewNow } from '#src/composables/useGoalInReview';
 import AlmostFundedNextStep from '#src/components/MyKiva/AlmostFundedNextStep';
 import {
 	getSlideTitle,
@@ -136,7 +138,7 @@ const {
 
 const { getCategoryLoansLastYear, hasGoal } = useGoalData();
 
-const emit = defineEmits(['update-journey', 'open-goal-modal', 'open-impact-insight-modal']);
+const emit = defineEmits(['update-journey', 'open-goal-modal', 'open-impact-insight-modal', 'view-goal-recap']);
 
 const props = defineProps({
 	userInfo: {
@@ -207,6 +209,10 @@ const props = defineProps({
 		type: Date,
 		default: null,
 	},
+	goalInReviewEnable: {
+		type: Boolean,
+		default: false,
+	},
 	latestLoan: {
 		type: Object,
 		default: null
@@ -269,6 +275,20 @@ const nonBadgesSlides = computed(() => filterNonBadgesSlides(props.slides));
 
 const hideGoalSignup = computed(() => shouldHideGoalSignup({
 	recapStartDate: props.goalInReviewInProgressStart,
+	now: getGoalInReviewNow(),
+}));
+
+const goalYear = computed(() => getGoalYear(props.userGoal));
+
+// Same question the featured slot and the Impact Progress row ask, so the completed
+// goal tile offers the recap wherever it is the surface that renders.
+const showRecapCta = computed(() => shouldShowRecapEntryPoint({
+	enabled: props.goalInReviewEnable,
+	goalStatus: props.userGoal?.status,
+	goalYear: goalYear.value,
+	currentYear: getGoalInReviewCurrentYear(),
+	loansTowardGoal: props.goalProgress,
+	activeGoalYear: goalYear.value,
 	now: getGoalInReviewNow(),
 }));
 

--- a/src/components/MyKiva/LendingStats.vue
+++ b/src/components/MyKiva/LendingStats.vue
@@ -46,8 +46,10 @@
 				:user-info="userInfo"
 				:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
 				:show-lending-next-steps-cards="true"
+				:goal-in-review-enable="goalInReviewEnable"
 				@open-goal-modal="openGoalModal($event)"
 				@open-impact-insight-modal="showImpactInsightsModal = true"
+				@view-goal-recap="$emit('view-goal-recap', $event)"
 			/>
 		</template>
 		<div
@@ -84,8 +86,10 @@
 			:latest-loan="latestLoan"
 			:user-info="userInfo"
 			:show-post-lending-next-steps-cards="showPostLendingNextStepsCards"
+			:goal-in-review-enable="goalInReviewEnable"
 			@open-goal-modal="openGoalModal($event)"
 			@open-impact-insight-modal="showImpactInsightsModal = true"
+			@view-goal-recap="$emit('view-goal-recap', $event)"
 		/>
 		<GoalSettingModal
 			:show="showGoalModal"
@@ -136,7 +140,7 @@ export default {
 		KvMaterialIcon,
 	},
 	inject: ['apollo', 'cookieStore'],
-	emits: ['add-to-basket'],
+	emits: ['add-to-basket', 'view-goal-recap'],
 	props: {
 		loans: {
 			type: Array,
@@ -194,6 +198,10 @@ export default {
 		goalInReviewInProgressStart: {
 			type: Date,
 			default: null,
+		},
+		goalInReviewEnable: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/components/MyKiva/NextYearGoalCard.vue
+++ b/src/components/MyKiva/NextYearGoalCard.vue
@@ -35,6 +35,7 @@
 				:goal-progress-percentage="goalProgressPercentage"
 				:category-name="categoryName"
 				:category-id="userGoal?.category"
+				:show-recap-cta="showRecapCta"
 				@button-click="handleContinueClick"
 				@edit-button-click="handleEditClick"
 			/>
@@ -58,6 +59,7 @@ import goalCopy, { GOAL_SIGNUP_COPY_NO_GOAL_YET } from '#src/util/goalCopy';
 import { useRouter } from 'vue-router';
 import confetti from 'canvas-confetti';
 import GoalProgressRing from '#src/components/MyKiva/GoalProgressRing';
+import { getGoalYear } from '#src/util/goalInReview';
 import HandsPlant from '#src/assets/images/thanks-page/hands-plant-v3.png';
 
 const props = defineProps({
@@ -81,9 +83,14 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	// Swaps the completed-goal CTA for the goal recap entry point.
+	showRecapCta: {
+		type: Boolean,
+		default: false,
+	},
 });
 
-const emit = defineEmits(['open-goal-modal']);
+const emit = defineEmits(['open-goal-modal', 'view-goal-recap']);
 
 const $kvTrackEvent = inject('$kvTrackEvent');
 const router = useRouter();
@@ -135,6 +142,11 @@ const showConfetti = () => {
 };
 
 const handleContinueClick = () => {
+	// The recap owns the click and its own tracking, so the goal CTA events stay out of it.
+	if (props.showRecapCta) {
+		emit('view-goal-recap', getGoalYear(props.userGoal));
+		return;
+	}
 	$kvTrackEvent('portfolio', 'click', 'continue-towards-goal');
 	if (goalProgressPercentage.value === COMPLETED_GOAL_THRESHOLD) {
 		$kvTrackEvent('portfolio', 'click', 'goal-completed-cta');

--- a/src/pages/MyKiva/MyKivaPageContent.vue
+++ b/src/pages/MyKiva/MyKivaPageContent.vue
@@ -43,10 +43,12 @@
 				:user-info="userInfo"
 				:goal-recommended-loan-enable="goalRecommendedLoanEnable"
 				:goals-row-enabled="goalsRowEnabled"
+				:goal-in-review-enable="goalInReviewEnable"
 				:goal-in-review-in-progress-start="goalInReviewInProgressStart"
 				:basket-items="basketItems"
 				:is-adding="isAdding"
 				@add-to-basket="addGoalRecommendedLoanToBasket"
+				@view-goal-recap="openGoalRecapFromCard"
 			/>
 		</section>
 		<section class="tw-mt-4" id="mykiva-achievements">

--- a/test/unit/specs/components/MyKiva/GoalProgressRing.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalProgressRing.spec.js
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/vue';
 import GoalProgressRing from '#src/components/MyKiva/GoalProgressRing';
 import goalCopy from '#src/util/goalCopy';
+import { RECAP_CTA_LABEL } from '#src/util/goalInReview';
 import {
 	ID_SUPPORT_ALL,
 	ID_CLIMATE_ACTION,
@@ -133,6 +134,15 @@ describe('GoalProgressRing', () => {
 		it('shows "Work towards your goal" for card variant below 100%', () => {
 			const { getByRole } = renderRing({ variant: 'card', goalProgressPercentage: 50 });
 			expect(getByRole('button', { name: goalCopy.RING_BUTTON_CARD_IN_PROGRESS })).toBeTruthy();
+		});
+
+		it('shows the recap CTA for a card variant offering the goal recap', () => {
+			const { getByRole } = renderRing({
+				variant: 'card',
+				goalProgressPercentage: 100,
+				showRecapCta: true,
+			});
+			expect(getByRole('button', { name: RECAP_CTA_LABEL })).toBeTruthy();
 		});
 	});
 

--- a/test/unit/specs/components/MyKiva/JourneyCardCarousel.spec.js
+++ b/test/unit/specs/components/MyKiva/JourneyCardCarousel.spec.js
@@ -18,13 +18,17 @@ vi.mock('#src/composables/useBreakpoints', () => ({
 	}),
 }));
 
-vi.mock('#src/composables/useGoalData', () => ({
-	default: () => ({
-		getCategoryLoansLastYear: () => 0,
-		hasGoal: goal => !!goal && Object.keys(goal).length > 0,
-	}),
-	GOALS_CURRENT_YEAR: new Date().getFullYear(),
-}));
+vi.mock('#src/composables/useGoalData', async importOriginal => {
+	const actual = await importOriginal();
+	return {
+		...actual,
+		default: () => ({
+			getCategoryLoansLastYear: () => 0,
+			hasGoal: goal => !!goal && Object.keys(goal).length > 0,
+		}),
+		GOALS_CURRENT_YEAR: new Date().getFullYear(),
+	};
+});
 
 vi.mock('#src/util/imageUtils', () => ({
 	optimizeContentfulUrl: url => url,
@@ -264,5 +268,72 @@ describe('JourneyCardCarousel', () => {
 	it('does not render the Almost Funded next step when showLendingNextStepsCards is false', () => {
 		const wrapper = mountForAlmostFunded(false);
 		expect(wrapper.findComponent({ name: 'AlmostFundedNextStep' }).exists()).toBe(false);
+	});
+
+	describe('goal recap entry point', () => {
+		const GOAL_YEAR = new Date().getFullYear();
+
+		const mountWithGoal = ({ goalInReviewEnable = true, status = 'completed' } = {}) => mount(
+			JourneyCardCarousel,
+			{
+				props: {
+					inLendingStats: true,
+					goalInReviewEnable,
+					goalProgress: 5,
+					goalProgressLoading: false,
+					userGoal: {
+						category: ID_WOMENS_EQUALITY,
+						target: 5,
+						status,
+						dateStarted: `${GOAL_YEAR}-02-01`,
+					},
+					slidesNumber: 3,
+					slides: [],
+					heroTieredAchievements: [],
+					heroBadgeData: [],
+					userInfo: { userPreferences: { preferences: '{}' } },
+				},
+				global: {
+					provide: { apollo: {}, cookieStore: {}, $kvTrackEvent: vi.fn() },
+					directives: { kvTrackEvent: () => ({}) },
+					stubs: {
+						MyKivaCard: true,
+						MyKivaSharingModal: true,
+						NextYearGoalCard: {
+							name: 'NextYearGoalCard',
+							props: ['showRecapCta'],
+							template: '<div />',
+						},
+						MyKivaEmailUpdatesTransition: true,
+						MyKivaLatestLoanCard: true,
+						MyKivaSurveyCard: true,
+						AlmostFundedNextStep: true,
+					},
+				},
+			},
+		);
+
+		it('offers the recap on the goal tile for a completed goal this year', () => {
+			const wrapper = mountWithGoal();
+			expect(wrapper.findComponent({ name: 'NextYearGoalCard' }).props('showRecapCta')).toBe(true);
+		});
+
+		it('leaves the goal tile alone while the goal is still in progress', () => {
+			const wrapper = mountWithGoal({ status: 'in-progress' });
+			expect(wrapper.findComponent({ name: 'NextYearGoalCard' }).props('showRecapCta')).toBe(false);
+		});
+
+		it('leaves the goal tile alone when the feature is off', () => {
+			const wrapper = mountWithGoal({ goalInReviewEnable: false });
+			expect(wrapper.findComponent({ name: 'NextYearGoalCard' }).props('showRecapCta')).toBe(false);
+		});
+
+		it('passes the requested recap year up to the page', async () => {
+			const wrapper = mountWithGoal();
+
+			await wrapper.findComponent({ name: 'NextYearGoalCard' }).vm.$emit('view-goal-recap', GOAL_YEAR);
+
+			expect(wrapper.emitted('view-goal-recap')).toEqual([[GOAL_YEAR]]);
+		});
 	});
 });

--- a/test/unit/specs/components/MyKiva/LendingStats.spec.js
+++ b/test/unit/specs/components/MyKiva/LendingStats.spec.js
@@ -13,6 +13,13 @@ describe('LendingStats', () => {
 			expect(prop.type).toBe(Array);
 			expect(prop.default()).toEqual([]);
 		});
+
+		it('takes the goal in review flag and relays the goal tile\'s recap request', () => {
+			const prop = LendingStats.props.goalInReviewEnable;
+			expect(prop.type).toBe(Boolean);
+			expect(prop.default).toBe(false);
+			expect(LendingStats.emits).toContain('view-goal-recap');
+		});
 	});
 
 	describe('recentLoanIds', () => {

--- a/test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js
+++ b/test/unit/specs/components/MyKiva/NextYearGoalCard.spec.js
@@ -33,6 +33,7 @@ describe('NextYearGoalCard', () => {
 	});
 
 	const mountCard = ({ goalData = createGoalData(), props = {} } = {}) => {
+		const trackEvent = vi.fn();
 		const wrapper = mount(NextYearGoalCard, {
 			props: {
 				userGoal: {
@@ -48,19 +49,21 @@ describe('NextYearGoalCard', () => {
 			global: {
 				provide: {
 					goalData,
-					$kvTrackEvent: vi.fn(),
+					$kvTrackEvent: trackEvent,
 				},
 				directives: {
 					kvTrackEvent: () => ({}),
 				},
 				stubs: {
 					GoalProgressRing: {
+						name: 'GoalProgressRing',
+						props: ['showRecapCta'],
 						template: '<div data-testid="goal-progress-ring" />',
 					},
 				},
 			},
 		});
-		return { wrapper, goalData };
+		return { wrapper, goalData, trackEvent };
 	};
 
 	beforeEach(() => {
@@ -76,6 +79,45 @@ describe('NextYearGoalCard', () => {
 
 		expect(confetti).toHaveBeenCalledTimes(1);
 		expect(goalData.setHideGoalCardPreference).not.toHaveBeenCalled();
+	});
+
+	describe('goal recap entry point', () => {
+		const GOAL_YEAR = 2026;
+		const recapProps = {
+			showRecapCta: true,
+			userGoal: {
+				category: ID_US_ECONOMIC_EQUALITY,
+				target: 5,
+				status: GOAL_STATUS.COMPLETED,
+				dateStarted: `${GOAL_YEAR}-02-01`,
+			},
+		};
+
+		it('offers the recap CTA to the progress ring', () => {
+			const { wrapper } = mountCard({ props: recapProps });
+
+			expect(wrapper.findComponent({ name: 'GoalProgressRing' }).props('showRecapCta')).toBe(true);
+		});
+
+		it('emits the goal year instead of navigating when the recap CTA is pressed', async () => {
+			const { wrapper, goalData, trackEvent } = mountCard({ props: recapProps });
+
+			await wrapper.findComponent({ name: 'GoalProgressRing' }).vm.$emit('button-click');
+
+			expect(wrapper.emitted('view-goal-recap')).toEqual([[GOAL_YEAR]]);
+			expect(goalData.getCtaHref).not.toHaveBeenCalled();
+			expect(trackEvent).not.toHaveBeenCalled();
+		});
+
+		it('keeps the continue behavior when the recap is not offered', async () => {
+			const { wrapper } = mountCard({
+				props: { ...recapProps, showRecapCta: false },
+			});
+
+			await wrapper.findComponent({ name: 'GoalProgressRing' }).vm.$emit('button-click');
+
+			expect(wrapper.emitted('view-goal-recap')).toBeUndefined();
+		});
 	});
 
 	it('uses date-based title copy', () => {


### PR DESCRIPTION
### Problem
After completing a goal, the goal card on MyKiva showed **"View impact progress"** instead of **"View goal recap"**, so the recap was unreachable from that card.

Two things made it look intermittent:
- The completed tile renders **once**. `hideGoalCard` is persisted after the first completed view, so it is hidden on every later load.
- It only renders in the **non-goals-row** experience. When `goalsRowEnabled` is on, `LendingStats` hides the tile and `MyKivaFeaturedSlot` takes over. So the unwired card was the only one some lenders saw.

`NextYearGoalCard` / `GoalProgressRing` had no goal-in-review wiring at all; the recap entry point had been added to the featured slot and the Impact Progress row