### PR TITLE
chore: build storybook in pr ci

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -48,3 +48,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: 'test/coverage/lcov.info'
         fail-on-error: false
+    # Storybook is otherwise only built when deploying from main, so a story that
+    # imports something deleted in a PR cannot fail until after merge.
+    - name: Build Storybook
+      run: npm run build-storybook


### PR DESCRIPTION
## Why

Storybook is not built on pull requests today. `storybook-to-gh-pages.yml` triggers on
`push` to `main` only, and `run-ui-tests.yml`, which does run on PRs, never builds it. So a
PR can be fully green and still break the Storybook build once merged.

That happened with #7247: it deleted a local component nothing in `src` or `test`
imported, but `.storybook/stories/KvChip.stories.js` did. The break only surfaced on `main`.
Fixed in #7248.

## What this does

Adds a `Build Storybook` step to the existing PR workflow. The deploy workflow stays
deploy-only rather than being repurposed into a check, so nobody reading
`storybook-to-gh-pages.yml` has to notice it sometimes does not deploy.

The step runs last, after Coveralls, so a Storybook failure still fails the job but does not
stop coverage being reported.

## Cost

Roughly 2 minutes added to each ui PR — `npm run build-storybook` takes about 1m50s locally
with a warm cache. If that is too much for every PR, the alternative is adding
`pull_request` to the deploy workflow and guarding the deploy step with
`if: github.event_name == 'push'`, which reuses its cache setup but mixes building with
deploying.
