### PR TITLE
fix: [MP-3195] design feedback adjustments for compact live loan card

### DIFF
--- a/server/util/live-loan/compact-card-constants.js
+++ b/server/util/live-loan/compact-card-constants.js
@@ -1,20 +1,22 @@
 // Compact (bundle) styling constants. Mirrors the on-site compact loan card:
 // square borrower image on the left, use statement on the right, callout pills,
 // then a "$X to go" label above a fundraising bar. No CTA button.
-export const compactResizeFactor = 3;
+export const compactResizeFactor = 4;
 export const compactCardWidth = 271;
 export const compactCardPadding = 12;
 export const compactCardRadius = 0;
 export const compactImageSize = 60;
 export const compactImageRadius = 8;
 export const compactImageGap = 8; // between image and copy
-export const compactUseLineHeight = 21; // 14px text at 1.5 line-height
+export const compactUseFontSize = 16;
+export const compactUseLineHeight = compactUseFontSize * 1.5;
+export const compactSecondaryFontSize = 14;
 export const compactMaxUseLines = 4;
 export const compactSectionGap = 12; // between the top row, pills, and bottom row
 export const compactPillHeight = 30;
 export const compactPillPadding = 8;
 export const compactPillGap = 8;
-export const compactToGoLineHeight = 14;
+export const compactToGoLineHeight = compactSecondaryFontSize;
 export const compactToGoBarGap = 8;
 export const compactBarHeight = 8;
 // Height is fixed to the worst case (4 lines of use text) so the pooled canvas
@@ -41,11 +43,10 @@ export const compactColors = {
 	brand: '#2aa967',
 	pillBg: '#f5f5f5',
 	progressTrack: '#d9d9d9',
-	border: '#757575',
+	border: '#dfd0bc',
 	white: '#ffffff'
 };
 
-export const compactRegularFont = '400 14px "Kiva Post Grot"';
-// Bold name+country in the use text and the pills / "$X to go" label are all
-// the same Medium weight in the design.
-export const compactMediumFont = '500 14px "Kiva Post Grot"';
+export const compactUseFont = `400 ${compactUseFontSize}px "Kiva Post Grot"`;
+export const compactUseMediumFont = `500 ${compactUseFontSize}px "Kiva Post Grot"`;
+export const compactSecondaryFont = `500 ${compactSecondaryFontSize}px "Kiva Post Grot"`;

--- a/server/util/live-loan/live-loan-draw.js
+++ b/server/util/live-loan/live-loan-draw.js
@@ -34,8 +34,9 @@ import {
 	compactCardHeight,
 	compactCardDimensions,
 	compactColors,
-	compactRegularFont,
-	compactMediumFont,
+	compactUseFont,
+	compactUseMediumFont,
+	compactSecondaryFont,
 } from './compact-card-constants.js';
 import { trace } from '../mockTrace.js';
 
@@ -460,14 +461,14 @@ async function drawCompact(loanData) {
 				textWidth,
 				compactMaxUseLines,
 				compactUseLineHeight,
-				{ regularFont: compactRegularFont, boldFont: compactMediumFont }
+				{ regularFont: compactUseFont, boldFont: compactUseMediumFont }
 			);
 		});
 
 		// Loan callouts (grey pills, never orange). Collapses when there are none;
 		// pills that would overflow the row are dropped so nothing spills past the card.
 		trace('loan-callouts', () => {
-			ctx.font = compactMediumFont;
+			ctx.font = compactSecondaryFont;
 			const availableWidth = compactCardWidth - (2 * pad);
 			const callouts = getLoanCallouts(loanData);
 			const labels = fitPillLabels(ctx, callouts, availableWidth, compactPillPadding, compactPillGap);
@@ -499,7 +500,7 @@ async function drawCompact(loanData) {
 			const loanAmountValue = numeral(loanData?.loanAmount).value() || 1;
 			const fundraisingPercent = Math.min(1, fundedAmount / loanAmountValue);
 
-			ctx.font = compactMediumFont;
+			ctx.font = compactSecondaryFont;
 			ctx.fillStyle = compactColors.textPrimary;
 			ctx.fillText(buildToGoText(loanData), pad, compactToGoY);
 
@@ -516,11 +517,18 @@ async function drawCompact(loanData) {
 		// Undo the content clip so the pooled canvas is clean for reuse
 		ctx.restore();
 
-		// Hairline border on top of the content, inset by half its width so the
-		// stroke lands fully inside the canvas edge.
+		// Hairline border on top of the content, inset from the canvas edge so the
+		// stroke lands inside it.
 		trace('border', () => {
-			const inset = compactBorderWidth / 4;
-			roundRect(ctx, 0, 0, compactCardWidth - inset, compactCardHeight - inset, compactCardRadius);
+			const inset = compactBorderWidth / 2;
+			roundRect(
+				ctx,
+				inset,
+				inset,
+				compactCardWidth - compactBorderWidth,
+				compactCardHeight - compactBorderWidth,
+				compactCardRadius,
+			);
 			ctx.lineWidth = compactBorderWidth;
 			ctx.strokeStyle = compactColors.border;
 			ctx.stroke();

--- a/test/unit/specs/server/util/live-loan/live-loan-draw.spec.js
+++ b/test/unit/specs/server/util/live-loan/live-loan-draw.spec.js
@@ -1,7 +1,13 @@
 // @vitest-environment node
 import { createCanvas, loadImage } from 'canvas';
 import draw, { compactCardDimensions } from '#server/util/live-loan/live-loan-draw';
-import { compactColors } from '#server/util/live-loan/compact-card-constants';
+import {
+	compactColors,
+	compactCardPadding,
+	compactTopRowHeight,
+	compactSectionGap,
+	compactResizeFactor,
+} from '#server/util/live-loan/compact-card-constants';
 import * as canvasImageUtils from '#server/util/live-loan/canvas-image-utils';
 
 vi.mock('#server/util/live-loan/canvas-image-utils');
@@ -10,9 +16,17 @@ vi.mock('#server/util/live-loan/canvas-image-utils');
 const SAMPLE_X_FRACTION = 0.77;
 // JPEG is lossy, so match a flat colour within a channel tolerance
 const COLOUR_TOLERANCE = 12;
-// Both greys are flat, so any channel of the hex is the target value
-const TRACK_GREY = parseInt(compactColors.progressTrack.slice(1, 3), 16);
-const BORDER_GREY = parseInt(compactColors.border.slice(1, 3), 16);
+
+function hexToRgb(hex) {
+	return {
+		r: parseInt(hex.slice(1, 3), 16),
+		g: parseInt(hex.slice(3, 5), 16),
+		b: parseInt(hex.slice(5, 7), 16),
+	};
+}
+
+const TRACK_COLOUR = hexToRgb(compactColors.progressTrack);
+const BORDER_COLOUR = hexToRgb(compactColors.border);
 
 // A real (drawable) node-canvas stands in for the borrower photo
 function fakeBorrowerImage() {
@@ -45,32 +59,32 @@ async function dimensionsOf(buffer) {
 	return { width: img.width, height: img.height };
 }
 
-// Decodes an image buffer onto a canvas context so its pixels can be sampled
-async function decodeToContext(buffer) {
+// Decodes an image buffer and returns the single pixel column at the given
+// fraction of its width, which is all the row scans below need.
+async function decodeColumn(buffer, xFraction) {
 	const img = await loadImage(buffer);
-	const ctx = createCanvas(img.width, img.height).getContext('2d');
-	ctx.drawImage(img, 0, 0);
-	return { ctx, width: img.width, height: img.height };
+	const x = Math.round(img.width * xFraction);
+	const ctx = createCanvas(1, img.height).getContext('2d');
+	ctx.drawImage(img, -x, 0);
+	return { data: ctx.getImageData(0, 0, 1, img.height).data, height: img.height };
 }
 
-// True when row y of a decoded 1px column matches the given flat grey within tolerance.
-function isGreyRow(data, y, target) {
+// True when row y of a decoded 1px column matches the given flat colour within tolerance.
+function isColourRow(data, y, target) {
 	const r = data[(y * 4)];
 	const g = data[(y * 4) + 1];
 	const b = data[(y * 4) + 2];
-	return Math.abs(r - target) < COLOUR_TOLERANCE
-		&& Math.abs(g - target) < COLOUR_TOLERANCE
-		&& Math.abs(b - target) < COLOUR_TOLERANCE;
+	return Math.abs(r - target.r) < COLOUR_TOLERANCE
+		&& Math.abs(g - target.g) < COLOUR_TOLERANCE
+		&& Math.abs(b - target.b) < COLOUR_TOLERANCE;
 }
 
-// Finds the top-most device row containing the border grey in a 1px-wide strip
+// Finds the top-most device row containing the border colour in a 1px-wide strip
 // down the horizontal centre, which locates the card's top border edge.
 async function topBorderY(buffer) {
-	const { ctx, width, height } = await decodeToContext(buffer);
-	const x = Math.round(width / 2);
-	const { data } = ctx.getImageData(x, 0, 1, height);
+	const { data, height } = await decodeColumn(buffer, 0.5);
 	for (let y = 0; y < height; y += 1) {
-		if (isGreyRow(data, y, BORDER_GREY)) {
+		if (isColourRow(data, y, BORDER_COLOUR)) {
 			return y;
 		}
 	}
@@ -80,16 +94,35 @@ async function topBorderY(buffer) {
 // Finds the bottom-most device row containing the progress-track grey in a
 // 1px-wide strip on the right half of the bar, which locates the bar vertically.
 async function barBottomY(buffer) {
-	const { ctx, width, height } = await decodeToContext(buffer);
-	const x = Math.round(width * SAMPLE_X_FRACTION);
-	const { data } = ctx.getImageData(x, 0, 1, height);
+	const { data, height } = await decodeColumn(buffer, SAMPLE_X_FRACTION);
 	let lastTrackRow = -1;
 	for (let y = 0; y < height; y += 1) {
-		if (isGreyRow(data, y, TRACK_GREY)) {
+		if (isColourRow(data, y, TRACK_COLOUR)) {
 			lastTrackRow = y;
 		}
 	}
 	return lastTrackRow;
+}
+
+// Anything this dark in the card is glyph ink rather than background or bar
+const TEXT_LUMINANCE_CEILING = 128;
+
+// Counts text-dark pixels in a horizontal band of the card, inside the padding so
+// the card border never counts as text.
+async function darkPixelsInBand(buffer, topDeviceY, bottomDeviceY) {
+	const img = await loadImage(buffer);
+	const ctx = createCanvas(img.width, img.height).getContext('2d');
+	ctx.drawImage(img, 0, 0);
+	const left = compactCardPadding * compactResizeFactor;
+	const { data } = ctx.getImageData(left, topDeviceY, img.width - (left * 2), bottomDeviceY - topDeviceY);
+	let count = 0;
+	for (let i = 0; i < data.length; i += 4) {
+		const luminance = (data[i] * 0.299) + (data[i + 1] * 0.587) + (data[i + 2] * 0.114);
+		if (luminance < TEXT_LUMINANCE_CEILING) {
+			count += 1;
+		}
+	}
+	return count;
 }
 
 describe('draw – compact-bundle style', () => {
@@ -157,6 +190,23 @@ describe('draw – compact-bundle style', () => {
 		expect(longBottom).toBeGreaterThan(compactCardDimensions.height * 0.75);
 		// ...and land in the same place whether the use text is 1 or 4 lines.
 		expect(Math.abs(shortBottom - longBottom)).toBeLessThanOrEqual(3);
+	});
+
+	it('keeps a full-length use statement inside the space reserved above the pills', async () => {
+		const { buffer } = await draw(
+			makeLoan({
+				use: 'To purchase additional flour, sugar, yeast, and other raw baking materials '
+					+ 'in bulk so she can expand her neighbourhood bakery and hire an assistant.',
+			}),
+			'compact-bundle',
+		);
+
+		// The gap between the reserved top row and the pill row must stay empty: if the
+		// use text outgrows its reserved height it descends into the pills.
+		const gapTop = (compactCardPadding + compactTopRowHeight) * compactResizeFactor;
+		const gapBottom = gapTop + (compactSectionGap * compactResizeFactor);
+
+		expect(await darkPixelsInBand(buffer, gapTop, gapBottom)).toBe(0);
 	});
 
 	it('leaves the existing bundle style at its own (non-compact) dimensions', async () => {


### PR DESCRIPTION
## What

Design feedback from Casey on the compact live loan card ([MP-3195](https://kiva.atlassian.net/browse/MP-3195)), which is the server-rendered node-canvas JPEG behind the `compact-bundle` style — not a Vue component.

- **Card outline is now `#dfd0bc`** (was `#757575`), matching the outline of the email section the card sits inside.
- **Description type is now 16px / line-height 24**, up from 14px / 21. Pills and "$X to go" stay at 14px — they're secondary content.
- **Canvas resize factor 3 → 4**, so the card holds up when an email client displays it wider than its 271px layout width on a dense screen.

Type values are taken from the card's Figma design (`text-[16px]`, `leading-[1.5]`, Post Grot Book with Medium on the name-and-country run). The column geometry already matched the design exactly, so only type changed.

## Also fixed

The border stroke was centred on a path at `(0, 0)` and shrunk by only a quarter of its width, so half of it fell off-canvas on the top and left and a quarter on the right and bottom. Measured at a 230px display width the outline rendered `#f0eadf` top/left and `#e6e3d1` right/bottom — washed out and visibly uneven. `#757575` survived that; a pale beige would not have, so the new colour wouldn't actually have landed. Now uses the same inset pattern `drawClassic` already uses in this file; all four edges measure ~`#e2d7c6`.

## Notes for review

- **Served image changes shape**: 813x576 → 1084x816 (`compactCardHeight` 192 → 204, since the top row now reserves 4 × 24 = 96px). The email template needs to size the card by width and let height follow.
- **Description capacity drops ~102 → ~87 characters** across the 4-line clamp — the card grew taller but kept 4 lines at the same 179px column, so more loans will ellipsize. Worth a designer look, since the ask was for bigger text rather than less of it.
- **Rendered size vs the ticket's "at least 14pt"**: at a 230px display width, 16px logical renders at ~13.58px (~10.2pt). A literal 14pt would need 22px logical, which costs roughly half the description to truncation. Followed the Figma over the prose number — flagging so Casey can confirm.
- **Cost of the resize bump**, measured: +2.08ms draw, +1.28ms encode, +22.6KB per card, +1.48MiB per pooled canvas (~+12.5ms and +136KB per 6-card email). Dropping JPEG quality 0.8 → 0.6 would recover the bytes at no CPU cost if we want it; left at 0.8 for text crispness.
- **Post-deploy transient**: rendered JPEGs are cached 10 minutes under an unversioned key, so one email can briefly mix both aspect ratios. Self-healing; a cache-key bump would cause a needless miss-storm.

## Testing

- New `keeps a full-length use statement inside the space reserved above the pills` — verified red-green (reports 45 stray pixels when glyphs outgrow their line boxes).
- Existing coverage: border colour reaching the canvas, output dimensions, bar pinned to the card bottom.
- Full suite **5381 passed / 6 skipped / 1 failed** — `possibleTypesCacheIntegrity`, a pre-existing flake that passes 3/3 in isolation. Lint **0 errors**.

## Screenshot

<img width="1156" height="873" alt="Screenshot 2026-09-09 at 1 45 01 p m" src="https://github.com/user-attachments/assets/f6c7db5a-6800-45d7-9a8e-e68a45d1015f" />


[MP-3195]: https://kiva.atlassian.net/browse/MP-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ