### PR TITLE
refactor: use loan category ids instead of loan channel ids

### DIFF
--- a/src/components/Contentful/HomePage/NewHomeLoansByCategoryGrid.vue
+++ b/src/components/Contentful/HomePage/NewHomeLoansByCategoryGrid.vue
@@ -8,7 +8,7 @@
 			<kv-page-container>
 				<div>
 					<kiva-multi-category-grid
-						:contentful-loan-channels="loanChannels"
+						:contentful-loan-categories="loanCategories"
 						:loan-display-settings="loanDisplaySettings"
 						:new-home-exp="true"
 					/>
@@ -28,25 +28,28 @@ import SectionWithBackgroundClassic from '#src/components/Contentful/SectionWith
 import { KvPageContainer } from '@kiva/kv-components';
 
 /**
- * Extract Loan Channel settings from Contentful Ui Setting dataObject
+ * Extract Loan Category settings from Contentful Ui Setting dataObject
 * */
-const getContentfulLoanChannels = content => {
+const getContentfulLoanCategories = content => {
 	const uiSetting = content?.contents?.find(({ contentType }) => {
 		return contentType ? contentType === 'uiSetting' : false;
 	});
-	return uiSetting?.dataObject?.loanChannels ?? [];
+	return uiSetting?.dataObject?.loanCategories ?? [];
 };
 
 const loanCategoryPrefetchQuery = gql`
 	${loanFieldsFragment}
-	query loanCategoryPrefetch($loanChannelIds: [Int]!, $limit: Int) {
-		lend {
-			loanChannelsById(ids: $loanChannelIds) {
-				id
-				loans(limit: $limit) {
-					values {
-						id
-						...loanFields
+	query loanCategoryPrefetch($categoryIds: [String!]!, $limit: Int) {
+		categoriesByIds(ids: $categoryIds) {
+			id
+			... on LoanCategorySearchOutput {
+				savedSearch(limit: $limit) {
+					id
+					loans {
+						values {
+							id
+							...loanFields
+						}
 					}
 				}
 			}
@@ -73,7 +76,7 @@ export default {
 	},
 	data() {
 		return {
-			loanChannels: [],
+			loanCategories: [],
 		};
 	},
 	computed: {
@@ -85,8 +88,8 @@ export default {
 				return contentType ? contentType === 'background' : false;
 			});
 		},
-		contentfulLoanChannels() {
-			return getContentfulLoanChannels(this.content);
+		contentfulLoanCategories() {
+			return getContentfulLoanCategories(this.content);
 		},
 		/**
 		 * Extract Loan Display settings from Contentful Ui Setting dataObject
@@ -103,12 +106,12 @@ export default {
 	},
 	apollo: {
 		preFetch(config, client, { content, device }) {
-			const contentfulLoanChannels = getContentfulLoanChannels(content);
-			const id = contentfulLoanChannels[0]?.id;
+			const contentfulLoanCategories = getContentfulLoanCategories(content);
+			const id = contentfulLoanCategories[0]?.id;
 			return client.query({
 				query: loanCategoryPrefetchQuery,
 				variables: {
-					loanChannelIds: id ? [id] : [],
+					categoryIds: id ? [id] : [],
 					limit: device?.platform?.type === 'desktop' ? 6 : 1
 				},
 			});
@@ -119,11 +122,11 @@ export default {
 		let data = {};
 		const isDesktop = this.device?.platform?.type === 'desktop';
 		try {
-			const id = this.contentfulLoanChannels[0]?.id;
+			const id = this.contentfulLoanCategories[0]?.id;
 			data = this.apollo.readQuery({
 				query: loanCategoryPrefetchQuery,
 				variables: {
-					loanChannelIds: id ? [id] : [],
+					categoryIds: id ? [id] : [],
 					limit: isDesktop ? 6 : 1
 				},
 			});
@@ -135,26 +138,27 @@ export default {
 		const { loanLimit = 0 } = this.loanDisplaySettings;
 
 		// Get the fetched loan and merge it into the placeholder loan array
-		const loanChannel = data?.lend?.loanChannelsById[0] ?? { loans: { values: [] } };
+		const category = data?.categoriesByIds?.[0];
+		const loanCategory = { ...category, loans: category?.savedSearch?.loans ?? { values: [] } };
 
 		let loanValues;
 		if (isDesktop) {
-			loanValues = loanChannel?.loans?.values;
+			loanValues = loanCategory?.loans?.values;
 		} else {
 			loanValues = Array(loanLimit).fill({ id: 0 });
-			loanValues[0] = loanChannel?.loans?.values[0];
+			[loanValues[0]] = loanCategory?.loans?.values ?? [];
 		}
 
-		const loanChannelCopy = {
-			...loanChannel,
+		const loanCategoryCopy = {
+			...loanCategory,
 			loans: {
 				values: loanValues,
 			},
 		};
 
-		// Set the channel with the prefetched loan
-		const [firstChannel, ...otherChannels] = this.contentfulLoanChannels;
-		this.loanChannels = [{ ...firstChannel, ...loanChannelCopy }, ...otherChannels];
+		// Set the category with the prefetched loan
+		const [firstCategory, ...otherCategories] = this.contentfulLoanCategories;
+		this.loanCategories = [{ ...firstCategory, ...loanCategoryCopy }, ...otherCategories];
 	},
 };
 </script>

--- a/src/components/Contentful/HomePage/NewHomeLoansCardCarousel.vue
+++ b/src/components/Contentful/HomePage/NewHomeLoansCardCarousel.vue
@@ -44,7 +44,7 @@ export default {
 	},
 	data() {
 		return {
-			loanChannelData: [],
+			loanCategoryData: [],
 			selectedChannel: {},
 			showCarousel: false,
 		};
@@ -59,13 +59,13 @@ export default {
 			});
 		},
 		/**
-		 * Extract Loan Channel settings from Contentful Ui Setting dataObject
+		 * Extract Loan Category settings from Contentful Ui Setting dataObject
 		* */
-		contentfulLoanChannels() {
+		contentfulLoanCategories() {
 			const uiSetting = this.content?.contents?.find(({ contentType }) => {
 				return contentType ? contentType === 'uiSetting' : false;
 			});
-			return uiSetting?.dataObject?.loanChannels ?? [];
+			return uiSetting?.dataObject?.loanCategories ?? [];
 		},
 		/**
 		 * Extract Loan Display settings from Contentful Ui Setting dataObject
@@ -80,14 +80,14 @@ export default {
 			};
 		},
 		combinedLoanChannelData() {
-			return this.contentfulLoanChannels.map(channel => {
-				const matchedLoanChannel = this.loanChannelData.find(lc => lc.id === channel.id);
-				return { ...matchedLoanChannel, ...channel };
+			return this.contentfulLoanCategories.map(category => {
+				const matchedLoanCategory = this.loanCategoryData.find(lc => lc.id === category.id);
+				return { ...matchedLoanCategory, ...category };
 			});
 		},
-		loanChannelIds() {
-			return this.contentfulLoanChannels.map(channelSetting => {
-				return channelSetting.id;
+		categoryIds() {
+			return this.contentfulLoanCategories.map(categorySetting => {
+				return categorySetting.id;
 			});
 		},
 		loanQueryLimit() {
@@ -109,29 +109,34 @@ export default {
 	methods: {
 		fetchLoanChannel() {
 			this.apollo.query({
-				query: gql`query selectedLoanCategory($loanChannelIds: [Int]!, $loanLimit: Int) {
-					lend {
-						loanChannelsById(ids: $loanChannelIds){
-							id
-							name
-							url
-							loans(limit: $loanLimit) {
-								values {
-									id
+				query: gql`query selectedLoanCategory($categoryIds: [String!]!, $loanLimit: Int) {
+					categoriesByIds(ids: $categoryIds) {
+						id
+						name
+						url
+						... on LoanCategorySearchOutput {
+							savedSearch(limit: $loanLimit) {
+								id
+								loans {
+									values {
+										id
+									}
 								}
 							}
 						}
 					}
 				}`,
 				variables: {
-					loanChannelIds: this.loanChannelIds,
+					categoryIds: this.categoryIds,
 					loanLimit: this.loanQueryLimit
 				},
 			}).then(result => {
-				// Set All Active Loan Channels Data
-				const loanChannels = result?.data?.lend?.loanChannelsById ?? [];
-				this.loanChannelData = loanChannels;
-				// Activate the first channel available
+				// Set All Active Loan Categories Data, flattening savedSearch so `loans` stays top level
+				const categories = result?.data?.categoriesByIds ?? [];
+				this.loanCategoryData = categories.map(category => {
+					return { ...category, loans: category?.savedSearch?.loans ?? {} };
+				});
+				// Activate the first category available
 				const initialChannel = this.combinedLoanChannelData[0];
 				this.selectedChannel = initialChannel;
 				// Make the carousel visible

--- a/src/components/Contentful/LoansByCategoryCarousel.vue
+++ b/src/components/Contentful/LoansByCategoryCarousel.vue
@@ -8,7 +8,7 @@
 			<kv-page-container>
 				<div>
 					<kiva-classic-multi-category-carousel
-						:contentful-loan-channels="contentfulLoanChannels"
+						:contentful-loan-categories="contentfulLoanCategories"
 						:loan-display-settings="loanDisplaySettings"
 					/>
 				</div>
@@ -55,13 +55,13 @@ export default {
 			});
 		},
 		/**
-		 * Extract Loan Channel settings from Contentful Ui Setting dataObject
+		 * Extract Loan Category settings from Contentful Ui Setting dataObject
 		* */
-		contentfulLoanChannels() {
+		contentfulLoanCategories() {
 			const uiSetting = this.content?.contents?.find(({ contentType }) => {
 				return contentType ? contentType === 'uiSetting' : false;
 			});
-			return uiSetting?.dataObject?.loanChannels ?? [];
+			return uiSetting?.dataObject?.loanCategories ?? [];
 		},
 		/**
 		 * Extract Loan Display settings from Contentful Ui Setting dataObject

--- a/src/components/Homepage/HomeExp/KivaMultiCategoryGrid.vue
+++ b/src/components/Homepage/HomeExp/KivaMultiCategoryGrid.vue
@@ -40,10 +40,10 @@ export default {
 	},
 	props: {
 		/**
-		 * Array of loan channel data in an object
-		 * ex. [{ id: 52, shortName: 'some short name' }]
+		 * Array of loan category data in an object
+		 * ex. [{ id: '43bb7beb-c666-4ff9-aa87-79b2043f8d94', shortName: 'some short name' }]
 		* */
-		contentfulLoanChannels: {
+		contentfulLoanCategories: {
 			type: Array,
 			default: () => [],
 		},
@@ -63,20 +63,20 @@ export default {
 	},
 	data() {
 		return {
-			loanChannelData: [],
-			selectedChannelId: 0,
+			loanCategoryData: [],
+			selectedCategoryId: '',
 		};
 	},
 	computed: {
 		combinedLoanChannelData() {
-			return this.contentfulLoanChannels.map(channel => {
-				const matchedLoanChannel = this.loanChannelData.find(lc => lc.id === channel.id);
-				return { ...matchedLoanChannel, ...channel, loans: { ...matchedLoanChannel?.loans } };
+			return this.contentfulLoanCategories.map(category => {
+				const matchedLoanCategory = this.loanCategoryData.find(lc => lc.id === category.id);
+				return { ...matchedLoanCategory, ...category, loans: { ...matchedLoanCategory?.loans } };
 			});
 		},
-		loanChannelIds() {
-			return this.contentfulLoanChannels.map(channelSetting => {
-				return channelSetting.id;
+		categoryIds() {
+			return this.contentfulLoanCategories.map(categorySetting => {
+				return categorySetting.id;
 			});
 		},
 		loanQueryLimit() {
@@ -84,7 +84,7 @@ export default {
 		},
 		selectedChannel() {
 			return this.combinedLoanChannelData.find(
-				loanChannel => loanChannel.id === this.selectedChannelId
+				loanCategory => loanCategory.id === this.selectedCategoryId
 			);
 		},
 		selectedChannelLoanIds() {
@@ -98,48 +98,54 @@ export default {
 		}
 	},
 	created() {
-		// Copy initial loan channel data from contentful and select first channel
-		this.loanChannelData = this.contentfulLoanChannels;
-		[this.selectedChannelId] = this.loanChannelIds;
+		// Copy initial loan category data from contentful and select first category
+		this.loanCategoryData = this.contentfulLoanCategories;
+		[this.selectedCategoryId] = this.categoryIds;
 	},
 	mounted() {
-		// Load data for first channel
-		this.fetchLoanChannel(this.selectedChannelId);
+		// Load data for first category
+		this.fetchLoanChannel(this.selectedCategoryId);
 	},
 	methods: {
 		handleCategoryClick(payload) {
-			this.selectedChannelId = payload.categoryId;
-			this.fetchLoanChannel(this.selectedChannelId);
+			this.selectedCategoryId = payload.categoryId;
+			this.fetchLoanChannel(this.selectedCategoryId);
 		},
 		fetchLoanChannel(id) {
 			this.apollo.query({
-				query: gql`query selectedLoanCategory($loanChannelIds: [Int]!, $loanLimit: Int) {
-					lend {
-						loanChannelsById(ids: $loanChannelIds){
-							id
-							name
-							url
-							loans(limit: $loanLimit) {
-								values {
-									id
+				query: gql`query selectedLoanCategory($categoryIds: [String!]!, $loanLimit: Int) {
+					categoriesByIds(ids: $categoryIds) {
+						id
+						name
+						url
+						... on LoanCategorySearchOutput {
+							savedSearch(limit: $loanLimit) {
+								id
+								loans {
+									values {
+										id
+									}
 								}
 							}
 						}
 					}
 				}`,
 				variables: {
-					loanChannelIds: [id],
+					categoryIds: [id],
 					loanLimit: this.loanQueryLimit
 				},
 			}).then(result => {
-				// Get clone of loanChannelData for modification
-				const loanChannelData = [...this.loanChannelData];
-				// Get array index of the fetched loan channel for updating the data
-				const channelIndex = this.loanChannelIds.indexOf(id);
-				// Set new channel data if available, otherwise use existing data
-				const loanChannel = result?.data?.lend?.loanChannelsById[0] ?? loanChannelData[channelIndex];
-				loanChannelData[channelIndex] = loanChannel;
-				this.loanChannelData = loanChannelData;
+				// Get clone of loanCategoryData for modification
+				const loanCategoryData = [...this.loanCategoryData];
+				// Get array index of the fetched loan category for updating the data
+				const categoryIndex = this.categoryIds.indexOf(id);
+				// Set new category data if available, otherwise use existing data, flattening savedSearch
+				const fetched = result?.data?.categoriesByIds?.[0];
+				const loanCategory = fetched
+					? { ...fetched, loans: fetched?.savedSearch?.loans ?? {} }
+					: loanCategoryData[categoryIndex];
+				loanCategoryData[categoryIndex] = loanCategory;
+				this.loanCategoryData = loanCategoryData;
 			});
 		}
 	}

--- a/src/components/LoanCollections/KivaClassicMultiCategoryCarousel.vue
+++ b/src/components/LoanCollections/KivaClassicMultiCategoryCarousel.vue
@@ -29,10 +29,10 @@ export default {
 	},
 	props: {
 		/**
-		 * Array of loan channel data in an object
-		 * ex. [{ id: 52, shortName: 'some short name' }]
+		 * Array of loan category data in an object
+		 * ex. [{ id: '43bb7beb-c666-4ff9-aa87-79b2043f8d94', shortName: 'some short name' }]
 		* */
-		contentfulLoanChannels: {
+		contentfulLoanCategories: {
 			type: Array,
 			default: () => [],
 		},
@@ -48,21 +48,21 @@ export default {
 	},
 	data() {
 		return {
-			loanChannelData: [],
+			loanCategoryData: [],
 			selectedChannel: {},
 			showCarousel: false,
 		};
 	},
 	computed: {
 		combinedLoanChannelData() {
-			return this.contentfulLoanChannels.map(channel => {
-				const matchedLoanChannel = this.loanChannelData.find(lc => lc.id === channel.id);
-				return { ...matchedLoanChannel, ...channel };
+			return this.contentfulLoanCategories.map(category => {
+				const matchedLoanCategory = this.loanCategoryData.find(lc => lc.id === category.id);
+				return { ...matchedLoanCategory, ...category };
 			});
 		},
-		loanChannelIds() {
-			return this.contentfulLoanChannels.map(channelSetting => {
-				return channelSetting.id;
+		categoryIds() {
+			return this.contentfulLoanCategories.map(categorySetting => {
+				return categorySetting.id;
 			});
 		},
 		loanQueryLimit() {
@@ -89,30 +89,34 @@ export default {
 		},
 		fetchLoanChannel() {
 			this.apollo.query({
-				query: gql`query selectedLoanCategory($loanChannelIds: [Int]!, $loanLimit: Int) {
-					lend {
-						loanChannelsById(ids: $loanChannelIds){
-							id
-							name
-							url
-							# description
-							loans(limit: $loanLimit) {
-								values {
-									id
+				query: gql`query selectedLoanCategory($categoryIds: [String!]!, $loanLimit: Int) {
+					categoriesByIds(ids: $categoryIds) {
+						id
+						name
+						url
+						... on LoanCategorySearchOutput {
+							savedSearch(limit: $loanLimit) {
+								id
+								loans {
+									values {
+										id
+									}
 								}
 							}
 						}
 					}
 				}`,
 				variables: {
-					loanChannelIds: this.loanChannelIds,
+					categoryIds: this.categoryIds,
 					loanLimit: this.loanQueryLimit
 				},
 			}).then(result => {
-				// Set All Active Loan Channels Data
-				const loanChannels = result?.data?.lend?.loanChannelsById ?? [];
-				this.loanChannelData = loanChannels;
-				// Activate the first channel available
+				// Set All Active Loan Categories Data, flattening savedSearch so `loans` stays top level
+				const categories = result?.data?.categoriesByIds ?? [];
+				this.loanCategoryData = categories.map(category => {
+					return { ...category, loans: category?.savedSearch?.loans ?? {} };
+				});
+				// Activate the first category available
 				const initialChannel = this.combinedLoanChannelData[0];
 				this.selectedChannel = initialChannel;
 				// Make the carousel visible


### PR DESCRIPTION
Ticket: https://kiva.atlassian.net/browse/CIT-4130

## Summary
- Swaps the deprecated `lend.loanChannelsById` for `categoriesByIds` in the five Contentful-driven category components, reading `loanCategories` from the uiSetting `dataObject`
- Normalises the response so `savedSearch.loans` becomes a top-level `loans`, leaving the existing merge and selection logic unchanged
- `KivaMultiCategoryGrid` now tracks `selectedCategoryId` as a string rather than a numeric channel id
- Fixes a latent crash: `data?.lend?.loanChannelsById[0]` had no optional chaining on the index and would throw if the field returned null

## Notes
- The `loanFields` fragment is declared `on LoanBasic` and `savedSearch.loans.values` is `[LoanBasic]`, so the home page grid keeps its single-query prefetch — verified against the dev gateway
- `combinedLoanChannelData`, `selectedChannel` and `fetchLoanChannel` keep their names on purpose: they cross into `KivaClassicLoanCategorySelector`, `KivaLoanCardCategory` and `LoanCategorySelectorHomeExp`, which are shared with components covered by CIT-5107/5108/5111/5117
- No spec covers any of these five components, so lint and GraphQL document validation are the only automated checks here

## Blocked
`categoriesByIds` is dev-only right now — production returns `Variable "$ids" is never used`. Do not merge until it is deployed. The Contentful content is already migrated and published in both environments. Pairs with cms-page-server#3287.
