### PR TITLE
refactor: pin the header by route match instead of path substring

### DIFF
--- a/src/components/WwwFrame/TheHeader.vue
+++ b/src/components/WwwFrame/TheHeader.vue
@@ -1,7 +1,7 @@
 <template>
 	<header
 		class="tw-transition-all tw-duration-1000 tw-ease-in-out"
-		:class="isInExperimentPages ? 'tw-sticky tw-top-0 tw-z-sticky' : ''"
+		:class="stickyHeader ? 'tw-sticky tw-top-0 tw-z-sticky' : ''"
 	>
 		<KvWwwHeaderBasic
 			v-if="showBasicHeader"
@@ -599,7 +599,6 @@ import MyKivaButton from '#src/components/WwwFrame/Header/MyKivaButton';
 import TeamsMenu from '#src/components/WwwFrame/Header/TeamsMenu';
 import { readBoolSetting } from '#src/util/settingsUtils';
 import experimentVersionFragment from '#src/graphql/fragments/experimentVersion.graphql';
-import addToBasketMixin from '#src/plugins/add-to-basket-mixin';
 import {
 	KvButton, KvLoadingPlaceholder, KvMaterialIcon, KvPageContainer, KvWwwHeaderBasic
 } from '@kiva/kv-components';
@@ -636,7 +635,6 @@ export default {
 		cookieStore: { default: null },
 		kvAuth0: { default: null },
 	},
-	mixins: [addToBasketMixin],
 	data() {
 		return {
 			aboutMenuId: 'about-header-dropdown',
@@ -677,6 +675,10 @@ export default {
 			default: false,
 		},
 		minimal: {
+			type: Boolean,
+			default: false
+		},
+		stickyHeader: {
 			type: Boolean,
 			default: false
 		},

--- a/src/components/WwwFrame/WwwPage.vue
+++ b/src/components/WwwFrame/WwwPage.vue
@@ -4,6 +4,7 @@
 		<the-header
 			v-show="!isKivaAppReferral"
 			:hide-search-in-header="hideSearchInHeader"
+			:sticky-header="stickyHeader"
 		/>
 		<slot name="secondary" v-if="!isKivaAppReferral"></slot>
 
@@ -22,6 +23,7 @@ import hasEverLoggedInQuery from '#src/graphql/query/shared/hasEverLoggedIn.grap
 import { userHasEverLoggedInBefore } from '#src/util/optimizelyUserMetrics';
 import logReadQueryError from '#src/util/logReadQueryError';
 import CookieBanner from '#src/components/WwwFrame/CookieBanner';
+import { isStickyHeaderRoute } from '#src/util/headerUtils';
 import GlobalPromoContentful from './PromotionalBanner/GlobalPromotionalBannerContentful';
 import TheHeader from './TheHeader';
 import TheFooter from './TheFooter';
@@ -74,6 +76,9 @@ export default {
 		}
 	},
 	computed: {
+		stickyHeader() {
+			return isStickyHeaderRoute(this.$route);
+		},
 		mainClasses() {
 			return [
 				this.mainClass,

--- a/src/components/WwwFrame/WwwPageCorporate.vue
+++ b/src/components/WwwFrame/WwwPageCorporate.vue
@@ -6,7 +6,7 @@
 			:corporate-logo-url="corporateLogoUrl"
 			:logo-height="logoHeight"
 			:logo-classes="logoClasses"
-			class="tw-sticky tw-z-sticky tw-top-0"
+			:sticky-header="true"
 			@show-basket="$emit('show-basket')"
 		/>
 		<main>

--- a/src/plugins/add-to-basket-mixin.js
+++ b/src/plugins/add-to-basket-mixin.js
@@ -5,10 +5,4 @@ export default {
 			this.$emit('show-cart-modal', payload);
 		},
 	},
-	computed: {
-		isInExperimentPages() {
-			const { path } = this.$route;
-			return path.includes('lend') || path.includes('mykiva');
-		},
-	}
 };

--- a/src/util/headerUtils.js
+++ b/src/util/headerUtils.js
@@ -1,1 +1,9 @@
 export const COUNTRIES_NOT_LENT_TO_URL = '/lend/filter?countries-not-lent-to=true';
+
+// The header pins only where a lender can add to basket: My Kiva and the borrower profile.
+// Matched exactly rather than by substring so neighbours like /lender/:publicId,
+// /settings/autolending and /portfolio/lending-stats are not caught incidentally.
+export function isStickyHeaderRoute(route) {
+	const { path = '', name } = route ?? {};
+	return path === '/mykiva' || path.startsWith('/mykiva/') || name === 'borrowerProfile';
+}

--- a/test/unit/specs/components/WwwFrame/TheHeader.spec.js
+++ b/test/unit/specs/components/WwwFrame/TheHeader.spec.js
@@ -138,6 +138,27 @@ describe('TheHeader', () => {
 		expect(queryByTestId('header-basket')).not.toBeNull();
 	});
 
+	// Stickiness is decided by the frame and applied here, so both frames pin the same element.
+	describe('stickyHeader', () => {
+		it('should not pin the header by default', () => {
+			const { container } = renderHeader();
+
+			expect(container.querySelector('header').className).not.toContain('tw-sticky');
+		});
+
+		it('should pin the header when stickyHeader is set', () => {
+			const { container } = renderHeader({ stickyHeader: true });
+
+			expect(container.querySelector('header').className).toContain('tw-sticky');
+		});
+
+		it('should pin the corporate header when stickyHeader is set', () => {
+			const { container } = renderHeader({ corporate: true, stickyHeader: true });
+
+			expect(container.querySelector('header').className).toContain('tw-sticky');
+		});
+	});
+
 	// The assignment is made client-side, so an unassigned visitor is resolved after mount rather
 	// than during SSR. Version b adds the Major gifts nav link and relabels "Support Kiva" as "Give".
 	describe('major gifts header experiment', () => {

--- a/test/unit/specs/plugins/add-to-basket-mixin.spec.js
+++ b/test/unit/specs/plugins/add-to-basket-mixin.spec.js
@@ -6,9 +6,6 @@ describe('add-to-basket-mixin.js', () => {
 	beforeEach(() => {
 		context = {
 			$emit: vi.fn(),
-			$route: {
-				path: '/'
-			}
 		};
 	});
 
@@ -33,40 +30,6 @@ describe('add-to-basket-mixin.js', () => {
 			it('should emit show-cart-modal with undefined when no payload is given', () => {
 				addToBasketMixin.methods.showCartModal.call(context);
 				expect(context.$emit).toHaveBeenCalledWith('show-cart-modal', undefined);
-			});
-		});
-	});
-
-	describe('computed', () => {
-		describe('isInExperimentPages', () => {
-			it('should return true when path includes "lend"', () => {
-				context.$route.path = '/lend/filter';
-				const result = addToBasketMixin.computed.isInExperimentPages.call(context);
-				expect(result).toBe(true);
-			});
-
-			it('should return true when path includes "mykiva"', () => {
-				context.$route.path = '/mykiva';
-				const result = addToBasketMixin.computed.isInExperimentPages.call(context);
-				expect(result).toBe(true);
-			});
-
-			it('should return true when path includes both "lend" and "mykiva"', () => {
-				context.$route.path = '/lend/mykiva';
-				const result = addToBasketMixin.computed.isInExperimentPages.call(context);
-				expect(result).toBe(true);
-			});
-
-			it('should return false for unrelated paths', () => {
-				context.$route.path = '/portfolio';
-				const result = addToBasketMixin.computed.isInExperimentPages.call(context);
-				expect(result).toBe(false);
-			});
-
-			it('should return false for root path', () => {
-				context.$route.path = '/';
-				const result = addToBasketMixin.computed.isInExperimentPages.call(context);
-				expect(result).toBe(false);
 			});
 		});
 	});

--- a/test/unit/specs/util/headerUtils.spec.js
+++ b/test/unit/specs/util/headerUtils.spec.js
@@ -1,0 +1,40 @@
+import { isStickyHeaderRoute } from '#src/util/headerUtils';
+
+describe('headerUtils.js', () => {
+	describe('isStickyHeaderRoute', () => {
+		it('should pin My Kiva', () => {
+			expect(isStickyHeaderRoute({ path: '/mykiva' })).toBe(true);
+		});
+
+		it('should pin My Kiva sub-pages', () => {
+			expect(isStickyHeaderRoute({ path: '/mykiva/next-steps' })).toBe(true);
+		});
+
+		it('should pin the borrower profile by route name', () => {
+			expect(isStickyHeaderRoute({ path: '/lend/2451905', name: 'borrowerProfile' })).toBe(true);
+		});
+
+		// These all matched the previous `path.includes('lend') || path.includes('mykiva')` rule.
+		it.each([
+			'/lend/saved-search',
+			'/lender/matt-2519',
+			'/settings/autolending',
+			'/portfolio/lending-stats',
+			'/instant-lending-error',
+			'/process-instant-lending/2451905/25',
+			'/possibility/12-days-of-lending',
+			'/lend-vue',
+			'/mykivalike',
+		])('should not pin %s', path => {
+			expect(isStickyHeaderRoute({ path })).toBe(false);
+		});
+
+		it('should not pin the homepage', () => {
+			expect(isStickyHeaderRoute({ path: '/' })).toBe(false);
+		});
+
+		it('should not pin when there is no route', () => {
+			expect(isStickyHeaderRoute(undefined)).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
The header's sticky rule came from `isInExperimentPages`, which matched any path containing "lend" or "mykiva". That caught eight routes incidentally — `/lender/:publicId`, `/settings/autolending`, `/portfolio/lending-stats`, `/instant-lending-error`, `/process-instant-lending/…`, `/possibility/12-days-of-lending`, `/lend/saved-search` and `/lend-vue` — none of which support add to basket. Those are no longer sticky.

Stickiness is now one route rule (`isStickyHeaderRoute`) feeding one `stickyHeader` prop on `TheHeader`, so the route-driven case and the corporate case pin the same element through the same code path. `/cc/*` renders identically to before. `isInExperimentPages` is gone; its backing flag was removed in 19fc0b469 and only the route substring was left behind.

Sticky set confirmed with Casey on the ticket: My Kiva, the borrower profile, and the cc pages.

https://kiva.atlassian.net/browse/CIT-5031