### PR TITLE
fix: [MP-3168] scroll goal-in-review modal to reveal feedback survey

### DIFF
--- a/src/components/MyKiva/GoalInReview/GoalInReviewThanksAndFeedback.vue
+++ b/src/components/MyKiva/GoalInReview/GoalInReviewThanksAndFeedback.vue
@@ -56,6 +56,7 @@
 						doesn't remount and reload the Form Assembly iframe.
 					-->
 					<div
+						ref="feedbackPlaceholderRef"
 						v-show="feedbackOpen"
 						class="tw-w-full tw-text-eco-green-1"
 						data-testid="goal-in-review-thanks-and-feedback-feedback-placeholder"
@@ -69,7 +70,9 @@
 </template>
 
 <script setup>
-import { computed, inject, ref } from 'vue';
+import {
+	computed, inject, nextTick, onBeforeUnmount, ref
+} from 'vue';
 import { KvButton, KvMaterialIcon } from '@kiva/kv-components';
 import { mdiChevronDown } from '@mdi/js';
 import GoalInReviewFeedbackForm from '#src/components/MyKiva/GoalInReview/GoalInReviewFeedbackForm';
@@ -103,22 +106,67 @@ const emit = defineEmits(['goal-recap-back-to-kiva', 'finish-goal', 'set-goal', 
 const $kvTrackEvent = inject('$kvTrackEvent', () => {});
 
 const feedbackOpen = ref(false);
+const feedbackPlaceholderRef = ref(null);
 // Set once the survey is submitted this session so the toggle disappears and can't
 // re-fire the share-feedback event.
 const feedbackSubmittedLocally = ref(false);
 
-const toggleFeedback = () => {
+let feedbackResizeObserver = null;
+let pendingFeedbackScrollFrame = null;
+
+const scrollFeedbackIntoView = () => {
+	// The survey is the last thing in the slide, so scrolling the container to its
+	// bottom is how we reveal it.
+	const lightboxBody = feedbackPlaceholderRef.value?.closest('#kvLightboxBody');
+	lightboxBody?.scrollTo({ top: lightboxBody.scrollHeight, behavior: 'smooth' });
+};
+
+// Coalesce bursts of resize notifications into one scroll per frame so they don't
+// keep restarting the animation.
+const scheduleScrollFeedbackIntoView = () => {
+	if (pendingFeedbackScrollFrame !== null) return;
+	pendingFeedbackScrollFrame = requestAnimationFrame(() => {
+		pendingFeedbackScrollFrame = null;
+		scrollFeedbackIntoView();
+	});
+};
+
+const stopWatchingFeedbackResize = () => {
+	feedbackResizeObserver?.disconnect();
+	feedbackResizeObserver = null;
+	if (pendingFeedbackScrollFrame !== null) {
+		cancelAnimationFrame(pendingFeedbackScrollFrame);
+		pendingFeedbackScrollFrame = null;
+	}
+};
+
+const toggleFeedback = async () => {
 	feedbackOpen.value = !feedbackOpen.value;
-	if (feedbackOpen.value) {
-		$kvTrackEvent('portfolio', 'click', 'goal-in-review-share-feedback');
+	if (!feedbackOpen.value) {
+		stopWatchingFeedbackResize();
+		return;
+	}
+
+	$kvTrackEvent('portfolio', 'click', 'goal-in-review-share-feedback');
+	await nextTick();
+	scrollFeedbackIntoView();
+
+	// The Form Assembly iframe reports its real height late (async postMessage), so
+	// keep re-scrolling as the survey's size changes.
+	if (typeof ResizeObserver !== 'undefined' && feedbackPlaceholderRef.value) {
+		feedbackResizeObserver = new ResizeObserver(scheduleScrollFeedbackIntoView);
+		feedbackResizeObserver.observe(feedbackPlaceholderRef.value);
 	}
 };
 
 const handleFeedbackSubmitted = () => {
 	feedbackSubmittedLocally.value = true;
 	feedbackOpen.value = false;
+	stopWatchingFeedbackResize();
 	emit('feedback-submitted');
 };
+
+onBeforeUnmount(stopWatchingFeedbackResize);
 
 const isComplete = computed(() => props.goalStatus === 'completed');
 

--- a/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewThanksAndFeedback.spec.js
+++ b/test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewThanksAndFeedback.spec.js
@@ -18,7 +18,7 @@ const GOAL_YEAR = 2026;
 const CURRENT_YEAR = 2026;
 const NEXT_YEAR = 2027;
 
-const renderSlide = (props = {}) => render(GoalInReviewThanksAndFeedback, {
+const renderSlide = (props = {}, renderOptions = {}) => render(GoalInReviewThanksAndFeedback, {
 	global: globalOptions,
 	props: {
 		goalStatus: 'completed',
@@ -27,6 +27,7 @@ const renderSlide = (props = {}) => render(GoalInReviewThanksAndFeedback, {
 		currentYear: CURRENT_YEAR,
 		...props,
 	},
+	...renderOptions,
 });
 
 describe('GoalInReviewThanksAndFeedback', () => {
@@ -148,6 +149,123 @@ describe('GoalInReviewThanksAndFeedback', () => {
 		expect(queryByText('Share your feedback')).toBeNull();
 		const shareCalls = trackEvent.mock.calls.filter(call => call[2] === 'goal-in-review-share-feedback');
 		expect(shareCalls).toHaveLength(1);
+	});
+
+	// Stands in for GoalInReviewModal's #kvLightboxBody, which the component scrolls.
+	const renderSlideInLightboxBody = (props = {}) => {
+		const container = document.createElement('div');
+		container.id = 'kvLightboxBody';
+		document.body.appendChild(container);
+		return renderSlide(props, { container });
+	};
+
+	it('scrolls the lightbox body to the bottom when the feedback survey is opened', async () => {
+		const scrollTo = vi.fn();
+		Element.prototype.scrollTo = scrollTo;
+		const { getByText } = renderSlideInLightboxBody();
+
+		await fireEvent.click(getByText('Share your feedback'));
+
+		expect(scrollTo).toHaveBeenCalledTimes(1);
+		const lightboxBody = document.getElementById('kvLightboxBody');
+		expect(scrollTo.mock.instances[0]).toBe(lightboxBody);
+		expect(scrollTo).toHaveBeenCalledWith({ top: lightboxBody.scrollHeight, behavior: 'smooth' });
+	});
+
+	it('does not scroll when the feedback survey is closed', async () => {
+		const scrollTo = vi.fn();
+		Element.prototype.scrollTo = scrollTo;
+		const { getByText } = renderSlideInLightboxBody();
+
+		await fireEvent.click(getByText('Share your feedback'));
+		scrollTo.mockClear();
+		await fireEvent.click(getByText('Share your feedback'));
+
+		expect(scrollTo).not.toHaveBeenCalled();
+	});
+
+	describe('feedback survey resize (Form Assembly iframe loads its real height late)', () => {
+		let resizeCallback;
+		let disconnect;
+		let scheduledFrame;
+
+		beforeEach(() => {
+			disconnect = vi.fn();
+			global.ResizeObserver = vi.fn(callback => {
+				resizeCallback = callback;
+				return { observe: vi.fn(), disconnect };
+			});
+			// Capture the frame instead of running it immediately, so tests can simulate
+			// several resize notifications before it fires.
+			global.requestAnimationFrame = callback => {
+				scheduledFrame = callback;
+				return 1;
+			};
+		});
+
+		afterEach(() => {
+			delete global.ResizeObserver;
+			delete global.requestAnimationFrame;
+		});
+
+		it('re-scrolls to the bottom when the survey resizes after opening', async () => {
+			const scrollTo = vi.fn();
+			Element.prototype.scrollTo = scrollTo;
+			const { getByText } = renderSlideInLightboxBody();
+
+			await fireEvent.click(getByText('Share your feedback'));
+			scrollTo.mockClear();
+
+			// Simulate the iframe reporting its real content height after the initial scroll.
+			resizeCallback();
+			scheduledFrame();
+
+			expect(scrollTo).toHaveBeenCalledTimes(1);
+		});
+
+		it('coalesces multiple resize notifications before the frame fires into one scroll', async () => {
+			const scrollTo = vi.fn();
+			Element.prototype.scrollTo = scrollTo;
+			const { getByText } = renderSlideInLightboxBody();
+
+			await fireEvent.click(getByText('Share your feedback'));
+			scrollTo.mockClear();
+
+			// The iframe can report several intermediate heights before settling.
+			resizeCallback();
+			resizeCallback();
+			resizeCallback();
+			scheduledFrame();
+
+			expect(scrollTo).toHaveBeenCalledTimes(1);
+		});
+
+		it('stops watching for resize once the feedback survey is closed', async () => {
+			const { getByText } = renderSlideInLightboxBody();
+
+			await fireEvent.click(getByText('Share your feedback'));
+			await fireEvent.click(getByText('Share your feedback'));
+
+			expect(disconnect).toHaveBeenCalledTimes(1);
+		});
+
+		it('stops watching for resize when the survey is submitted', async () => {
+			const { getByText, getByTestId } = renderSlideInLightboxBody();
+
+			await fireEvent.click(getByText('Share your feedback'));
+			await fireEvent.click(getByTestId('fa-submit'));
+
+			expect(disconnect).toHaveBeenCalledTimes(1);
+		});
+
+		it('stops watching for resize when the component unmounts', async () => {
+			const { getByText, unmount } = renderSlideInLightboxBody();
+
+			await fireEvent.click(getByText('Share your feedback'));
+			unmount();
+
+			expect(disconnect).toHaveBeenCalledTimes(1);
+		});
 	});
 
 	it('tracks opening the feedback survey', async () => {


### PR DESCRIPTION
## Summary
When a lender clicks "Share your feedback" at the end of the goal-in-review
recap, the feedback survey below the fold went unnoticed. Clicking the toggle
now smooth-scrolls the modal to the bottom so the revealed survey is visible.

## Approach
- `GoalInReviewThanksAndFeedback.vue` scrolls the lightbox's `#kvLightboxBody`
  scroll container to its bottom (not just `scrollIntoView` on the survey
  element) on open, since the toggle and survey are the last content in the
  slide — the two bottoms coincide, and this is more robust if the survey is
  taller than the viewport.
- The embedded Form Assembly survey iframe (`KvFormAssemblyForm`, from
  `@kiva/kv-components`) starts at a placeholder height and only reports its
  real height later via an async cross-origin `postMessage`. A `ResizeObserver`
  on the survey wrapper re-triggers the scroll once that real height lands,
  coalesced through one `requestAnimationFrame` so a burst of resize
  notifications collapses into a single scroll instead of repeatedly
  restarting the animation.
- The observer disconnects on close, on submit, and on unmount.
- No behavior change to the pre-existing `feedbackSubmitted` gating (toggle
  still hidden once feedback was already submitted for the year).

## Related links
- Jira: https://kiva.atlassian.net/browse/MP-3168
- Demo video (from the ticket): https://www.loom.com/share/66e2273834c645679ede488c93ed8d6b

## Related tests
`test/unit/specs/components/MyKiva/GoalInReview/GoalInReviewThanksAndFeedback.spec.js`
- scrolls the lightbox body to the bottom when the feedback survey is opened
- does not scroll when the feedback survey is closed
- re-scrolls to the bottom when the survey resizes after opening
- coalesces multiple resize notifications before the frame fires into one scroll
- stops watching for resize once the feedback survey is closed
- stops watching for resize when the survey is submitted
- stops watching for resize when the component unmounts

## Dev verification
1. Open a goal-in-review modal (My Kiva / Impact Dashboard) for a goal not yet
   flagged `feedbackSubmitted`.
2. Reach the final "Thank you" slide, click "Share your feedback".
3. Confirm the modal smooth-scrolls to reveal the survey, correcting itself
   once the embedded form finishes loading.