### PR TITLE
refactor: remap deprecated Contentful theme values to approved themes

### DIFF
--- a/src/components/Contentful/SectionWithBackgroundClassic.vue
+++ b/src/components/Contentful/SectionWithBackgroundClassic.vue
@@ -34,16 +34,11 @@
 
 <script>
 import {
-	darkTheme,
-	darkGreenTheme,
-	mintTheme,
 	defaultTheme,
-	darkMintTheme,
 	greenLightTheme,
 	greenDarkTheme,
 	marigoldLightTheme,
 	stoneLightTheme,
-	stoneDarkTheme,
 } from '@kiva/kv-tokens';
 import { defineAsyncComponent } from 'vue';
 
@@ -93,10 +88,15 @@ export default {
 		 *
 		 * Can be one of:
 		 * - 'kivaClassicLight'
-		 * - 'kivaClassicMint'
-		 * - 'kivaClassicGreen'
-		 * - 'kivaClassicDark'
-		 * - 'imageCard'
+		 * - 'ecoGreenLight'
+		 * - 'ecoGreenDark'
+		 * - 'ecoMarigoldLight'
+		 * - 'ecoStoneLight'
+		 *
+		 * The legacy 'kivaClassicMint', 'kivaClassicGreen', 'kivaClassicDark',
+		 * 'kivaClassicDarkStone', 'kivaDarkMint', 'imageCard', and 'ecoStoneDark' values
+		 * still render, mapped to their closest approved theme, until they are retired
+		 * in Contentful.
 		 *
 		 * The default theme 'kivaClassicLight' will be used for any other value.
 		 */
@@ -166,16 +166,19 @@ export default {
 		themeStyles() {
 			const themeMapper = {
 				kivaClassicLight: defaultTheme,
-				kivaClassicMint: mintTheme,
-				kivaClassicGreen: darkGreenTheme,
-				kivaClassicDark: darkTheme,
-				imageCard: darkTheme,
-				kivaDarkMint: darkMintTheme,
+				// The kivaClassic*, kivaDarkMint, and ecoStoneDark values are pending retirement
+				// in Contentful. Until then they render as their closest approved theme.
+				kivaClassicMint: greenLightTheme,
+				kivaClassicGreen: greenDarkTheme,
+				kivaClassicDark: greenDarkTheme,
+				kivaClassicDarkStone: greenDarkTheme,
+				kivaDarkMint: greenDarkTheme,
+				imageCard: greenDarkTheme,
+				ecoStoneDark: greenDarkTheme,
 				ecoGreenLight: greenLightTheme,
 				ecoGreenDark: greenDarkTheme,
 				ecoMarigoldLight: marigoldLightTheme,
 				ecoStoneLight: stoneLightTheme,
-				ecoStoneDark: stoneDarkTheme,
 			};
 			const theme = themeMapper[this.themeName] ?? defaultTheme;
 			// No styles needed if using the default theme

--- a/src/components/Contentful/StoryCard.vue
+++ b/src/components/Contentful/StoryCard.vue
@@ -74,15 +74,11 @@
 import { richTextRenderer } from '#src/util/contentful/richTextRenderer';
 import DynamicRichText from '#src/components/Contentful/DynamicRichText';
 import {
-	darkTheme,
-	darkGreenTheme,
-	mintTheme,
 	defaultTheme,
 	greenLightTheme,
 	greenDarkTheme,
 	marigoldLightTheme,
 	stoneLightTheme,
-	stoneDarkTheme,
 } from '@kiva/kv-tokens';
 import { KvContentfulImg, KvThemeProvider } from '@kiva/kv-components';
 /**
@@ -117,16 +113,19 @@ export default {
 		},
 		theme() {
 			const themeMapper = {
-				kivaCLassicLight: defaultTheme,
-				kivaClassicMint: mintTheme,
-				kivaClassicGreen: darkGreenTheme,
-				kivaClassicDark: darkTheme,
-				imageCard: darkTheme,
+				kivaClassicLight: defaultTheme,
+				// The kivaClassic* and ecoStoneDark values are pending retirement in Contentful.
+				// Until then they render as their closest approved theme.
+				kivaClassicMint: greenLightTheme,
+				kivaClassicGreen: greenDarkTheme,
+				kivaClassicDark: greenDarkTheme,
+				kivaClassicDarkStone: greenDarkTheme,
+				imageCard: greenDarkTheme,
+				ecoStoneDark: greenDarkTheme,
 				ecoGreenLight: greenLightTheme,
 				ecoGreenDark: greenDarkTheme,
 				ecoMarigoldLight: marigoldLightTheme,
 				ecoStoneLight: stoneLightTheme,
-				ecoStoneDark: stoneDarkTheme,
 			};
 			return themeMapper[this.content?.theme] ?? defaultTheme;
 		},

--- a/src/pages/MonthlyGood/HowItWorks.vue
+++ b/src/pages/MonthlyGood/HowItWorks.vue
@@ -1,5 +1,5 @@
 <template>
-	<kv-theme-provider :theme="darkGreenTheme">
+	<kv-theme-provider :theme="greenDarkTheme">
 		<div
 			class="
 			tw-bg-primary
@@ -16,7 +16,7 @@
 <script>
 import CenteredRichText from '#src/components/Contentful/CenteredRichText';
 import RichTextItemsCentered from '#src/components/Contentful/RichTextItemsCentered';
-import { darkGreenTheme } from '@kiva/kv-tokens';
+import { greenDarkTheme } from '@kiva/kv-tokens';
 import { KvThemeProvider } from '@kiva/kv-components';
 
 export default {
@@ -37,7 +37,7 @@ export default {
 		},
 	},
 	data() {
-		return { darkGreenTheme };
+		return { greenDarkTheme };
 	}
 };
 


### PR DESCRIPTION
Ticket: https://kiva.atlassian.net/browse/CIT-4445

## Summary

- Points the legacy `kivaClassicMint`, `kivaClassicGreen`, `kivaClassicDark`, `kivaClassicDarkStone`, `kivaDarkMint`, `imageCard`, and `ecoStoneDark` Contentful values at their closest approved theme in `Contentful/StoryCard.vue` and `Contentful/SectionWithBackgroundClassic.vue`. `kivaClassicMint` goes to `greenLightTheme`; the dark variants all go to `greenDarkTheme`, the only approved dark theme. The values stay accepted, so no Contentful content has to move for this to ship.
- Swaps `darkGreenTheme` for `greenDarkTheme` in `pages/MonthlyGood/HowItWorks.vue`. Despite the near-identical names these are different themes — `dark-green` vs `green-dark` — so this one does change how that section looks. See below.
- Adds the missing `kivaClassicDarkStone` mapping. ui had no entry for it and silently fell back to `defaultTheme` while CPS rendered it dark stone, so 7 published cards (the `success-story-*` set) looked different between the two apps.
- Fixes the `kivaCLassicLight` typo (capital L) in `StoryCard.vue`, which made that key unreachable. No behavior change since the fallback already landed on `defaultTheme`.

## Expected visual changes

**`/monthlygood` — How It Works section.** The only change in this PR that is not Contentful-driven, and the most visible. `darkGreenTheme` and `greenDarkTheme` are different themes, not two spellings of one:

| | `darkGreenTheme` (before) | `greenDarkTheme` (after) |
| --- | --- | --- |
| `--bg-primary` | `#2AA967` bright Kiva green | `#223829` dark green |
| `--text-primary` | `#F5F5F5` | `#EDF4F1` |
| `--text-action` | `#2B7C5F` | `#78C79F` |

The section wrapper carries `tw-bg-primary`, so its background goes from bright green to dark green. Confirmed against production, which currently serves `--bg-primary:42, 169, 103` on that band. Text stays near-white and remains legible; links get lighter. This is a deliberate move onto the approved theme, but it is a real design change and **the only production-visible change in this PR** — worth a look before merge.

**The Contentful components in this repo are largely not exercised in production.** Contentful landing pages are served by cms-page-server, which has its own copies of `StoryCard` and `SectionWithBackgroundClassic`. In this repo the `/lp/:dynamicRoute` route that fed `ContentfulPage` is commented out (`// Preserved for cms-page-server rollout, will remove after validation`), leaving `/hp/:dynamicRoute`, `/cc/:dynamicRoute` (corporate campaign) and `/categories`. Cross-checking the audit: no affected page key starts with `hp/`, and no affected page has `pageType: corporate-campaign`. I sampled 14 of the audited paths against production and every one is CPS-rendered, with none containing `background-color:rgb(var(--bg-primary))` — the fallback unique to this repo's section component.

So the Contentful mapper changes here are correctness work to keep this code compiling and consistent with CPS, not a production visual change. The equivalent CPS change is kiva/cms-page-server#3264, and the visible Contentful-driven changes are described there.

Residual unknown: `/categories` pulls a themed `FrequentlyAskedQuestions` group by key rather than through a `page` entry, so it would not appear in a page-keyed audit. Worth a spot check.

Six previously distinct looks now collapse onto `greenDark`, since it is the only approved dark theme. CIT-5073 carries the full audit and the design decision on whether some should land on `marigoldLight` or `stoneLight` instead.

## Why now

kv-ui-elements PR #885 removes the `mintTheme`, `darkTheme`, `darkGreenTheme`, `darkMintTheme`, `darkStoneTheme`, and `stoneDarkTheme` exports from kv-tokens. This repo imported five of them, so it needs to be off those names before a kv-tokens version carrying that change is picked up here.

Retiring the legacy values in Contentful and dropping these transitional mapper keys is tracked in CIT-5073, which carries the full audit: 238 published entries sit on a deprecated value, 145 of them reachable from a published page, spanning 85 pages.
