### PR TITLE
fix: move tooltips to the new neutral variants

### DIFF
--- a/src/components/BorrowerProfile/SupporterDetails.vue
+++ b/src/components/BorrowerProfile/SupporterDetails.vue
@@ -90,7 +90,7 @@
 			class="tooltip"
 			:controller="toolTipId"
 			:data-testid="`tooltip-id-${toolTipId}`"
-			theme="ecoGreenDark"
+			variant="dark"
 			v-if="teamTooltipData && !isMobile"
 		>
 			{{ teamTooltipData.category }}<br>

--- a/src/components/Checkout/CheckoutReceipt.vue
+++ b/src/components/Checkout/CheckoutReceipt.vue
@@ -98,7 +98,6 @@
 									<kv-tooltip
 										data-testid="kcard-tool-tip-text"
 										:controller="`print-card-${card.id}`"
-										theme="ecoGreenLight"
 									>
 										You can print this card now. We'll also send it to
 										you in an email so you can print it later.

--- a/src/components/Checkout/OrderTotals.vue
+++ b/src/components/Checkout/OrderTotals.vue
@@ -162,7 +162,6 @@
 				class="tooltip"
 				data-testid="promo-tool-tip"
 				controller="promo_name"
-				theme="ecoGreenLight"
 				v-if="promoFundDisplayDescription && !isCorporateCampaign"
 			>
 				{{ promoFundDisplayDescription }}


### PR DESCRIPTION
Ticket: https://kiva.atlassian.net/browse/CIT-4884

## Summary

- One tooltip moves from `theme="ecoGreenDark"` to `variant="dark"`; two `ecoGreenLight`
  attributes are removed, since `light` is the new default. Three call sites already
  passed no theme and are unchanged.
- No dependency change: main already carries `@kiva/kv-components` `^9.2.0`.
- Colours shift as intended. The dark chip goes from #223829 to #212121, and light chips'
  body text from #223829 to #212121.
- No KvThemeProvider is an ancestor of any tooltip, so slot content resolves against
  `:root` exactly as it did inside the tooltip's own provider. Checked `LoanStatsTable`'s
  `kv-loading-placeholder` (`--bg-tertiary` is #C4C4C4 in every theme, so it renders
  identically) and its sanitised `v-html`, which permits bare `<a>` — on a light chip
  that is #276A43 on white, roughly 7.2:1.
