### PR TITLE
fix(lighthouse): survive PSI failures instead of aborting the collect AD-481

### DIFF
--- a/.github/workflows/lighthouse-prod.yml
+++ b/.github/workflows/lighthouse-prod.yml
@@ -4,10 +4,15 @@ on:
   schedule:
     # run at midnight, 8am + 4pm UTC time
     - cron:  '0 0,8,16 * * *'
+  workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
+
+concurrency:
+  group: lighthouse-prod
+  cancel-in-progress: false
 
 jobs:
   lhci:
@@ -28,7 +33,9 @@ jobs:
       - name: Run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.15.x
-          lhci autorun --config=./lighthouserc-prod.cjs
+          lhci healthcheck --config=./lighthouserc-prod.cjs --fatal
+          ./scripts/lighthouse-collect.sh ./lighthouserc-prod.cjs
+          lhci assert --config=./lighthouserc-prod.cjs
           lhci upload --target=filesystem --outputDir=./lhci
           node format-lh-for-s3.cjs
       - name: Configure AWS Credentials

--- a/scripts/lighthouse-collect.sh
+++ b/scripts/lighthouse-collect.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+config="${1:?usage: lighthouse-collect.sh <lighthouserc path>}"
+# Absolute form of the config argument, for the require() below.
+config_path="$(cd "$(dirname "${config}")" && pwd)/$(basename "${config}")"
+# The job summary when running in Actions, a throwaway file otherwise.
+summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+max_attempts=4
+backoffs=(30 60 120)
+collected=0
+dropped=()
+index=0
+
+# Empty the directory that --additive accumulates reports into.
+rm -rf .lighthouseci
+
+# One URL per line from the config's collect.url list, blank lines removed.
+urls=()
+while IFS= read -r line; do
+  urls+=("${line}")
+done < <(node -e "require('${config_path}').ci.collect.url.forEach(u => console.log(u))" | grep -v '^[[:space:]]*$')
+if [ "${#urls[@]}" -eq 0 ]; then
+  echo "::error::No URLs read from ${config}"
+  exit 1
+fi
+
+# Collect each URL on its own, retrying that URL alone when it fails.
+for url in "${urls[@]}"; do
+  index=$((index + 1))
+  attempt=1
+  while true; do
+    # Timestamp reference for whatever reports this attempt writes.
+    marker="$(mktemp)"
+    echo "::group::Collect ${url} (attempt ${attempt}/${max_attempts})"
+    if lhci collect --config="${config}" --url="${url}" --additive; then
+      echo "::endgroup::"
+      rm -f "${marker}"
+      collected=$((collected + 1))
+      break
+    fi
+    echo "::endgroup::"
+
+    # Discard the reports the failed attempt had already written.
+    if [ -d .lighthouseci ]; then
+      find .lighthouseci -type f -newer "${marker}" -delete
+    fi
+    rm -f "${marker}"
+
+    if [ "${attempt}" -ge "${max_attempts}" ]; then
+      # A first URL that never collects ends the run instead of being dropped.
+      if [ "${index}" -eq 1 ]; then
+        echo "::error::${url} failed all ${max_attempts} attempts as the first URL, so the run is treated as broken rather than flaky"
+        exit 1
+      fi
+      # Record the URL as dropped and carry on with the remaining ones.
+      echo "::warning title=Lighthouse collect dropped a URL::${url} failed all ${max_attempts} attempts"
+      dropped+=("${url}")
+      break
+    fi
+
+    # Wait longer before each successive retry.
+    sleep "${backoffs[attempt - 1]}"
+    attempt=$((attempt + 1))
+  done
+done
+
+# Report the collected and dropped tallies on the job summary.
+{
+  echo "### Lighthouse CI PROD"
+  echo ""
+  echo "Collected ${collected} of ${#urls[@]} URLs."
+  if [ "${#dropped[@]}" -gt 0 ]; then
+    echo ""
+    echo "Dropped after ${max_attempts} attempts:"
+    echo ""
+    printf -- '- %s\n' "${dropped[@]}"
+  fi
+} >> "${summary_file}"

--- a/test/unit/specs/scripts/lighthouseCollect.spec.js
+++ b/test/unit/specs/scripts/lighthouseCollect.spec.js
@@ -1,0 +1,169 @@
+// @vitest-environment node
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const SCRIPT = path.resolve(
+	fileURLToPath(new URL('.', import.meta.url)),
+	'../../../../scripts/lighthouse-collect.sh',
+);
+
+/*
+ * These stubs are bash rather than a JS mock because the subject under test is a shell script run
+ * in its own process: the only seam available is what it finds on PATH, so the fake has to be a
+ * real executable. The lhci stub reproduces the failure shape of the actual CLI, which saves each
+ * run's report as it completes and only then throws. That ordering is what leaves partial reports
+ * on disk for `--additive` to stack, so reproducing it here is what gives the cleanup assertions
+ * something real to catch.
+ */
+const STUB_LHCI = `#!/usr/bin/env bash
+cmd="$1"; shift
+# Only collect is modelled; healthcheck, assert and upload are no-ops.
+[ "$cmd" = "collect" ] || exit 0
+url=""
+for a in "$@"; do case "$a" in --url=*) url="\${a#--url=}" ;; esac; done
+# Filename-safe form of the URL, used to key both attempt state and report names.
+key="$(printf '%s' "$url" | tr -c 'a-zA-Z0-9' '_')"
+mkdir -p "$STUB_STATE"
+# Attempt number for this URL, carried across invocations on disk.
+n=$(cat "$STUB_STATE/$key" 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > "$STUB_STATE/$key"
+fail_for=$(awk -v u="$url" '$1==u{print $2}' "$STUB_FAILURES" 2>/dev/null); fail_for="\${fail_for:-0}"
+mkdir -p .lighthouseci
+/bin/sleep 0.05
+# A failing attempt writes 2 of the 5 reports, then errors the way a PSI 500 does.
+if [ "$n" -le "$fail_for" ]; then
+  touch ".lighthouseci/lhr-\${key}-a\${n}-r1.json" ".lighthouseci/lhr-\${key}-a\${n}-r2.json"
+  echo "PSI Failed (500): Lighthouse returned error: Something went wrong." >&2
+  exit 1
+fi
+for r in 1 2 3 4 5; do touch ".lighthouseci/lhr-\${key}-a\${n}-r\${r}.json"; done
+exit 0
+`;
+
+// Records each backoff duration instead of waiting it out.
+const STUB_SLEEP = `#!/usr/bin/env bash
+echo "$1" >> "$STUB_SLEEP_LOG"
+`;
+
+const writeExecutable = (file, contents) => {
+	fs.writeFileSync(file, contents);
+	fs.chmodSync(file, 0o755);
+};
+
+const reportsByUrl = workDir => {
+	const dir = path.join(workDir, '.lighthouseci');
+	if (!fs.existsSync(dir)) return {};
+	return fs.readdirSync(dir).reduce((counts, file) => {
+		const key = file.replace(/^lhr-/, '').replace(/-a\d+-r\d+\.json$/, '');
+		return { ...counts, [key]: (counts[key] ?? 0) + 1 };
+	}, {});
+};
+
+// Runs the real script against a stub lhci whose failures are scripted per URL.
+const runCollect = ({ urls, failures = {} }) => {
+	const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lhci-collect-'));
+	const binDir = path.join(workDir, 'bin');
+	const stateDir = path.join(workDir, 'state');
+	const failureSpec = path.join(workDir, 'failures.txt');
+	const summaryFile = path.join(workDir, 'summary.md');
+	const sleepLog = path.join(workDir, 'sleeps.txt');
+	fs.mkdirSync(binDir);
+
+	const config = JSON.stringify({ ci: { collect: { url: urls } } });
+	fs.writeFileSync(path.join(workDir, 'config.cjs'), `module.exports = ${config};\n`);
+	fs.writeFileSync(failureSpec, Object.entries(failures).map(([url, count]) => `${url}\t${count}`).join('\n'));
+	fs.writeFileSync(summaryFile, '');
+	fs.writeFileSync(sleepLog, '');
+	writeExecutable(path.join(binDir, 'lhci'), STUB_LHCI);
+	writeExecutable(path.join(binDir, 'sleep'), STUB_SLEEP);
+
+	const result = spawnSync('bash', [SCRIPT, './config.cjs'], {
+		cwd: workDir,
+		encoding: 'utf8',
+		env: {
+			...process.env,
+			PATH: `${binDir}:${process.env.PATH}`,
+			GITHUB_STEP_SUMMARY: summaryFile,
+			STUB_FAILURES: failureSpec,
+			STUB_STATE: stateDir,
+			STUB_SLEEP_LOG: sleepLog,
+		},
+	});
+
+	return {
+		workDir,
+		status: result.status,
+		output: `${result.stdout}${result.stderr}`,
+		summary: fs.readFileSync(summaryFile, 'utf8'),
+		backoffs: fs.readFileSync(sleepLog, 'utf8').split('\n').filter(Boolean),
+		reports: reportsByUrl(workDir),
+	};
+};
+
+const cleanupDirs = [];
+const collect = args => {
+	const run = runCollect(args);
+	cleanupDirs.push(run.workDir);
+	return run;
+};
+
+afterEach(() => {
+	while (cleanupDirs.length) fs.rmSync(cleanupDirs.pop(), { recursive: true, force: true });
+});
+
+describe('lighthouse-collect.sh', () => {
+	it('collects every URL when PSI is healthy', () => {
+		const run = collect({ urls: ['https://www.kiva.org/', 'https://www.kiva.org/about'] });
+
+		expect(run.status).toBe(0);
+		expect(run.reports).toEqual({ https___www_kiva_org_: 5, https___www_kiva_org_about: 5 });
+		expect(run.summary).toContain('Collected 2 of 2 URLs.');
+	});
+
+	it('discards the partial reports a failed attempt left behind before retrying', () => {
+		const run = collect({
+			urls: ['https://www.kiva.org/', 'https://www.kiva.org/about'],
+			failures: { 'https://www.kiva.org/about': 2 },
+		});
+
+		expect(run.status).toBe(0);
+		expect(run.reports.https___www_kiva_org_about).toBe(5);
+		expect(run.backoffs).toEqual(['30', '60']);
+		expect(run.summary).toContain('Collected 2 of 2 URLs.');
+	});
+
+	it('drops a URL that exhausts every attempt without discarding the other URLs', () => {
+		const run = collect({
+			urls: ['https://www.kiva.org/', 'https://www.kiva.org/about'],
+			failures: { 'https://www.kiva.org/about': 4 },
+		});
+
+		expect(run.status).toBe(0);
+		expect(run.reports).toEqual({ https___www_kiva_org_: 5 });
+		expect(run.backoffs).toEqual(['30', '60', '120']);
+		expect(run.output).toContain('::warning');
+		expect(run.summary).toContain('Collected 1 of 2 URLs.');
+		expect(run.summary).toContain('- https://www.kiva.org/about');
+	});
+
+	it('stops the run when the first URL exhausts every attempt', () => {
+		const run = collect({
+			urls: ['https://www.kiva.org/', 'https://www.kiva.org/about'],
+			failures: { 'https://www.kiva.org/': 4 },
+		});
+
+		expect(run.status).toBe(1);
+		expect(run.output).toContain('failed all 4 attempts as the first URL');
+		expect(run.reports).toEqual({});
+		expect(run.summary).toBe('');
+	});
+
+	it('fails when the config lists no URLs', () => {
+		const run = collect({ urls: [] });
+
+		expect(run.status).toBe(1);
+		expect(run.output).toContain('No URLs read from');
+	});
+});


### PR DESCRIPTION
The Lighthouse CI PROD runs have been failing since September 1st, due to internal errors in the PageSpeed Insights API. Most of the run succeeds, but then a single fail crashes the entire run, and the collected data is lost.

It's not clear what the cause of the 500 error is, especially because it is intermittent and happens for any URL that we test. It's possible that it has something to do with the current production header, so maybe the pending updates there will address the underlying issue. Until then, I've created this PR to change how we execute the lighthouse tests so that a single run failing doesn't lose all the data.

This switches from using a single `lhci autorun` call with all the test URLs to using one retry-able `lhci collect --additive` call for each URL. Using `--additive` keeps results of previous runs around for collection. Failed runs of individual URLs are retried, up to 4 total attempts with an increased timeout after each retry. 