### PR TITLE
fix: mp-3193-show the switch only when credit can reach the tip

### DIFF
--- a/src/components/Checkout/KivaCreditTipToggle.vue
+++ b/src/components/Checkout/KivaCreditTipToggle.vue
@@ -35,16 +35,19 @@ const AUDIENCE_DEPOSIT_LIMIT = 1000;
 export const TIP_FROM_BALANCE_SEEDED_COOKIE = 'kvtipseeded';
 
 /**
- * Whether the lender is in the experiment audience, ignoring which arm they are in.
- * Unknown deposits read as ineligible until the basket query lands. The checkout page reads
- * this too, so the variant treatment only appears where the switch itself can.
+ * Whether the lender is in the experiment audience, ignoring which arm they are in. The checkout
+ * page reads this too, so the variant treatment only appears where the switch itself can.
+ *
+ * The balance has to exceed the loans and Kiva Cards, not merely be positive: below that the
+ * amount due is the raw shortfall either way, so the switch cannot change what is charged.
+ * Unknown deposits read as ineligible until the basket query lands.
  *
  * @param {Object} state The basket state provided by the checkout page
  * @returns {boolean} Whether the lender is in the experiment audience
  */
 export function meetsTipFromBalanceCriteria(state = {}) {
 	return !!state.myId
-		&& state.balance > 0
+		&& state.balance > state.nonTipTotal
 		&& state.hasLoans
 		&& state.tipAmount > 0
 		&& !state.onTeam

--- a/src/components/Checkout/KivaCreditTipToggle.vue
+++ b/src/components/Checkout/KivaCreditTipToggle.vue
@@ -38,9 +38,9 @@ export const TIP_FROM_BALANCE_SEEDED_COOKIE = 'kvtipseeded';
  * Whether the lender is in the experiment audience, ignoring which arm they are in. The checkout
  * page reads this too, so the variant treatment only appears where the switch itself can.
  *
- * The balance has to exceed the loans and Kiva Cards, not merely be positive: below that the
- * amount due is the raw shortfall either way, so the switch cannot change what is charged.
- * Unknown deposits read as ineligible until the basket query lands.
+ * The balance has to exceed everything in the basket but the tip, not merely be positive: below
+ * that the amount due is the raw shortfall either way, so the switch cannot change what is
+ * charged. Unknown deposits read as ineligible until the basket query lands.
  *
  * @param {Object} state The basket state provided by the checkout page
  * @returns {boolean} Whether the lender is in the experiment audience

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -961,7 +961,6 @@ export default {
 				applyKivaCreditToDonation: this.applyKivaCreditToDonation,
 				// Everything the balance has to pay for before the tip, campaign donations included
 				nonTipTotal: (numeral(this.totals.itemTotal).value() ?? 0) - tipAmount,
-
 				onTeam: this.teams?.length > 0,
 				lifetimeDeposits: this.lifetimeDeposits,
 			};

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -958,6 +958,9 @@ export default {
 				tipAmount: numeral(tip?.price).value() ?? 0,
 				basketId: this.basketId,
 				applyKivaCreditToDonation: this.applyKivaCreditToDonation,
+				// What credit pays for before it can reach the tip
+				nonTipTotal: (numeral(this.totals.loanReservationTotal).value() ?? 0)
+					+ (numeral(this.totals.kivaCardTotal).value() ?? 0),
 				onTeam: this.teams?.length > 0,
 				lifetimeDeposits: this.lifetimeDeposits,
 			};

--- a/src/pages/Checkout/CheckoutPage.vue
+++ b/src/pages/Checkout/CheckoutPage.vue
@@ -951,16 +951,17 @@ export default {
 		tipToggleBasketState() {
 			// What the tip toggle needs, so it does not run its own copy of the checkout query
 			const tip = this.donations.find(donation => !donation.metadata?.campaignId);
+			const tipAmount = numeral(tip?.price).value() ?? 0;
 			return {
 				myId: this.myId,
 				balance: numeral(this.myBalance).value() ?? 0,
 				hasLoans: this.loans.length > 0,
-				tipAmount: numeral(tip?.price).value() ?? 0,
+				tipAmount,
 				basketId: this.basketId,
 				applyKivaCreditToDonation: this.applyKivaCreditToDonation,
-				// What credit pays for before it can reach the tip
-				nonTipTotal: (numeral(this.totals.loanReservationTotal).value() ?? 0)
-					+ (numeral(this.totals.kivaCardTotal).value() ?? 0),
+				// Everything the balance has to pay for before the tip, campaign donations included
+				nonTipTotal: (numeral(this.totals.itemTotal).value() ?? 0) - tipAmount,
+
 				onTeam: this.teams?.length > 0,
 				lifetimeDeposits: this.lifetimeDeposits,
 			};

--- a/test/unit/specs/components/Checkout/KivaCreditTipToggle.spec.js
+++ b/test/unit/specs/components/Checkout/KivaCreditTipToggle.spec.js
@@ -12,9 +12,11 @@ vi.mock('#src/util/logFormatter', () => ({ default: vi.fn() }));
 
 const BASKET_ID = 'basket-abc123';
 
-// What the checkout page provides: a $25 loan and a $3.75 tip, for a lender with balance
+// What the checkout page provides: a $25 loan and a $3.75 tip, for a lender whose balance
+// covers the loan and reaches the tip
 const basketState = ({
-	balance = 25,
+	balance = 30,
+	nonTipTotal = 25,
 	hasLoans = true,
 	tipAmount = 3.75,
 	preference = true,
@@ -24,6 +26,7 @@ const basketState = ({
 } = {}) => ({
 	myId,
 	balance,
+	nonTipTotal,
 	hasLoans,
 	tipAmount,
 	onTeam,
@@ -116,6 +119,8 @@ describe('KivaCreditTipToggle', () => {
 		['no tip', { preference: false, tipAmount: 0 }],
 		['no loan in the basket', { preference: false, hasLoans: false }],
 		['no balance', { preference: false, balance: 0 }],
+		['a balance that does not reach the loan total', { preference: false, balance: 20 }],
+		['a balance exactly equal to the loan total', { preference: false, balance: 25 }],
 		['logged out', { preference: false, myId: null }],
 		['a team membership', { preference: false, onTeam: true }],
 		['lifetime deposits at the ceiling', { preference: false, lifetimeDeposits: 1000 }],

--- a/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
+++ b/test/unit/specs/pages/Checkout/CheckoutPage.spec.js
@@ -5,6 +5,7 @@ import { initializeExperiment } from '#src/util/experiment/experimentUtils';
 import { getPromoFromBasket } from '#src/util/campaignUtils';
 import { isAdminRewardTipEligible } from '#src/util/promoCredit';
 import { formatTransactionData, getTransactionAnalyticsData } from '#src/util/checkoutUtils';
+import { meetsTipFromBalanceCriteria } from '#src/components/Checkout/KivaCreditTipToggle';
 import { trackMetaEvent } from '@kiva/kv-analytics';
 /* eslint-disable-next-line import/no-extraneous-dependencies -- devDependency used only in tests */
 import { flushPromises } from '@vue/test-utils';
@@ -567,5 +568,55 @@ describe('CheckoutPage getPromoInformationFromBasket', () => {
 		});
 		expect(context.stopHidingTip).toBe(false);
 		expect(context.ensureTipDonationExists).not.toHaveBeenCalled();
+	});
+});
+
+describe('CheckoutPage tipToggleBasketState', () => {
+	const tipToggleBasketState = context => CheckoutPage.computed.tipToggleBasketState.call(context);
+
+	// A $25 loan with a $5 tip, so the basket is $30 and the balance reaches the tip at $30.01
+	const makeContext = (overrides = {}) => ({
+		myId: 1234,
+		myBalance: '40.00',
+		loans: [{ id: 1 }],
+		donations: [{ id: 1, price: '5.00', metadata: null }],
+		basketId: 'basket-abc123',
+		applyKivaCreditToDonation: false,
+		totals: { itemTotal: '30.00' },
+		teams: [],
+		lifetimeDeposits: 0,
+		...overrides,
+	});
+
+	it('reports the basket without the tip, so the switch can change what is charged', () => {
+		expect(tipToggleBasketState(makeContext())).toMatchObject({ tipAmount: 5, nonTipTotal: 25 });
+	});
+
+	it('counts a campaign donation the balance still has to pay for', () => {
+		// $25 loan, $10 giving fund donation and a $5 tip: $35 stands between the balance and the tip
+		const state = tipToggleBasketState(makeContext({
+			totals: { itemTotal: '40.00' },
+			donations: [
+				{ id: 1, price: '5.00', metadata: null },
+				{ id: 2, price: '10.00', metadata: { campaignId: 'abc' } },
+			],
+		}));
+
+		expect(state).toMatchObject({ tipAmount: 5, nonTipTotal: 35 });
+	});
+
+	it('keeps a lender out when a campaign donation puts the tip beyond their balance', () => {
+		// The loan alone would qualify a $30 balance, but the donation has to be paid first
+		const context = makeContext({
+			myBalance: '30.00',
+			totals: { itemTotal: '40.00' },
+			donations: [
+				{ id: 1, price: '5.00', metadata: null },
+				{ id: 2, price: '10.00', metadata: { campaignId: 'abc' } },
+			],
+		});
+
+		expect(meetsTipFromBalanceCriteria(tipToggleBasketState(context))).toBe(false);
+		expect(meetsTipFromBalanceCriteria(tipToggleBasketState({ ...context, myBalance: '40.00' }))).toBe(true);
 	});
 });


### PR DESCRIPTION
What this does

Fixes Lauren's finding: the tip-from-balance toggle appeared for lenders whose basket is as large as (or larger than) their balance. For them the switch does nothing — the amount due is the raw shortfall whether the tip comes from balance or not — so it read as a broken control.

The gate

Eligibility now requires the balance to exceed everything in the basket except the tip, instead of merely being positive. Below that line the switch can't change what's charged, so it doesn't render.

That "everything except the tip" is computed as itemTotal minus the tip donation, so a giving-fund (campaign) donation counts as something the balance has to pay for before it can reach the tip — and the definition holds if a new basket item type ever appears.

Exposure follows

Both arms read the same criteria, so control exposure narrows with the treatment and the arms stay comparable. Lenders excluded by this change never fire the experiment event in either arm.

Testing

Toggle spec: new cases for a balance below and exactly equal to the non-tip basket total.
Page spec: new coverage that checkout actually supplies the basket state the criteria read — including a campaign-donation basket where the loan alone would qualify but the donation pushes the tip out of reach. Previously nothing failed if that wiring was lost.
Verified by mutation, not just green tests: loosening the threshold back to balance > 0, changing > to >=, reverting the gate to loans + cards, and dropping the provided field each fail tests now.
Full unit suite and lint pass.
To see it: variant-b lender with, say, $30 balance and a $30+ basket → no toggle; drop the basket below the balance → toggle appears.