### PR TITLE
refactor: remove legacy contentful theme mappings

### DIFF
--- a/src/components/Contentful/SectionWithBackgroundClassic.vue
+++ b/src/components/Contentful/SectionWithBackgroundClassic.vue
@@ -92,11 +92,7 @@ export default {
 		 * - 'ecoGreenDark'
 		 * - 'ecoMarigoldLight'
 		 * - 'ecoStoneLight'
-		 *
-		 * The legacy 'kivaClassicMint', 'kivaClassicGreen', 'kivaClassicDark',
-		 * 'kivaClassicDarkStone', 'kivaDarkMint', 'imageCard', and 'ecoStoneDark' values
-		 * still render, mapped to their closest approved theme, until they are retired
-		 * in Contentful.
+		 * - 'imageCard' (a layout, retained as a valid value)
 		 *
 		 * The default theme 'kivaClassicLight' will be used for any other value.
 		 */
@@ -166,15 +162,8 @@ export default {
 		themeStyles() {
 			const themeMapper = {
 				kivaClassicLight: defaultTheme,
-				// The kivaClassic*, kivaDarkMint, and ecoStoneDark values are pending retirement
-				// in Contentful. Until then they render as their closest approved theme.
-				kivaClassicMint: greenLightTheme,
-				kivaClassicGreen: greenDarkTheme,
-				kivaClassicDark: greenDarkTheme,
-				kivaClassicDarkStone: greenDarkTheme,
-				kivaDarkMint: greenDarkTheme,
+				// imageCard is a layout, not a colour theme, so it stays a valid value.
 				imageCard: greenDarkTheme,
-				ecoStoneDark: greenDarkTheme,
 				ecoGreenLight: greenLightTheme,
 				ecoGreenDark: greenDarkTheme,
 				ecoMarigoldLight: marigoldLightTheme,

--- a/src/components/Contentful/StoryCard.vue
+++ b/src/components/Contentful/StoryCard.vue
@@ -114,14 +114,9 @@ export default {
 		theme() {
 			const themeMapper = {
 				kivaClassicLight: defaultTheme,
-				// The kivaClassic* and ecoStoneDark values are pending retirement in Contentful.
-				// Until then they render as their closest approved theme.
-				kivaClassicMint: greenLightTheme,
-				kivaClassicGreen: greenDarkTheme,
-				kivaClassicDark: greenDarkTheme,
-				kivaClassicDarkStone: greenDarkTheme,
+				// imageCard is a layout, not a colour theme: StoryCard keys CSS off
+				// .story-card__imageCard for the background image treatment.
 				imageCard: greenDarkTheme,
-				ecoStoneDark: greenDarkTheme,
 				ecoGreenLight: greenLightTheme,
 				ecoGreenDark: greenDarkTheme,
 				ecoMarigoldLight: marigoldLightTheme,


### PR DESCRIPTION
Ticket: [CIT-5073](https://kiva.atlassian.net/browse/CIT-5073)

## Summary

- Removes the `kivaClassicMint`, `kivaClassicGreen`, `kivaClassicDark`, `kivaClassicDarkStone`, `kivaDarkMint` and `ecoStoneDark` entries from the theme mappers in `StoryCard.vue` and `SectionWithBackgroundClassic.vue`. Those values no longer exist in Contentful (dev or master) after the CIT-5073 migration, so the mappings were dead code.
- Keeps `imageCard`, which is a layout rather than a colour theme — `StoryCard` keys its background-image treatment off `.story-card__imageCard`.
- Updates the `themeName` prop docs on `SectionWithBackgroundClassic`, which still described the legacy values as rendering "until they are retired in Contentful".
- No visual change expected: every remaining Contentful entry uses an approved value, and unrecognised values already fell through to the default theme.

[CIT-5073]: https://kiva.atlassian.net/browse/CIT-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ