### PR TITLE
feat: [MP-3132] fire badge-claim-modal view event on email auto-open

### DIFF
--- a/src/pages/Portfolio/LendingStats/BadgesList.vue
+++ b/src/pages/Portfolio/LendingStats/BadgesList.vue
@@ -146,6 +146,9 @@ export default {
 	},
 	methods: {
 		autoOpenBadgeFromEmail() {
+			if (this.showBadgeModal) {
+				return;
+			}
 			const campaign = this.$route?.query?.utm_campaign ?? '';
 			if (!campaign.startsWith('badge_')) {
 				return;
@@ -157,6 +160,7 @@ export default {
 			}
 			this.selectedBadgeData = badge;
 			this.showBadgeModal = true;
+			this.$kvTrackEvent('portfolio', 'view', 'badge-claim-modal', badge.challengeName);
 		},
 		navigateToLoanFindingUrl(id) {
 			const loanFindingUrl = this.getLoanFindingUrl(id, this.$router.currentRoute.value);

--- a/test/unit/specs/pages/Portfolio/LendingStats/BadgesList.spec.js
+++ b/test/unit/specs/pages/Portfolio/LendingStats/BadgesList.spec.js
@@ -20,7 +20,7 @@ const rerenderWith = (rerender, completedAchievements) => rerender({
 	badgesData: [],
 });
 
-const renderBadgesList = ({ completedAchievements = [], query = {} } = {}) => {
+const renderBadgesList = ({ completedAchievements = [], query = {}, trackEvent = () => {} } = {}) => {
 	return render(BadgesList, {
 		props: {
 			completedAchievements,
@@ -34,7 +34,7 @@ const renderBadgesList = ({ completedAchievements = [], query = {} } = {}) => {
 			},
 			directives: { kvTrackEvent: () => {} },
 			mocks: {
-				$kvTrackEvent: () => {},
+				$kvTrackEvent: trackEvent,
 				$router: { push: () => {}, currentRoute: { value: { query } } },
 				$route: { query },
 			},
@@ -109,5 +109,73 @@ describe('BadgesList email-link auto-open', () => {
 		await rerenderWith(rerender, [eventBadge('stewardship-2026')]);
 
 		await waitFor(() => expect(queryByTestId('badge-modal')).toBeTruthy());
+	});
+});
+
+describe('BadgesList badge-claim-modal view tracking', () => {
+	it('fires a portfolio view event with the badge name when the modal auto-opens', async () => {
+		const trackEvent = vi.fn();
+		renderBadgesList({
+			completedAchievements: [eventBadge('stewardship-2026')],
+			query: { utm_campaign: 'badge_stewardship-2026' },
+			trackEvent,
+		});
+
+		await waitFor(() => expect(trackEvent).toHaveBeenCalledWith(
+			'portfolio',
+			'view',
+			'badge-claim-modal',
+			'Stewardship',
+		));
+	});
+
+	it('does not fire the view event without the email param', async () => {
+		const trackEvent = vi.fn();
+		renderBadgesList({
+			completedAchievements: [eventBadge('stewardship-2026')],
+			query: {},
+			trackEvent,
+		});
+
+		await flushPromises();
+		expect(trackEvent).not.toHaveBeenCalledWith(
+			'portfolio',
+			'view',
+			'badge-claim-modal',
+			expect.anything(),
+		);
+	});
+
+	it('does not fire the view event when the user does not own the linked badge', async () => {
+		const trackEvent = vi.fn();
+		renderBadgesList({
+			completedAchievements: [eventBadge('some-other-badge')],
+			query: { utm_campaign: 'badge_stewardship-2026' },
+			trackEvent,
+		});
+
+		await flushPromises();
+		expect(trackEvent).not.toHaveBeenCalledWith(
+			'portfolio',
+			'view',
+			'badge-claim-modal',
+			expect.anything(),
+		);
+	});
+
+	it('fires the view event only once even when badges reload after the modal opens', async () => {
+		const trackEvent = vi.fn();
+		const { rerender } = renderBadgesList({
+			completedAchievements: [eventBadge('stewardship-2026')],
+			query: { utm_campaign: 'badge_stewardship-2026' },
+			trackEvent,
+		});
+
+		await waitFor(() => expect(trackEvent).toHaveBeenCalledTimes(1));
+
+		await rerenderWith(rerender, [eventBadge('stewardship-2026')]);
+		await flushPromises();
+
+		expect(trackEvent).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary
Fires the single analytics event MP-3132 specifies when the badge-claim
modal auto-opens from the marketing email link (the auto-open itself
shipped in MP-3131).

Event: `$kvTrackEvent('portfolio', 'view', 'badge-claim-modal', badge.challengeName)`

- `se_category` = `portfolio`, `se_action` = `view`, `se_label` = `badge-claim-modal`, `se_property` = badge name
- `view` matches existing portfolio modal-display events (e.g. `edit-goal-modal`)
- Fires at most once: `autoOpenBadgeFromEmail()` now early-returns when the
  modal is already open, so reactive re-runs of the `completedAchievements`
  watcher can't emit duplicate views.

## Testing
- 4 new unit tests: fires with correct args on valid email open; no fire
  without the campaign param; no fire when the badge isn't owned; fires only
  once across a badges reload.
- `BadgesList.spec.js` 9/9 pass, lint clean.

## Jira
MP-3132
