### PR TITLE
fix: keep text links uppercase and bump kv-components to 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@graphql-tools/load": "^7.7.0",
 				"@graphql-tools/url-loader": "^7.17.18",
 				"@kiva/kv-analytics": "^1.4.0",
-				"@kiva/kv-components": "^9.2.0",
+				"@kiva/kv-components": "^10.0.0",
 				"@kiva/kv-shop": "^3.8.24",
 				"@kiva/kv-tokens": "^5.0.0",
 				"@mdi/js": "^7.4.47",
@@ -3716,9 +3716,9 @@
 			"integrity": "sha512-Cw+HFQTWg9xhz7LYSxI+hCbfAX358EX+0uiojk3X0h+NtqD/EOYGlsPJmTHkWa41YCIsN9rdGGzwLxjHgSYF1A=="
 		},
 		"node_modules/@kiva/kv-components": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-9.2.0.tgz",
-			"integrity": "sha512-z30p6dG8UrbCer6bOMHzJDnuPB6NCCSH6A0g6cMBqKYxD4GMylR1+dTny0rC23uNc97bIzL6y3tSpaIDEbL0WA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-10.0.0.tgz",
+			"integrity": "sha512-Hvr5uQje0Zj9rfVekjMlVJoTYhlkT0rvRE6bUNHTGzHBl6vjldrZmhAfrdgEAFLEfVuSCWQiTN9Oilp62OBtcg==",
 			"bundleDependencies": [
 				"aria-hidden",
 				"embla-carousel",
@@ -33233,9 +33233,9 @@
 			"integrity": "sha512-Cw+HFQTWg9xhz7LYSxI+hCbfAX358EX+0uiojk3X0h+NtqD/EOYGlsPJmTHkWa41YCIsN9rdGGzwLxjHgSYF1A=="
 		},
 		"@kiva/kv-components": {
-			"version": "9.2.0",
-			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-9.2.0.tgz",
-			"integrity": "sha512-z30p6dG8UrbCer6bOMHzJDnuPB6NCCSH6A0g6cMBqKYxD4GMylR1+dTny0rC23uNc97bIzL6y3tSpaIDEbL0WA==",
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@kiva/kv-components/-/kv-components-10.0.0.tgz",
+			"integrity": "sha512-Hvr5uQje0Zj9rfVekjMlVJoTYhlkT0rvRE6bUNHTGzHBl6vjldrZmhAfrdgEAFLEfVuSCWQiTN9Oilp62OBtcg==",
 			"requires": {
 				"aria-hidden": "*",
 				"embla-carousel": "*",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@graphql-tools/load": "^7.7.0",
 		"@graphql-tools/url-loader": "^7.17.18",
 		"@kiva/kv-analytics": "^1.4.0",
-		"@kiva/kv-components": "^9.2.0",
+		"@kiva/kv-components": "^10.0.0",
 		"@kiva/kv-shop": "^3.8.24",
 		"@kiva/kv-tokens": "^5.0.0",
 		"@mdi/js": "^7.4.47",

--- a/src/components/BorrowerProfile/BorrowerBusinessDetails.vue
+++ b/src/components/BorrowerProfile/BorrowerBusinessDetails.vue
@@ -10,7 +10,7 @@
 		<kv-text-link
 			v-if="processedWebsite"
 			:icon="mdiArrowTopRight"
-			class="tw-mb-2"
+			class="tw-mb-2 tw-uppercase"
 			data-testid="bp-direct-business-website"
 			target="_blank"
 			:href="processedWebsite"

--- a/src/components/BorrowerProfile/FieldPartnerDetails.vue
+++ b/src/components/BorrowerProfile/FieldPartnerDetails.vue
@@ -156,6 +156,7 @@
 		</dl>
 
 		<kv-text-link
+			class="tw-uppercase"
 			data-testid="bp-field-partner-details-more-about"
 			:icon="mdiArrowRight"
 			:href="`/partners/${partnerId}`"

--- a/src/components/BorrowerProfile/LendersAndTeams.vue
+++ b/src/components/BorrowerProfile/LendersAndTeams.vue
@@ -77,6 +77,7 @@
 
 			<kv-text-link
 				v-if="totalItemCount > initialItemLimit"
+				class="tw-uppercase"
 				:data-testid="`bp-${displayType}-see-all-link`"
 				@click="openLightbox"
 			>

--- a/src/components/BorrowerProfile/LoanComments.vue
+++ b/src/components/BorrowerProfile/LoanComments.vue
@@ -53,6 +53,7 @@
 		<!-- Conversation guidelines -->
 		<p class="tw-mb-3">
 			<kv-text-link
+				class="tw-uppercase"
 				data-testid="bp-comment-guidelines-link"
 				@click="showGuidelines"
 			>
@@ -98,7 +99,7 @@
 					<div class="tw-flex tw-gap-2 tw-mt-0.5 tw-text-small">
 						<kv-text-link
 							v-if="isAdmin"
-							class="!tw-text-danger hover:!tw-text-danger-highlight"
+							class="!tw-text-danger hover:!tw-text-danger-highlight tw-uppercase"
 							data-testid="bp-comment-delete"
 							@click="openDeleteConfirm(comment.id)"
 						>
@@ -106,7 +107,7 @@
 						</kv-text-link>
 						<kv-text-link
 							v-if="!comment.isFlagged"
-							class="!tw-text-secondary"
+							class="!tw-text-secondary tw-uppercase"
 							data-testid="bp-comment-flag"
 							@click="openReportLightbox(comment.id)"
 						>

--- a/src/components/BorrowerProfile/PreviousLoanDescription.vue
+++ b/src/components/BorrowerProfile/PreviousLoanDescription.vue
@@ -1,6 +1,7 @@
 <template>
 	<section data-testid="bp-story-previous-loan">
 		<kv-text-link
+			class="tw-uppercase"
 			v-kv-track-event="['Borrower profile', 'click-Loan details', 'Show previous loan details', loanId]"
 			@click.prevent="performClick"
 		>

--- a/src/components/BorrowerProfile/SummaryCard.vue
+++ b/src/components/BorrowerProfile/SummaryCard.vue
@@ -100,6 +100,7 @@
 			{{ use }}
 			<kv-text-link
 				v-if="anonymizationLevel === 'full'"
+				class="tw-uppercase"
 				data-testid="bp-summary-anonymous-learn-more"
 				@click="openDefinition({ cid: 'bp-def-anonymous-description', sfid: '50150000000SXVz' })"
 				v-kv-track-event="[

--- a/src/components/BorrowerProfile/TrusteeDetails.vue
+++ b/src/components/BorrowerProfile/TrusteeDetails.vue
@@ -144,6 +144,7 @@
 			/>
 		</dl>
 		<kv-text-link
+			class="tw-uppercase"
 			data-testid="bp-details-trustee-more-about-link"
 			:icon="mdiArrowRight"
 			:href="`/trustees/${trusteeId}`"

--- a/src/components/Lightboxes/EcoChallengeLightbox.vue
+++ b/src/components/Lightboxes/EcoChallengeLightbox.vue
@@ -88,6 +88,7 @@
 			</kv-button>
 			<kv-text-link
 				v-else
+				class="tw-uppercase"
 				:icon="mdiArrowRight"
 				href="/basket"
 				v-kv-track-event="[

--- a/src/components/LoanCards/KivaClassicBasicLoanCard.vue
+++ b/src/components/LoanCards/KivaClassicBasicLoanCard.vue
@@ -99,6 +99,7 @@
 		<p v-if="!isLoading" class="tw-mb-2.5 tw-flex-grow">
 			{{ loanUse }}
 			<kv-text-link
+				class="tw-uppercase"
 				v-kv-track-event="['Lending', 'click-Read more', 'Learn more', loanId]"
 				@click="showLoanDetails"
 			>

--- a/src/pages/Portfolio/ImpactDashboard/CreditSummaryLightbox.vue
+++ b/src/pages/Portfolio/ImpactDashboard/CreditSummaryLightbox.vue
@@ -1,6 +1,7 @@
 <template>
 	<div>
 		<kv-text-link
+			class="tw-uppercase"
 			:icon="mdiFileDocumentOutline"
 			@click="openLightbox"
 			v-kv-track-event="['portfolio', 'click', 'credit-stats-details']"


### PR DESCRIPTION
Ticket: https://kiva.atlassian.net/browse/CIT-5101

## Summary

- Bumps `@kiva/kv-components` to `^10.0.0`. That major removes KvTooltip's deprecated
  `theme` prop and drops uppercase from KvTextLink.
- No tooltip changes needed — CIT-4884 already moved every tooltip to `variant`.
- KvTextLink now uses `tw-text-label` instead of `tw-text-upper`, which is the same type
  style minus `text-transform`. All 12 links across 10 files add `class="tw-uppercase"`
  so nothing changes appearance without design review.
- No link here sits inside a tooltip, so none was skipped.

No unit test covers any of these call sites, so a green suite says nothing about the
visuals here. Worth a look at the borrower profile and checkout surfaces.
