### PR TITLE
feat(live-loan): add compact bundle loan card image variant

### DIFF
--- a/server/live-loan-router.js
+++ b/server/live-loan-router.js
@@ -249,6 +249,13 @@ export default function liveLoanRouter(cache) {
 		});
 	});
 
+	// User IMG Router (Compact Bundle - no CTA)
+	router.use('/u/:id(\\d{0,})/bundle-img-compact/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'compact-bundle', cache, req, res, QUERY_TYPE.DEFAULT, MAX_BUNDLE_COUNT);
+		});
+	});
+
 	// User URL Router FLSS
 	router.use('/flss/u/:id(\\d{0,})/url/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToUrl', { resource: req.path }, async () => {
@@ -284,6 +291,13 @@ export default function liveLoanRouter(cache) {
 		});
 	});
 
+	// User IMG Router FLSS (Compact Bundle - no CTA)
+	router.use('/flss/u/:id(\\d{0,})/bundle-img-compact/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.flss.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'compact-bundle', cache, req, res, QUERY_TYPE.FLSS, MAX_BUNDLE_COUNT);
+		});
+	});
+
 	// User URL Router Recommendations
 	router.use('/recommendations/u/:id(\\d{0,})/url/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.flss.user.redirectToUrl', { resource: req.path }, async () => {
@@ -316,6 +330,13 @@ export default function liveLoanRouter(cache) {
 	router.use('/recommendations/u/:id(\\d{0,})/bundle-img-legacy/:offset(\\d{0,})', async (req, res) => {
 		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
 			await serveImg('user', 'bundle-legacy', cache, req, res, QUERY_TYPE.RECOMMENDATIONS, MAX_BUNDLE_COUNT);
+		});
+	});
+
+	// User IMG Router Recommendations (Compact Bundle - no CTA)
+	router.use('/recommendations/u/:id(\\d{0,})/bundle-img-compact/:offset(\\d{0,})', async (req, res) => {
+		await trace('live-loan.recommendations.user.serveImg', { resource: req.path }, async () => {
+			await serveImg('user', 'compact-bundle', cache, req, res, QUERY_TYPE.RECOMMENDATIONS, MAX_BUNDLE_COUNT);
 		});
 	});
 

--- a/server/util/live-loan/canvas-utils.js
+++ b/server/util/live-loan/canvas-utils.js
@@ -79,6 +79,167 @@ export function wrapText(ctx, text, x, y, maxWidth, maxLines, lineHeight) {
 }
 
 /**
+ * Splits an array of styled runs into individual words, each carrying the bold
+ * flag of the run it came from. Whitespace is collapsed.
+ * @param {Array<{ text: String, bold: Boolean }>} runs
+ * @returns {Array<{ word: String, bold: Boolean }>}
+ */
+export function styledRunsToWords(runs = []) {
+	const words = [];
+	for (let i = 0; i < runs.length; i += 1) {
+		const run = runs[i];
+		const parts = String(run.text).split(/\s+/).filter(Boolean);
+		for (let j = 0; j < parts.length; j += 1) {
+			words.push({ word: parts[j], bold: !!run.bold });
+		}
+	}
+	return words;
+}
+
+/**
+ * Draws styled (mixed regular/bold) text with word wrapping, clamping to a max
+ * number of lines and appending an ellipsis when the text overflows.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {Array<{ text: String, bold: Boolean }>} runs The styled text runs
+ * @param {Number} x The top left x coordinate
+ * @param {Number} y The top left y coordinate
+ * @param {Number} maxWidth The width available for the paragraph
+ * @param {Number} maxLines The max number of lines to draw
+ * @param {Number} lineHeight The line height in px
+ * @param {Object} fonts Canvas font strings: { regularFont, boldFont }
+ */
+export function wrapStyledText(ctx, runs, x, y, maxWidth, maxLines, lineHeight, { regularFont, boldFont }) {
+	const words = styledRunsToWords(runs);
+	const fontFor = bold => (bold ? boldFont : regularFont);
+	ctx.font = regularFont;
+	const spaceWidth = ctx.measureText(' ').width;
+
+	// Group words into lines, measuring each word once and only re-parsing the
+	// font when the bold flag changes. A line's width counts a trailing space
+	// per word, mirroring the single-font wrapText helper.
+	let currentBold = null;
+	const lines = [];
+	let line = [];
+	let lineWidth = 0;
+	for (let i = 0; i < words.length; i += 1) {
+		const w = words[i];
+		if (w.bold !== currentBold) {
+			ctx.font = fontFor(w.bold);
+			currentBold = w.bold;
+		}
+		w.width = ctx.measureText(w.word).width;
+		const nextWidth = lineWidth + w.width + spaceWidth;
+		if (line.length && nextWidth > maxWidth) {
+			lines.push(line);
+			line = [w];
+			lineWidth = w.width + spaceWidth;
+		} else {
+			line.push(w);
+			lineWidth = nextWidth;
+		}
+	}
+	if (line.length) {
+		lines.push(line);
+	}
+
+	const truncated = lines.length > maxLines;
+	const visibleLines = lines.slice(0, maxLines);
+
+	// Append an ellipsis to the final visible word when content was dropped,
+	// trimming it until the line fits. The other words' width is constant.
+	if (truncated && visibleLines.length) {
+		const lastLine = visibleLines[visibleLines.length - 1];
+		const last = lastLine[lastLine.length - 1];
+		const otherWidth = lastLine.slice(0, -1).reduce((sum, wd) => sum + wd.width + spaceWidth, 0);
+		ctx.font = fontFor(last.bold);
+		last.word = `${last.word}…`;
+		while (last.word.length > 1 && otherWidth + ctx.measureText(last.word).width > maxWidth) {
+			last.word = `${last.word.slice(0, -2)}…`;
+		}
+	}
+
+	// Draw each visible line word by word, switching fonts only on change.
+	currentBold = null;
+	for (let i = 0; i < visibleLines.length; i += 1) {
+		let cursorX = x;
+		const lineY = y + (i * lineHeight);
+		for (let j = 0; j < visibleLines[i].length; j += 1) {
+			const w = visibleLines[i][j];
+			if (w.bold !== currentBold) {
+				ctx.font = fontFor(w.bold);
+				currentBold = w.bold;
+			}
+			ctx.fillText(w.word, cursorX, lineY);
+			cursorX += w.width + spaceWidth;
+		}
+	}
+
+	return visibleLines.length;
+}
+
+/**
+ * Computes how to draw a source image so it fully covers a square box without
+ * distortion (object-fit: cover): scaled to the larger dimension and centered,
+ * so the overflowing axis is cropped equally on both sides.
+ * @param {Number} srcWidth Source image width
+ * @param {Number} srcHeight Source image height
+ * @param {Number} size The square box side length
+ * @returns {{ width: Number, height: Number, offsetX: Number, offsetY: Number }}
+ *   Draw size and top-left offset relative to the box origin
+ */
+export function coverRect(srcWidth, srcHeight, size) {
+	const scale = Math.max(size / srcWidth, size / srcHeight);
+	const width = srcWidth * scale;
+	const height = srcHeight * scale;
+	return {
+		width,
+		height,
+		offsetX: (size - width) / 2,
+		offsetY: (size - height) / 2,
+	};
+}
+
+/**
+ * Rendered width of a pill for the given text, matching drawPill's geometry.
+ * ctx.font must be set to the pill font before calling.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {String} text The pill text
+ * @param {Number} padding The pill inner padding
+ * @param {String} [icon] Optional leading icon path (adds a square icon slot)
+ * @returns {Number} The pill width in px
+ */
+export function measurePillWidth(ctx, text, padding, icon) {
+	const metrics = ctx.measureText(text);
+	const iconSize = icon ? (metrics.emHeightAscent + metrics.emHeightDescent) : 0;
+	return (3 * padding) + iconSize + metrics.width;
+}
+
+/**
+ * Selects which pill labels fit on a single row of the given width. Any pill
+ * that does not fit — including a lone pill too wide on its own — is dropped.
+ * ctx.font must be set to the pill font before calling.
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {Array<String>} labels Ordered pill labels (highest priority first)
+ * @param {Number} maxWidth The available row width
+ * @param {Number} padding The pill inner padding (matches drawPill)
+ * @param {Number} gap The gap between pills
+ * @returns {Array<String>} The labels to render, in order
+ */
+export function fitPillLabels(ctx, labels, maxWidth, padding, gap) {
+	const result = [];
+	let used = 0;
+	for (let i = 0; i < labels.length; i += 1) {
+		const needed = (result.length ? gap : 0) + measurePillWidth(ctx, labels[i], padding);
+		if (used + needed > maxWidth) {
+			break;
+		}
+		result.push(labels[i]);
+		used += needed;
+	}
+	return result;
+}
+
+/**
  * Draws a Material Design Icon at the given x,y position (top left corner).
  * Scales the icon to a square of side length `size`.
  * @param {CanvasRenderingContext2D} ctx
@@ -111,10 +272,9 @@ export function drawMDIcon(ctx, icon, x, y, size) {
 export function drawPill(ctx, text, x, y, padding, color, bgColor, icon) {
 	const metrics = ctx.measureText(text);
 	const textHeight = metrics.emHeightAscent + metrics.emHeightDescent;
-	const textWidth = metrics.width;
 	const iconSize = icon ? textHeight : 0;
 	const pillHeight = (2 * padding) + textHeight;
-	const pillWidth = (3 * padding) + iconSize + textWidth;
+	const pillWidth = measurePillWidth(ctx, text, padding, icon);
 	const radius = pillHeight / 2;
 	roundRect(ctx, x, y, pillWidth, pillHeight, radius);
 	ctx.fillStyle = bgColor;
@@ -134,6 +294,11 @@ export default {
 	ellipsisLine,
 	roundRect,
 	wrapText,
+	styledRunsToWords,
+	wrapStyledText,
+	coverRect,
+	measurePillWidth,
+	fitPillLabels,
 	drawMDIcon,
 	drawPill
 };

--- a/server/util/live-loan/compact-card-constants.js
+++ b/server/util/live-loan/compact-card-constants.js
@@ -1,0 +1,46 @@
+// Compact (bundle) styling constants. Mirrors the on-site compact loan card:
+// square borrower image on the left, use statement on the right, callout pills,
+// then a "$X to go" label above a fundraising bar. No CTA button.
+export const compactResizeFactor = 3;
+export const compactCardWidth = 271;
+export const compactCardPadding = 12;
+export const compactCardRadius = 16;
+export const compactImageSize = 60;
+export const compactImageRadius = 8;
+export const compactImageGap = 8; // between image and copy
+export const compactUseLineHeight = 21; // 14px text at 1.5 line-height
+export const compactMaxUseLines = 4;
+export const compactSectionGap = 12; // between the top row, pills, and bottom row
+export const compactPillHeight = 30;
+export const compactPillPadding = 8;
+export const compactPillGap = 8;
+export const compactToGoLineHeight = 14;
+export const compactToGoBarGap = 8;
+export const compactBarHeight = 8;
+// Height is fixed to the worst case (4 lines of use text) so the pooled canvas
+// and the email layout stay a consistent size; shorter cards flow from the top.
+export const compactTopRowHeight = Math.max(compactImageSize, compactMaxUseLines * compactUseLineHeight);
+export const compactCardHeight = compactCardPadding
+	+ compactTopRowHeight + compactSectionGap
+	+ compactPillHeight + compactSectionGap
+	+ (compactToGoLineHeight + compactToGoBarGap + compactBarHeight)
+	+ compactCardPadding;
+// Outer margin around the card, baked onto white, so the drop shadow has room
+export const compactCardMargin = 16;
+export const compactCardDimensions = {
+	width: (compactCardWidth + (2 * compactCardMargin)) * compactResizeFactor,
+	height: (compactCardHeight + (2 * compactCardMargin)) * compactResizeFactor,
+};
+
+export const compactColors = {
+	textPrimary: '#212121',
+	brand: '#2aa967',
+	pillBg: '#f5f5f5',
+	progressTrack: '#d9d9d9',
+	white: '#ffffff'
+};
+
+export const compactRegularFont = '400 14px "Kiva Post Grot"';
+// Bold name+country in the use text and the pills / "$X to go" label are all
+// the same Medium weight in the design.
+export const compactMediumFont = '500 14px "Kiva Post Grot"';

--- a/server/util/live-loan/compact-card-text.js
+++ b/server/util/live-loan/compact-card-text.js
@@ -1,0 +1,79 @@
+import numeral from 'numeral';
+
+const DIRECT = 'direct';
+const PRIVACY_STATEMENT = 'For the borrower\'s privacy, this loan has been made anonymous.';
+
+// Statuses that read in the present tense ("helps"); every other status —
+// including "issue" — reads "helped", matching the on-site compact loan card.
+const PRESENT_TENSE_STATUSES = ['fundraising', 'inactive', 'reviewed'];
+
+function helpLanguage(status = '') {
+	return PRESENT_TENSE_STATUSES.includes(status) ? 'helps' : 'helped';
+}
+
+function lowerFirst(text = '') {
+	return `${text.charAt(0).toLowerCase()}${text.slice(1)}`;
+}
+
+/**
+ * Builds the compact loan card use statement as styled runs so the canvas
+ * renderer can bold the borrower name + country while keeping the rest regular.
+ * Matches the sentence structure of the on-site compact loan card.
+ *
+ * @param {Object} loan Live-loan GraphQL loan object
+ * @returns {Array<{ text: string, bold: boolean }>}
+ */
+export function buildCompactLoanUseRuns(loan = {}) {
+	const {
+		name = '',
+		use = '',
+		loanAmount = '',
+		status = '',
+		distributionModel,
+		borrowerCount = 0,
+		anonymizationLevel = 'none',
+	} = loan;
+	const country = loan?.geocode?.country?.name ?? '';
+
+	if (anonymizationLevel === 'full' || !use) {
+		return [{ text: PRIVACY_STATEMENT, bold: false }];
+	}
+
+	const help = helpLanguage(status);
+	const isDirect = distributionModel === DIRECT;
+	const member = borrowerCount > 1 ? 'a member of ' : '';
+	const nameCountry = country ? `${name} in ${country}` : name;
+	const amount = numeral(loanAmount).format('$0,0');
+	const normalizedUse = lowerFirst(use);
+
+	// Direct loans read "$X to {name} {help} {use}"; partner loans read
+	// "$X {help} {name} {use}" — only the text around the bold name differs.
+	const prefix = isDirect ? `${amount} to ${member}` : `${amount} ${help} ${member}`;
+	const suffix = isDirect ? ` ${help} ${normalizedUse}` : ` ${normalizedUse}`;
+	return [
+		{ text: prefix, bold: false },
+		{ text: nameCountry, bold: true },
+		{ text: suffix, bold: false },
+	];
+}
+
+/**
+ * Builds the "$X to go" fundraising label used on the compact loan card.
+ * Mirrors KvLoanProgressGroup: appends "!" when under $100 remains and
+ * shows "funded!" once fully raised.
+ *
+ * @param {Object} loan Live-loan GraphQL loan object
+ * @returns {string}
+ */
+export function buildToGoText(loan = {}) {
+	const loanAmount = numeral(loan?.loanAmount).value() ?? 0;
+	const fundedAmount = numeral(loan?.loanFundraisingInfo?.fundedAmount).value() ?? 0;
+	const remaining = loanAmount - fundedAmount;
+
+	if (remaining <= 0) {
+		return 'funded!';
+	}
+	return `${numeral(remaining).format('$0,0')} to go${remaining < 100 ? '!' : ''}`;
+}
+
+export default { buildCompactLoanUseRuns, buildToGoText };

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -14,7 +14,34 @@ import { loadBorrowerImage } from './canvas-image-utils.js';
 import getLoanCallouts from '../../../src/util/loanCallouts.js';
 import getLoanUse from '../../../src/util/loanUse.js';
 import { buildCompactLoanUseRuns, buildToGoText } from './compact-card-text.js';
+import {
+	compactResizeFactor,
+	compactCardWidth,
+	compactCardPadding,
+	compactCardRadius,
+	compactImageSize,
+	compactImageRadius,
+	compactImageGap,
+	compactUseLineHeight,
+	compactMaxUseLines,
+	compactSectionGap,
+	compactPillHeight,
+	compactPillPadding,
+	compactPillGap,
+	compactToGoLineHeight,
+	compactToGoBarGap,
+	compactBarHeight,
+	compactCardMargin,
+	compactCardHeight,
+	compactCardDimensions,
+	compactColors,
+	compactRegularFont,
+	compactMediumFont,
+} from './compact-card-constants.js';
 import { trace } from '../mockTrace.js';
+
+// Re-exported for the image-dimension assertions in the renderer's tests
+export { compactCardDimensions } from './compact-card-constants.js';
 
 // Polyfill Path2D for material design icon support
 global.CanvasRenderingContext2D = CanvasRenderingContext2D;
@@ -31,40 +58,6 @@ const bundleLegacyCardHeight = 450 * resizeFactor;
 const classicResizeFactor = 3;
 const classicCardWidth = 440 * classicResizeFactor;
 const classicCardHeight = 510 * classicResizeFactor;
-
-// Compact (bundle) styling constants. Mirrors the on-site compact loan card:
-// square borrower image on the left, use statement on the right, callout pills,
-// then a "$X to go" label above a fundraising bar. No CTA button.
-const compactResizeFactor = 3;
-const compactCardWidth = 271;
-const compactCardPadding = 12;
-const compactCardRadius = 16;
-const compactImageSize = 60;
-const compactImageRadius = 8;
-const compactImageGap = 8; // between image and copy
-const compactUseLineHeight = 21; // 14px text at 1.5 line-height
-const compactMaxUseLines = 4;
-const compactSectionGap = 12; // between the top row, pills, and bottom row
-const compactPillHeight = 30;
-const compactPillPadding = 8;
-const compactPillGap = 8;
-const compactToGoLineHeight = 14;
-const compactToGoBarGap = 8;
-const compactBarHeight = 8;
-// Height is fixed to the worst case (4 lines of use text) so the pooled canvas
-// and the email layout stay a consistent size; shorter cards flow from the top.
-const compactTopRowHeight = Math.max(compactImageSize, compactMaxUseLines * compactUseLineHeight);
-const compactCardHeight = compactCardPadding
-	+ compactTopRowHeight + compactSectionGap
-	+ compactPillHeight + compactSectionGap
-	+ (compactToGoLineHeight + compactToGoBarGap + compactBarHeight)
-	+ compactCardPadding;
-// Outer margin around the card, baked onto white, so the drop shadow has room
-const compactCardMargin = 16;
-export const compactCardDimensions = {
-	width: (compactCardWidth + (2 * compactCardMargin)) * compactResizeFactor,
-	height: (compactCardHeight + (2 * compactCardMargin)) * compactResizeFactor,
-};
 
 function fontFile(name) {
 	return join(dirname(fileURLToPath(import.meta.url)), './fonts', name);
@@ -414,19 +407,6 @@ async function drawCompact(loanData) {
 	const canvas = trace('compactCanvasPool.use', () => compactCanvasPool.use());
 	const ctx = trace('canvas.getContext', () => canvas.getContext('2d', { alpha: false }));
 
-	const compactColors = {
-		textPrimary: '#212121',
-		brand: '#2aa967',
-		pillBg: '#f5f5f5',
-		progressTrack: '#d9d9d9',
-		white: '#ffffff'
-	};
-
-	const regularFont = '400 14px "Kiva Post Grot"';
-	// Bold name+country in the use text and the pills / "$X to go" label are all
-	// the same Medium weight in the design.
-	const mediumFont = '500 14px "Kiva Post Grot"';
-
 	try {
 		// Work in logical (unscaled) units; the pooled canvas is reused so reset
 		// the transform explicitly on every render.
@@ -491,7 +471,7 @@ async function drawCompact(loanData) {
 				textWidth,
 				compactMaxUseLines,
 				compactUseLineHeight,
-				{ regularFont, boldFont: mediumFont }
+				{ regularFont: compactRegularFont, boldFont: compactMediumFont }
 			);
 		});
 
@@ -501,7 +481,7 @@ async function drawCompact(loanData) {
 		// Loan callouts (grey pills, never orange). Collapses when there are none;
 		// pills that would overflow the row are dropped so nothing spills past the card.
 		const pillsBottom = trace('loan-callouts', () => {
-			ctx.font = mediumFont;
+			ctx.font = compactMediumFont;
 			const availableWidth = compactCardWidth - (2 * pad);
 			const callouts = getLoanCallouts(loanData);
 			const labels = fitPillLabels(ctx, callouts, availableWidth, compactPillPadding, compactPillGap);
@@ -534,7 +514,7 @@ async function drawCompact(loanData) {
 			const loanAmountValue = numeral(loanData?.loanAmount).value() || 1;
 			const fundraisingPercent = Math.min(1, fundedAmount / loanAmountValue);
 
-			ctx.font = mediumFont;
+			ctx.font = compactMediumFont;
 			ctx.fillStyle = compactColors.textPrimary;
 			ctx.fillText(buildToGoText(loanData), pad, toGoY);
 

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -8,11 +8,12 @@ import deePool from 'deepool';
 import numeral from 'numeral';
 import { polyfillPath2D } from 'path2d-polyfill';
 import {
-	ellipsisLine, drawPill, wrapText, roundRect
+	ellipsisLine, drawPill, wrapText, wrapStyledText, fitPillLabels, coverRect, roundRect
 } from './canvas-utils.js';
 import { loadBorrowerImage } from './canvas-image-utils.js';
 import getLoanCallouts from '../../../src/util/loanCallouts.js';
 import getLoanUse from '../../../src/util/loanUse.js';
+import { buildCompactLoanUseRuns, buildToGoText } from './compact-card-text.js';
 import { trace } from '../mockTrace.js';
 
 // Polyfill Path2D for material design icon support
@@ -31,21 +32,60 @@ const classicResizeFactor = 3;
 const classicCardWidth = 440 * classicResizeFactor;
 const classicCardHeight = 510 * classicResizeFactor;
 
+// Compact (bundle) styling constants. Mirrors the on-site compact loan card:
+// square borrower image on the left, use statement on the right, callout pills,
+// then a "$X to go" label above a fundraising bar. No CTA button.
+const compactResizeFactor = 3;
+const compactCardWidth = 271;
+const compactCardPadding = 12;
+const compactCardRadius = 16;
+const compactImageSize = 60;
+const compactImageRadius = 8;
+const compactImageGap = 8; // between image and copy
+const compactUseLineHeight = 21; // 14px text at 1.5 line-height
+const compactMaxUseLines = 4;
+const compactSectionGap = 12; // between the top row, pills, and bottom row
+const compactPillHeight = 30;
+const compactPillPadding = 8;
+const compactPillGap = 8;
+const compactToGoLineHeight = 14;
+const compactToGoBarGap = 8;
+const compactBarHeight = 8;
+// Height is fixed to the worst case (4 lines of use text) so the pooled canvas
+// and the email layout stay a consistent size; shorter cards flow from the top.
+const compactTopRowHeight = Math.max(compactImageSize, compactMaxUseLines * compactUseLineHeight);
+const compactCardHeight = compactCardPadding
+	+ compactTopRowHeight + compactSectionGap
+	+ compactPillHeight + compactSectionGap
+	+ (compactToGoLineHeight + compactToGoBarGap + compactBarHeight)
+	+ compactCardPadding;
+// Outer margin around the card, baked onto white, so the drop shadow has room
+const compactCardMargin = 16;
+export const compactCardDimensions = {
+	width: (compactCardWidth + (2 * compactCardMargin)) * compactResizeFactor,
+	height: (compactCardHeight + (2 * compactCardMargin)) * compactResizeFactor,
+};
+
 function fontFile(name) {
 	return join(dirname(fileURLToPath(import.meta.url)), './fonts', name);
 }
 
 trace('registerFonts', () => {
-	/* eslint-disable max-len */
-	registerFont(fontFile('PostGrotesk-Light.ttf'), { family: 'Kiva Post Grot', weight: '300' });
-	// registerFont(fontFile('PostGrotesk-LightItalic.ttf'), { family: 'Kiva Post Grot', weight: '300', style: 'italic' });
-	registerFont(fontFile('PostGrotesk-Book.ttf'), { family: 'Kiva Post Grot', weight: '400' });
-	// registerFont(fontFile('PostGrotesk-BookItalic.ttf'), { family: 'Kiva Post Grot', weight: '400', style: 'italic' });
-	registerFont(fontFile('PostGrotesk-Medium.ttf'), { family: 'Kiva Post Grot', weight: '500' });
-	registerFont(fontFile('PostGrotesk-MediumItalic.ttf'), { family: 'Kiva Post Grot', weight: '500', style: 'italic' });
-	// registerFont(fontFile('PostGrotesk-Bold.ttf'), { family: 'Kiva Post Grot', weight: '700' });
-	// registerFont(fontFile('PostGrotesk-BoldItalic.ttf'), { family: 'Kiva Post Grot', weight: '700', style: 'italic' });
-	/* eslint-enable max-len */
+	// registerFont writes to the process-wide font host and throws if the module
+	// is loaded more than once in a single process (e.g. across test files); the
+	// first registration wins, so a repeat registration can be safely ignored.
+	const register = (file, opts) => {
+		try {
+			registerFont(fontFile(file), opts);
+		} catch (e) {
+			// Font already registered for this process
+		}
+	};
+
+	register('PostGrotesk-Light.ttf', { family: 'Kiva Post Grot', weight: '300' });
+	register('PostGrotesk-Book.ttf', { family: 'Kiva Post Grot', weight: '400' });
+	register('PostGrotesk-Medium.ttf', { family: 'Kiva Post Grot', weight: '500' });
+	register('PostGrotesk-MediumItalic.ttf', { family: 'Kiva Post Grot', weight: '500', style: 'italic' });
 });
 
 // Use pool of canvas objects instead to avoid creating a new canvas for each request
@@ -62,9 +102,14 @@ const bundleLegacyCanvasPool = deePool.create(function makeCanvas() {
 const classicCanvasPool = deePool.create(function makeCanvas() {
 	return trace('createClassicCanvas', () => createCanvas(classicCardWidth, classicCardHeight));
 });
+// eslint-disable-next-line prefer-arrow-callback
+const compactCanvasPool = deePool.create(function makeCanvas() {
+	return trace('createCompactCanvas', () => createCanvas(compactCardDimensions.width, compactCardDimensions.height));
+});
 legacyCanvasPool.grow(2);
 bundleLegacyCanvasPool.grow(2);
 classicCanvasPool.grow(2);
+compactCanvasPool.grow(2);
 
 async function drawLegacy(loanData, { skipButton = false } = {}) {
 	const pool = skipButton ? bundleLegacyCanvasPool : legacyCanvasPool;
@@ -365,10 +410,164 @@ async function drawClassic(loanData, { skipButton = false } = {}) {
 	}
 }
 
+async function drawCompact(loanData) {
+	const canvas = trace('compactCanvasPool.use', () => compactCanvasPool.use());
+	const ctx = trace('canvas.getContext', () => canvas.getContext('2d', { alpha: false }));
+
+	const compactColors = {
+		textPrimary: '#212121',
+		brand: '#2aa967',
+		pillBg: '#f5f5f5',
+		progressTrack: '#d9d9d9',
+		white: '#ffffff'
+	};
+
+	const regularFont = '400 14px "Kiva Post Grot"';
+	// Bold name+country in the use text and the pills / "$X to go" label are all
+	// the same Medium weight in the design.
+	const mediumFont = '500 14px "Kiva Post Grot"';
+
+	try {
+		// Work in logical (unscaled) units; the pooled canvas is reused so reset
+		// the transform explicitly on every render.
+		trace('canvas-prep', () => {
+			ctx.setTransform(compactResizeFactor, 0, 0, compactResizeFactor, 0, 0);
+			ctx.textAlign = 'left';
+			ctx.textBaseline = 'top';
+
+			// White background across the whole image (incl. the shadow margin)
+			ctx.fillStyle = compactColors.white;
+			ctx.fillRect(0, 0, compactCardWidth + (2 * compactCardMargin), compactCardHeight + (2 * compactCardMargin));
+
+			// Card with a subtle drop shadow, baked onto the white background
+			ctx.save();
+			ctx.shadowColor = 'rgba(0, 0, 0, 0.08)';
+			ctx.shadowBlur = 12;
+			ctx.shadowOffsetX = 0;
+			ctx.shadowOffsetY = 4;
+			// eslint-disable-next-line max-len
+			roundRect(ctx, compactCardMargin, compactCardMargin, compactCardWidth, compactCardHeight, compactCardRadius);
+			ctx.fillStyle = compactColors.white;
+			ctx.fill();
+			ctx.restore();
+
+			// Move the origin into the card and clip content to its rounded corners.
+			// Balanced by the restore before export so the pooled canvas resets.
+			ctx.save();
+			ctx.translate(compactCardMargin, compactCardMargin);
+			roundRect(ctx, 0, 0, compactCardWidth, compactCardHeight, compactCardRadius);
+			ctx.clip();
+		});
+
+		const pad = compactCardPadding;
+
+		// Borrower image (square, rounded, left). Cover-crop so the 4:3 source
+		// photo fills the square without distortion.
+		const hasBorrowerImage = await trace('borrower-image', async () => {
+			const result = await loadBorrowerImage(loanData);
+			const { image } = result;
+			const {
+				width, height, offsetX, offsetY,
+			} = coverRect(image.width, image.height, compactImageSize);
+			ctx.save();
+			roundRect(ctx, pad, pad, compactImageSize, compactImageSize, compactImageRadius);
+			ctx.clip();
+			ctx.drawImage(image, pad + offsetX, pad + offsetY, width, height);
+			ctx.restore();
+			return result.hasBorrowerImage;
+		});
+
+		// Loan use statement (right of image, bold name + country, clamped to 4 lines)
+		const useLines = trace('borrower-use', () => {
+			const textX = pad + compactImageSize + compactImageGap;
+			const textWidth = compactCardWidth - textX - pad;
+			const runs = buildCompactLoanUseRuns(loanData);
+			ctx.fillStyle = compactColors.textPrimary;
+			return wrapStyledText(
+				ctx,
+				runs,
+				textX,
+				pad,
+				textWidth,
+				compactMaxUseLines,
+				compactUseLineHeight,
+				{ regularFont, boldFont: mediumFont }
+			);
+		});
+
+		// Top row hugs the taller of the image and the wrapped use text
+		const topRowBottom = pad + Math.max(compactImageSize, useLines * compactUseLineHeight);
+
+		// Loan callouts (grey pills, never orange). Collapses when there are none;
+		// pills that would overflow the row are dropped so nothing spills past the card.
+		const pillsBottom = trace('loan-callouts', () => {
+			ctx.font = mediumFont;
+			const availableWidth = compactCardWidth - (2 * pad);
+			const callouts = getLoanCallouts(loanData);
+			const labels = fitPillLabels(ctx, callouts, availableWidth, compactPillPadding, compactPillGap);
+			if (!labels.length) {
+				return topRowBottom;
+			}
+			const pillY = topRowBottom + compactSectionGap;
+			let lastTagRight = pad;
+			for (let i = 0; i < labels.length; i += 1) {
+				const { pillWidth } = drawPill(
+					ctx,
+					labels[i],
+					lastTagRight,
+					pillY,
+					compactPillPadding,
+					compactColors.textPrimary,
+					compactColors.pillBg
+				);
+				lastTagRight += pillWidth + compactPillGap;
+			}
+			return pillY + compactPillHeight;
+		});
+
+		// Fundraising info: "$X to go" label above a full-width progress bar
+		trace('fundraising-info', () => {
+			const toGoY = pillsBottom + compactSectionGap;
+			const barY = toGoY + compactToGoLineHeight + compactToGoBarGap;
+			const barWidth = compactCardWidth - (2 * pad);
+			const fundedAmount = loanData?.loanFundraisingInfo?.fundedAmount ?? 0;
+			const loanAmountValue = numeral(loanData?.loanAmount).value() || 1;
+			const fundraisingPercent = Math.min(1, fundedAmount / loanAmountValue);
+
+			ctx.font = mediumFont;
+			ctx.fillStyle = compactColors.textPrimary;
+			ctx.fillText(buildToGoText(loanData), pad, toGoY);
+
+			ctx.save();
+			roundRect(ctx, pad, barY, barWidth, compactBarHeight, compactBarHeight / 2);
+			ctx.clip();
+			ctx.fillStyle = compactColors.progressTrack;
+			ctx.fillRect(pad, barY, barWidth, compactBarHeight);
+			ctx.fillStyle = compactColors.brand;
+			ctx.fillRect(pad, barY, barWidth * fundraisingPercent, compactBarHeight);
+			ctx.restore();
+		});
+
+		// Undo the card translate + clip so the pooled canvas is clean for reuse
+		ctx.restore();
+
+		const buffer = trace('export-jpeg', () => canvas.toBuffer('image/jpeg', { quality: 0.5 }));
+		trace('compactCanvasPool.recycle', () => compactCanvasPool.recycle(canvas));
+		return { buffer, hasBorrowerImage };
+	} catch (e) {
+		if (canvas) {
+			trace('compactCanvasPool.recycle', () => compactCanvasPool.recycle(canvas));
+		}
+		throw e;
+	}
+}
+
 export default async function draw(loanData, style) {
 	switch (style) {
 		case 'bundle':
 			return drawClassic(loanData, { skipButton: true });
+		case 'compact-bundle':
+			return drawCompact(loanData);
 		case 'classic':
 			return drawClassic(loanData);
 		case 'bundle-legacy':

--- a/test/unit/specs/server/live-loan-router.spec.js
+++ b/test/unit/specs/server/live-loan-router.spec.js
@@ -450,6 +450,65 @@ describe('live-loan-router bundle-url routes', () => {
 		});
 	});
 
+	describe('serveImg - bundle-img-compact routes', () => {
+		beforeEach(() => {
+			drawLoanCard.mockResolvedValue({ buffer: Buffer.from('jpeg-bytes'), hasBorrowerImage: true });
+		});
+
+		it('serves jpeg for /u/:id/bundle-img-compact/:offset with compact-bundle style', async () => {
+			liveLoanFetch.default.mockResolvedValue([
+				{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 },
+			]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/u/42/bundle-img-compact/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 1 }, 'compact-bundle');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.DEFAULT,
+				6,
+			);
+		});
+
+		it('FLSS bundle-img-compact route passes FLSS query type and compact-bundle style', async () => {
+			liveLoanFetch.default.mockResolvedValue([{ id: 11 }, { id: 22 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/flss/u/42/bundle-img-compact/2');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 22 }, 'compact-bundle');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.FLSS,
+				6,
+			);
+		});
+
+		it('recommendations bundle-img-compact route uses recs query type and compact-bundle style', async () => {
+			liveLoanFetch.default.mockResolvedValue([{ id: 33 }]);
+
+			const app = createApp(cache);
+			const result = await makeRequest(app, '/live-loan/recommendations/u/42/bundle-img-compact/1');
+
+			expect(result.statusCode).toBe(200);
+			expect(result.headers['content-type']).toBe('image/jpeg');
+			expect(drawLoanCard).toHaveBeenCalledWith({ id: 33 }, 'compact-bundle');
+			expect(liveLoanFetch.default).toHaveBeenCalledWith(
+				'user',
+				'42',
+				liveLoanFetch.QUERY_TYPE.RECOMMENDATIONS,
+				6,
+			);
+		});
+	});
+
 	describe('serveImg - bundle-img-legacy routes', () => {
 		beforeEach(() => {
 			drawLoanCard.mockResolvedValue({ buffer: Buffer.from('jpeg-bytes'), hasBorrowerImage: true });

--- a/test/unit/specs/server/util/live-loan/canvas-utils.spec.js
+++ b/test/unit/specs/server/util/live-loan/canvas-utils.spec.js
@@ -1,0 +1,152 @@
+// @vitest-environment node
+import {
+	styledRunsToWords, wrapStyledText, fitPillLabels, coverRect,
+} from '#server/util/live-loan/canvas-utils';
+
+// Fake 2d context: 1px per character, records every fillText with the active font
+function makeFakeCtx() {
+	const calls = [];
+	return {
+		font: '',
+		fillStyle: '',
+		measureText(str) {
+			return { width: str.length };
+		},
+		fillText(text, x, y) {
+			calls.push({
+				text, x, y, font: this.font
+			});
+		},
+		calls,
+	};
+}
+
+describe('coverRect', () => {
+	it('scales a 4:3 landscape source to cover a square, cropping the sides', () => {
+		const {
+			width, height, offsetX, offsetY
+		} = coverRect(960, 720, 60);
+
+		expect(width).toBeCloseTo(80);
+		expect(height).toBeCloseTo(60);
+		// horizontal overflow is centered (negative), vertical is flush
+		expect(offsetX).toBeCloseTo(-10);
+		expect(offsetY).toBeCloseTo(0);
+	});
+
+	it('scales a portrait source to cover a square, cropping top and bottom', () => {
+		const {
+			width, height, offsetX, offsetY
+		} = coverRect(720, 960, 60);
+
+		expect(width).toBeCloseTo(60);
+		expect(height).toBeCloseTo(80);
+		expect(offsetX).toBeCloseTo(0);
+		expect(offsetY).toBeCloseTo(-10);
+	});
+
+	it('does not distort a square source', () => {
+		const {
+			width, height, offsetX, offsetY
+		} = coverRect(100, 100, 60);
+
+		expect(width).toBeCloseTo(60);
+		expect(height).toBeCloseTo(60);
+		expect(offsetX).toBeCloseTo(0);
+		expect(offsetY).toBeCloseTo(0);
+	});
+});
+
+describe('fitPillLabels', () => {
+	// pill width = 3*padding + textWidth (1px/char); gap between pills
+	it('keeps every pill when they all fit', () => {
+		const ctx = makeFakeCtx();
+
+		expect(fitPillLabels(ctx, ['ab', 'cd'], 200, 8, 8)).toEqual(['ab', 'cd']);
+	});
+
+	it('drops a trailing pill that overflows the row', () => {
+		const ctx = makeFakeCtx();
+
+		// first pill = 24+2 = 26 (fits in 30); second needs 8+26 more -> overflow
+		expect(fitPillLabels(ctx, ['ab', 'cd'], 30, 8, 8)).toEqual(['ab']);
+	});
+
+	it('drops a lone pill that is too wide on its own', () => {
+		const ctx = makeFakeCtx();
+
+		// pill = 24+10 = 34 > 30 -> dropped entirely (no ellipsis)
+		expect(fitPillLabels(ctx, ['abcdefghij'], 30, 8, 8)).toEqual([]);
+	});
+
+	it('returns an empty array for no callouts', () => {
+		const ctx = makeFakeCtx();
+
+		expect(fitPillLabels(ctx, [], 200, 8, 8)).toEqual([]);
+	});
+});
+
+describe('styledRunsToWords', () => {
+	it('splits runs into words carrying their bold flag', () => {
+		const words = styledRunsToWords([
+			{ text: '$100 helps ', bold: false },
+			{ text: 'Margaret in Guatemala', bold: true },
+			{ text: ' to build', bold: false },
+		]);
+
+		expect(words).toEqual([
+			{ word: '$100', bold: false },
+			{ word: 'helps', bold: false },
+			{ word: 'Margaret', bold: true },
+			{ word: 'in', bold: true },
+			{ word: 'Guatemala', bold: true },
+			{ word: 'to', bold: false },
+			{ word: 'build', bold: false },
+		]);
+	});
+});
+
+describe('wrapStyledText', () => {
+	const fonts = { regularFont: 'regular', boldFont: 'bold' };
+
+	it('draws bold words with the bold font and regular words with the regular font', () => {
+		const ctx = makeFakeCtx();
+		const runs = [
+			{ text: 'a ', bold: false },
+			{ text: 'Bob', bold: true },
+		];
+
+		const lines = wrapStyledText(ctx, runs, 0, 0, 1000, 4, 10, fonts);
+
+		expect(ctx.calls.map(c => ({ text: c.text, font: c.font }))).toEqual([
+			{ text: 'a', font: 'regular' },
+			{ text: 'Bob', font: 'bold' },
+		]);
+		expect(lines).toBe(1);
+	});
+
+	it('wraps words onto a new line when they exceed the max width and returns the line count', () => {
+		const ctx = makeFakeCtx();
+		const runs = [{ text: 'aaaa bbbb cccc', bold: false }];
+
+		// maxWidth 9 fits one 4-char word per line (word + trailing space)
+		const lines = wrapStyledText(ctx, runs, 0, 0, 9, 4, 10, fonts);
+
+		const ys = ctx.calls.map(c => c.y);
+		expect(ys).toEqual([0, 10, 20]);
+		expect(lines).toBe(3);
+	});
+
+	it('clamps to maxLines, appends an ellipsis, and returns the clamped count', () => {
+		const ctx = makeFakeCtx();
+		const runs = [{ text: 'aaaa bbbb cccc', bold: false }];
+
+		const lines = wrapStyledText(ctx, runs, 0, 0, 9, 1, 10, fonts);
+
+		// Only the first line is drawn; nothing lands on a second line
+		expect(ctx.calls.every(c => c.y === 0)).toBe(true);
+		// The final drawn token includes the ellipsis
+		expect(ctx.calls.at(-1).text).toContain('…');
+		expect(lines).toBe(1);
+	});
+});

--- a/test/unit/specs/server/util/live-loan/compact-card-text.spec.js
+++ b/test/unit/specs/server/util/live-loan/compact-card-text.spec.js
@@ -1,0 +1,93 @@
+// @vitest-environment node
+import { buildCompactLoanUseRuns, buildToGoText } from '#server/util/live-loan/compact-card-text';
+
+// Base loan shaped like the live-loan GraphQL response
+function makeLoan(overrides = {}) {
+	return {
+		name: 'Margaret',
+		geocode: { country: { name: 'Guatemala' } },
+		use: 'To build a sanitary toilet',
+		loanAmount: 100,
+		status: 'fundraising',
+		distributionModel: 'fieldPartner',
+		borrowerCount: 1,
+		anonymizationLevel: 'none',
+		loanFundraisingInfo: { fundedAmount: 0 },
+		...overrides,
+	};
+}
+
+// Concatenate runs back into the full sentence for readability assertions
+function joinRuns(runs) {
+	return runs.map(r => r.text).join('');
+}
+
+describe('buildCompactLoanUseRuns', () => {
+	it('bolds the borrower name and country inside a partner loan sentence', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan());
+
+		expect(joinRuns(runs)).toBe('$100 helps Margaret in Guatemala to build a sanitary toilet');
+		const boldRun = runs.find(r => r.bold);
+		expect(boldRun.text).toBe('Margaret in Guatemala');
+	});
+
+	it('uses past tense "helped" for a funded loan', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan({ status: 'funded' }));
+
+		expect(joinRuns(runs)).toBe('$100 helped Margaret in Guatemala to build a sanitary toilet');
+	});
+
+	it('places the help language after the name for direct loans', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan({ distributionModel: 'direct' }));
+
+		expect(joinRuns(runs)).toBe('$100 to Margaret in Guatemala helps to build a sanitary toilet');
+		expect(runs.find(r => r.bold).text).toBe('Margaret in Guatemala');
+	});
+
+	it('adds "a member of" for group loans', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan({ borrowerCount: 5 }));
+
+		expect(joinRuns(runs)).toBe('$100 helps a member of Margaret in Guatemala to build a sanitary toilet');
+	});
+
+	it('omits the country when there is no geocode', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan({ geocode: null }));
+
+		expect(joinRuns(runs)).toBe('$100 helps Margaret to build a sanitary toilet');
+		expect(runs.find(r => r.bold).text).toBe('Margaret');
+	});
+
+	it('returns a single privacy run when the loan is anonymized', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan({ anonymizationLevel: 'full' }));
+
+		expect(runs).toHaveLength(1);
+		expect(runs[0].bold).toBe(false);
+		expect(runs[0].text).toBe('For the borrower\'s privacy, this loan has been made anonymous.');
+	});
+
+	it('returns the privacy run when the use statement is empty', () => {
+		const runs = buildCompactLoanUseRuns(makeLoan({ use: '' }));
+
+		expect(joinRuns(runs)).toBe('For the borrower\'s privacy, this loan has been made anonymous.');
+	});
+});
+
+describe('buildToGoText', () => {
+	it('formats the remaining amount', () => {
+		const loan = makeLoan({ loanAmount: 1000, loanFundraisingInfo: { fundedAmount: 115 } });
+
+		expect(buildToGoText(loan)).toBe('$885 to go');
+	});
+
+	it('adds an exclamation point when under $100 remains', () => {
+		const loan = makeLoan({ loanAmount: 100, loanFundraisingInfo: { fundedAmount: 25 } });
+
+		expect(buildToGoText(loan)).toBe('$75 to go!');
+	});
+
+	it('shows "funded!" when nothing remains', () => {
+		const loan = makeLoan({ loanAmount: 100, loanFundraisingInfo: { fundedAmount: 100 } });
+
+		expect(buildToGoText(loan)).toBe('funded!');
+	});
+});

--- a/test/unit/specs/server/util/live-loan/live-loan-draw.spec.js
+++ b/test/unit/specs/server/util/live-loan/live-loan-draw.spec.js
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { createCanvas, loadImage } from 'canvas';
+import draw, { compactCardDimensions } from '#server/util/live-loan/live-loan-draw';
+import * as canvasImageUtils from '#server/util/live-loan/canvas-image-utils';
+
+vi.mock('#server/util/live-loan/canvas-image-utils');
+
+// A real (drawable) node-canvas stands in for the borrower photo
+function fakeBorrowerImage() {
+	return createCanvas(120, 120);
+}
+
+function makeLoan(overrides = {}) {
+	return {
+		name: 'Margaret',
+		id: 1,
+		geocode: { country: { name: 'Guatemala' } },
+		use: 'To build a sanitary toilet to improve her family health',
+		loanAmount: 1000,
+		status: 'fundraising',
+		distributionModel: 'fieldPartner',
+		borrowerCount: 1,
+		anonymizationLevel: 'none',
+		activity: { name: 'Sanitation' },
+		sector: { name: 'Health' },
+		tags: [],
+		tagsData: [],
+		themes: [],
+		loanFundraisingInfo: { fundedAmount: 115 },
+		...overrides,
+	};
+}
+
+async function dimensionsOf(buffer) {
+	const img = await loadImage(buffer);
+	return { width: img.width, height: img.height };
+}
+
+describe('draw – compact-bundle style', () => {
+	beforeEach(() => {
+		canvasImageUtils.loadBorrowerImage.mockResolvedValue({
+			image: fakeBorrowerImage(),
+			hasBorrowerImage: true,
+		});
+	});
+
+	it('renders the compact-bundle style as a compact-sized JPEG', async () => {
+		const { buffer, hasBorrowerImage } = await draw(makeLoan(), 'compact-bundle');
+
+		expect(Buffer.isBuffer(buffer)).toBe(true);
+		expect(hasBorrowerImage).toBe(true);
+		expect(await dimensionsOf(buffer)).toEqual(compactCardDimensions);
+	});
+
+	it('passes hasBorrowerImage through when the borrower photo is missing', async () => {
+		canvasImageUtils.loadBorrowerImage.mockResolvedValue({
+			image: fakeBorrowerImage(),
+			hasBorrowerImage: false,
+		});
+
+		const { hasBorrowerImage } = await draw(makeLoan(), 'compact-bundle');
+
+		expect(hasBorrowerImage).toBe(false);
+	});
+
+	it('renders an anonymized loan without throwing', async () => {
+		const { buffer } = await draw(makeLoan({ anonymizationLevel: 'full' }), 'compact-bundle');
+
+		expect(Buffer.isBuffer(buffer)).toBe(true);
+	});
+
+	it('leaves the existing bundle style at its own (non-compact) dimensions', async () => {
+		const { buffer } = await draw(makeLoan(), 'bundle');
+
+		const dims = await dimensionsOf(buffer);
+		expect(dims).not.toEqual(compactCardDimensions);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new **`compact-bundle`** server-rendered loan-card image style for bundle
emails, replicating the on-site compact loan card. This is **additive** — the
existing `bundle` style and its routes are untouched.

Resolves [MP-3005](https://kiva.atlassian.net/browse/MP-3005).
Design: [Figma — ERL Loan Bundle email 2026, compact card](https://www.figma.com/design/rLBhG6XIPcYWYoeOJnMf1M/%E2%9C%85--ERL-LB--ERL-Loan-Bundle-email-2026?node-id=19534-4929).

## What changed

- **New draw style `compact-bundle`** (`server/util/live-loan/live-loan-draw.js`) →
  `drawCompact()`, with its own canvas pool. Layout mirrors the on-site compact card:
  - Borrower image **left**, 60×60, 8px radius, **cover-cropped** (no distortion of the 4:3 source).
  - Use statement **right**: `"$X helps **Name in Country** {use}…"` — name+country bold, 14px / line-height 21, **clamped to 4 lines**.
  - Grey callout pills (`#f5f5f5`); pills that don't fit the row are **dropped**.
  - `"$X to go"` + progress bar (track `#d9d9d9`, fill `#2aa967`). No CTA button.
  - Card: 271px wide, 16px radius, drop shadow `0 4px 12px rgba(0,0,0,0.08)`, exported as JPEG on a white margin.
- **New routes** `bundle-img-compact` in all three contexts (`server/live-loan-router.js`), matching the existing `bundle` routes (same `MAX_BUNDLE_COUNT`).
- **New helpers**: `compact-card-text.js` (`buildCompactLoanUseRuns`, `buildToGoText`); `canvas-utils.js` (`styledRunsToWords`, `wrapStyledText`, `coverRect`, `measurePillWidth`, `fitPillLabels`).

## Example renders

On `https://www.development.kiva.org` (base path `/live-loan`, `:id` = lender id).
For bundles, `:offset` selects which loan in the bundle to render and ranges **1–6**
(`MAX_BUNDLE_COUNT`).

- **User:** https://www.development.kiva.org/live-loan/u/42/bundle-img-compact/1
- **FLSS:** https://www.development.kiva.org/live-loan/flss/u/42/bundle-img-compact/1
- **Recommendations:** https://www.development.kiva.org/live-loan/recommendations/u/42/bundle-img-compact/1

## Tests

- `test/unit/specs/server/util/live-loan/compact-card-text.spec.js` — use-statement runs (tense, direct/partner, group, no-country, anonymized, empty) + `$X to go` label (10).
- `test/unit/specs/server/util/live-loan/canvas-utils.spec.js` — `styledRunsToWords`, `wrapStyledText` (wrap/clamp/fonts/line-count), `coverRect` (cover-crop), `fitPillLabels` (drop overflow) (15).
- `test/unit/specs/server/util/live-loan/live-loan-draw.spec.js` — `compact-bundle` → compact dimensions, `hasBorrowerImage` passthrough, anonymized render, `bundle` unchanged (4).
- `test/unit/specs/server/live-loan-router.spec.js` — the 3 new routes → `compact-bundle` with correct query type + count (+3).

Live-loan suites: **149 passing**. Full unit suite green aside from one pre-existing, unrelated flake (`possibleTypesCacheIntegrity`, passes in isolation).

## Notes / limitations

- JPEG-on-white: the 16px radius + shadow are baked onto white, so it renders correctly on **light** email backgrounds (matches how the other bundle cards ship).
- Use-statement tense mirrors the on-site compact card (`issue` status reads "helped"), which intentionally differs from the classic card's `getLoanUse`.
- Downstream email/Merchant consumption wiring is owned by Marketing (out of scope).


[MP-3005]: https://kiva.atlassian.net/browse/MP-3005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Screenshot

<img width="991" height="742" alt="Screenshot 2026-08-26 at 10 02 21 a m" src="https://github.com/user-attachments/assets/3410bec3-a311-430c-8a67-4bc46768b996" />
