### PR TITLE
fix: count up animation in collective impact section and some tweaks …

### DIFF
--- a/src/components/MyKiva/GoalInReview/GoalInReviewCollectiveImpact.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewCollectiveImpact.vue
@@ -14,21 +14,26 @@
 		</h1>
 		<div class="tw-mx-auto tw-max-w-3xl">
 			<ul
-				class="tw-list-none tw-p-0 tw-m-0 md:tw-flex kv-fade-up"
+				class="tw-list-none tw-p-0 tw-m-0 md:tw-flex"
 				data-testid="goal-in-review-collective-impact-stats"
 			>
 				<li
 					v-for="stat, idx in stats"
 					:key="stat.label"
 					class="tw-grid tw-grid-cols-2 tw-items-center tw-gap-2 tw-border-gray-200 tw-py-3 tw-px-3
-						md:tw-flex md:tw-flex-1 md:tw-flex-col md:tw-justify-start md:tw-border-t-0 md:tw-px-4"
+						md:tw-flex md:tw-flex-1 md:tw-flex-col md:tw-justify-start md:tw-border-t-0 md:tw-px-4
+						kv-fade-up"
 					:class="idx > 0 ? 'tw-border-t' : ''"
+					:style="{ animationDelay: staggerDelay(idx) }"
 				>
 					<div class="tw-text-left md:tw-text-center">
 						<p class="tw-text-base tw-text-gray-500">
 							{{ stat.label }}
 						</p>
-						<p class="tw-text-jumbo tw-tabular-nums" :class="stat.numberClass">
+						<p
+							class="tw-text-jumbo tw-tabular-nums"
+							:class="[stat.numberClass, { 'tw-invisible': !counting }]"
+						>
 							{{ stat.format(displayValues[idx]) }}
 						</p>
 					</div>
@@ -50,6 +55,7 @@
 			<p
 				class="tw-text-base tw-text-center tw-border-t md:tw-border-t-0 tw-border-gray-200
 					tw-pt-3 md:tw-pt-1 kv-fade-up"
+				:style="{ animationDelay: staggerDelay(stats.length) }"
 			>
 				Kiva goal setters create extraordinary impact.
 				<span class="tw-text-h3 tw-block !tw-font-medium">And you were part of it!</span>
@@ -94,8 +100,15 @@ const stats = [
 const COUNT_UP_DURATION = 2200;
 const easeOutCubic = t => 1 - (1 - t) ** 3;
 
+// Each card follows 120ms behind the last, with the closing line completing the cascade.
+const STAGGER_SECONDS = 0.12;
+const staggerDelay = index => `${((index + 1) * STAGGER_SECONDS).toFixed(2)}s`;
+
 const section = ref(null);
-const displayValues = ref(stats.map(stat => stat.target));
+// Zero, not the targets: those would show the finished numbers before the slide is reached.
+const displayValues = ref(stats.map(() => 0));
+// Invisible until counting, not unrendered, so the stats keep their space.
+const counting = ref(false);
 
 let observer = null;
 let rafId = null;
@@ -104,9 +117,15 @@ const prefersReducedMotion = () => typeof window !== 'undefined'
 	&& typeof window.matchMedia === 'function'
 	&& window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+const showFinalValues = () => {
+	displayValues.value = stats.map(stat => stat.target);
+	counting.value = true;
+};
+
 const runCountUp = () => {
 	if (prefersReducedMotion() || typeof requestAnimationFrame !== 'function') {
-		return; // leave the final values in place
+		showFinalValues();
+		return;
 	}
 	let startTime = null;
 	const step = now => {
@@ -120,14 +139,13 @@ const runCountUp = () => {
 			rafId = requestAnimationFrame(step);
 		}
 	};
-	displayValues.value = stats.map(() => 0);
+	counting.value = true;
 	rafId = requestAnimationFrame(step);
 };
 
 onMounted(() => {
-	// A focused observer that only starts the counter — the fade-up itself is
-	// gated by the modal wrapper. Same scroll root + midpoint trigger the modal
-	// uses, so the numbers begin counting as the slide fades in.
+	// Starts the counter only; the modal wrapper owns the fade-up. Same margin the modal
+	// reveals slides on (REVEAL_ROOT_MARGIN), so the number arrives with its copy.
 	observer = createIntersectionObserver({
 		targets: [section.value].filter(Boolean),
 		callback: entries => {
@@ -140,10 +158,14 @@ onMounted(() => {
 		},
 		options: {
 			root: section.value?.closest('#kvLightboxBody'),
-			rootMargin: '0px 0px -50% 0px',
+			rootMargin: '0px 0px -10% 0px',
 			threshold: 0,
 		},
 	});
+	if (!observer) {
+		// IntersectionObserver unsupported, so show the numbers rather than a row of zeroes.
+		showFinalValues();
+	}
 });
 
 onBeforeUnmount(() => {

--- a/src/components/MyKiva/GoalInReview/GoalInReviewHeadline.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewHeadline.vue
@@ -1,7 +1,8 @@
 <template>
 	<section
 		class="tw-w-full tw-pb-2 md:tw-pb-0 tw-relative tw-isolate
-			tw-bg-gray-50 tw-bg-no-repeat tw-bg-bottom goal-in-review-headline"
+			tw-bg-gray-50 tw-bg-no-repeat tw-bg-bottom goal-in-review-headline
+			tw-flex tw-flex-col md:tw-justify-between tw-gap-4 md:tw-gap-0"
 		:class="{ 'goal-in-review-headline--in-progress': !isComplete }"
 		data-testid="goal-in-review-headline"
 	>
@@ -78,14 +79,14 @@
 					Your goal moved <br> <span class="tw-text-marigold">lives forward</span>
 				</template>
 			</h1>
+
+			<h3 class="tw-mx-auto tw-max-w-lg kv-fade-up headline-subtext">
+				Because of your commitment, borrowers could count on Kiva to be there when it mattered.
+			</h3>
 		</div>
 
 		<div>
 			<div class="tw-px-2 md:tw-px-4 lg:tw-px-8 tw-mx-auto tw-text-center">
-				<h3 class="tw-mx-auto tw-mb-8 lg:tw-mb-6 tw-max-w-lg kv-fade-up headline-subtext">
-					Because of your commitment, borrowers could count on Kiva to be there when it mattered.
-				</h3>
-
 				<ul
 					class="tw-grid tw-grid-cols-2 md:tw-grid-cols-4 tw-gap-2 tw-list-none tw-p-0 tw-m-0"
 					data-testid="goal-in-review-headline-stats"

--- a/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewCollectiveImpact.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewCollectiveImpact.spec.js
@@ -2,20 +2,113 @@ import { render } from '@testing-library/vue';
 import GoalInReviewCollectiveImpact from '#src/components/MyKiva/GoalInReview/GoalInReviewCollectiveImpact';
 import { globalOptions } from '../../../../specUtils';
 
+const COUNT_UP_DURATION = 2200;
+
+let observers = [];
+let frames = [];
+
+class MockIntersectionObserver {
+	constructor(callback, options) {
+		this.callback = callback;
+		this.options = options;
+		observers.push(this);
+	}
+
+	// eslint-disable-next-line class-methods-use-this
+	observe() {}
+
+	// eslint-disable-next-line class-methods-use-this
+	unobserve() {}
+
+	// eslint-disable-next-line class-methods-use-this
+	disconnect() {}
+
+	scrollIntoView() {
+		this.callback([{ isIntersecting: true, target: {} }]);
+	}
+}
+
+// Runs the queued frames to the end of the count-up.
+const finishCountUp = async () => {
+	frames.shift()?.(0);
+	frames.shift()?.(COUNT_UP_DURATION);
+	await Promise.resolve();
+};
+
 describe('GoalInReviewCollectiveImpact', () => {
-	it('renders the static community-impact stats', () => {
+	beforeEach(() => {
+		observers = [];
+		frames = [];
+		vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+		vi.stubGlobal('IntersectionObserverEntry', { prototype: { intersectionRatio: 0 } });
+		vi.stubGlobal('requestAnimationFrame', callback => frames.push(callback));
+		vi.stubGlobal('cancelAnimationFrame', () => {});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('renders the collective impact copy', () => {
 		const { getByText } = render(GoalInReviewCollectiveImpact, { global: globalOptions });
 
 		getByText('Collective impact');
 		getByText(/Goal Setters create something/);
+		getByText('borrowers');
+		getByText('countries');
+		getByText('women');
+		getByText(/And you were part of it/);
+	});
+
+	// The finished numbers used to render before the slide was reached.
+	it('keeps the stats out of sight until the slide is scrolled to', () => {
+		const { getByText, queryByText } = render(GoalInReviewCollectiveImpact, { global: globalOptions });
+
+		expect(queryByText('400K+')).toBeNull();
+		expect(queryByText('95%')).toBeNull();
+		// In the layout, not unrendered, so the row does not reflow.
+		expect(getByText('0K+').className).toContain('tw-invisible');
+	});
+
+	// Header leads at 0s, then 120ms between each card (MP-3178).
+	it('cascades the stat cards in behind the header', () => {
+		const { getByTestId } = render(GoalInReviewCollectiveImpact, { global: globalOptions });
+
+		const delays = [...getByTestId('goal-in-review-collective-impact-stats').children]
+			.map(card => card.style.animationDelay);
+
+		expect(delays).toEqual(['0.12s', '0.24s', '0.36s']);
+	});
+
+	// Must match the modal's reveal margin, or the number lags its copy.
+	it('starts counting on the same trigger the modal reveals the slide on', () => {
+		render(GoalInReviewCollectiveImpact, { global: globalOptions });
+
+		expect(observers[0].options.rootMargin).toBe('0px 0px -10% 0px');
+	});
+
+	it('counts up to the stats once the slide comes into view', async () => {
+		const { getByText } = render(GoalInReviewCollectiveImpact, { global: globalOptions });
+
+		observers[0].scrollIntoView();
+		await finishCountUp();
 
 		getByText('400K+');
-		getByText('borrowers');
 		getByText('62');
-		getByText('countries');
 		getByText('95%');
-		getByText('women');
+		expect(getByText('400K+').className).not.toContain('tw-invisible');
+	});
 
-		getByText(/And you were part of it/);
+	it('shows the stats without animating when IntersectionObserver is unsupported', async () => {
+		// What the support check reads: an entry prototype with no intersectionRatio.
+		vi.stubGlobal('IntersectionObserverEntry', { prototype: {} });
+
+		const { getByText } = render(GoalInReviewCollectiveImpact, { global: globalOptions });
+		await Promise.resolve();
+
+		getByText('400K+');
+		getByText('62');
+		getByText('95%');
+		expect(getByText('400K+').className).not.toContain('tw-invisible');
 	});
 });


### PR DESCRIPTION
…on first section

Already validated with product about spacing and distribution in first section

<img width="979" height="799" alt="image" src="https://github.com/user-attachments/assets/f730be02-a212-40a4-bce5-a091ab5208ed" />

Previous: 

https://github.com/user-attachments/assets/8a6c0e6e-83fa-4672-be49-a87280abbc24


Now:

https://github.com/user-attachments/assets/7694906a-9d2d-43a9-8e6d-78501329d735



