### PR TITLE
fix: release withdraw page migration

### DIFF
--- a/src/util/withdraw/withdrawConstants.js
+++ b/src/util/withdraw/withdrawConstants.js
@@ -8,13 +8,13 @@ export const WITHDRAWAL_STATUS = {
 	ERROR: 'ERROR',
 };
 
-// Route paths for the withdraw-beta flow. Imported by the router and the pages so
+// Route paths for the withdraw flow. Imported by the router and the pages so
 // every navigation target resolves to a single source of truth.
 export const WITHDRAW_ROUTE = {
-	BASE: '/withdraw-beta',
-	CONFIRM: '/withdraw-beta/confirm',
-	CHECK_INBOX: '/withdraw-beta/check-inbox',
-	AUTHORIZE: '/withdraw-beta/authorize',
+	BASE: '/withdraw',
+	CONFIRM: '/withdraw/confirm',
+	CHECK_INBOX: '/withdraw/check-inbox',
+	AUTHORIZE: '/withdraw/authorize',
 };
 
 // Human-readable action shown on the email-verification step-up page

--- a/test/unit/specs/pages/Withdraw/WithdrawConfirmPage.spec.js
+++ b/test/unit/specs/pages/Withdraw/WithdrawConfirmPage.spec.js
@@ -63,7 +63,7 @@ const renderConfirm = ({
 describe('WithdrawConfirmPage', () => {
 	it('redirects back to the form when arrived without an amount', () => {
 		const { replace } = renderConfirm({ state: {} });
-		expect(replace).toHaveBeenCalledWith({ path: '/withdraw-beta' });
+		expect(replace).toHaveBeenCalledWith({ path: '/withdraw' });
 	});
 
 	it('renders the request summary', async () => {
@@ -91,7 +91,7 @@ describe('WithdrawConfirmPage', () => {
 		await fireEvent.click(getByTestId('withdraw-submit'));
 		await waitFor(() => {
 			expect(push).toHaveBeenCalledWith({
-				path: '/withdraw-beta/check-inbox',
+				path: '/withdraw/check-inbox',
 				state: { withdrawEmail: 'a@example.org' },
 			});
 		});

--- a/test/unit/specs/pages/Withdraw/WithdrawPage.spec.js
+++ b/test/unit/specs/pages/Withdraw/WithdrawPage.spec.js
@@ -178,7 +178,7 @@ describe('WithdrawPage', () => {
 
 		await waitFor(() => {
 			expect(push).toHaveBeenCalledWith({
-				path: '/withdraw-beta/confirm',
+				path: '/withdraw/confirm',
 				state: { withdrawAmount: '50', withdrawPaypalEmail: 'a@example.org' },
 			});
 		});


### PR DESCRIPTION
https://kiva.atlassian.net/browse/MP-2963

PayPal withdraw flow worked on prod last week for my personal account on the new beta page. Now it's time to release the migration to all users.