### PR TITLE
feat: [MP-3106] add monthly good auto-lending faq to credit settings page

### DIFF
--- a/src/pages/Settings/CreditSettings/components/CreditSettingsSidebar.vue
+++ b/src/pages/Settings/CreditSettings/components/CreditSettingsSidebar.vue
@@ -72,7 +72,7 @@
 			<li v-for="faq in faqItems" :key="faq.key">
 				<button
 					type="button"
-					class="tw-text-link tw-font-medium tw-bg-transparent tw-border-0 tw-p-0"
+					class="tw-text-link tw-text-left tw-font-medium tw-bg-transparent tw-border-0 tw-p-0"
 					@click="
 						$kvTrackEvent('user-settings', 'click', faq.value);
 						openFaq(faq.key)
@@ -168,15 +168,15 @@
 					<li>You can automatically make a donation to Kiva’s operating expenses.</li>
 					<li>
 						You can enable auto lending.
-						<a
+						<router-link
 							class="tw-text-link tw-font-medium"
-							href="/settings/autolending"
+							to="/settings/autolending"
 							@click="
 								$kvTrackEvent('user-settings', 'click', 'auto-lending-settings')
 							"
 						>
 							Click here
-						</a>
+						</router-link>
 						to change your auto lending settings.
 					</li>
 				</ul>
@@ -234,6 +234,49 @@
 				</p>
 			</div>
 		</kv-lightbox>
+
+		<kv-lightbox
+			:visible="showMonthlyGoodAutoLendingFaq"
+			title="Why can't I access my auto-lending settings as a Monthly Good subscriber?"
+			@lightbox-closed="
+				$kvTrackEvent('user-settings', 'click', 'autolending-settings-faq');
+				closeFaq('showMonthlyGoodAutoLendingFaq')
+			"
+		>
+			<div class="tw-space-y-3">
+				<p>
+					If you’re subscribed to Monthly Good, your lending preferences are based on the Monthly Good
+					category you selected, so you won’t be able to customize your standard auto-lending settings
+					separately.
+				</p>
+				<p>
+					You can update your
+					<span class="tw-font-medium">Monthly Good category or subscription</span> in your
+					<router-link
+						class="tw-text-link tw-font-medium"
+						to="/settings/subscriptions"
+						@click="
+							$kvTrackEvent('user-settings', 'click', 'autolending-settings-faq-subscription-settings')
+						"
+					>
+						subscription settings
+					</router-link>.
+				</p>
+				<p>
+					If you’d prefer to choose your own auto-lending criteria, you’ll need to cancel Monthly Good.
+					Once canceled, you can customize your preferences in your
+					<router-link
+						class="tw-text-link tw-font-medium"
+						to="/settings/autolending"
+						@click="
+							$kvTrackEvent('user-settings', 'click', 'autolending-settings-faq-autolending-settings')
+						"
+					>
+						auto-lending settings
+					</router-link>.
+				</p>
+			</div>
+		</kv-lightbox>
 	</aside>
 </template>
 
@@ -245,6 +288,11 @@ const FAQ_ITEMS = [
 	{ key: 'showInactiveWithdrawalFaq', label: 'What is inactive withdrawal?', value: 'inactive-withdrawal' },
 	{ key: 'showAutoLendingFaq', label: 'What is auto lending?', value: 'auto-lending' },
 	{ key: 'showAutoDepositsFaq', label: 'What are auto deposits?', value: 'auto-deposits' },
+	{
+		key: 'showMonthlyGoodAutoLendingFaq',
+		label: "Why can't I access my auto-lending settings as a Monthly Good subscriber?",
+		value: 'autolending-settings-faq',
+	},
 ];
 
 export default {
@@ -271,6 +319,7 @@ export default {
 			showDonationsFaq: false,
 			showInactiveWithdrawalFaq: false,
 			showLearnMoreFaq: false,
+			showMonthlyGoodAutoLendingFaq: false,
 		};
 	},
 	computed: {

--- a/test/unit/specs/pages/Settings/CreditSettings/CreditSettingsSidebar.spec.js
+++ b/test/unit/specs/pages/Settings/CreditSettings/CreditSettingsSidebar.spec.js
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from '@testing-library/vue';
+import CreditSettingsSidebar from '#src/pages/Settings/CreditSettings/components/CreditSettingsSidebar';
+import { globalOptions, routerLinkStub } from '../../../../specUtils';
+
+const MONTHLY_GOOD_FAQ_LABEL = "Why can't I access my auto-lending settings as a Monthly Good subscriber?";
+
+function renderSidebar(trackEvent = vi.fn()) {
+	render(CreditSettingsSidebar, {
+		props: { balance: 10, loading: false, promoBalance: 0 },
+		global: {
+			...globalOptions,
+			stubs: { RouterLink: routerLinkStub },
+			mocks: { ...globalOptions.mocks, $kvTrackEvent: trackEvent },
+		},
+	});
+	return trackEvent;
+}
+
+function openMonthlyGoodFaq() {
+	return fireEvent.click(screen.getByRole('button', { name: MONTHLY_GOOD_FAQ_LABEL }));
+}
+
+// kv-lightbox keeps every FAQ body mounted (v-show), so multiple router-links can share
+// a `to` target at once — match by link text, which stays unique, not by `to`.
+async function expectRouterLinkTracksClick(trackEvent, text, to, label) {
+	const link = screen.getByText(text, { selector: 'router-link' });
+	expect(link.getAttribute('to')).toBe(to);
+	await fireEvent.click(link);
+	expect(trackEvent).toHaveBeenCalledWith('user-settings', 'click', label);
+}
+
+describe('CreditSettingsSidebar', () => {
+	describe('FAQ list', () => {
+		test('renders the sidebar FAQ links left-aligned so long labels wrap without centering', () => {
+			renderSidebar();
+
+			const donationsLink = screen.getByRole('button', { name: 'How does Kiva use donations?' });
+			expect(donationsLink.className).toContain('tw-text-left');
+		});
+	});
+
+	describe('an existing FAQ (auto-lending)', () => {
+		test('opens the lightbox and tracks open/close events', async () => {
+			const trackEvent = renderSidebar();
+
+			await fireEvent.click(screen.getByRole('button', { name: 'What is auto lending?' }));
+			expect(trackEvent).toHaveBeenCalledWith('user-settings', 'click', 'auto-lending');
+			expect(screen.getByText(/Kiva’s auto-lending tool enables you/)).toBeTruthy();
+
+			await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+			expect(trackEvent).toHaveBeenCalledTimes(2);
+			expect(trackEvent).toHaveBeenLastCalledWith('user-settings', 'click', 'auto-lending');
+		});
+	});
+
+	describe('an existing FAQ with an embedded link (inactive withdrawal)', () => {
+		test('links to auto-lending settings via router-link and tracks the click', async () => {
+			const trackEvent = renderSidebar();
+
+			await fireEvent.click(screen.getByRole('button', { name: 'What is inactive withdrawal?' }));
+			await expectRouterLinkTracksClick(
+				trackEvent,
+				'Click here',
+				'/settings/autolending',
+				'auto-lending-settings',
+			);
+		});
+	});
+
+	describe('the Monthly Good auto-lending FAQ', () => {
+		test('opens with the approved copy and tracks the FAQ open event', async () => {
+			const trackEvent = renderSidebar();
+
+			await openMonthlyGoodFaq();
+
+			expect(trackEvent).toHaveBeenCalledWith('user-settings', 'click', 'autolending-settings-faq');
+			expect(screen.getByText(/your lending preferences are based on the Monthly Good category/)).toBeTruthy();
+			expect(screen.getByText('Monthly Good category or subscription').tagName).toBe('SPAN');
+		});
+
+		test('links to subscription settings and auto-lending settings with their own tracking labels', async () => {
+			const trackEvent = renderSidebar();
+
+			await openMonthlyGoodFaq();
+
+			await expectRouterLinkTracksClick(
+				trackEvent,
+				'subscription settings',
+				'/settings/subscriptions',
+				'autolending-settings-faq-subscription-settings',
+			);
+			await expectRouterLinkTracksClick(
+				trackEvent,
+				'auto-lending settings',
+				'/settings/autolending',
+				'autolending-settings-faq-autolending-settings',
+			);
+		});
+
+		test('tracks the FAQ close event when the lightbox is dismissed', async () => {
+			const trackEvent = renderSidebar();
+
+			await openMonthlyGoodFaq();
+			await fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+
+			expect(trackEvent).toHaveBeenLastCalledWith('user-settings', 'click', 'autolending-settings-faq');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Adds the "Why can't I access my auto-lending settings as a Monthly Good subscriber?" FAQ to the Credit Settings page sidebar, using the same lightbox format and open/close tracking convention as the other 5 FAQs on this page.
- Fires `user-settings`/`click`/`autolending-settings-faq` tracking on open and close, per the ticket's AC.
- Fixes a pre-existing bug where FAQ list button labels default-centered (browser `<button>` text-align) instead of left-aligning when wrapping to multiple lines.
- Converts the FAQ-body inline links (this new FAQ's two links, plus the pre-existing `inactive-withdrawal` FAQ's link) from plain `<a href>` to `router-link`, so internal navigation happens client-side (SPA) instead of a full page reload — matching the pattern already used elsewhere on this page (nav bar, `CreditSettingsLinkedSection`).

## Decisions to flag
- The ticket's description links "auto-lending settings" to `https://www.kiva.org/settings/credit` (this same page). This PR points it to `/settings/autolending` instead — this page's own `CreditSettingsLinkedSection` already establishes that as the canonical "Auto-lending settings" destination, and `/settings/credit` has no auto-lending criteria controls to land on. Worth a quick sanity check/correction on the ticket itself.
- The ticket's bolded phrase ("**Monthly Good category or subscription**") is rendered bold in the UI (`tw-font-medium`), assuming it was a literal UI requirement and not just ticket-formatting emphasis.

## Related links
- Jira: [MP-3106](https://kiva.atlassian.net/browse/MP-3106)

## Related tests
- `test/unit/specs/pages/Settings/CreditSettings/CreditSettingsSidebar.spec.js` (new, 6 tests): left-align regression, an existing FAQ's open/close/tracking baseline, the pre-existing embedded link's router-link conversion, and full coverage of the new FAQ (copy, both links + destinations + tracking, open/close tracking).

## Dev verification
- `npm run lint` — 0 errors
- `npm run unit` — full suite green aside from one pre-existing, unrelated flaky test (`possibleTypesCacheIntegrity.spec.js`, confirmed passing in isolation)
- Manually reviewed rendered lightbox markup/structure against sibling FAQs

[MP-3106]: https://kiva.atlassian.net/browse/MP-3106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ