### PR TITLE
feat: mp-3194 layout fixes

### DIFF
--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -108,15 +108,17 @@
 						</div>
 					</div>
 
+					<!-- The margin sits on the row, not the copy: items-center counts margins, so a top
+						margin on one child alone offsets it from the CTA beside it. The switch below
+						brings its own top margin, so the variant needs no bottom one -->
 					<div
-						:class="{ 'md:tw-flex md:tw-items-center md:tw-gap-0.5': showTipFromBalanceVariant }"
+						:class="showTipFromBalanceVariant
+							? 'tw-mt-1 md:tw-flex md:tw-items-center md:tw-gap-0.5'
+							: ''"
 					>
-						<!-- The switch below brings its own top margin, so the variant drops the bottom one -->
 						<div
 							class="tw-max-w-2xl"
-							:class="showTipFromBalanceVariant
-								? 'tw-mt-1 md:tw-min-w-0'
-								: 'tw-my-1'"
+							:class="showTipFromBalanceVariant ? 'md:tw-min-w-0' : 'tw-my-1'"
 							data-testid="basket-donation-tagline"
 						>
 							<!-- Two lines before clipping: a long group name would otherwise cut the ask itself -->

--- a/src/components/Checkout/DonationItem.vue
+++ b/src/components/Checkout/DonationItem.vue
@@ -147,6 +147,7 @@
 						>
 							{{ donationDetailsLink }}
 							<kv-material-icon
+								v-if="!showTipFromBalanceVariant"
 								class="tw-ml-0.5 tw-w-2 tw-h-2"
 								:icon="mdiArrowRight"
 							/>

--- a/src/components/Checkout/UpsellModule.vue
+++ b/src/components/Checkout/UpsellModule.vue
@@ -2,7 +2,7 @@
 	<div
 		class="tw-bg-brand-100 tw-rounded"
 		:class="showTipFromBalanceVariant
-			? 'tw-relative tw-p-4 md:tw-p-1 md:tw-min-h-15 md:tw-flex md:tw-flex-col md:tw-justify-center'
+			? 'tw-relative tw-p-4 md:tw-px-1 md:tw-py-3 md:tw-flex md:tw-flex-col md:tw-justify-center'
 			: 'tw-p-4'"
 	>
 		<button

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -1595,10 +1595,10 @@ export default {
 	min-height: 250px;
 }
 
-/* The compact banner is 120px on desktop; mobile keeps the taller reservation below */
+/* The compact banner is ~128px on desktop; mobile keeps the taller reservation below */
 .upsell-container-compact,
 .upsell-container-compact > .loading-placeholder {
-	@apply tw-min-h-15;
+	@apply tw-min-h-16;
 }
 
 @media screen and (width <= 733px) {


### PR DESCRIPTION
## What this does

Layout fixes for the tip-from-balance variant based on design review. All changes are variant-only; control is untouched.

### Learn more alignment

* Fixes the alignment between the tip copy and **Learn more** link.
* Removes the arrow icon from the link in the variant.

### Upsell banner spacing

* Updates desktop padding to match Figma.
* Updates the container and loading placeholder height to prevent layout shift while the loan loads.

### Testing

* No spec changes needed since these are presentation-only changes.
* Full unit suite and lint pass.
* To verify, use an eligible variant-B lender with the toggle visible. Control should remain unchanged.
