### PR TITLE
fix(live-loan): pin compact bundle card progress bar to card bottom

### DIFF
--- a/server/util/live-loan/compact-card-constants.js
+++ b/server/util/live-loan/compact-card-constants.js
@@ -25,6 +25,10 @@ export const compactCardHeight = compactCardPadding
 	+ compactPillHeight + compactSectionGap
 	+ (compactToGoLineHeight + compactToGoBarGap + compactBarHeight)
 	+ compactCardPadding;
+// The "$X to go" label + bar are pinned to the bottom of the fixed-height card
+// so their position stays put no matter how many lines the use text wraps to.
+export const compactBarY = compactCardHeight - compactCardPadding - compactBarHeight;
+export const compactToGoY = compactBarY - compactToGoBarGap - compactToGoLineHeight;
 // Outer margin around the card, baked onto white, so the drop shadow has room
 export const compactCardMargin = 16;
 export const compactCardDimensions = {

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -25,12 +25,11 @@ import {
 	compactUseLineHeight,
 	compactMaxUseLines,
 	compactSectionGap,
-	compactPillHeight,
 	compactPillPadding,
 	compactPillGap,
-	compactToGoLineHeight,
-	compactToGoBarGap,
 	compactBarHeight,
+	compactBarY,
+	compactToGoY,
 	compactCardMargin,
 	compactCardHeight,
 	compactCardDimensions,
@@ -475,19 +474,18 @@ async function drawCompact(loanData) {
 			);
 		});
 
-		// Top row hugs the taller of the image and the wrapped use text
-		const topRowBottom = pad + Math.max(compactImageSize, useLines * compactUseLineHeight);
-
 		// Loan callouts (grey pills, never orange). Collapses when there are none;
 		// pills that would overflow the row are dropped so nothing spills past the card.
-		const pillsBottom = trace('loan-callouts', () => {
+		trace('loan-callouts', () => {
 			ctx.font = compactMediumFont;
 			const availableWidth = compactCardWidth - (2 * pad);
 			const callouts = getLoanCallouts(loanData);
 			const labels = fitPillLabels(ctx, callouts, availableWidth, compactPillPadding, compactPillGap);
 			if (!labels.length) {
-				return topRowBottom;
+				return;
 			}
+			// Pills sit below the top row, which hugs the taller of the image and the wrapped use text
+			const topRowBottom = pad + Math.max(compactImageSize, useLines * compactUseLineHeight);
 			const pillY = topRowBottom + compactSectionGap;
 			let lastTagRight = pad;
 			for (let i = 0; i < labels.length; i += 1) {
@@ -502,13 +500,10 @@ async function drawCompact(loanData) {
 				);
 				lastTagRight += pillWidth + compactPillGap;
 			}
-			return pillY + compactPillHeight;
 		});
 
 		// Fundraising info: "$X to go" label above a full-width progress bar
 		trace('fundraising-info', () => {
-			const toGoY = pillsBottom + compactSectionGap;
-			const barY = toGoY + compactToGoLineHeight + compactToGoBarGap;
 			const barWidth = compactCardWidth - (2 * pad);
 			const fundedAmount = loanData?.loanFundraisingInfo?.fundedAmount ?? 0;
 			const loanAmountValue = numeral(loanData?.loanAmount).value() || 1;
@@ -516,15 +511,15 @@ async function drawCompact(loanData) {
 
 			ctx.font = compactMediumFont;
 			ctx.fillStyle = compactColors.textPrimary;
-			ctx.fillText(buildToGoText(loanData), pad, toGoY);
+			ctx.fillText(buildToGoText(loanData), pad, compactToGoY);
 
 			ctx.save();
-			roundRect(ctx, pad, barY, barWidth, compactBarHeight, compactBarHeight / 2);
+			roundRect(ctx, pad, compactBarY, barWidth, compactBarHeight, compactBarHeight / 2);
 			ctx.clip();
 			ctx.fillStyle = compactColors.progressTrack;
-			ctx.fillRect(pad, barY, barWidth, compactBarHeight);
+			ctx.fillRect(pad, compactBarY, barWidth, compactBarHeight);
 			ctx.fillStyle = compactColors.brand;
-			ctx.fillRect(pad, barY, barWidth * fundraisingPercent, compactBarHeight);
+			ctx.fillRect(pad, compactBarY, barWidth * fundraisingPercent, compactBarHeight);
 			ctx.restore();
 		});
 

--- a/test/unit/specs/server/util/live-loan/live-loan-draw.spec.js
+++ b/test/unit/specs/server/util/live-loan/live-loan-draw.spec.js
@@ -1,9 +1,17 @@
 // @vitest-environment node
 import { createCanvas, loadImage } from 'canvas';
 import draw, { compactCardDimensions } from '#server/util/live-loan/live-loan-draw';
+import { compactColors } from '#server/util/live-loan/compact-card-constants';
 import * as canvasImageUtils from '#server/util/live-loan/canvas-image-utils';
 
 vi.mock('#server/util/live-loan/canvas-image-utils');
+
+// Sample the right half of the bar, clear of the lighter pill background
+const SAMPLE_X_FRACTION = 0.77;
+// JPEG at quality 0.5 is lossy, so match the track colour within a channel tolerance
+const COLOUR_TOLERANCE = 12;
+// Progress-track grey is a flat grey, so any channel of its hex is the target value
+const TRACK_GREY = parseInt(compactColors.progressTrack.slice(1, 3), 16);
 
 // A real (drawable) node-canvas stands in for the borrower photo
 function fakeBorrowerImage() {
@@ -34,6 +42,30 @@ function makeLoan(overrides = {}) {
 async function dimensionsOf(buffer) {
 	const img = await loadImage(buffer);
 	return { width: img.width, height: img.height };
+}
+
+// Finds the bottom-most device row containing the progress-track grey in a
+// 1px-wide strip on the right half of the bar, which locates the bar vertically.
+async function barBottomY(buffer) {
+	const img = await loadImage(buffer);
+	const canvas = createCanvas(img.width, img.height);
+	const ctx = canvas.getContext('2d');
+	ctx.drawImage(img, 0, 0);
+	const x = Math.round(img.width * SAMPLE_X_FRACTION);
+	const { data } = ctx.getImageData(x, 0, 1, img.height);
+	let lastTrackRow = -1;
+	for (let y = 0; y < img.height; y += 1) {
+		const r = data[(y * 4)];
+		const g = data[(y * 4) + 1];
+		const b = data[(y * 4) + 2];
+		const isTrackGrey = Math.abs(r - TRACK_GREY) < COLOUR_TOLERANCE
+			&& Math.abs(g - TRACK_GREY) < COLOUR_TOLERANCE
+			&& Math.abs(b - TRACK_GREY) < COLOUR_TOLERANCE;
+		if (isTrackGrey) {
+			lastTrackRow = y;
+		}
+	}
+	return lastTrackRow;
 }
 
 describe('draw – compact-bundle style', () => {
@@ -67,6 +99,27 @@ describe('draw – compact-bundle style', () => {
 		const { buffer } = await draw(makeLoan({ anonymizationLevel: 'full' }), 'compact-bundle');
 
 		expect(Buffer.isBuffer(buffer)).toBe(true);
+	});
+
+	it('pins the progress bar to the card bottom regardless of use-text length', async () => {
+		const shortUse = await draw(makeLoan({ use: 'Bread.' }), 'compact-bundle');
+		const longUse = await draw(
+			makeLoan({
+				use: 'To purchase additional flour, sugar, yeast, and other raw baking materials '
+					+ 'in bulk so she can expand her neighbourhood bakery and hire an assistant.',
+			}),
+			'compact-bundle',
+		);
+
+		const shortBottom = await barBottomY(shortUse.buffer);
+		const longBottom = await barBottomY(longUse.buffer);
+
+		expect(shortBottom).toBeGreaterThan(0);
+		expect(longBottom).toBeGreaterThan(0);
+		// The bar must sit near the bottom of the card, not partway up.
+		expect(longBottom).toBeGreaterThan(compactCardDimensions.height * 0.75);
+		// ...and land in the same place whether the use text is 1 or 4 lines.
+		expect(Math.abs(shortBottom - longBottom)).toBeLessThanOrEqual(3);
 	});
 
 	it('leaves the existing bundle style at its own (non-compact) dimensions', async () => {


### PR DESCRIPTION
## What
On the `compact-bundle` live-loan card, the "$X to go" label and progress bar now sit at a fixed position at the bottom of the card, regardless of how many lines the borrower use text wraps to.

## Why
The card canvas is a fixed height (sized to the 4-line worst case), but the fundraising section flowed top-down from the pill position, which tracks the actual wrapped use-line count. With shorter use text the whole stack floated up, leaving the bar partway up the card with empty space below it.

## How
- Added derived constants `compactBarY` / `compactToGoY` in `compact-card-constants.js`, peeling the bottom terms off the fixed `compactCardHeight`, and reference them in `drawCompact`.
- Pills still flow top-down from the use text; in the 4-line worst case the pinned position equals the old flowed position (no pill/bar overlap).

## Testing
- New spec: renders 1-line and 4-line use text and asserts the bar bottom lands in the same place (was 72px apart) and sits in the bottom quarter.
- Full live-loan suite green; full unit suite green (one pre-existing, unrelated flake); lint clean.
