### PR TITLE
chore(checkout): roll out stop_hiding_tip_campaign experiment to 100%

### DIFF
--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -386,7 +386,6 @@ const DEPOSIT_REWARD_EXP_KEY = 'deposit_incentive_banner';
 const BANDIT_UPSELL_EXP_KEY = 'checkout_bandit_upsell_enable';
 const EXPIRING_SOON_EXP_KEY = 'checkout_expiring_soon_upsell';
 const KIVA_CREDIT_REPLACEMENT_EXP_KEY = 'checkout_kiva_credit_copy_replacement';
-const STOP_HIDING_TIP_EXP_KEY = 'stop_hiding_tip_campaign';
 const TIP_PERCENTAGE = 0.2;
 
 // Assigned during SSR so versions are available before hydration
@@ -525,7 +524,7 @@ export default {
 			isExpiringSoonExpEnabled: false,
 			isKivaCreditReplacementExpEnabled: false,
 			enableAdminRewardTipFlag: false,
-			isStopHidingTipExpEnabled: false,
+			stopHidingTip: false,
 			customTipDefaultVersion: null,
 		};
 	},
@@ -734,7 +733,7 @@ export default {
 				]);
 				this.getUpsellModuleData();
 			}
-			if (!newValue && this.isStopHidingTipExpEnabled) {
+			if (!newValue && this.stopHidingTip) {
 				this.ensureTipDonationExists();
 			}
 		},
@@ -1016,7 +1015,7 @@ export default {
 				if (hasFreeCredits && refreshEvent === 'kiva-card-applied') {
 					this.disableGuestCheckout();
 				}
-				if (this.isStopHidingTipExpEnabled) {
+				if (this.stopHidingTip) {
 					const items = _get(data, 'shop.basket.items.values');
 					if (items) {
 						this.donations = _filter(items, { __typename: 'Donation' });
@@ -1118,9 +1117,10 @@ export default {
 				this.promoData = data?.shop?.promoCampaign;
 
 				const adminRewardTipEligible = isAdminRewardTipEligible(this.promoData, this.enableAdminRewardTipFlag);
-				// If user is eligible for admin reward tip, initialize experiment to stop hiding tip for them
+				// If user is eligible for admin reward tip, stop hiding the tip for them
 				if (adminRewardTipEligible) {
-					this.initializeStopHidingTipExperiment();
+					this.stopHidingTip = true;
+					this.ensureTipDonationExists();
 				}
 
 				this.$nextTick(() => {
@@ -1473,23 +1473,6 @@ export default {
 					this.setUpdatingTotals(false);
 					logReadQueryError(error, 'CheckoutPage ensureTipDonationExists');
 				});
-		},
-		initializeStopHidingTipExperiment() {
-			initializeExperiment(
-				this.cookieStore,
-				this.apollo,
-				this.$route,
-				STOP_HIDING_TIP_EXP_KEY,
-				version => {
-					this.isStopHidingTipExpEnabled = version === 'b';
-					if (this.isStopHidingTipExpEnabled) {
-						this.ensureTipDonationExists();
-					}
-				},
-				this.$kvTrackEvent,
-				'EXP-MP-2852-Jun2026',
-				'basket',
-			);
 		},
 		initializeCustomTipDefaultExperiment() {
 			// Assignment only; exposure is tracked separately when the tip modal is viewed

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -2,6 +2,8 @@ import { reactive } from 'vue';
 import { setDonationAmount } from '#src/util/basketUtils';
 import logReadQueryError from '#src/util/logReadQueryError';
 import { initializeExperiment } from '#src/util/experiment/experimentUtils';
+import { getPromoFromBasket } from '#src/util/campaignUtils';
+import { isAdminRewardTipEligible } from '#src/util/promoCredit';
 import { formatTransactionData, getTransactionAnalyticsData } from '#src/util/checkoutUtils';
 import { trackMetaEvent } from '@kiva/kv-analytics';
 
@@ -33,6 +35,14 @@ beforeAll(async () => {
 	}));
 	vi.mock('#src/util/experiment/experimentUtils', () => ({
 		initializeExperiment: vi.fn(),
+	}));
+	vi.mock('#src/util/campaignUtils', async importOriginal => ({
+		...(await importOriginal()),
+		getPromoFromBasket: vi.fn(),
+	}));
+	vi.mock('#src/util/promoCredit', async importOriginal => ({
+		...(await importOriginal()),
+		isAdminRewardTipEligible: vi.fn(),
 	}));
 	// keeps getTransactionTimestamp real, which lifecycleStage depends on
 	vi.mock('#src/util/myKivaUtils', async importOriginal => ({
@@ -409,5 +419,51 @@ describe('CheckoutPage lifecycle capture', () => {
 		await CheckoutPage.mounted.call(context);
 
 		expect(context.startLifecycleCapture).not.toHaveBeenCalled();
+	});
+});
+
+describe('CheckoutPage getPromoInformationFromBasket', () => {
+	const makeContext = (overrides = {}) => ({
+		apollo: {},
+		derivedPromoFund: { id: 'fund-1' },
+		promoData: null,
+		enableAdminRewardTipFlag: false,
+		stopHidingTip: false,
+		ensureTipDonationExists: vi.fn(),
+		// no-op so the post-resolve verification branch stays out of this test
+		$nextTick: vi.fn(),
+		...overrides,
+	});
+
+	beforeEach(() => {
+		getPromoFromBasket.mockReset();
+		isAdminRewardTipEligible.mockReset();
+	});
+
+	it('stops hiding the tip and ensures a tip donation for admin-reward-eligible users', async () => {
+		getPromoFromBasket.mockResolvedValue({ data: { shop: { promoCampaign: { id: 'promo-1' } } } });
+		isAdminRewardTipEligible.mockReturnValue(true);
+		const context = makeContext();
+
+		CheckoutPage.methods.getPromoInformationFromBasket.call(context);
+
+		await vi.waitFor(() => {
+			expect(context.ensureTipDonationExists).toHaveBeenCalledTimes(1);
+		});
+		expect(context.stopHidingTip).toBe(true);
+	});
+
+	it('leaves the tip hidden when the user is not admin-reward eligible', async () => {
+		getPromoFromBasket.mockResolvedValue({ data: { shop: { promoCampaign: { id: 'promo-1' } } } });
+		isAdminRewardTipEligible.mockReturnValue(false);
+		const context = makeContext();
+
+		CheckoutPage.methods.getPromoInformationFromBasket.call(context);
+
+		await vi.waitFor(() => {
+			expect(isAdminRewardTipEligible).toHaveBeenCalled();
+		});
+		expect(context.stopHidingTip).toBe(false);
+		expect(context.ensureTipDonationExists).not.toHaveBeenCalled();
 	});
 });

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -430,7 +430,6 @@ describe('CheckoutPage getPromoInformationFromBasket', () => {
 		enableAdminRewardTipFlag: false,
 		stopHidingTip: false,
 		ensureTipDonationExists: vi.fn(),
-		// no-op so the post-resolve verification branch stays out of this test
 		$nextTick: vi.fn(),
 		...overrides,
 	});


### PR DESCRIPTION
## Summary

Rolls out the `stop_hiding_tip_campaign` experiment to 100% in code by making the
winning variant (`b`) permanent and removing the experiment scaffolding.

The flag is now live 100% on prod, so this bakes the behavior in. The experiment
was **client-only** (never in `PREFETCH_EXPERIMENT_IDS`) and was only ever
initialized inside the `adminRewardTipEligible` branch of
`getPromoInformationFromBasket`. So 100% rollout of variant `b` collapses to:
*admin-reward-tip-eligible users always get the tip donation ensured (no longer
hidden)* — that same population, unconditionally.

All changes are in `src/pages/Checkout/CheckoutPage.vue`.

## Changes

- Remove `STOP_HIDING_TIP_EXP_KEY` const and the `initializeStopHidingTipExperiment()`
  method (including the `EXP-MP-2852-Jun2026` exposure tracking).
- The `adminRewardTipEligible` branch now sets `stopHidingTip = true` and calls
  `ensureTipDonationExists()` directly.
- Rename data prop `isStopHidingTipExpEnabled` → `stopHidingTip` (the name is no
  longer experiment-scoped); update both consumers — the `emptyBasket` watcher and
  `refreshTotals`.

## Not in this PR (manual follow-ups)

- Remove the flag from Settings Manager.
- Update the active-experiments doc.

## Tests

- New `describe('CheckoutPage getPromoInformationFromBasket')` block in
  `test/unit/specs/pages/Checkout/CheckoutPage.spec.js`:
  - eligible → sets `stopHidingTip` and calls `ensureTipDonationExists` once
  - not eligible → leaves the tip hidden, no `ensureTipDonationExists` call
- Mutation-verified red-green (neutering the eligible branch fails the new test).
- Checkout spec: **23 passed**. Full unit suite: **5284 passed / 6 skipped**
  (one unrelated flake in `possibleTypesCacheIntegrity.spec.js` that passes on a
  clean tree and alongside the Checkout spec). Lint clean.

## Links

- Jira: [MP-3157](https://kiva.atlassian.net/browse/MP-3157)


[MP-3157]: https://kiva.atlassian.net/browse/MP-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ