### PR TITLE
feat: giving funds link redirect fix

### DIFF
--- a/src/components/GivingFunds/MyGivingFundsCard.vue
+++ b/src/components/GivingFunds/MyGivingFundsCard.vue
@@ -17,6 +17,7 @@
 			class="tw-w-full md:tw-w-auto md:tw-ml-auto"
 			variant="primary"
 			:to="ctaTo"
+			target="_blank"
 			:aria-label="ctaCopy"
 			v-kv-track-event="clickTrackEventProps"
 		>


### PR DESCRIPTION
**Ticket reference:** https://kiva.atlassian.net/jira/software/projects/MP/boards/275?filter=&groupBy=none&selectedIssue=MP-3161

**Proposed solution**: passing the `target` prop to KvButton ( when clicked link opens in new tab)

**Proof of testing:**  
https://github.com/user-attachments/assets/f90803dd-d214-4aac-9b87-736b25b5726e

